### PR TITLE
fix(memory): enforce identity singularity across scopes

### DIFF
--- a/anton/core/memory/base.py
+++ b/anton/core/memory/base.py
@@ -104,6 +104,10 @@ class HippocampusProtocol(Protocol):
         """Merge new entries into the identity snapshot and rewrite."""
         ...
 
+    def clear_identity(self) -> None:
+        """Delete the identity snapshot file if present."""
+        ...
+
     # --- update / delete ---
 
     def del_rule(self, id: str) -> None:

--- a/anton/core/memory/cortex.py
+++ b/anton/core/memory/cortex.py
@@ -129,6 +129,13 @@ class Cortex:
         self._llm = llm_client
         self._turn_count = 0
 
+        # One-time migration: identity is singular and global. Any entries that
+        # landed in project scope from the old encode() bug are merged upward.
+        orphaned = [e.text for e in self.project_hc.get_identities()]
+        if orphaned:
+            self.global_hc.rewrite_identity(orphaned)
+            self.project_hc.clear_identity()
+
     # ~6000 chars ≈ ~1500 tokens — above this, use LLM to filter rules
     _RULES_BUDGET_CHARS = 6000
 
@@ -297,7 +304,10 @@ Do NOT add, modify, or summarize rules — return them verbatim.
 
         actions: list[str] = []
         for engram in engrams:
-            hc = self.global_hc if engram.scope == "global" else self.project_hc
+            if engram.kind == "profile":
+                hc = self.global_hc
+            else:
+                hc = self.global_hc if engram.scope == "global" else self.project_hc
 
             if engram.kind == "profile":
                 hc.rewrite_identity([engram.text])

--- a/anton/core/memory/cortex.py
+++ b/anton/core/memory/cortex.py
@@ -131,9 +131,26 @@ class Cortex:
 
         # One-time migration: identity is singular and global. Any entries that
         # landed in project scope from the old encode() bug are merged upward.
+        # Global wins on key conflicts — orphaned entries are likely stale
+        # (the bug wrote them; the user may have since corrected to global),
+        # so we only import keys that don't already exist globally.
         orphaned = [e.text for e in self.project_hc.get_identities()]
         if orphaned:
-            self.global_hc.rewrite_identity(orphaned)
+            existing_global_keys = {
+                e.text.split(":", 1)[0].strip().lower()
+                for e in self.global_hc.get_identities()
+                if ":" in e.text
+            }
+            to_migrate = [
+                fact
+                for fact in orphaned
+                if not (
+                    ":" in fact
+                    and fact.split(":", 1)[0].strip().lower() in existing_global_keys
+                )
+            ]
+            if to_migrate:
+                self.global_hc.rewrite_identity(to_migrate)
             self.project_hc.clear_identity()
 
     # ~6000 chars ≈ ~1500 tokens — above this, use LLM to filter rules

--- a/anton/core/memory/hippocampus.py
+++ b/anton/core/memory/hippocampus.py
@@ -184,6 +184,10 @@ class Hippocampus:
         content = "# Profile\n" + "\n".join(f"- {e.text}" for e in entries) + "\n"
         self._encode_with_lock(self._profile_path, content, mode="write")
 
+    def clear_identity(self) -> None:
+        if self._profile_path.is_file():
+            self._profile_path.unlink()
+
 
     # ---------  lessons --------------
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -105,6 +105,7 @@ class ChatSession:
             list(config.initial_history) if config.initial_history else []
         )
         self._pending_memory_confirmations: list = []
+        self._identity_buffer: list[str] = []
         self._turn_count = (
             sum(1 for m in self._history if m.get("role") == "user")
             if config.initial_history
@@ -782,8 +783,11 @@ class ChatSession:
         self._turn_count += 1
         self._persist_history()
         if self._cortex is not None and self._cortex.mode != "off":
-            if self._turn_count % 5 == 0 and isinstance(user_input, str):
-                asyncio.create_task(self._cortex.maybe_update_identity(user_input))
+            self._identity_buffer.append(user_input)
+            if self._turn_count % 5 == 0:
+                buffered = "\n\n".join(self._identity_buffer)
+                self._identity_buffer.clear()
+                asyncio.create_task(self._cortex.maybe_update_identity(buffered))
             # Periodic memory vacuum (Systems Consolidation)
             self._cortex.maybe_vacuum()
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -783,7 +783,7 @@ class ChatSession:
         self._turn_count += 1
         self._persist_history()
         if self._cortex is not None and self._cortex.mode != "off":
-            self._identity_buffer.append(user_input)
+            self._identity_buffer.append(user_msg_str)
             if self._turn_count % 5 == 0:
                 buffered = "\n\n".join(self._identity_buffer)
                 self._identity_buffer.clear()

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -106,7 +106,6 @@ class ChatSession:
             list(config.initial_history) if config.initial_history else []
         )
         self._pending_memory_confirmations: list = []
