### PR TITLE
Wire ChatSessionConfig.cells into ScratchpadManager

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -125,6 +125,7 @@ class ChatSession:
             coding_model=config.llm_client.coding_model,
             coding_api_key=coding_conn.api_key or "",
             coding_base_url=coding_conn.base_url or "",
+            cells=config.cells,
             workspace_path=config.workspace.base if config.workspace else None,
         )
 

--- a/tests/test_chat_scratchpad.py
+++ b/tests/test_chat_scratchpad.py
@@ -6,6 +6,7 @@ from tests.conftest import make_mock_llm
 
 import pytest
 
+from anton.core.backends.base import Cell
 from anton.core.session import ChatSession, ChatSessionConfig
 from anton.core.tools.tool_defs import SCRATCHPAD_TOOL
 from anton.commands.session import handle_resume
@@ -399,3 +400,26 @@ class TestResumeSessionScratchpadCleanup:
 
         mock_mgr.close_all.assert_awaited_once()
         mock_mgr.cancel_all_running.assert_not_awaited()
+
+
+class TestChatSessionReplayedCells:
+    def test_scratchpad_manager_receives_config_cells(self, workspace):
+        """Hosts (e.g. Minds) pass ChatSessionConfig.cells for cross-turn replay; they must reach the manager."""
+        mock_llm = make_mock_llm()
+
+        replayed = [
+            Cell(code="print(1)", stdout="1", stderr="", error=None),
+            Cell(code="print(2)", stdout="2", stderr="", error=None),
+        ]
+
+        session = ChatSession(
+            ChatSessionConfig(
+                llm_client=mock_llm,
+                workspace=workspace,
+                cells=list(replayed),
+            )
+        )
+        assert session._scratchpads._cells is not None
+        assert len(session._scratchpads._cells) == 2
+        assert session._scratchpads._cells[0].code == "print(1)"
+        assert session._scratchpads._cells[1].code == "print(2)"


### PR DESCRIPTION
Minds passes replayed cells for cross-turn scratchpad state, but ChatSession never forwarded them to ScratchpadManager, so _cells stayed None and every new session started with an empty notebook regardless of dump/view/exec fixes.

Made-with: Cursor