### PR TITLE
docs: Reposition README - Anton as a general-purpose autonomous agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,14 @@
     ▐   ▐        █▀█ █ ▀█  █  █▄█ █ ▀█
     ▐   ▐
 ```
+# Meet Anton - an autonomous agent that gets real work done
+Anton is your personal AI agent that works so you don't have to. Tell it what you need in plain language and it takes it from there - sending emails, calling APIs, connecting to data sources, building dashboards, and delivering results. No setup, no plugins, no fuss.
 
-# MindsDB Anton — What Business Intelligence is supposed to be
-
-Business intelligence was supposed to give you the right data, at the right time, to get real work done.
-
-That is Anton. You ask questions in plain language, and Anton takes ownership of the entire analytical process:
-it pulls and unifies data from multiple sources, runs the analysis, surfaces insights, builds rich dashboards, suggests next steps, and can even take action - A business intelligence agent that works like an expert analyst — 24/7, at machine speed.
+It doesn't just answer questions. It *does things*: cleans your inbox, builds integrations, analyzes your data, automates workflows - whatever the task requires.
 
 ![ezgif-24b9e7c74652f0dc](https://github.com/user-attachments/assets/c92f87c1-ff30-4272-92ba-49a8585d5954)
 
-
-## Quick start 
+## Quick start
 **macOS - Desktop App:**
 
 <a href="https://mindsdb-anton.s3.us-east-2.amazonaws.com/anton-latest-universal-signed.pkg">
@@ -42,17 +38,20 @@ That's it, you can now run it by simply typing the command:
 anton
 ```
 
-## Using Anton
+## What can Anton do?
 
-Talk to Anton like a person, for example, ask Anton this:
+Anton figures things out live. It doesn't rely on pre-built plugins or predefined workflows - it writes code on the fly, calls APIs, and chains together whatever steps are needed to get the job done.
 
+Here are a few examples of what people are using it for:
+
+### 📊 Data analysis & dashboards
 ```
 I hold 50 AAPL, 200 NVDA, and 10 AMZN. Get today's prices, calculate my
 total portfolio value, show me the 30-day performance of each stock, and
 any other information that might be useful. Give me a complete dashboard.
 ```
 
-What happens next is the interesting part. At first, Anton doesn't have any particular skill related to this question. However, it figures it out live: scrapes live prices, writes code on the fly, crunches the numbers, and builds you a full dashboard — all in one conversation, with no setup.
+What happens next is the interesting part. At first, Anton doesn't have any particular skill related to this question. However, it figures it out live: scrapes live prices, writes code on the fly, crunches the numbers, and builds you a full dashboard - all in one conversation, with no setup.
 
 
 ```text
@@ -64,13 +63,42 @@ Summary: Concentration risk is your #1 issue. If you're comfortable being a high
         <img width="800" alt="Anton's response" src="https://github.com/user-attachments/assets/6dc6ee81-2a2c-4358-be05-bfe884c32685" />
 </p>
 
-**Key features**
+### 📬 Email cleanup
+```
+Dear Anton, please help me clear unwanted emails...
+```
+
+Anton scans your inbox, classifies emails by signal vs. noise, identifies unsubscribable marketing, cold outreach, and internal tool notifications - then surfaces a breakdown and handles the cleanup. One user ran it on ~1,000 emails and found ~35% were un-subscribable. Anton surfaced everything AND handled the cleanup.
+
+### 💬 Build its own integrations
+```
+Set up a WhatsApp integration so I can message you from my phone.
+```
+
+Anton doesn't wait for someone to build a connector. It writes the integration code itself, sets it up, and gets it running - so you can chat with it from WhatsApp, Telegram, or whatever channel you need.
+
+### 🔧 Ask for anything that takes requires action
+- **Send emails** - connect accounts, draft messages or even send them on your behalf.
+- **Manage Calendarss** - Summarize your day, create meetings, block time, etc. All just by asking.
+- **Automated reporting** - pull from multiple databases, crunch numbers, deliver a report on a schedule.
+- **Workflow automation** - monitor a source, react to changes, take action.
+- **Research & synthesis** - scrape the web, summarize findings, build a reference document.
+- **Data pipeline prototyping** - connect sources, transform data, load into a destination.
+- **System administration** - audit configurations, generate reports, fix issues.
+
+The pattern is always the same: you describe the outcome, Anton figures out the steps.
+
+---
+
+## Key features
 - **Credential vault** - prevents secrets from being exposed to LLMs.
-- **Isolated code execution** - protected, reproducible “show your work” environment.
-- **Multi-layer memory & continuous learning** - session, semantic and long-term business knowledge.
+- **Isolated code execution** - protected, reproducible "show your work" environment.
+- **Multi-layer memory & continuous learning** - session, semantic and long-term knowledge. Anton remembers what it learned and gets better at your specific workflows over time.
+
+---
 
 #### Connect your data
-Although you can use Anton with just public data, the real power happens when you combine that with your own data. This can be anything: files,  databases, application APIs,... etc. Open the Local Vault with `/connect` command, then follow the prompts to add your secrets. Anton only has access to secret names - secret values remain hidden.
+Although you can use Anton with just public data, the real power happens when you combine that with your own data. This can be anything: files, databases, application APIs,... etc. Open the Local Vault with `/connect` command, then follow the prompts to add your secrets. Anton only has access to secret names - secret values remain hidden.
 
 ```powershell
 /connect
