### PR TITLE
feat: render image paths as vision input via @-resolver and read_image tool

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -17,6 +17,7 @@ from anton.clipboard import (
     grab_clipboard,
     is_clipboard_supported,
     parse_dropped_paths as _parse_dropped_paths,
+    replace_at_image_paths,
     save_clipboard_image,
 )
 from anton.core.session import ChatSession, ChatSessionConfig
@@ -1319,6 +1320,11 @@ async def _chat_loop(
             # message_content holds what we send to the LLM — may be str or
             # list[dict] (multimodal content blocks for images).
             message_content: str | list[dict] | None = None
+
+            # Resolve manual @<path> image references → [Image #N] tokens so
+            # they go through the same base64/multimodal pipeline as
+            # drag-and-drop pastes.
+            user_input, _ = replace_at_image_paths(user_input, image_registry)
 
             # Expand any [Image #N] placeholders into multimodal blocks. After
             # this, the registry only keeps entries that were actually sent.

--- a/anton/clipboard.py
+++ b/anton/clipboard.py
@@ -23,6 +23,9 @@ from typing import Any
 
 IMAGE_EXTENSION_REGEX = re.compile(r"\.(png|jpe?g|gif|webp|bmp)$", re.IGNORECASE)
 IMAGE_REF_REGEX = re.compile(r"\[Image #(\d+)\]")
+AT_PATH_REGEX = re.compile(
+    r'(?:(?<=\s)|^)@(?:"([^"]+)"|\'([^\']+)\'|(\S+))'
+)
 
 
 @dataclass
@@ -152,6 +155,36 @@ def replace_image_paths_in_pasted(text: str, registry: PastedImageRegistry) -> t
         out_lines.append(body + suffix)
 
     return "".join(out_lines), registered
+
+
+def replace_at_image_paths(
+    text: str, registry: PastedImageRegistry
+) -> tuple[str, list[PastedImage]]:
+    """Find @<path> references to image files, register them, replace each with [Image #N].
+
+    Supports absolute paths and paths relative to cwd. Non-image or non-existent
+    paths are left untouched (the literal "@<path>" stays in the text).
+    """
+    registered: list[PastedImage] = []
+
+    def _sub(match: re.Match) -> str:
+        token = match.group(1) or match.group(2) or match.group(3) or ""
+        if not token or not is_image_path(token):
+            return match.group(0)
+        try:
+            candidate = Path(token).expanduser()
+            if not candidate.is_absolute():
+                candidate = (Path.cwd() / candidate).resolve()
+            if not candidate.is_file():
+                return match.group(0)
+        except OSError:
+            return match.group(0)
+        item = registry.add(candidate)
+        registered.append(item)
+        return format_image_ref(item.id)
+
+    new_text = AT_PATH_REGEX.sub(_sub, text)
+    return new_text, registered
 
 
 def _linux_clipboard_tool() -> str | None:

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -141,19 +141,60 @@ def _translate_user_blocks(blocks: list[dict], supports_vision: bool = True, vis
             if content_parts:
                 result.append({"role": "user", "content": content_parts})
                 content_parts = []
-            # tool_result -> role:tool message
-            content = block.get("content", "")
-            if isinstance(content, list):
-                content = "\n".join(
-                    b.get("text", "") for b in content if b.get("type") == "text"
-                )
+            # tool_result -> role:tool message. The Chat Completions API only
+            # accepts a string in `tool` messages, so when the tool returned
+            # multimodal blocks (image + text), we split them: text → tool
+            # message, image → a follow-up role:user message right after.
+            raw = block.get("content", "")
+            extra_images: list[dict] = []
+            if isinstance(raw, list):
+                text_parts_for_tool: list[str] = []
+                for b in raw:
+                    if b.get("type") == "text":
+                        text_parts_for_tool.append(b.get("text", ""))
+                    elif b.get("type") == "image" and supports_vision:
+                        extra_images.append(b)
+                if text_parts_for_tool:
+                    tool_text = "\n".join(text_parts_for_tool)
+                elif extra_images:
+                    tool_text = "Image attached in next user message."
+                else:
+                    tool_text = ""
+            else:
+                tool_text = str(raw)
+
             result.append(
                 {
                     "role": "tool",
                     "tool_call_id": block["tool_use_id"],
-                    "content": str(content),
+                    "content": tool_text,
                 }
             )
+
+            if extra_images:
+                img_parts: list[dict] = [
+                    {
+                        "type": "text",
+                        "text": "Image(s) returned by previous tool call:",
+                    }
+                ]
+                for img in extra_images:
+                    if vision_format == "anthropic":
+                        img_parts.append(img)
+                        continue
+                    source = img.get("source", {})
+                    if source.get("type") == "base64":
+                        media_type = source.get("media_type", "image/png")
+                        data = source.get("data", "")
+                        img_parts.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:{media_type};base64,{data}"
+                                },
+                            }
+                        )
+                result.append({"role": "user", "content": img_parts})
         elif block.get("type") == "text":
             content_parts.append({"type": "text", "text": block.get("text", "")})
         elif block.get("type") == "image" and supports_vision:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -34,6 +34,7 @@ from anton.core.tools.tool_defs import (
     LIST_ARTIFACTS_TOOL,
     MEMORIZE_TOOL,
     OPEN_ARTIFACT_TOOL,
+    READ_IMAGE_TOOL,
     RECALL_TOOL,
     SCRATCHPAD_TOOL,
     SET_ARTIFACT_PRIMARY_TOOL,
@@ -590,6 +591,7 @@ class ChatSession:
                 )
 
         self.tool_registry.register_tool(scratchpad_tool)
