### PR TITLE
Remove env info from base prompt

### DIFF
--- a/anton/llm/prompts.py
+++ b/anton/llm/prompts.py
@@ -57,7 +57,6 @@ Pydantic models. Define a class with BaseModel, and the LLM fills it. Supports l
 tool-call loop inside scratchpad code. The LLM reasons and calls your tools iteratively. \
 handle_tool(name, inputs) is a plain sync function returning a string result. Use this for \
 multi-step AI workflows like classification, extraction, or analysis with structured outputs.
-- All .anton/.env secrets are available as environment variables (os.environ).
 - When the user asks how you solved something or wants to see your work, use the scratchpad \
 dump action — it shows a clean notebook-style summary without wasting tokens on reformatting.
 - Always use print() to produce output — scratchpad captures stdout.


### PR DESCRIPTION
This PR removes the info about .env file from the system prompt. The secrets are still available to the scratchpad code we just don't say that in the system prompt