### PR TITLE
fix(publish): clear bad API key on 401 to unblock re-entry

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -370,8 +370,8 @@ async def _handle_publish(
             return
         api_key = api_key.strip()
         settings.minds_api_key = api_key
-        if workspace:
-            workspace.set_secret("ANTON_MINDS_API_KEY", api_key)
+        # Key is not persisted yet — wait until publish succeeds to avoid
+        # locking the user out with a bad key on every subsequent /publish call.
         console.print()
 
     # 2. Find the HTML file to publish
@@ -479,9 +479,20 @@ async def _handle_publish(
                 ssl_verify=settings.minds_ssl_verify,
             )
         except Exception as e:
-            console.print(f"  [anton.error]Publish failed: {e}[/]")
+            import urllib.error
+            if isinstance(e, urllib.error.HTTPError) and e.code == 401:
+                settings.minds_api_key = None
+                if workspace:
+                    workspace.set_secret("ANTON_MINDS_API_KEY", "")
+                console.print("  [anton.error]Invalid API key — run /publish again to enter a new one.[/]")
+            else:
+                console.print(f"  [anton.error]Publish failed: {e}[/]")
             console.print()
             return
+
+    # Persist the key now that we know it works
+    if workspace:
+        workspace.set_secret("ANTON_MINDS_API_KEY", settings.minds_api_key)
 
     view_url = result.get("view_url", "")
     returned_report_id = result.get("report_id", "")

--- a/tests/test_publish_api_key.py
+++ b/tests/test_publish_api_key.py
@@ -1,0 +1,124 @@
+"""Tests for /publish API key handling — specifically the 401 fix.
+
+Covers:
+- Bad key entered on first /publish: 401 clears the key so user is re-prompted
+- Good key: persisted to workspace only after successful publish
+"""
+from __future__ import annotations
+
+import urllib.error
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_settings(tmp_path: Path, api_key: str | None = None) -> MagicMock:
+    settings = MagicMock()
+    settings.minds_api_key = api_key
+    settings.workspace_path = tmp_path
+    settings.publish_url = "https://4nton.ai"
+    settings.minds_ssl_verify = True
+    return settings
+
+
+def _make_workspace() -> MagicMock:
+    ws = MagicMock()
+    ws.set_secret = MagicMock()
+    return ws
+
+
+def _make_console() -> MagicMock:
+    console = MagicMock()
+    console.print = MagicMock()
+    return console
+
+
+def _make_html_file(tmp_path: Path) -> Path:
+    output_dir = tmp_path / ".anton" / "output"
+    output_dir.mkdir(parents=True)
+    html = output_dir / "report.html"
+    html.write_text("<html><title>Test</title></html>")
+    return html
+
+
+@pytest.mark.asyncio
+async def test_401_clears_api_key(tmp_path):
+    """When publish returns 401, the key is cleared so the user can re-enter it."""
+    from anton.chat import _handle_publish
+
+    html = _make_html_file(tmp_path)
+    settings = _make_settings(tmp_path, api_key=None)
+    workspace = _make_workspace()
+    console = _make_console()
+
+    http_401 = urllib.error.HTTPError(
+        url="https://4nton.ai/upload", code=401, msg="Unauthorized", hdrs=None, fp=None
+    )
+
+    with (
+        patch("anton.chat.prompt_or_cancel", new=AsyncMock(side_effect=["y", "wrongkey", "1"])),
+        patch("anton.publisher.publish", side_effect=http_401),
+    ):
+        await _handle_publish(console, settings, workspace, file_arg=str(html))
+
+    # Key must be cleared after 401
+    assert settings.minds_api_key is None
+    # Workspace must have the key blanked out
+    workspace.set_secret.assert_called_with("ANTON_MINDS_API_KEY", "")
+    # User must see a helpful message, not a raw exception
+    error_calls = [str(c) for c in console.print.call_args_list]
+    assert any("Invalid API key" in c for c in error_calls)
+
+
+@pytest.mark.asyncio
+async def test_successful_publish_persists_key(tmp_path):
+    """When publish succeeds, the key is saved to the workspace."""
+    from anton.chat import _handle_publish
+
+    html = _make_html_file(tmp_path)
+    settings = _make_settings(tmp_path, api_key=None)
+    workspace = _make_workspace()
+    console = _make_console()
+
+    publish_result = {
+        "view_url": "https://4nton.ai/r/abc123",
+        "report_id": "abc123",
+        "md5": "deadbeef",
+        "version": 1,
+        "unchanged": False,
+    }
+
+    with (
+        patch("anton.chat.prompt_or_cancel", new=AsyncMock(side_effect=["y", "goodkey", "1"])),
+        patch("anton.publisher.publish", return_value=publish_result),
+        patch("webbrowser.open"),
+    ):
+        await _handle_publish(console, settings, workspace, file_arg=str(html))
+
+    # Key must be persisted after success
+    workspace.set_secret.assert_called_with("ANTON_MINDS_API_KEY", "goodkey")
+
+
+@pytest.mark.asyncio
+async def test_401_with_existing_key_clears_it(tmp_path):
+    """If a bad key was already saved (e.g. from a previous failed attempt),
+    a new 401 clears it so /publish re-prompts next time."""
+    from anton.chat import _handle_publish
+
+    html = _make_html_file(tmp_path)
+    settings = _make_settings(tmp_path, api_key="stale-bad-key")
+    workspace = _make_workspace()
+    console = _make_console()
+
+    http_401 = urllib.error.HTTPError(
+        url="https://4nton.ai/upload", code=401, msg="Unauthorized", hdrs=None, fp=None
+    )
+
+    with (
+        patch("anton.publisher.publish", side_effect=http_401),
+    ):
+        await _handle_publish(console, settings, workspace, file_arg=str(html))
+
+    assert settings.minds_api_key is None
+    workspace.set_secret.assert_called_with("ANTON_MINDS_API_KEY", "")


### PR DESCRIPTION
## Summary

- When a user entered a wrong API key during `/publish`, the key was saved before the upload attempt. Every subsequent `/publish` silently reused the bad key, returning 401 with no recovery path from within the command.
- Defer persisting `ANTON_MINDS_API_KEY` until publish succeeds
- On 401, clear the key from settings and workspace so the user is re-prompted on the next `/publish` run
- Show a clear "Invalid API key — run /publish again to enter a new one." message instead of a raw exception

## Test plan

- [ ] 3 new unit tests in `tests/test_publish_api_key.py` — all passing
  - `test_401_clears_api_key` — bad key entered fresh → 401 → key cleared, user sees correct message
  - `test_successful_publish_persists_key` — good key → success → key written to workspace
  - `test_401_with_existing_key_clears_it` — stale bad key already saved → 401 → cleared, user re-prompted next run
- [ ] Full test suite: 796 passed

Fixes [STRC-987](https://linear.app/mindsdb/issue/STRC-987/bug-publish-saves-wrong-api-key-before-validation-user-stuck-in-401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)