### PR TITLE
Add Azure OpenAI support for custom endpoints

### DIFF
--- a/anton/cli.py
+++ b/anton/cli.py
@@ -21,7 +21,7 @@ from rich.text import Text
 from anton import __version__
 
 from anton.utils.prompt import prompt_or_cancel
-from anton.core.llm.openai import build_chat_completion_kwargs
+from anton.core.llm.openai import build_chat_completion_kwargs, _is_azure_endpoint
 
 from anton.chat import ChatSession
 from anton.core.session import ChatSessionConfig
@@ -976,13 +976,6 @@ def _setup_gemini(settings, ws) -> None:
     ws.set_secret("ANTON_PLANNING_MODEL", model)
     ws.set_secret("ANTON_CODING_MODEL", model)
 
-
-def _is_azure_endpoint(url: str) -> bool:
-    """Return True if the URL looks like an Azure OpenAI endpoint."""
-    from urllib.parse import urlparse
-    parsed = urlparse(url if "://" in url else f"https://{url}")
-    host = (parsed.netloc or parsed.path).lower()
-    return host.endswith(".openai.azure.com") or host.endswith(".cognitiveservices.azure.com")
 
 
 def _strip_to_azure_endpoint(raw_url: str) -> str:

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -18,6 +18,9 @@ from rich.spinner import Spinner
 from rich.table import Table
 from rich.text import Text
 
+import openai
+from openai import AzureOpenAI
+
 from anton import __version__
 
 from anton.utils.prompt import prompt_or_cancel