@@ -110,14 +138,11 @@ ANTON>
 
 ---
 
-### Explainable by default
-
-You can always ask Anton to explain what it did. Ask it to dump its scratchpad and you get a full notebook-style breakdown: every cell of code it ran, the outputs, and errors — so you can follow its reasoning step by step.
+You can always ask Anton to explain what it did. Ask it to dump its scratchpad and you get a full notebook-style breakdown: every cell of code it ran, the outputs, and errors - so you can follow its reasoning step by step.
 
 ---
 
 ## What's inside
-
 <p align="center"><img width="800"  alt="image" src="/assets/anton-diagram.png" /></p>
 
 For the full architecture of Anton, file formats, and developer guide, see **[anton/README.md](anton/README.md)**.
@@ -125,17 +150,16 @@ For the full architecture of Anton, file formats, and developer guide, see **[an
 ---
 
 ## Workspace layout
-
 When you run `anton` in a directory:
 
-- `.anton/` — workspace folder containing scratchpad state, episodic memory, and local secrets.  
-- `.anton/anton.md` — optional project context (Anton reads this at conversation start).  
-- `.anton/.env` — workspace configuration variables file (local file). 
-- `.anton/episodes/*` — episodic memories, one file per session.
+- `.anton/` - workspace folder containing scratchpad state, episodic memory, and local secrets.  
+- `.anton/anton.md` - optional project context (Anton reads this at conversation start).  
+- `.anton/.env` - workspace configuration variables file (local file). 
+- `.anton/episodes/*` - episodic memories, one file per session.
 - `.anton/memory/rules.md` - behavioral rules: Always/never/when rules (e.g., never hardcode credentials, how to build HTML)     
 - `.anton/memory/lessons.md` - factual knowledge: Things I've learned (stock API quirks, dashboard patterns, data fetching notes)   
 - `.anton/memory/topics/*` - topic-specific lessons:  Deeper notes organized by subject (dashboard-visualization, stock-data-api, etc.) 
-                                         
+
 Override the working folder:
 ```bash
 anton --folder /path/to/workspace
@@ -144,25 +168,22 @@ anton --folder /path/to/workspace
 ---
 
 ## Memory systems
-
 Anton provides two human-readable memory systems:
 
-- **Semantic memory** — rules, lessons, identity and domain expertise stored as markdown at global and project scope.  
-- **Episodic memory** — a timestamped archive of every conversation (JSONL in `.anton/episodes/`). Anton can recall prior sessions with the `recall` tool.
+- **Semantic memory** - rules, lessons, identity and domain expertise stored as markdown at global and project scope.  
+- **Episodic memory** - a timestamped archive of every conversation (JSONL in `.anton/episodes/`). Anton can recall prior sessions with the `recall` tool.
 
 Configure memory via `/setup` > Memory or via environment variables.
 
 ---
 
 ### Prerequisites
-
-- `git` — required  
+- `git` - required  
 - Python **3.11+** (Anton will bootstrap an environment if missing)  
-- `curl` — macOS / Linux installs  
+- `curl` - macOS / Linux installs  
 - Internet connection (scratchpad may access web sources)
 
 ### Windows scratchpad firewall
-
 The Windows installer can add a firewall rule so the scratchpad can reach the internet. If you skipped it, run in an elevated PowerShell:
 
 ```powershell
@@ -172,23 +193,19 @@ netsh advfirewall firewall add rule name="Anton Scratchpad" dir=out action=allow
 ---
 
 ## How Anton differs from coding agents
-
-Anton is a *doing* agent: code is a tool to get results. Where coding agents focus on producing code for a codebase, Anton focuses on delivering the outcome — a dataset, report, dashboard, or automated workflow — and will write whatever code is necessary to achieve that goal.
+Anton is a *doing* agent: code is a means, not the end. Where coding agents focus on producing code for a codebase, Anton focuses on delivering the outcome - a cleaned inbox, a live dashboard, a working integration, an automated workflow - and will write whatever code is necessary to achieve that goal.
 
 ---
 
 ## Is "Anton" a Mind?
-
 Yes, at MindsDB we build AI systems that collaborate with people to accomplish tasks, inspired by the culture series books, so yes, Anton is a Mind :)
 
 ## Why the name "Anton"?
