### PR TITLE
feat: implement slash command autocompletion with styled menu in cha session

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -81,6 +81,7 @@ from anton.core.datasources.datasource_registry import (
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.styles import Style as PTStyle
 from rich.prompt import Prompt
 from anton.memory.manage import MemoryManage, MEMORY_COMMANDS
@@ -1136,6 +1137,13 @@ async def _chat_loop(
     pt_style = PTStyle.from_dict(
         {
             "bottom-toolbar": "noreverse nounderline bg:default",
+            "completion-menu": "bg:#08131c #7aa3b8",
+            "completion-menu.completion": "bg:#08131c #9cc5d9",
+            "completion-menu.completion.current": "bg:#0a3340 #32d9ff bold",
+            "completion-menu.meta.completion": "bg:#08131c #5b7d8f",
+            "completion-menu.meta.completion.current": "bg:#0a3340 #9adff0",
+            "scrollbar.background": "bg:#08131c",
+            "scrollbar.button": "bg:#11404c",
         }
     )
 
@@ -1145,6 +1153,8 @@ async def _chat_loop(
         style=pt_style,
         completer=make_completer([THEME_COMMANDS, SKILLS_COMMANDS, COMMANDS, MEMORY_COMMANDS]),
         complete_while_typing=True,
+        complete_style=CompleteStyle.COLUMN,
+        reserve_space_for_menu=8,
     )
 
     memory_manage = MemoryManage(console, settings, cortex, episodic=episodic)

--- a/anton/commands/ui.py
+++ b/anton/commands/ui.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from rich.console import Console
 from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.document import Document
 
 from anton.explainability import ExplainabilityStore
 
@@ -155,7 +156,7 @@ def handle_explain(console: Console, workspace_path) -> None:
 
 def make_completer(command_sources: list[list]) -> Completer:
     """Return a Completer that suggests slash commands extracted from *sources*."""
-    commands = set()
+    command_meta: dict[str, str] = {}
     for source in command_sources:
         for item in source:
             if not isinstance(item, Command):
@@ -165,16 +166,34 @@ def make_completer(command_sources: list[list]) -> Completer:
                 # split options [a|b|c] to separated commands
                 prefix = item.command[:match.start()]
                 for variant in match.group(1).split("|"):
-                    commands.add(prefix + variant)
+                    cmd = prefix + variant
+                    command_meta.setdefault(cmd, item.description or "")
             else:
-                commands.add(item.command)
+                command_meta.setdefault(item.command, item.description or "")
+
+    commands = sorted(command_meta.keys())
 
     class _Completer(Completer):
-        def get_completions(self, document, complete_event):
+        def get_completions(self, document: Document, complete_event):
             text = document.text_before_cursor
             if not text.startswith("/"):
                 return
 
+            # First token: show full command list with descriptions.
+            if " " not in text.strip():
+                prefix = text.strip()
+                for cmd in commands:
+                    if not cmd.startswith(prefix):
+                        continue
+                    yield Completion(
+                        cmd,
+                        start_position=-len(prefix),
+                        display=cmd,
+                        display_meta=command_meta.get(cmd, ""),
+                    )
+                return
+
+            # Subsequent tokens: preserve old token-level completion behavior.
             word_start = text.rfind(" ") + 1
             current_word = text[word_start:]
             seen = set()
@@ -189,4 +208,3 @@ def make_completer(command_sources: list[list]) -> Completer:
                     yield Completion(next_word, start_position=-len(current_word))
 
     return _Completer()
-


### PR DESCRIPTION
# Description

- Updated completion menu styling to match your reference more closely: dark panel background, cyan-highlighted active item, and clearer metadata text.


**Before**
<img width="476" height="392" alt="image" src="https://github.com/user-attachments/assets/20c33e56-0db7-47ad-8694-61d27cf3f1fb" />

**After**
<img width="514" height="291" alt="image" src="https://github.com/user-attachments/assets/585f1c88-ffce-4956-8520-fb82135bac66" />
