### PR TITLE
Handle malformed user skills and avoid persisting failed builds

### DIFF
--- a/anton/skill/registry.py
+++ b/anton/skill/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 from anton.skill.base import SkillInfo
@@ -16,7 +17,17 @@ class SkillRegistry:
             return
 
         for skill_file in sorted(skills_path.glob("*/skill.py")):
-            for info in load_skill_module(skill_file):
+            try:
+                loaded = load_skill_module(skill_file)
+            except Exception as exc:  # noqa: BLE001
+                warnings.warn(
+                    f"Skipping invalid skill module '{skill_file}': {exc}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                continue
+
+            for info in loaded:
                 self.register(info)
 
     def register(self, skill: SkillInfo) -> None:


### PR DESCRIPTION
## Why This Fix

Anton can crash on startup if a previously generated user skill file in `~/.anton/skills` is malformed (for example, truncated code with a syntax error).

In the reproduced case, startup failed when loading `read_and_summarize_the_contents_of/skill.py` with:
- `SyntaxError: unterminated string literal`

This happened because:
1. Skill discovery imported each user skill module without guarding per-file failures.
2. The skill builder wrote generated code directly to final `skill.py` before validation, so failed generations could leave broken artifacts behind.

## What This PR Changes

1. **Make skill discovery resilient to malformed user skills**
- File: `anton/skill/registry.py`
- `SkillRegistry.discover()` now catches exceptions from `load_skill_module()` per skill file.
- Invalid skill files are skipped with a `RuntimeWarning` instead of crashing startup.

2. **Only publish generated skills after validation passes**
- File: `anton/skill/builder.py`
- Builder now writes each generation attempt to `.{skill_name}.attempt.py`.
- Validation runs against the attempt file.
- Final `skill.py` is replaced only when validation succeeds.
- Failed attempts are cleaned up, so broken code is not persisted as a loadable skill.

## Tests Added

- `tests/test_registry.py`
  - `test_discover_skips_invalid_skill_files`
- `tests/test_skill_builder.py`
  - `test_failed_build_does_not_publish_broken_skill_file`
  - `test_failed_build_preserves_existing_skill_file`

## Validation

Ran:
- `python -m pytest tests/test_registry.py tests/test_skill_builder.py`

Result:
- `19 passed`

