### PR TITLE
Avoid prompt redraw spam on terminal resize

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -776,6 +776,15 @@ def _build_runtime_context(settings: AntonSettings) -> str:
     return ctx
 
 
+def _format_bottom_toolbar(status: str, stats: str, *, width: int) -> str:
+    if not stats and not status:
+        return ""
+    gap = width - len(status) - len(stats)
+    if gap < 1:
+        gap = 1
+    return status + " " * gap + stats
+
+
 def _rebuild_session(
     *,
     settings: AntonSettings,
@@ -1978,11 +1987,8 @@ async def _chat_loop(console: Console, settings: AntonSettings, *, resume: bool 
             width = os.get_terminal_size().columns
         except OSError:
             width = 80
-        gap = width - len(status) - len(stats)
-        if gap < 1:
-            gap = 1
-        line = status + " " * gap + stats
-        return HTML(f"\n<style fg='#555570'>{line}</style>")
+        line = _format_bottom_toolbar(status, stats, width=width)
+        return HTML(f"<style fg='#555570'>{line}</style>")
 
     pt_style = PTStyle.from_dict({
         "bottom-toolbar": "noreverse nounderline bg:default",

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from anton.chat import ChatSession
+from anton.chat import ChatSession, _format_bottom_toolbar
 from anton.tools import MEMORIZE_TOOL
 from anton.context.self_awareness import SelfAwarenessContext
 from anton.llm.provider import LLMResponse, ToolCall, Usage
@@ -285,3 +285,12 @@ class TestRuntimeContext:
         call_kwargs = mock_llm.plan.call_args
         system_prompt = call_kwargs.kwargs.get("system", "")
         assert "WAIT for their reply" in system_prompt
+
+
+class TestPromptToolbar:
+    def test_bottom_toolbar_does_not_prefix_newline(self):
+        rendered = _format_bottom_toolbar("working", "stats", width=30)
+
+        assert rendered
+        assert not rendered.startswith("\n")
+        assert rendered.startswith("working")


### PR DESCRIPTION
## Summary
- remove the literal newline from the prompt-toolkit bottom toolbar renderer
- extract toolbar spacing into a small helper so the formatting is testable
- add a regression test that the rendered toolbar text does not start with a newline

## Testing
- pytest -q tests/test_chat_context.py tests/test_chat_ui.py
- python3 -m compileall anton