+        self.tool_registry.register_tool(READ_IMAGE_TOOL)
 
         if self._cortex is not None or self._self_awareness is not None:
             self.tool_registry.register_tool(MEMORIZE_TOOL)
@@ -1219,25 +1221,39 @@ class ChatSession:
             tool_results: list[dict] = []
             for tc in response.tool_calls:
                 try:
-                    result_text = await self.tool_registry.dispatch_tool(
+                    result = await self.tool_registry.dispatch_tool(
                         self, tc.name, tc.input
                     )
                 except Exception as exc:
-                    result_text = f"Tool '{tc.name}' failed: {exc}"
+                    result = f"Tool '{tc.name}' failed: {exc}"
 
-                result_text = scrub_credentials(result_text)
-                result_text = self._apply_error_tracking(
-                    result_text,
-                    tc.name,
-                    error_streak,
-                    resilience_nudged,
-                )
+                if isinstance(result, list):
+                    # Multimodal tool result — scrub credentials from text
+                    # blocks; image-block payloads are raw bytes and have
+                    # nothing to scrub. Error-tracking is skipped: a list
+                    # result signals success (handlers return a plain string
+                    # on failure).
+                    content: "str | list[dict]" = [
+                        {**b, "text": scrub_credentials(b.get("text", ""))}
+                        if b.get("type") == "text"
+                        else b
+                        for b in result
+                    ]
+                else:
+                    result = scrub_credentials(result)
+                    result = self._apply_error_tracking(
+                        result,
+                        tc.name,
+                        error_streak,
+                        resilience_nudged,
+                    )
+                    content = result
 
                 tool_results.append(
                     {
                         "type": "tool_result",
                         "tool_use_id": tc.id,
-                        "content": result_text,
+                        "content": content,
                     }
                 )
 
@@ -1688,6 +1704,38 @@ class ChatSession:
                                 )
                     except Exception as exc:
                         result_text = f"Tool '{tc.name}' failed: {exc}"
