### PR TITLE
fix: update reference URLs to mindshub.ai

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -425,9 +425,9 @@ async def _handle_publish(
             return
         if has_key.lower() == "n":
             webbrowser.open(
-                "https://mdb.ai/auth/realms/mindsdb/protocol/openid-connect/registrations"
+                "https://auth.mindshub.ai/auth/realms/mindsdb/protocol/openid-connect/registrations"
                 "?client_id=public-client&response_type=code&scope=openid"
-                "&redirect_uri=https%3A%2F%2Fmdb.ai"
+                "&redirect_uri=https%3A%2F%2Fconsole.mindshub.ai"
             )
             console.print()
 

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -665,7 +665,7 @@ def _setup_minds(settings, ws, *, default_url: str | None = "https://mdb.ai") ->
         )
         if not has_key:
             webbrowser.open(
-                "https://mdb.ai/auth/realms/mindsdb/protocol/openid-connect/registrations?client_id=public-client&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fmdb.ai"
+                "https://auth.mindshub.ai/auth/realms/mindsdb/protocol/openid-connect/registrations?client_id=public-client&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fconsole.mindshub.ai"
             )
             console.print()
 

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -297,7 +297,7 @@ class TestRuntimeContext:
 class TestMindsSetupRecovery:
     def test_describe_minds_http_401_is_factual(self):
         error = urllib.error.HTTPError(
-            "https://mdb.ai/api/v1/minds/",
+            "https://api.mindshub.ai/v1/minds/",
             401,
             "Unauthorized",
             None,


### PR DESCRIPTION
Replaces old URLs with updated references to mindshub.ai, ensuring users are directed to the correct registration and API endpoints.
