### PR TITLE
Fix: don't skip user messages to extract identity 

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -105,6 +105,7 @@ class ChatSession:
             list(config.initial_history) if config.initial_history else []
         )
         self._pending_memory_confirmations: list = []
+        self._identity_buffer: list[str] = []
         self._turn_count = (
             sum(1 for m in self._history if m.get("role") == "user")
             if config.initial_history
@@ -782,8 +783,11 @@ class ChatSession:
         self._turn_count += 1
         self._persist_history()
         if self._cortex is not None and self._cortex.mode != "off":
-            if self._turn_count % 5 == 0 and isinstance(user_input, str):
-                asyncio.create_task(self._cortex.maybe_update_identity(user_input))
+            self._identity_buffer.append(user_input)
+            if self._turn_count % 5 == 0:
+                buffered = "\n\n".join(self._identity_buffer)
+                self._identity_buffer.clear()
+                asyncio.create_task(self._cortex.maybe_update_identity(buffered))
             # Periodic memory vacuum (Systems Consolidation)
             self._cortex.maybe_vacuum()
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -783,7 +783,7 @@ class ChatSession:
         self._turn_count += 1
         self._persist_history()
         if self._cortex is not None and self._cortex.mode != "off":
-            self._identity_buffer.append(user_input)
+            self._identity_buffer.append(user_msg_str)
             if self._turn_count % 5 == 0:
                 buffered = "\n\n".join(self._identity_buffer)
                 self._identity_buffer.clear()


### PR DESCRIPTION
`self._cortex.maybe_update_identity` is called on every 5th message. and only the last message is sent to it
Fix: accumulate previous messages and send all of them on 5th step