### PR TITLE
Improve Minds setup recovery flow

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -1243,6 +1243,95 @@ def _normalize_minds_url(url: str) -> str:
     return url.rstrip("/")
 
 
+def _mask_secret(value: str, *, keep: int = 4) -> str:
+    if len(value) <= keep * 2:
+        return "*" * max(len(value), 3)
+    return f"{value[:keep]}...{value[-keep:]}"
+
+
+def _prompt_minds_api_key(
+    console: Console,
+    *,
+    current_key: str,
+    allow_empty_keep: bool,
+) -> str | None:
+    from rich.prompt import Prompt
+
+    prompt = "API key"
+    if current_key:
+        masked = _mask_secret(current_key)
+        if allow_empty_keep:
+            prompt += f" [dim](Enter to keep {masked})[/]"
+        else:
+            prompt += f" [dim](current: {masked}; Enter to cancel)[/]"
+
+    if current_key:
+        api_key = Prompt.ask(prompt, default="", console=console, password=True).strip()
+    else:
+        api_key = Prompt.ask(prompt, console=console, password=True).strip()
+    if api_key:
+        return api_key
+    if current_key and allow_empty_keep:
+        return current_key
+    return None
+
+
+def _describe_minds_connection_error(err: Exception) -> tuple[str, str]:
+    import socket
+    import ssl
+    import urllib.error
+
+    if isinstance(err, urllib.error.HTTPError):
+        reason = err.reason or "HTTP error"
+        if err.code in (401, 403):
+            return (
+                f"Connection failed (HTTP {err.code}: {reason}). The server rejected the request.",
+                "Common reasons: invalid or expired credentials, insufficient access, or the wrong server/endpoint.",
+            )
+        if 400 <= err.code < 500:
+            return (
+                f"Connection failed (HTTP {err.code}: {reason}). The server rejected the request.",
+                "Common reasons: wrong URL, malformed request, or access restrictions on that endpoint.",
+            )
+        if err.code >= 500:
+            return (
+                f"Connection failed (HTTP {err.code}: {reason}). The server returned an error.",
+                "Common reasons: server-side failure or a temporary outage.",
+            )
+        return (
+            f"Connection failed (HTTP {err.code}: {reason}).",
+            "Common reasons: a server response Anton could not use or a transient connectivity problem.",
+        )
+
+    if isinstance(err, urllib.error.URLError):
+        reason = getattr(err, "reason", None)
+        if isinstance(reason, ssl.SSLCertVerificationError):
+            return (
+                "Connection failed during TLS certificate verification.",
+                "Common reasons: a self-signed, expired, or otherwise untrusted certificate.",
+            )
+        if isinstance(reason, (TimeoutError, socket.timeout)) or "timed out" in str(reason).lower():
+            return (
+                "Connection failed because the request timed out.",
+                "Common reasons: the server is slow or unavailable, the URL is wrong, or there is a network path issue.",
+            )
+        return (
+            f"Connection failed ({err}).",
+            "Common reasons: network connectivity problems, DNS issues, or a server Anton could not reach.",
+        )
+
+    if "timed out" in str(err).lower():
+        return (
+            "Connection failed because the request timed out.",
+            "Common reasons: the server is slow or unavailable, the URL is wrong, or there is a network path issue.",
+        )
+
+    return (
+        f"Connection failed ({err}).",
+        "Common reasons: network connectivity problems, authentication issues, or a server-side failure.",
+    )
+
+
 def _minds_list_minds(base_url: str, api_key: str, verify: bool = True) -> list[dict]:
     """Fetch minds list from a Minds server using stdlib urllib."""
     import json as _json
@@ -1395,7 +1484,6 @@ async def _handle_connect(
     episodic: EpisodicMemory | None = None,
 ) -> ChatSession:
     """Connect to a Minds server: select a Mind, then optionally a datasource."""
-    import ssl
     import urllib.error
 
     from rich.prompt import Prompt
