### PR TITLE
Incorporated Storage Instructions to System Prompt Context

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -994,7 +994,7 @@ async def _chat_loop(
         episodic=episodic,
         system_prompt_context=SystemPromptContext(
             runtime_context=runtime_context,
-            resource_storage_context=f"Save output to `{output_path}` (create it if needed).",
+            output_context=f"Save output to `{output_path}` (create it if needed).",
         ),
         workspace=workspace,
         console=console,

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -986,12 +986,16 @@ async def _chat_loop(
     # Build runtime context so the LLM knows what it's running on
     runtime_context = build_runtime_context(settings)
 
+    output_path = f"{settings.output_dir.rstrip('/')}/"
     session = ChatSession(ChatSessionConfig(
         llm_client=state["llm_client"],
         self_awareness=self_awareness,
         cortex=cortex,
         episodic=episodic,
-        system_prompt_context=SystemPromptContext(runtime_context=runtime_context),
+        system_prompt_context=SystemPromptContext(
+            runtime_context=runtime_context,
+            resource_storage_context=f"Save output to `{output_path}` (create it if needed).",
+        ),
         workspace=workspace,
         console=console,
         history_store=history_store,

--- a/anton/chat_session.py
+++ b/anton/chat_session.py
@@ -81,11 +81,6 @@ def rebuild_session(
     refresh_knowledge(settings, cortex)
 
     runtime_context = build_runtime_context(settings)
-    api_key = (
-        settings.anthropic_api_key
-        if settings.coding_provider == "anthropic"
-        else settings.openai_api_key
-    ) or ""
     output_path = f"{settings.output_dir.rstrip('/')}/"
     return ChatSession(ChatSessionConfig(
         llm_client=state["llm_client"],

--- a/anton/chat_session.py
+++ b/anton/chat_session.py
@@ -89,7 +89,7 @@ def rebuild_session(
         episodic=episodic,
         system_prompt_context=SystemPromptContext(
             runtime_context=runtime_context,
-            resource_storage_context=f"Save output to `{output_path}` (create it if needed).",
+            output_context=f"Save output to `{output_path}` (create it if needed).",
         ),
         workspace=workspace,
         console=console,

--- a/anton/chat_session.py
+++ b/anton/chat_session.py
@@ -86,16 +86,19 @@ def rebuild_session(
         if settings.coding_provider == "anthropic"
         else settings.openai_api_key
     ) or ""
+    output_path = f"{settings.output_dir.rstrip('/')}/"
     return ChatSession(ChatSessionConfig(
         llm_client=state["llm_client"],
         self_awareness=self_awareness,
         cortex=cortex,
         episodic=episodic,
-        system_prompt_context=SystemPromptContext(runtime_context=runtime_context),
+        system_prompt_context=SystemPromptContext(
+            runtime_context=runtime_context,
+            resource_storage_context=f"Save output to `{output_path}` (create it if needed).",
+        ),
         workspace=workspace,
         console=console,
         history_store=history_store,
         session_id=session_id,
         proactive_dashboards=settings.proactive_dashboards,
-        output_dir=settings.output_dir,
     ))

--- a/anton/core/llm/prompt_builder.py
+++ b/anton/core/llm/prompt_builder.py
@@ -22,7 +22,7 @@ class SystemPromptContext:
     Four levels with increasing importance (later = stronger influence):
       1. ``prefix``  — prepended before the base prompt
       2. ``runtime_context`` — interpolated into the RUNTIME IDENTITY section
-      3. ``resource_storage_context`` — free-text instructions on where to
+      3. ``output_context`` — free-text instructions on where to
          store generated resources (visualizations, HTML files, data exports)
       4. ``suffix``  — appended after all other sections
     """
@@ -30,7 +30,7 @@ class SystemPromptContext:
     runtime_context: str = ""
     prefix: str = ""
     suffix: str = ""
-    resource_storage_context: str = ""
+    output_context: str = ""
 
 
 class ChatSystemPromptBuilder:
@@ -110,7 +110,7 @@ class ChatSystemPromptBuilder:
         self,
         *,
         proactive_dashboards: bool,
-        resource_storage_context: str,
+        output_context: str,
     ) -> str:
         visualizations_output_format_prompt = (
             VISUALIZATIONS_HTML_OUTPUT_FORMAT_PROMPT
@@ -118,7 +118,7 @@ class ChatSystemPromptBuilder:
             else VISUALIZATIONS_MARKDOWN_OUTPUT_FORMAT_PROMPT
         )
         output_format = visualizations_output_format_prompt.format(
-            resource_storage_context=resource_storage_context,
+            output_context=output_context,
         )
         return BASE_VISUALIZATIONS_PROMPT.format(output_format=output_format)
 
@@ -137,7 +137,7 @@ class ChatSystemPromptBuilder:
     ) -> str:
         visualizations_section = self._build_visualizations_section(
             proactive_dashboards=proactive_dashboards,
-            resource_storage_context=system_prompt_context.resource_storage_context,
+            output_context=system_prompt_context.output_context,
         )
 
         prompt = ""

--- a/anton/core/llm/prompt_builder.py
+++ b/anton/core/llm/prompt_builder.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .prompts import (
@@ -20,15 +19,18 @@ if TYPE_CHECKING:
 class SystemPromptContext:
     """Bundled prompt-injection points for the system prompt.
 
-    Three levels with increasing importance (later = stronger influence):
+    Four levels with increasing importance (later = stronger influence):
       1. ``prefix``  — prepended before the base prompt
       2. ``runtime_context`` — interpolated into the RUNTIME IDENTITY section
-      3. ``suffix``  — appended after all other sections
+      3. ``resource_storage_context`` — free-text instructions on where to
+         store generated resources (visualizations, HTML files, data exports)
+      4. ``suffix``  — appended after all other sections
     """
 
     runtime_context: str = ""
     prefix: str = ""
     suffix: str = ""
+    resource_storage_context: str = ""
 
 
 class ChatSystemPromptBuilder:
@@ -108,16 +110,15 @@ class ChatSystemPromptBuilder:
         self,
         *,
         proactive_dashboards: bool,
-        output_path: str,
+        resource_storage_context: str,
     ) -> str:
         visualizations_output_format_prompt = (
             VISUALIZATIONS_HTML_OUTPUT_FORMAT_PROMPT
             if proactive_dashboards
             else VISUALIZATIONS_MARKDOWN_OUTPUT_FORMAT_PROMPT
         )
-        # The output-format prompt can reference `{output_path}`.
         output_format = visualizations_output_format_prompt.format(
-            output_path=output_path
+            resource_storage_context=resource_storage_context,
         )
         return BASE_VISUALIZATIONS_PROMPT.format(output_format=output_format)
 
@@ -127,7 +128,6 @@ class ChatSystemPromptBuilder:
         current_datetime: str,
         system_prompt_context: SystemPromptContext,
         proactive_dashboards: bool,
-        output_dir: str,
         tool_defs: list["ToolDef"] | None = None,
         memory_context: str = "",
         project_context: str = "",
@@ -135,11 +135,9 @@ class ChatSystemPromptBuilder:
         datasource_context: str = "",
         skill_store: "SkillStore | None" = None,
     ) -> str:
-        output_path = f"{Path(str(output_dir)).as_posix().rstrip('/')}/"
-
         visualizations_section = self._build_visualizations_section(
             proactive_dashboards=proactive_dashboards,
-            output_path=output_path,
+            resource_storage_context=system_prompt_context.resource_storage_context,
         )
 
         prompt = ""

--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -304,7 +304,7 @@ breaks JavaScript string literals. Rules:
 Output format:
 - Unless the user explicitly asks for a different format, always output visualizations \
 as polished, single-file HTML pages — never raw PNGs or bare image files.
-{resource_storage_context}
+{output_context}
 
 Visual design:
 - Make it look good by default. Use a dark theme (#0d1117 background, #e6edf3 text), \
@@ -362,7 +362,7 @@ inline numbers. The terminal is the primary display — make it look great there
 - For large datasets, summarize the top N and offer to show more.
 - When the user EXPLICITLY asks for a chart, dashboard, plot, or HTML visualization, \
 THEN build it as a self-contained HTML file with inlined CSS, JS, and data. \
-{resource_storage_context}
+{output_context}
 Use Apache ECharts (CDN), dark theme (#0d1117), and follow standard dashboard best practices. \
 If the dataset is very large (>100KB), write it to a separate .js file in the same directory. \
 Never split CSS or chart logic into separate files — only large data payloads.\

--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -304,7 +304,7 @@ breaks JavaScript string literals. Rules:
 Output format:
 - Unless the user explicitly asks for a different format, always output visualizations \
 as polished, single-file HTML pages — never raw PNGs or bare image files.
-Save output to `{output_path}` (create it if needed).
+{resource_storage_context}
 
 Visual design:
 - Make it look good by default. Use a dark theme (#0d1117 background, #e6edf3 text), \
@@ -362,7 +362,7 @@ inline numbers. The terminal is the primary display — make it look great there
 - For large datasets, summarize the top N and offer to show more.
 - When the user EXPLICITLY asks for a chart, dashboard, plot, or HTML visualization, \
 THEN build it as a self-contained HTML file with inlined CSS, JS, and data. \
-Save to `{output_path}`.
+{resource_storage_context}
 Use Apache ECharts (CDN), dark theme (#0d1117), and follow standard dashboard best practices. \
 If the dataset is very large (>100KB), write it to a separate .js file in the same directory. \
 Never split CSS or chart logic into separate files — only large data payloads.\

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -77,7 +77,6 @@ class ChatSessionConfig:
     history_store: HistoryStore | None = None
     session_id: str | None = None
     proactive_dashboards: bool = False
-    output_dir: str = ""
     tools: list[ToolDef] = field(default_factory=list)
 
 
@@ -99,7 +98,6 @@ class ChatSession:
         self._system_prompt_context = config.system_prompt_context
         self._proactive_dashboards = config.proactive_dashboards
         self._extra_tools = config.tools
-        self._output_dir = config.output_dir
         self._workspace = config.workspace
         self._data_vault = config.data_vault
         self._console = config.console
@@ -304,7 +302,6 @@ class ChatSession:
 
         prompt_builder = ChatSystemPromptBuilder()
         prompt = prompt_builder.build(
-            output_dir=self._output_dir,
             current_datetime=_current_datetime,
             system_prompt_context=self._system_prompt_context,
             proactive_dashboards=self._proactive_dashboards,

--- a/tests/test_prompt_builder_skills.py
+++ b/tests/test_prompt_builder_skills.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from anton.core.llm.prompt_builder import ChatSystemPromptBuilder
+from anton.core.llm.prompt_builder import ChatSystemPromptBuilder, SystemPromptContext
 from anton.core.memory.skills import Skill, SkillStore
 
 
@@ -40,9 +40,8 @@ def populated_store(tmp_path: Path) -> SkillStore:
 def _build_prompt(builder: ChatSystemPromptBuilder, **overrides) -> str:
     defaults = dict(
         current_datetime="2026-04-10T12:00:00+00:00",
-        runtime_context="test runtime",
+        system_prompt_context=SystemPromptContext(runtime_context="test runtime"),
         proactive_dashboards=False,
-        output_dir="/tmp/anton_out",
     )
     defaults.update(overrides)
     return builder.build(**defaults)

--- a/tests/test_session_skills_init.py
+++ b/tests/test_session_skills_init.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from anton.core.llm.prompt_builder import ChatSystemPromptBuilder
+from anton.core.llm.prompt_builder import ChatSystemPromptBuilder, SystemPromptContext
 from anton.core.memory.skills import Skill, SkillStore
 from anton.core.tools.recall_skill import RECALL_SKILL_TOOL, handle_recall_skill
 from anton.core.tools.registry import ToolRegistry
@@ -67,9 +67,8 @@ class TestPromptBuilderReceivesStore:
         builder = ChatSystemPromptBuilder()
         prompt = builder.build(
             current_datetime="2026-04-10",
-            runtime_context="test",
+            system_prompt_context=SystemPromptContext(runtime_context="test"),
             proactive_dashboards=False,
-            output_dir="/tmp/x",
             skill_store=store_with_one_skill,
         )
         assert "## Procedural memory" in prompt
@@ -79,9 +78,8 @@ class TestPromptBuilderReceivesStore:
         builder = ChatSystemPromptBuilder()
         prompt = builder.build(
             current_datetime="2026-04-10",
-            runtime_context="test",
+            system_prompt_context=SystemPromptContext(runtime_context="test"),
             proactive_dashboards=False,
-            output_dir="/tmp/x",
             skill_store=None,
         )
         assert "Procedural memory" not in prompt

--- a/tests/test_skills_e2e.py
+++ b/tests/test_skills_e2e.py
@@ -24,7 +24,7 @@ import pytest
 from rich.console import Console
 
 from anton.commands.skills import _SkillDraft, handle_skill_save
-from anton.core.llm.prompt_builder import ChatSystemPromptBuilder
+from anton.core.llm.prompt_builder import ChatSystemPromptBuilder, SystemPromptContext
 from anton.core.memory.skills import SkillStore
 from anton.core.tools.recall_skill import RECALL_SKILL_TOOL
 from anton.core.tools.registry import ToolRegistry
@@ -123,9 +123,8 @@ async def test_full_skills_loop(console, store_root):
     builder = ChatSystemPromptBuilder()
     prompt = builder.build(
         current_datetime="2026-04-10T13:00:00+00:00",
-        runtime_context="test",
+        system_prompt_context=SystemPromptContext(runtime_context="test"),
         proactive_dashboards=False,
-        output_dir="/tmp/x",
         skill_store=fresh_store,
     )
     assert "## Procedural memory" in prompt


### PR DESCRIPTION
This PR removes the `output_dir` parameter from the Anton callers and incorporates a more robust `output_context` to `SystemPromptContext`. The idea is to provide more comprehensive details related to storing generated artifacts, especially when using other types of backends.