+
+                    if isinstance(result_text, list):
+                        # Multimodal tool result — scrub credentials from text
+                        # blocks (image payloads carry no secrets). Error-
+                        # tracking is skipped: a list result signals success.
+                        scrubbed_blocks = [
+                            {**b, "text": scrub_credentials(b.get("text", ""))}
+                            if b.get("type") == "text"
+                            else b
+                            for b in result_text
+                        ]
+                        if self._episodic is not None:
+                            self._episodic.log_turn(
+                                self._turn_count + 1,
+                                "tool_result",
+                                f"[{tc.name} → multimodal result]",
+                                tool=tc.name,
+                            )
+                        self._acc_observe(
+                            "tool_result",
+                            {"name": tc.name, "success": True, "error": ""},
+                            severity=1,
+                            round_idx=tool_round,
+                        )
+                        tool_results.append(
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": tc.id,
+                                "content": scrubbed_blocks,
+                            }
+                        )
+                        continue
 
                     if self._episodic is not None:
                         self._episodic.log_turn(

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1230,15 +1230,18 @@ class ChatSession:
                 if isinstance(result, list):
                     # Multimodal tool result — scrub credentials from text
                     # blocks; image-block payloads are raw bytes and have
-                    # nothing to scrub. Error-tracking is skipped: a list
-                    # result signals success (handlers return a plain string
-                    # on failure).
+                    # nothing to scrub. A list result signals success, so
+                    # mirror the success branch of `_apply_error_tracking`
+                    # and reset the streak instead of running the full
+                    # string-only nudge logic.
                     content: "str | list[dict]" = [
                         {**b, "text": scrub_credentials(b.get("text", ""))}
                         if b.get("type") == "text"
                         else b
                         for b in result
                     ]
+                    error_streak[tc.name] = 0
+                    resilience_nudged.discard(tc.name)
                 else:
                     result = scrub_credentials(result)
                     result = self._apply_error_tracking(
@@ -1707,14 +1710,19 @@ class ChatSession:
 
                     if isinstance(result_text, list):
                         # Multimodal tool result — scrub credentials from text
-                        # blocks (image payloads carry no secrets). Error-
-                        # tracking is skipped: a list result signals success.
+                        # blocks (image payloads carry no secrets). A list
+                        # result signals success, so mirror the success
+                        # branch of `_apply_error_tracking` and reset the
+                        # streak instead of running the full string-only
+                        # nudge logic.
                         scrubbed_blocks = [
                             {**b, "text": scrub_credentials(b.get("text", ""))}
                             if b.get("type") == "text"
                             else b
                             for b in result_text
                         ]
+                        error_streak[tc.name] = 0
+                        resilience_nudged.discard(tc.name)
                         if self._episodic is not None:
                             self._episodic.log_turn(
                                 self._turn_count + 1,

--- a/anton/core/tools/registry.py
+++ b/anton/core/tools/registry.py
@@ -30,8 +30,8 @@ class ToolRegistry:
 
     async def dispatch_tool(
         self, session: "ChatSession", tool_name: str, tc_input: dict
-    ) -> str:
-        """Dispatch a tool call by name. Returns result text."""
+    ) -> "str | list[dict]":
+        """Dispatch a tool call by name. Returns result text or multimodal blocks."""
         tool_def = next((t for t in self._tools if t.name == tool_name), None)
         if tool_def is None:
             raise ValueError(f"Tool {tool_name} not found")

--- a/anton/core/tools/tool_defs.py
+++ b/anton/core/tools/tool_defs.py
@@ -3,6 +3,7 @@ from anton.core.tools.tool_handlers import (
     handle_list_artifacts,
     handle_memorize,
     handle_open_artifact,
+    handle_read_image,
     handle_recall,
     handle_scratchpad,
     handle_set_artifact_primary,
@@ -302,4 +303,29 @@ RECALL_TOOL = ToolDef(
         "required": ["query"],
     },
     handler=handle_recall,
+)
+
+
+READ_IMAGE_TOOL = ToolDef(
+    name="read_image",
+    description=(
+        "Read an image file from disk so you can see its contents. Use this "
+        "whenever the user references a path to an image file (PNG, JPG, "
+        "JPEG, GIF, WEBP, BMP) and you need to actually view the picture to "
+        "answer. Pass `file_path` as an absolute path or a path relative to "
+        "the current working directory. The image will appear in your next "
+        "turn as a vision input — do not call this tool again for the same "
+        "path within one turn."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "file_path": {
+                "type": "string",
+                "description": "Absolute or relative path to the image file.",
+            },
+        },
+        "required": ["file_path"],
+    },
+    handler=handle_read_image,
 )

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -410,3 +410,92 @@ async def handle_scratchpad(session: ChatSession, tc_input: dict) -> str:
 
     else:
         return f"Unknown scratchpad action: {action}"
+
+
+async def handle_read_image(
+    session: "ChatSession", tc_input: dict
+) -> str | list[dict]:
+    """Read an image file from disk and return it as an image content block.
+
+    Returns a list of content blocks (image + text) on success so the model
+    sees the picture on its next turn. Returns a plain error string on
+    failure (missing file, non-image extension, oversized image, etc.).
+    """
+    import base64
+    from pathlib import Path
+
+    from anton.clipboard import is_image_path
+    from anton.utils.clipboard import (
+        MAX_IMAGE_BYTES,
+        _media_type_for,
+        human_size,
+    )
+
+    file_path = (tc_input.get("file_path") or "").strip()
+    if not file_path:
+        return "Error: file_path is required."
+
+    try:
+        path = Path(file_path).expanduser()
+        if not path.is_absolute():
+            path = (Path.cwd() / path).resolve()
+    except OSError as exc:
+        return f"Error: invalid path '{file_path}': {exc}"
+
+    if not path.is_file():
+        return f"Error: file not found: {path}"
+
+    if not is_image_path(path.name):
+        return (
+            f"Error: '{path.name}' is not a supported image format "
+            "(expected .png/.jpg/.jpeg/.gif/.webp/.bmp)."
+        )
+
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        return f"Error: cannot read '{path}': {exc}"
+
+    suffix = path.suffix.lstrip(".").lower()
+    if suffix == "bmp":
+        try:
+            import io
+            from PIL import Image as _PILImage
+
+            buf = io.BytesIO()
+            _PILImage.open(io.BytesIO(raw)).save(buf, format="PNG")
+            raw = buf.getvalue()
+            suffix = "png"
+        except Exception as exc:
+            return f"Error: failed to convert BMP to PNG: {exc}"
+
+    if len(raw) * 4 // 3 > MAX_IMAGE_BYTES:
+        return (
+            f"Error: image is too large ({human_size(len(raw))}); "
+            "the API limit is ~3.7 MB raw / 5 MB base64. "
+            "Resize the image and try again."
+        )
+
+    b64 = base64.standard_b64encode(raw).decode("ascii")
+    media_type = _media_type_for(suffix)
+
+    summary = f"Loaded {path.name} ({human_size(len(raw))})."
+    try:
+        from PIL import Image as _PILImage
+
+        with _PILImage.open(path) as im:
+            summary = f"Loaded {path.name} ({im.width}x{im.height}, {human_size(len(raw))})."
+    except Exception:
+        pass
+
+    return [
+        {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": media_type,
+                "data": b64,
+            },
+        },
+        {"type": "text", "text": summary},
+    ]

