### PR TITLE
Moved Artifacts Directory

### DIFF
--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -125,11 +125,12 @@ class AntonSettings(CoreSettings):
         """
         base = Path(folder).resolve() if folder else Path.cwd()
         self._workspace = base
+        memory_dir = base / self.memory_dir
 
         # Convert relative paths to absolute under base
-        if not Path(self.memory_dir).is_absolute():
-            self.memory_dir = str(base / self.memory_dir)
+        if not memory_dir.is_absolute():
+            self.memory_dir = str(memory_dir)
         if not Path(self.context_dir).is_absolute():
             self.context_dir = str(base / self.context_dir)
         if not Path(self.artifacts_dir).is_absolute():
-            self.artifacts_dir = str(self.memory_dir / self.artifacts_dir)
+            self.artifacts_dir = str(memory_dir / self.artifacts_dir)

--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -38,6 +38,7 @@ class AntonSettings(CoreSettings):
     openai_api_version: str | None = None  # Azure api-version query param
 
     memory_enabled: bool = True
+    # TODO: Calling this memory_dir is a bit misleading, because there are other directories that live here
     memory_dir: str = ".anton"
 
     context_dir: str = ".anton/context"
@@ -131,4 +132,4 @@ class AntonSettings(CoreSettings):
         if not Path(self.context_dir).is_absolute():
             self.context_dir = str(base / self.context_dir)
         if not Path(self.artifacts_dir).is_absolute():
-            self.artifacts_dir = str(base / self.artifacts_dir)
+            self.artifacts_dir = str(self.memory_dir / self.artifacts_dir)

--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -125,12 +125,15 @@ class AntonSettings(CoreSettings):
         """
         base = Path(folder).resolve() if folder else Path.cwd()
         self._workspace = base
-        memory_dir = base / self.memory_dir
 
         # Convert relative paths to absolute under base
-        if not memory_dir.is_absolute():
-            self.memory_dir = str(memory_dir)
+        if not Path(self.memory_dir).is_absolute():
+            memory_root = base / self.memory_dir
+            self.memory_dir = str(memory_root)
+        else:
+            memory_root = Path(self.memory_dir)
+
         if not Path(self.context_dir).is_absolute():
             self.context_dir = str(base / self.context_dir)
         if not Path(self.artifacts_dir).is_absolute():
-            self.artifacts_dir = str(memory_dir / self.artifacts_dir)
+            self.artifacts_dir = str(memory_root / self.artifacts_dir)

--- a/anton/workspace.py
+++ b/anton/workspace.py
@@ -12,6 +12,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+from anton.config.settings import AntonSettings
+
 ANTON_MD_TEMPLATE = """\
 # Anton Workspace
 
@@ -31,6 +33,9 @@ class Workspace:
         self._anton_md = self._anton_dir / "anton.md"
         self._env_file = self._anton_dir / ".env"
         self._anton_md_last_read: datetime | None = None
+
+        settings = AntonSettings()
+        self._artifacts_dir = self._anton_dir / settings.artifacts_dir
 
     @property
     def base(self) -> Path:
@@ -99,17 +104,16 @@ class Workspace:
         # the legacy hidden `.anton/output/` dump — one folder per
         # artifact, each owning its own metadata.json + README.md.
         # Idempotent: existing artifact subfolders are left alone.
-        artifacts_dir = self._base / "artifacts"
-        if not artifacts_dir.exists():
-            artifacts_dir.mkdir(parents=True, exist_ok=True)
-            actions.append(f"Created {artifacts_dir}")
+        if not self._artifacts_dir.exists():
+            self._artifacts_dir.mkdir(parents=True, exist_ok=True)
+            actions.append(f"Created {self._artifacts_dir}")
 
         return actions
 
     @property
     def artifacts_dir(self) -> Path:
         """Where artifacts live. Created lazily by `initialize()`."""
-        return self._base / "artifacts"
+        return self._artifacts_dir
 
     # ── anton.md reading ─────────────────────────────────────────
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -79,10 +79,10 @@ class TestInitialization:
 
     def test_creates_artifacts_dir(self, ws, tmp_path):
         ws.initialize()
-        assert (tmp_path / "artifacts").is_dir()
+        assert (tmp_path / ".anton" / "artifacts").is_dir()
 
     def test_artifacts_dir_property(self, ws, tmp_path):
-        assert ws.artifacts_dir == tmp_path / "artifacts"
+        assert ws.artifacts_dir == tmp_path / ".anton" / "artifacts"
 
 
 class TestAntonMd:


### PR DESCRIPTION
This PR moves the artifacts directory to .anton. This is mainly done to unify the file layout for projects in Cowork.