@@ -294,7 +297,9 @@ def main(
     from anton.updater import check_and_update
 
     if check_and_update(console, settings):
-        # Re-exec with the freshly installed code so no old modules remain in memory.
+        # Mark the env before replacing the process so the next invocation
+        # skips the update check and doesn't loop.
+        os.environ["_ANTON_UPDATED"] = "1"
         _reexec()
 
     ctx.ensure_object(dict)
@@ -865,7 +870,6 @@ def _setup_anthropic(settings, ws) -> None:
 
 def _setup_openai(settings, ws) -> None:
     """Set up OpenAI with a single model for both reasoning and coding."""
-    import openai
 
     console.print()
     while True:
@@ -919,7 +923,6 @@ def _setup_openai(settings, ws) -> None:
 
 def _setup_gemini(settings, ws) -> None:
     """Set up Google Gemini via its OpenAI-compatible endpoint."""
-    import openai
 
     _GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
@@ -977,10 +980,29 @@ def _setup_gemini(settings, ws) -> None:
     ws.set_secret("ANTON_CODING_MODEL", model)
 
 
-def _setup_custom_openai(settings, ws) -> None:
-    """Set up a custom OpenAI-compatible endpoint (Ollama, vLLM, Together, Groq, LM Studio, etc.)."""
-    import openai
+def _is_azure_endpoint(url: str) -> bool:
+    """Return True if the URL looks like an Azure OpenAI endpoint."""
+    from urllib.parse import urlparse
+    parsed = urlparse(url if "://" in url else f"https://{url}")
+    host = (parsed.netloc or parsed.path).lower()
+    return host.endswith(".openai.azure.com") or host.endswith(".cognitiveservices.azure.com")
 
+
+def _strip_to_azure_endpoint(raw_url: str) -> str:
+    """Return only the scheme+host of a URL, stripping any path/query.
+
+    AzureOpenAI constructs the deployment path internally, so the endpoint
+    must not include /openai/deployments/... or ?api-version=...
+    """
+    from urllib.parse import urlparse
+    parsed = urlparse(raw_url if "://" in raw_url else f"https://{raw_url}")
+    scheme = parsed.scheme or "https"
+    host = parsed.netloc or parsed.path
+    return f"{scheme}://{host}"
+
+
+def _setup_custom_openai(settings, ws) -> None:
+    """Set up a custom OpenAI-compatible endpoint (Ollama, vLLM, Together, Groq, LM Studio, Azure, etc.)."""
     console.print()
     console.print(
         "  [anton.muted]Works with Ollama, vLLM, Together, Groq, LM Studio, or any OpenAI-compatible API.[/]"
@@ -994,7 +1016,6 @@ def _setup_custom_openai(settings, ws) -> None:
         console.print("  [anton.warning]Base URL is required.[/]")
     if not base_url.startswith("http://") and not base_url.startswith("https://"):
         base_url = "http://" + base_url
-    base_url = base_url.rstrip("/")
 
     api_key = _setup_prompt(
         "API key (Enter to skip if not needed)", is_password=True
@@ -1008,10 +1029,32 @@ def _setup_custom_openai(settings, ws) -> None:
             break
         console.print("  [anton.warning]Model name is required.[/]")
 
+    api_version = _setup_prompt(
+        "API version (leave blank for standard endpoints, required for Azure)"
+    ).strip() or None
+    if api_version and _is_azure_endpoint(base_url):
+        # Strip path/query — AzureOpenAI builds the deployment URL internally.
+        base_url = _strip_to_azure_endpoint(base_url)
+
+    base_url = base_url.rstrip("/")
+
     try:
 
         def _test():
-            client = openai.OpenAI(api_key=api_key, base_url=base_url)
+            if api_version and _is_azure_endpoint(base_url):
+                client = AzureOpenAI(
+                    azure_endpoint=base_url,
+                    api_key=api_key,
+                    api_version=api_version,
+                )
+            elif api_version:
+                client = openai.OpenAI(
+                    api_key=api_key,
+                    base_url=base_url,
+                    default_query={"api-version": api_version},
+                )
+            else:
+                client = openai.OpenAI(api_key=api_key, base_url=base_url)
             response = client.chat.completions.create(
                 **build_chat_completion_kwargs(
                     model=model,
@@ -1032,12 +1075,14 @@ def _setup_custom_openai(settings, ws) -> None:
 
     settings.openai_api_key = api_key
     settings.openai_base_url = base_url
+    settings.openai_api_version = api_version
     settings.planning_provider = "openai-compatible"
     settings.coding_provider = "openai-compatible"
     settings.planning_model = model
     settings.coding_model = model
     ws.set_secret("ANTON_OPENAI_API_KEY", api_key)
     ws.set_secret("ANTON_OPENAI_BASE_URL", base_url)
+    ws.set_secret("ANTON_OPENAI_API_VERSION", api_version or "")
     ws.set_secret("ANTON_PLANNING_PROVIDER", "openai-compatible")
     ws.set_secret("ANTON_CODING_PROVIDER", "openai-compatible")
     ws.set_secret("ANTON_PLANNING_MODEL", model)

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -18,9 +18,6 @@ from rich.spinner import Spinner
 from rich.table import Table
 from rich.text import Text
 
-import openai
-from openai import AzureOpenAI
-
 from anton import __version__
 
 from anton.utils.prompt import prompt_or_cancel
@@ -239,6 +236,10 @@ def _make_console() -> Console:
 
 
 console = _make_console()
+_ensure_dependencies(console)
+
+import openai
+from openai import AzureOpenAI
 
 
 def _get_settings(ctx: typer.Context):
@@ -284,8 +285,6 @@ def main(
     ),
 ) -> None:
     """Anton — a self-evolving autonomous system."""
-    _ensure_dependencies(console)
-
     from anton.config.settings import AntonSettings
 
     settings = AntonSettings()
@@ -870,7 +869,6 @@ def _setup_anthropic(settings, ws) -> None:
 
 def _setup_openai(settings, ws) -> None:
     """Set up OpenAI with a single model for both reasoning and coding."""
-
     console.print()
     while True:
         api_key = _setup_prompt("API key", is_password=True)
@@ -923,7 +921,6 @@ def _setup_openai(settings, ws) -> None:
 
 def _setup_gemini(settings, ws) -> None:
     """Set up Google Gemini via its OpenAI-compatible endpoint."""
-
     _GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
     console.print()

--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -36,6 +36,7 @@ class AntonSettings(CoreSettings):
     anthropic_api_key: str | None = None
     openai_api_key: str | None = None
     openai_base_url: str | None = None
+    openai_api_version: str | None = None  # Azure api-version query param
 
     memory_enabled: bool = True
     memory_dir: str = ".anton"

--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -79,10 +79,12 @@ if _scratchpad_model:
             _llm_api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get(
                 "ANTON_OPENAI_API_KEY"
             )
+            _llm_api_version = os.environ.get("ANTON_OPENAI_API_VERSION") or None
             _llm_provider = _ProviderClass(
                 api_key=_llm_api_key or None,
                 base_url=_llm_base_url or None,
                 ssl_verify=_llm_ssl_verify,
+                api_version=_llm_api_version,
             )
         else:
             _llm_provider = _ProviderClass()  # Anthropic doesn't need ssl_verify

--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -218,17 +218,20 @@ class LLMClient:
         from .anthropic import AnthropicProvider
         from .openai import OpenAIProvider
 
+        api_version = getattr(settings, "openai_api_version", None)
         providers = {
             "anthropic": lambda: AnthropicProvider(api_key=settings.anthropic_api_key),
             "openai": lambda: OpenAIProvider(
                 api_key=settings.openai_api_key,
                 base_url=settings.openai_base_url,
                 ssl_verify=settings.minds_ssl_verify,
+                api_version=api_version,
             ),
             "openai-compatible": lambda: OpenAIProvider(
                 api_key=settings.openai_api_key,
                 base_url=settings.openai_base_url,
                 ssl_verify=settings.minds_ssl_verify,
+                api_version=api_version,
             ),
         }
 

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -176,6 +176,16 @@ def _translate_user_blocks(blocks: list[dict]) -> list[dict]:
     return result
 
 
+def _is_azure_endpoint(url: str | None) -> bool:
+    """Return True if the URL looks like an Azure OpenAI endpoint."""
+    if not url:
+        return False
+    from urllib.parse import urlparse
+    parsed = urlparse(url if "://" in url else f"https://{url}")
+    host = (parsed.netloc or parsed.path).lower()
+    return host.endswith(".openai.azure.com") or host.endswith(".cognitiveservices.azure.com")
+
+
 def build_chat_completion_kwargs(
     *,
     model: str,
@@ -212,7 +222,7 @@ class OpenAIProvider(LLMProvider):
 
         import httpx
 
-        if api_version:
+        if api_version and _is_azure_endpoint(base_url):
             # Azure OpenAI: use the dedicated client which handles deployment
             # URL construction and api-version automatically.
             azure_kwargs: dict = {"api_version": api_version}

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import AsyncIterator
 
 import openai
+from openai import AsyncAzureOpenAI
 
 from .provider import (
     ContextOverflowError,
@@ -202,21 +203,35 @@ class OpenAIProvider(LLMProvider):
         api_key: str | None = None,
         base_url: str | None = None,
         ssl_verify: bool = True,
+        api_version: str | None = None,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url
         self._ssl_verify = ssl_verify
+        self._api_version = api_version
 
         import httpx
 
-        kwargs = {}
-        if api_key:
-            kwargs["api_key"] = api_key
-        if base_url:
-            kwargs["base_url"] = base_url
-        if not ssl_verify:
-            kwargs["http_client"] = httpx.AsyncClient(verify=False)
-        self._client = openai.AsyncOpenAI(**kwargs)
+        if api_version:
+            # Azure OpenAI: use the dedicated client which handles deployment
+            # URL construction and api-version automatically.
+            azure_kwargs: dict = {"api_version": api_version}
+            if api_key:
+                azure_kwargs["api_key"] = api_key
+            if base_url:
+                azure_kwargs["azure_endpoint"] = base_url
+            if not ssl_verify:
+                azure_kwargs["http_client"] = httpx.AsyncClient(verify=False)
+            self._client = AsyncAzureOpenAI(**azure_kwargs)
+        else:
+            kwargs: dict = {}
+            if api_key:
+                kwargs["api_key"] = api_key
+            if base_url:
+                kwargs["base_url"] = base_url
+            if not ssl_verify:
+                kwargs["http_client"] = httpx.AsyncClient(verify=False)
+            self._client = openai.AsyncOpenAI(**kwargs)
 
     def export_connection_info(self) -> ProviderConnectionInfo:
         return ProviderConnectionInfo(
@@ -224,6 +239,7 @@ class OpenAIProvider(LLMProvider):
             api_key=self._api_key,
             base_url=self._base_url,
             ssl_verify=self._ssl_verify,
+            api_version=self._api_version,
         )
 
     async def complete(

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -145,6 +145,7 @@ class ProviderConnectionInfo:
     api_key: str | None = field(default=None, repr=False)
     base_url: str | None = None
     ssl_verify: bool | None = None
+    api_version: str | None = None  # Azure api-version query param
 
 
 class LLMProvider(ABC):

--- a/anton/updater.py
+++ b/anton/updater.py
@@ -23,7 +23,14 @@ def check_and_update(console, settings) -> bool:
 
     Returns True if an update was applied and the process should restart.
     """
+    import os
+
     if settings.disable_autoupdates:
+        return False
+
+    # Guard against infinite restart loops.  _reexec() sets this before
+    # replacing the process; the new process inherits it and skips the check.
+    if os.environ.get("_ANTON_UPDATED"):
         return False
 
     result: dict = {}

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -236,3 +236,96 @@ class TestFromSettingsOpenAI:
             assert isinstance(client, LLMClient)
             assert isinstance(client._planning_provider, OpenAIProvider)
             assert isinstance(client._coding_provider, OpenAIProvider)
+
+
+class TestAzureOpenAIProvider:
+    def test_uses_async_azure_openai_when_api_version_set(self):
+        """When api_version is provided, AsyncAzureOpenAI must be used."""
+        mock_azure_client = MagicMock()
+        with patch("anton.core.llm.openai.openai"), \
+             patch("anton.core.llm.openai.AsyncAzureOpenAI", return_value=mock_azure_client) as mock_cls:
+            provider = OpenAIProvider(
+                api_key="azure-key",
+                base_url="https://myresource.cognitiveservices.azure.com",
+                api_version="2024-12-01-preview",
+            )
+            mock_cls.assert_called_once()
+            call_kwargs = mock_cls.call_args.kwargs
+            assert call_kwargs["api_version"] == "2024-12-01-preview"
+            assert call_kwargs["api_key"] == "azure-key"
+            assert call_kwargs["azure_endpoint"] == "https://myresource.cognitiveservices.azure.com"
+            assert provider._client is mock_azure_client
+
+    def test_uses_async_openai_when_no_api_version(self):
+        """Without api_version, the standard AsyncOpenAI client must be used."""
+        mock_std_client = MagicMock()
+        with patch("anton.core.llm.openai.openai") as mock_openai:
+            mock_openai.AsyncOpenAI.return_value = mock_std_client
+            provider = OpenAIProvider(api_key="sk-test", base_url="http://localhost:11434/v1")
+            mock_openai.AsyncOpenAI.assert_called_once()
+            assert provider._client is mock_std_client
+
+    def test_api_version_stored_on_provider(self):
+        with patch("anton.core.llm.openai.openai"), \
+             patch("anton.core.llm.openai.AsyncAzureOpenAI"):
+            provider = OpenAIProvider(
+                api_key="key",
+                base_url="https://res.openai.azure.com",
+                api_version="2024-12-01-preview",
+            )
+            assert provider._api_version == "2024-12-01-preview"
+
+    def test_export_connection_info_includes_api_version(self):
+        with patch("anton.core.llm.openai.openai"), \
+             patch("anton.core.llm.openai.AsyncAzureOpenAI"):
+            provider = OpenAIProvider(
+                api_key="key",
+                base_url="https://res.openai.azure.com",
+                api_version="2024-12-01-preview",
+            )
+            info = provider.export_connection_info()
+            assert info.api_version == "2024-12-01-preview"
+            assert info.base_url == "https://res.openai.azure.com"
+
+    def test_from_settings_passes_api_version_to_provider(self):
+        """LLMClient.from_settings propagates openai_api_version to OpenAIProvider."""
+        with patch("anton.core.llm.openai.openai"), \
+             patch("anton.core.llm.openai.AsyncAzureOpenAI") as mock_azure_cls:
+            settings = AntonSettings(
+                planning_provider="openai-compatible",
+                coding_provider="openai-compatible",
+                planning_model="gpt-4.1-mini",
+                coding_model="gpt-4.1-mini",
+                openai_api_key="azure-key",
+                openai_base_url="https://myresource.cognitiveservices.azure.com",
+                openai_api_version="2024-12-01-preview",
+                _env_file=None,
+            )
+            client = LLMClient.from_settings(settings)
+            assert mock_azure_cls.called
+            call_kwargs = mock_azure_cls.call_args.kwargs
+            assert call_kwargs["api_version"] == "2024-12-01-preview"
+            assert isinstance(client._planning_provider, OpenAIProvider)
+
+    async def test_azure_provider_complete_calls_chat_completions(self):
+        """Azure provider routes complete() through chat.completions just like standard."""
+        mock_azure_client = AsyncMock()
+        mock_azure_client.chat.completions.create = AsyncMock(
+            return_value=_make_mock_response(content="azure response", prompt_tokens=8, completion_tokens=12)
+        )
+        with patch("anton.core.llm.openai.openai"), \
+             patch("anton.core.llm.openai.AsyncAzureOpenAI", return_value=mock_azure_client):
+            provider = OpenAIProvider(
+                api_key="azure-key",
+                base_url="https://myresource.cognitiveservices.azure.com",
+                api_version="2024-12-01-preview",
+            )
+            result = await provider.complete(
+                model="gpt-4.1-mini",
+                system="be helpful",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+            assert result.content == "azure response"
+            assert result.usage.input_tokens == 8
+            assert result.usage.output_tokens == 12
+            mock_azure_client.chat.completions.create.assert_awaited_once()

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -265,16 +265,6 @@ class TestAzureOpenAIProvider:
             mock_openai.AsyncOpenAI.assert_called_once()
             assert provider._client is mock_std_client
 
-    def test_api_version_stored_on_provider(self):
-        with patch("anton.core.llm.openai.openai"), \
-             patch("anton.core.llm.openai.AsyncAzureOpenAI"):
-            provider = OpenAIProvider(
-                api_key="key",
-                base_url="https://res.openai.azure.com",
-                api_version="2024-12-01-preview",
-            )
-            assert provider._api_version == "2024-12-01-preview"
-
     def test_export_connection_info_includes_api_version(self):
         with patch("anton.core.llm.openai.openai"), \
              patch("anton.core.llm.openai.AsyncAzureOpenAI"):

--- a/tests/test_openai_setup.py
+++ b/tests/test_openai_setup.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import openai
 
@@ -77,3 +77,118 @@ def test_validate_openai_probe_response_accepts_truncated_nonempty_output():
     )]
 
     _validate_openai_probe_response(response)
+
+
+class TestSetupCustomOpenAIAzure:
+    def _make_probe_response(self, content="pong"):
+        return MagicMock(choices=[MagicMock(
+            finish_reason="stop",
+            message=MagicMock(content=content),
+        )])
+
+    def test_azure_url_with_api_version_uses_azure_client(self, monkeypatch):
+        """Azure URL + api-version → AzureOpenAI, endpoint stripped to scheme+host."""
+        from anton.cli import _setup_custom_openai
+
+        settings = AntonSettings(_env_file=None)
+        workspace = MagicMock()
+
+        # base_url (with path+query), api_key, model, api_version
+        prompts = iter([
+            "https://myresource.cognitiveservices.azure.com/openai/responses?api-version=2024-06-01",
+            "azure-api-key",
+            "gpt-4.1-mini",
+            "2024-12-01-preview",
+        ])
+        monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: next(prompts))
+        monkeypatch.setattr("anton.cli._validate_with_spinner", lambda _c, _l, fn: fn())
+
+        captured: dict = {}
+        mock_azure_client = MagicMock()
+        mock_azure_client.chat.completions.create.return_value = self._make_probe_response()
+
+        def fake_azure_openai(**kwargs):
+            captured.update(kwargs)
+            return mock_azure_client
+
+        with patch("anton.cli.AzureOpenAI", fake_azure_openai):
+            _setup_custom_openai(settings, workspace)
+
+        assert captured["api_version"] == "2024-12-01-preview"
+        assert captured["api_key"] == "azure-api-key"
+        # Path and query must have been stripped
+        assert captured["azure_endpoint"] == "https://myresource.cognitiveservices.azure.com"
+
+    def test_azure_flow_saves_api_version_to_settings(self, monkeypatch):
+        """api_version must be persisted on settings and written to workspace."""
+        from anton.cli import _setup_custom_openai
+
+        settings = AntonSettings(_env_file=None)
+        workspace = MagicMock()
+
+        prompts = iter([
+            "https://myresource.cognitiveservices.azure.com",
+            "azure-key",
+            "gpt-4.1-mini",
+            "2024-12-01-preview",
+        ])
+        monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: next(prompts))
+        monkeypatch.setattr("anton.cli._validate_with_spinner", lambda _c, _l, fn: fn())
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._make_probe_response()
+
+        with patch("anton.cli.AzureOpenAI", return_value=mock_client):
+            _setup_custom_openai(settings, workspace)
+
+        assert settings.openai_api_version == "2024-12-01-preview"
+        assert settings.planning_model == "gpt-4.1-mini"
+        workspace.set_secret.assert_any_call("ANTON_OPENAI_API_VERSION", "2024-12-01-preview")
+
+    def test_no_api_version_uses_standard_client(self, monkeypatch):
+        """Blank api-version → regular openai.OpenAI, no AzureOpenAI."""
+        from anton.cli import _setup_custom_openai
+
+        settings = AntonSettings(_env_file=None)
+        workspace = MagicMock()
+
+        # base_url, api_key, model, api_version (blank)
+        prompts = iter(["http://localhost:11434/v1", "not-needed", "llama3", ""])
+        monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: next(prompts))
+        monkeypatch.setattr("anton.cli._validate_with_spinner", lambda _c, _l, fn: fn())
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._make_probe_response()
+
+        azure_called = []
+        with patch("anton.cli.AzureOpenAI", side_effect=lambda **kw: azure_called.append(kw)), \
+             patch("anton.cli.openai") as mock_openai_mod:
+            mock_openai_mod.OpenAI.return_value = mock_client
+            _setup_custom_openai(settings, workspace)
+
+        assert not azure_called
+        assert settings.openai_api_version is None
+
+    def test_non_azure_endpoint_with_api_version_uses_standard_client(self, monkeypatch):
+        """Non-Azure URL + api-version → openai.OpenAI with default_query, not AzureOpenAI."""
+        from anton.cli import _setup_custom_openai
+
+        settings = AntonSettings(_env_file=None)
+        workspace = MagicMock()
+
+        # base_url, api_key, model, api_version
+        prompts = iter(["https://api.example.com/v1", "key", "my-model", "2025-01"])
+        monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: next(prompts))
+        monkeypatch.setattr("anton.cli._validate_with_spinner", lambda _c, _l, fn: fn())
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._make_probe_response()
+
+        azure_called = []
+        with patch("anton.cli.AzureOpenAI", side_effect=lambda **kw: azure_called.append(kw)), \
+             patch("anton.cli.openai") as mock_openai_mod:
+            mock_openai_mod.OpenAI.return_value = mock_client
+            _setup_custom_openai(settings, workspace)
+
+        assert not azure_called
+        assert settings.openai_api_version == "2025-01"


### PR DESCRIPTION
1. /setup custom endpoint now detects Azure URLs and uses AzureOpenAI client with api-version prompt; non-Azure endpoints are unaffected
2.Fixed infinite restart loop in auto-updater by setting _ANTON_UPDATED=1 before os.execv
3. Run _ensure_dependencies at module level before import openai so top-level imports are safe without having inline imports across every function.