-        self._identity_buffer: list[str] = []
         self._turn_count = (
             sum(1 for m in self._history if m.get("role") == "user")
             if config.initial_history
@@ -785,11 +784,8 @@ class ChatSession:
         self._turn_count += 1
         self._persist_history()
         if self._cortex is not None and self._cortex.mode != "off":
-            self._identity_buffer.append(user_msg_str)
-            if self._turn_count % 5 == 0:
-                buffered = "\n\n".join(self._identity_buffer)
-                self._identity_buffer.clear()
-                asyncio.create_task(self._cortex.maybe_update_identity(buffered))
+            if self._turn_count % 5 == 0 and isinstance(user_input, str):
+                asyncio.create_task(self._cortex.maybe_update_identity(user_input))
             # Periodic memory vacuum (Systems Consolidation)
             self._cortex.maybe_vacuum()
 

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -96,12 +96,42 @@ class TestEncode:
         assert (g / "profile.md").exists()
         assert "Name: Jorge" in (g / "profile.md").read_text()
 
+    async def test_encode_profile_with_project_scope_routes_to_global(self, cortex, dirs):
+        g, p = dirs
+        engram = Engram(text="Name: Jorge", kind="profile", scope="project")
+        await cortex.encode([engram])
+        assert (g / "profile.md").exists()
+        assert "Name: Jorge" in (g / "profile.md").read_text()
+        assert not (p / "profile.md").exists()
+
     async def test_off_mode_returns_disabled(self, dirs):
         g, p = dirs
         cortex = Cortex(global_hc=Hippocampus(g), project_hc=Hippocampus(p), mode="off")
         engram = Engram(text="test", kind="lesson", scope="global")
         actions = await cortex.encode([engram])
         assert any("disabled" in a.lower() for a in actions)
+
+
+class TestOrphanedIdentityMigration:
+    def test_migrates_project_identity_to_global_on_init(self, dirs):
+        g, p = dirs
+        # Simulate orphaned state from the old bug: identity entries in project scope.
+        Hippocampus(p).rewrite_identity(["Name: Jorge", "TZ: PST"])
+        assert (p / "profile.md").exists()
+
+        Cortex(global_hc=Hippocampus(g), project_hc=Hippocampus(p), mode="copilot")
+
+        assert (g / "profile.md").exists()
+        merged = (g / "profile.md").read_text()
+        assert "Name: Jorge" in merged
+        assert "TZ: PST" in merged
+        assert not (p / "profile.md").exists()
+
+    def test_migration_noop_when_project_identity_empty(self, dirs):
+        g, p = dirs
+        Cortex(global_hc=Hippocampus(g), project_hc=Hippocampus(p), mode="copilot")
+        assert not (g / "profile.md").exists()
+        assert not (p / "profile.md").exists()
 
 
 class TestEncodingGate:

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -127,6 +127,21 @@ class TestOrphanedIdentityMigration:
         assert "TZ: PST" in merged
         assert not (p / "profile.md").exists()
 
+    def test_migration_does_not_overwrite_fresh_global_entries(self, dirs):
+        # Orphaned project data is likely stale (old bug wrote it, user may
+        # have since corrected to global). Global must win on key conflicts.
+        g, p = dirs
+        Hippocampus(g).rewrite_identity(["Name: Alejandro"])
+        Hippocampus(p).rewrite_identity(["Name: Alec", "TZ: PST"])
+
+        Cortex(global_hc=Hippocampus(g), project_hc=Hippocampus(p), mode="copilot")
+
+        merged = (g / "profile.md").read_text()
+        assert "Name: Alejandro" in merged
+        assert "Name: Alec" not in merged
+        assert "TZ: PST" in merged  # non-conflicting keys still migrate
+        assert not (p / "profile.md").exists()
+
     def test_migration_noop_when_project_identity_empty(self, dirs):
         g, p = dirs
         Cortex(global_hc=Hippocampus(g), project_hc=Hippocampus(p), mode="copilot")


### PR DESCRIPTION
## Summary
- `Cortex.encode()` routed profile engrams by declared scope, so `memorize(kind=profile)` with the default `scope=project` wrote to `project/profile.md` — which no read path ever loads. The facts were silently lost.
- Force `kind=profile` to `global_hc` regardless of declared scope, matching the existing `build_memory_context()` comment *"identity is singular"*.
- One-time startup migration in `Cortex.__init__` merges any orphaned project identity into global and clears the project copy, so existing users recover data already written to the wrong place.
- Adds `clear_identity()` to `Hippocampus` (and to `HippocampusProtocol`) to support the migration without reaching into private paths.

## Notes
- Unrelated bug in `maybe_update_identity` (only the last user message is scanned despite the every-5-turns cadence) is being handled separately in #125.

## Test plan
- [x] `pytest tests/test_cortex.py tests/test_hippocampus.py` — 55 passed
- [x] New test: `kind=profile, scope=project` routes to global, never writes project `profile.md`
- [x] New test: orphaned project identity is migrated into global on init, project file removed
- [x] New test: migration is a no-op when project identity is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)