--- a/anton/utils/clipboard.py
+++ b/anton/utils/clipboard.py
@@ -74,17 +74,21 @@ def format_file_message(text: str, paths: list[Path], console: Console) -> str:
 
         console.print(f"  [anton.muted]attached: {p.name} ({human_size(size)})[/]")
 
-        if size > 512_000:
-            parts.append(
-                f'\n<file path="{p}">\n(File too large to inline — {human_size(size)}. '
-                f"Use the scratchpad to read it.)\n</file>"
-            )
-            continue
-
+        # Image check runs before the size guard: `read_image` accepts files
+        # up to ~3.75 MB raw, well above 512 KB, so the generic 'too large
+        # to inline' message would silently hide the tool hint for typical
+        # photos and screenshots.
         if is_image_path(p.name):
             parts.append(
                 f'\n<file path="{p}">\n(Image file — {human_size(size)}. '
                 f'Call the `read_image` tool with file_path="{p}" to view it, or use the scratchpad to process it)\n</file>'
+            )
+            continue
+
+        if size > 512_000:
+            parts.append(
+                f'\n<file path="{p}">\n(File too large to inline — {human_size(size)}. '
+                f"Use the scratchpad to read it.)\n</file>"
             )
             continue
 

--- a/anton/utils/clipboard.py
+++ b/anton/utils/clipboard.py
@@ -13,6 +13,7 @@ from anton.clipboard import (
     IMAGE_REF_REGEX,
     PastedImageRegistry,
     clipboard_unavailable_reason,
+    is_image_path,
     replace_image_paths_in_pasted,
 )
 