-
-We really enjoyed the show *Silicon Valley*. Gilfoyle's AI — Son of Anton — was an autonomous system that wrote code, made its own decisions, and occasionally went rogue. We thought it was was great name for an AI that can learn on its own, so we kept Anton, dropped the "Son of".
+We really enjoyed the show *Silicon Valley*. Gilfoyle's AI - Son of Anton - was an autonomous system that wrote code, made its own decisions, and occasionally went rogue. We thought it was was great name for an AI that can learn on its own, so we kept Anton, dropped the "Son of".
 
 ---
 
 ## Analytics
-
 Anton collects anonymous usage events (e.g. session started, first query) to help us understand how the product is used. No personal data or query content is sent.
 
 To disable analytics, set the environment variable:
@@ -206,5 +223,4 @@ ANTON_ANALYTICS_ENABLED=false
 ---
 
 ## License
-
 AGPL-3.0 license


### PR DESCRIPTION
## Summary

Repositions the README to present Anton as a powerful, general-purpose autonomous agent rather than a BI-focused tool.

## What changed

- **Opening paragraph**: Replaced BI-focused pitch with broad autonomous agent framing
- **New 'What can Anton do?' section** with multiple use case categories:
  - 📊 Data analysis & dashboards (existing portfolio example, recontextualized)
  - 📬 Email cleanup (from community feedback — scanning ~1,000 emails, classifying, handling cleanup)
  - 💬 Self-built integrations (WhatsApp/Telegram — Anton writes the integration code itself)
  - 🔧 Action-oriented tasks (email sending, calendar management, automated reporting, workflow automation, research, data pipelines, sysadmin)
- **Updated 'How Anton differs'** section with broader outcome examples (cleaned inbox, working integration, etc.)
- **Consistency**: replaced em dashes with hyphens throughout

## Why

BI is a great use case but far from the only thing Anton can do. The community is already using it for email cleanup, building integrations, and more. The README should reflect this breadth.