### PR TITLE
Emitted StreamToolResult Events on Scratchpad Executions

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -1435,7 +1435,8 @@ async def _chat_loop(
                                 ttft = time.monotonic() - t0
                             display.append_text(event.text)
                         elif isinstance(event, StreamToolResult):
-                            display.show_tool_result(event.content)
+                            if event.name == "scratchpad" and event.action == "dump":
+                                display.show_tool_result(event.content)
                         elif isinstance(event, StreamToolUseStart):
                             display.on_tool_use_start(event.id, event.name)
                         elif isinstance(event, StreamToolUseDelta):

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -68,8 +68,8 @@ class StreamTaskProgress:
 class StreamToolResult:
     """Tool result that should be displayed to the user (e.g. scratchpad dump)."""
     name: str
-    action: str | None = None  # Relevant only for scratchpad tool calls.
     content: str
+    action: str | None = None  # Relevant only for scratchpad tool calls.
 
 
 @dataclass

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -67,7 +67,8 @@ class StreamTaskProgress:
 @dataclass
 class StreamToolResult:
     """Tool result that should be displayed to the user (e.g. scratchpad dump)."""
-
+    name: str
+    action: str | None = None  # Relevant only for scratchpad tool calls.
     content: str
 
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
+import json
 from typing import TYPE_CHECKING
 
 from anton.core.backends.base import Cell, ScratchpadRuntimeFactory
@@ -1025,6 +1026,11 @@ class ChatSession:
                                         description=description,
                                         cell=cell,
                                     )
+                                    yield StreamToolResult(
+                                        name=tc.name,
+                                        action="exec",
+                                        content=json.dumps(asdict(cell))
+                                    )
                                 if self._episodic is not None and cell is not None:
                                     self._episodic.log_turn(
                                         self._turn_count + 1,
@@ -1071,7 +1077,7 @@ class ChatSession:
                                 tc.name == "scratchpad"
                                 and tc.input.get("action") == "dump"
                             ):
-                                yield StreamToolResult(content=result_text)
+                                yield StreamToolResult(name=tc.name, action="dump", content=result_text)
                                 result_text = (
                                     "The full notebook has been displayed to the user above. "
                                     "Do not repeat it. Here is the content for your reference:\n\n"

--- a/tests/test_chat_scratchpad.py
+++ b/tests/test_chat_scratchpad.py
@@ -250,8 +250,8 @@ class TestScratchpadDumpStreaming:
                 events.append(event)
 
             tool_results = [e for e in events if isinstance(e, StreamToolResult)]
-            assert len(tool_results) == 1
-            assert "## Scratchpad: main" in tool_results[0].content
+            assert len(tool_results) == 2  # One for the exec, one for the dump.
+            assert "## Scratchpad: main" in tool_results[1].content
 
             # The LLM should get a short summary, not the full dump
             history = session.history


### PR DESCRIPTION
This PR updates the core session to yield the `StreamToolResult` event when a scratchpad execution (`exec` action) takes place. This is done because the enterprise version looks for these events when collecting cells executed as part of a given conversation.