@@ -1412,66 +1500,66 @@ async def _handle_connect(
     minds_url = _normalize_minds_url(minds_url)
 
     saved_key = settings.minds_api_key or ""
-    default_key = saved_key if saved_key else None
-    api_key = Prompt.ask("API key", default=default_key, console=console, password=True)
-    if not api_key or not api_key.strip():
+    api_key = _prompt_minds_api_key(
+        console,
+        current_key=saved_key,
+        allow_empty_keep=True,
+    )
+    if not api_key:
         console.print("[anton.error]API key is required.[/]")
         console.print()
         return session
-    api_key = api_key.strip()
 
     ssl_verify = settings.minds_ssl_verify
 
-    # --- Try to connect (with retry on auth/SSL failure) ---
+    # --- Try to connect ---
     minds = None
-    max_attempts = 3
-    for _attempt in range(max_attempts):
+    while minds is None:
         console.print()
         console.print(f"[anton.muted]Connecting to {minds_url}...[/]")
         try:
             minds = _minds_list_minds(minds_url, api_key, verify=ssl_verify)
             break
-        except urllib.error.HTTPError as e:
-            if e.code in (401, 403):
-                console.print("[anton.error]Authentication failed — check your URL and API key.[/]")
-                if _attempt >= max_attempts - 1:
-                    console.print("[anton.muted]Too many failed attempts. Aborted.[/]")
-                    console.print()
-                    return session
-                minds_url = Prompt.ask("Minds server URL", default=minds_url, console=console)
-                minds_url = _normalize_minds_url(minds_url)
-                api_key = Prompt.ask("API key", console=console, password=True)
-                if not api_key or not api_key.strip():
-                    console.print("[anton.muted]Aborted.[/]")
-                    console.print()
-                    return session
-                api_key = api_key.strip()
+        except (urllib.error.URLError, urllib.error.HTTPError) as err:
+            headline, advice = _describe_minds_connection_error(err)
+            console.print(f"[anton.error]{headline}[/]")
+            console.print(f"[anton.muted]{advice}[/]")
+        except Exception as err:
+            headline, advice = _describe_minds_connection_error(err)
+            console.print(f"[anton.error]{headline}[/]")
+            console.print(f"[anton.muted]{advice}[/]")
+
+        console.print()
+        console.print("  Recovery options:")
+        console.print("    [bold]1[/]  Reconfigure API key")
+        console.print("    [bold]2[/]  Retry without SSL verification")
+        console.print("    [bold]q[/]  Back")
+        console.print()
+
+        action = Prompt.ask(
+            "Select",
+            choices=["1", "2", "q"],
+            default="q",
+            console=console,
+        )
+        if action == "q":
+            console.print("[anton.muted]Aborted.[/]")
+            console.print()
+            return session
+        if action == "1":
+            new_key = _prompt_minds_api_key(
+                console,
+                current_key=api_key,
+                allow_empty_keep=False,
+            )
+            if new_key is None:
+                console.print("[anton.muted]API key unchanged.[/]")
                 continue
-            console.print(f"[anton.error]Connection failed (HTTP {e.code}): {e.reason}[/]")
-            console.print()
-            return session
-        except urllib.error.URLError as e:
-            if isinstance(getattr(e, "reason", None), ssl.SSLCertVerificationError):
-                console.print("[anton.warning]This server uses a self-signed or untrusted certificate.[/]")
-                trust = Prompt.ask(
-                    "Trust this certificate anyway? (y/n)",
-                    choices=["y", "n"],
-                    default="n",
-                    console=console,
-                )
-                if trust == "y":
-                    ssl_verify = False
-                    continue
-                console.print("[anton.muted]Aborted.[/]")
-                console.print()
-                return session
-            console.print(f"[anton.error]Connection failed: {e}[/]")
-            console.print()
-            return session
-        except Exception as e:
-            console.print(f"[anton.error]Connection failed: {e}[/]")
-            console.print()
-            return session
+            api_key = new_key
+            ssl_verify = settings.minds_ssl_verify
+            continue
+
+        ssl_verify = False
 
     if not minds:
         console.print("[anton.warning]No minds found on this server.[/]")

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import socket
+import urllib.error
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from anton.chat import ChatSession
+from anton.chat import ChatSession, _describe_minds_connection_error, _handle_connect
+from anton.config.settings import AntonSettings
 from anton.tools import MEMORIZE_TOOL
 from anton.context.self_awareness import SelfAwarenessContext
 from anton.llm.provider import LLMResponse, ToolCall, Usage
@@ -285,3 +288,142 @@ class TestRuntimeContext:
         call_kwargs = mock_llm.plan.call_args
         system_prompt = call_kwargs.kwargs.get("system", "")
         assert "WAIT for their reply" in system_prompt
+
+
+class TestMindsSetupRecovery:
+    def test_describe_minds_http_401_is_factual(self):
+        error = urllib.error.HTTPError(
+            "https://mdb.ai/api/v1/minds/",
+            401,
+            "Unauthorized",
+            None,
+            None,
+        )
+
+        headline, advice = _describe_minds_connection_error(error)
+
+        assert headline == "Connection failed (HTTP 401: Unauthorized). The server rejected the request."
+        assert "invalid or expired credentials" in advice
+
+    def test_describe_minds_timeout_is_factual(self):
+        error = urllib.error.URLError(socket.timeout("timed out"))
+
+        headline, advice = _describe_minds_connection_error(error)
+
+        assert headline == "Connection failed because the request timed out."
+        assert "server is slow or unavailable" in advice
+
+    async def test_connect_can_reconfigure_api_key_after_auth_failure(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        prompts = iter(["mdb.ai", "", "1", "new-key", "1"])
+        monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *args, **kwargs: next(prompts))
+
+        calls: list[tuple[str, str, bool]] = []
+
+        def fake_list_minds(base_url: str, api_key: str, verify: bool = True):
+            calls.append((base_url, api_key, verify))
+            if len(calls) == 1:
+                raise urllib.error.HTTPError(
+                    f"{base_url}/api/v1/minds/",
+                    401,
+                    "Unauthorized",
+                    None,
+                    None,
+                )
+            return [{"name": "warehouse", "datasources": []}]
+
+        monkeypatch.setattr("anton.chat._minds_list_minds", fake_list_minds)
+        monkeypatch.setattr("anton.chat._minds_test_llm", lambda *args, **kwargs: True)
+        rebuilt = object()
+        monkeypatch.setattr("anton.chat._rebuild_session", lambda **kwargs: rebuilt)
+
+        workspace_base = tmp_path / "workspace"
+        workspace_base.mkdir()
+        workspace = Workspace(workspace_base)
+        workspace.initialize()
+        settings = AntonSettings(minds_api_key="old-key", _env_file=None)
+        console = MagicMock()
+
+        result = await _handle_connect(
+            console,
+            settings,
+            workspace,
+            state={},
+            self_awareness=None,
+            cortex=None,
+            session=object(),
+        )
+
+        assert result is rebuilt
+        assert calls == [
+            ("https://mdb.ai", "old-key", True),
+            ("https://mdb.ai", "new-key", True),
+        ]
+        assert settings.minds_api_key == "new-key"
+        assert "ANTON_MINDS_API_KEY=new-key" in (home / ".anton" / ".env").read_text()
+        printed = "\n".join(str(call.args[0]) for call in console.print.call_args_list if call.args)
+        assert "The server rejected the request." in printed
+        assert "Common reasons: invalid or expired credentials" in printed
+        assert "Recovery options:" in printed
+        assert "certificate issue" not in printed
+
+    async def test_connect_can_retry_without_ssl_verification_after_timeout(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        prompts = iter(["https://terabase.dev.mdb.ai", "", "2", "1"])
+        monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *args, **kwargs: next(prompts))
+
+        calls: list[tuple[str, str, bool]] = []
+
+        def fake_list_minds(base_url: str, api_key: str, verify: bool = True):
+            calls.append((base_url, api_key, verify))
+            if len(calls) == 1:
+                raise urllib.error.URLError(socket.timeout("timed out"))
+            return [{"name": "warehouse", "datasources": []}]
+
+        monkeypatch.setattr("anton.chat._minds_list_minds", fake_list_minds)
+        monkeypatch.setattr("anton.chat._minds_test_llm", lambda *args, **kwargs: True)
+        rebuilt = object()
+        monkeypatch.setattr("anton.chat._rebuild_session", lambda **kwargs: rebuilt)
+
+        workspace_base = tmp_path / "workspace"
+        workspace_base.mkdir()
+        workspace = Workspace(workspace_base)
+        workspace.initialize()
+        settings = AntonSettings(minds_api_key="minds-key", _env_file=None)
+        console = MagicMock()
+
+        result = await _handle_connect(
+            console,
+            settings,
+            workspace,
+            state={},
+            self_awareness=None,
+            cortex=None,
+            session=object(),
+        )
+
+        assert result is rebuilt
+        assert calls == [
+            ("https://terabase.dev.mdb.ai", "minds-key", True),
+            ("https://terabase.dev.mdb.ai", "minds-key", False),
+        ]
+        assert settings.minds_ssl_verify is False
+        assert "ANTON_MINDS_SSL_VERIFY=false" in (home / ".anton" / ".env").read_text()
+        printed = "\n".join(str(call.args[0]) for call in console.print.call_args_list if call.args)
+        assert "Connection failed because the request timed out." in printed
+        assert "server is slow or unavailable" in printed
+        assert "Recovery options:" in printed


### PR DESCRIPTION
## Summary
- make Minds setup failures factual-first instead of treating many failures as certificate issues
- add an in-flow recovery menu for reconfiguring the API key or retrying without SSL verification
- add regression tests for auth-failure and timeout recovery paths

## Testing
- pytest -q tests/test_chat_context.py
- python3 -m compileall anton