@@ -80,8 +81,15 @@ def format_file_message(text: str, paths: list[Path], console: Console) -> str:
             )
             continue
 
+        if is_image_path(p.name):
+            parts.append(
+                f'\n<file path="{p}">\n(Image file — {human_size(size)}. '
+                f'Call the `read_image` tool with file_path="{p}" to view it, or use the scratchpad to process it)\n</file>'
+            )
+            continue
+
         if suffix in (
-            ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".webp",
+            ".ico",
             ".pdf", ".zip", ".tar", ".gz", ".exe", ".dll", ".so",
             ".pyc", ".pyo", ".whl", ".egg", ".db", ".sqlite",
         ):


### PR DESCRIPTION
### Overview

There are 2 ways to attach an image that worked well in anton before this update:
 - /paste command
 - drag-and-drop

However, if you enter a path to an image file, the result becomes unpredictable. According to the instructions, the agent [should use scratchpad to process the image](https://github.com/mindsdb/anton/blob/main/anton/utils/clipboard.py#L83). However, the result of scratchpad execution is a text message, not an image. As a result, the agent could get stuck in lengthy "thinking," trying to find a way to process the image. You can see this in the first two screenshots in the description [of this issue](https://linear.app/mindsdb/issue/ENG-82/anton-minds-hub-mistakes-images).

This PR contains two changes:
 - if the image path is preceded by the `@` symbol, it is immediately read as an image block. Claude Code does the same thing.
 - a read_image tool has been added, which returns an image block. Now the agent can directly read image files when it encounters a path to an image in the request.
 
 ## Changes (autogenerated text)

### `@<path>` image resolver
- `anton/clipboard.py`: new `AT_PATH_REGEX` and `replace_at_image_paths()` — recognizes `@<path>`, `@"path with spaces"`, `@'...'`; only triggers at start-of-string or after whitespace (so `a@b.png` in an email is not matched); supports absolute paths and paths relative to `cwd`; non-image / nonexistent paths are left untouched.
- `anton/chat.py`: runs the resolver immediately before `build_image_ref_message` so `@`-references join the existing `[Image #N]` → base64 pipeline.

### `read_image` tool
- `anton/core/tools/tool_handlers.py`: new `handle_read_image` — validates path + extension via `is_image_path`, enforces `MAX_IMAGE_BYTES`, converts BMP → PNG (BMP is rejected by both vendor APIs), base64-encodes, returns `[image-block, text-block]` on success or a plain error string on failure.
- `anton/core/tools/tool_defs.py`: `READ_IMAGE_TOOL` definition.
- `anton/core/session.py`: registers `READ_IMAGE_TOOL` in `_build_core_tools()`.

### Multimodal tool-result plumbing
- `anton/core/tools/registry.py`: `dispatch_tool` return type widened to `str | list[dict]`.
- `anton/core/session.py` (`turn` and `turn_stream`): branch on result type. For `list` results, scrub credentials from text blocks only (image payloads are raw bytes), skip the string-only `_apply_error_tracking` and `_failed` heuristics (a list result signals success), and write a short summary to episodic memory rather than slicing a list.

### OpenAI Chat Completions workaround
- `anton/core/llm/openai.py` (`_translate_user_blocks`): when a `tool_result.content` is a list with image blocks, the text parts go into the `role:"tool"` message (the only kind of content Chat Completions accepts there) and the image parts are emitted in a follow-up `role:"user"` message as `image_url` (or in Anthropic format when `vision_format="anthropic"`, e.g. for MDB.AI). With `supports_vision=False`, images are silently dropped and the tool message gets a short stub.
- Anthropic provider is unchanged — list-content tool_results are passed straight to the SDK, which supports image blocks natively.

### UX nudge for typed image paths
- `anton/utils/clipboard.py` (`format_file_message`): when an attached file is an image, the inline `<file>` stub now tells the model to call `read_image` (or fall back to the scratchpad) instead of the generic "use the scratchpad" hint. Non-image binaries keep the existing message.
