### PR TITLE
Strip credentials from HTML archives before publishing

### DIFF
--- a/anton/llm/prompts.py
+++ b/anton/llm/prompts.py
@@ -258,6 +258,13 @@ across all charts.
 Do NOT reference external local files (like data.js) — browsers block local file:// cross-references \
 for security reasons and the dashboard will silently fail to load data.
 
+  SECURITY (critical): Dashboards may be published to the web. NEVER embed API keys, tokens, \
+passwords, connection strings, or any credentials in the HTML, JS, or inline data. Fetch data \
+in scratchpad cells using credentials from environment variables, then serialize only the \
+resulting data into the dashboard. If the user explicitly asks to embed a credential \
+(e.g. for a live-updating dashboard), warn them that publishing will expose it and get \
+confirmation before proceeding.
+
   Build the parts in separate cells, then assemble at the end:
 
   CELL 1 — Serialize data to a JS string variable (programmatic, no HTML):

--- a/anton/publisher.py
+++ b/anton/publisher.py
@@ -5,11 +5,23 @@ from __future__ import annotations
 import base64
 import io
 import json
+import os
 import re
 import zipfile
 from pathlib import Path
 
 from anton.minds_client import minds_request
+from anton.utils.datasources import scrub_credentials
+
+# LLM API key env vars whose values must be stripped from published files.
+_LLM_SECRET_VARS = (
+    "ANTON_ANTHROPIC_API_KEY",
+    "ANTON_OPENAI_API_KEY",
+    "ANTON_MINDS_API_KEY",
+)
+
+# File extensions treated as text and subject to credential scrubbing.
+_TEXT_EXTENSIONS = {".html", ".htm", ".js", ".css"}
 
 
 DEFAULT_PUBLISH_URL = "https://4nton.ai"
@@ -46,22 +58,40 @@ def _find_referenced_files(html_path: Path) -> list[Path]:
     return sorted(refs)
 
 
+def _scrub_content(text: str) -> str:
+    """Strip LLM API keys and DB credentials from text before it enters the archive."""
+    for var in _LLM_SECRET_VARS:
+        value = os.environ.get(var, "")
+        if value:
+            text = text.replace(value, "")
+    return scrub_credentials(text)
+
+
+def _write_scrubbed(zf: zipfile.ZipFile, src: Path, arc_name: str) -> None:
+    """Add *src* to *zf* as *arc_name*, scrubbing credentials from text files."""
+    if src.suffix.lower() in _TEXT_EXTENSIONS:
+        raw = src.read_text(encoding="utf-8", errors="ignore")
+        zf.writestr(arc_name, _scrub_content(raw))
+    else:
+        zf.write(src, arc_name)
+
+
 def _zip_html(path: Path) -> bytes:
     """Create a ZIP archive from an HTML file (with referenced siblings) or a directory."""
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         if path.is_file():
-            zf.write(path, "index.html")
+            _write_scrubbed(zf, path, "index.html")
             # Bundle any referenced sibling files (JS, CSS, images, etc.)
             parent = path.resolve().parent
             for ref in _find_referenced_files(path):
                 arc_name = str(ref.relative_to(parent))
-                zf.write(ref, arc_name)
+                _write_scrubbed(zf, ref, arc_name)
         else:
             # Directory — include all files
             for f in sorted(path.rglob("*")):
                 if f.is_file():
-                    zf.write(f, str(f.relative_to(path)))
+                    _write_scrubbed(zf, f, str(f.relative_to(path)))
     return buf.getvalue()
 
 


### PR DESCRIPTION
Prevent API keys and database credentials from leaking into published dashboards.

Before creating the ZIP archive, all text files (.html, .htm, .js, .css) are scrubbed:
- Values of `ANTON_ANTHROPIC_API_KEY`, `ANTON_OPENAI_API_KEY`, `ANTON_MINDS_API_KEY` are removed
- DB credentials registered in the data vault are redacted via `scrub_credentials()`
