### PR TITLE
Add contributing guidelines for Anton

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Anton
+
+Thanks for your interest in contributing to Anton.
+
+Anton is an open-source project, and we welcome contributions from anyone who wants to help improve it — whether that is by reporting bugs, improving documentation, testing the project, or contributing code.
+
+## How you can help
+
+You can contribute by:
+
+- Reporting bugs
+- Improving documentation
+- Testing Anton and sharing feedback
+- Discussing implementation ideas
+- Submitting bug fixes
+- Proposing new features
+- Improving examples, tests, or developer experience
+
+## Code contributions
+
+We follow the standard fork-and-pull Git workflow:
+
+1. Fork the Anton repository.
+2. Clone your fork locally.
+3. Create a new branch for your changes.
+4. Make your changes.
+5. Add or update tests when needed.
+6. Run the tests locally.
+7. Commit your changes with a clear commit message.
+8. Push your branch to your fork.
+9. Open a pull request against the `main` branch.
+10. Make sure all CI checks pass.
+
+> Note: Before opening a pull request, please sync your fork with the latest changes from `upstream/main`.
+
+## Feature requests and bug reports
+
+We use GitHub Issues to track bugs, feature requests, and improvements.
+
+Before opening a new issue, please check whether a similar issue already exists. If not, open a [new issue](https://github.com/mindsdb/anton/issues) and fill out the required information.
+
+When reporting a bug, please include:
+
+- What you expected to happen
+- What actually happened
+- Steps to reproduce the issue
+- Relevant logs, screenshots, or environment details, if available
+
+## Pull request review process
+
+Pull requests are reviewed regularly by the maintainers.
+
+Please make sure your pull request is focused, easy to review, and includes enough context about the change. If we leave feedback or questions, please respond so we can move the review forward.
+
+## Community
+
+If you have questions or want to discuss Anton with the MindsDB team, you can join our [Slack community](https://mindsdb.com/joincommunity) or post in [GitHub Discussions](https://github.com/mindsdb/mindsdb/discussions).
+
+You can also sign up for the [MindsDB Monthly Community Newsletter](https://mindsdb.com/newsletter/?utm_medium=community&utm_source=github&utm_campaign=mindsdb%20repo) to get updates about announcements, releases, and events.
+
+## Contributor Code of Conduct
+
+This project follows the [Contributor Code of Conduct](https://github.com/mindsdb/anton/blob/main/CODE_OF_CONDUCT.md). By participating in this project, you agree to follow its terms.


### PR DESCRIPTION
Added a CONTRIBUTING.md file outlining how to contribute to the Anton project, including guidelines for code contributions, feature requests, and community engagement.