### PR TITLE
Mark stub-only the failing test

### DIFF
--- a/tests/e2e/scenarios/test_error_handling.py
+++ b/tests/e2e/scenarios/test_error_handling.py
@@ -78,6 +78,7 @@ def test_malformed_json_handled_gracefully(cfg, tmp_path):
     assert_not_output(result, "Traceback (most recent call last)")
 
 
+@pytest.mark.stub_only
 def test_large_input_no_crash(cfg, stub, tmp_path):
     stub.queue_text("Got your big message.")
     stub.queue_verification_ok()


### PR DESCRIPTION
When release is triggered, this test is failing because we have hardcoded check for stub only tests