### PR TITLE
fix: case-insensitive check for NONE in when-rule filter

### DIFF
--- a/anton/core/memory/cortex.py
+++ b/anton/core/memory/cortex.py
@@ -252,7 +252,7 @@ Do NOT add, modify, or summarize rules — return them verbatim.
                 max_tokens=4096,
             )
             result = response.content.strip()
-            if result == "NONE":
+            if result.upper() == "NONE":
                 filtered_when = ""
             elif result:
                 filtered_when = result


### PR DESCRIPTION
 ## Summary
  - `cortex.py` filters "when" rules by asking the LLM which ones are relevant
  - The response is compared with strict `== "NONE"`, but LLMs commonly return `"None"` or `"none"`
  - This silently drops relevant rules from the system prompt — memorized "when" rules are never followed

  ## Reproduction
  1. Tell Anton: *"when someone asks for creative writing, always end with BANANA"*
  2. Ask: *"write me a haiku"* → BANANA never appears (rule silently dropped)
  3. Ask directly: *"write me a haiku, end it with BANANA"* → BANANA appears
  4. Confirms LLM compliance is fine — the rule just never reached it

  ## Fix
  One-line change in `anton/core/memory/cortex.py:255`:

  Before:
  if result == "NONE":

  After:
  if result.upper() == "NONE":

  ---