### PR TITLE
fix scratchpad: pass images through get_llm() correctly

### DIFF
--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -80,12 +80,26 @@ if _scratchpad_model:
                 "ANTON_OPENAI_API_KEY"
             )
             _llm_api_version = os.environ.get("ANTON_OPENAI_API_VERSION") or None
-            _llm_provider = _ProviderClass(
-                api_key=_llm_api_key or None,
-                base_url=_llm_base_url or None,
-                ssl_verify=_llm_ssl_verify,
-                api_version=_llm_api_version,
+            # Mirror LLMClient.from_settings: openai-compatible endpoints
+            # (Minds/MindsHub) expect image blocks in Anthropic native format,
+            # not OpenAI image_url data-URLs.
+            _llm_provider_kwargs: dict = {
+                "api_key": _llm_api_key or None,
+                "base_url": _llm_base_url or None,
+                "ssl_verify": _llm_ssl_verify,
+                "api_version": _llm_api_version,
+            }
+            # Endpoints that proxy to Minds / MindsHub / MDB.AI
+            # speak Anthropic content format over the OpenAI HTTP envelope,
+            # so image blocks must be Anthropic-shaped, not OpenAI image_url.
+            _llm_url_lower = (_llm_base_url or "").lower()
+            _anthropic_proxy = any(
+                host in _llm_url_lower for host in ("mdb.ai", "mindshub.ai")
             )
+            if _scratchpad_provider_name == "openai-compatible" or _anthropic_proxy:
+                _llm_provider_kwargs["supports_vision"] = True
+                _llm_provider_kwargs["vision_format"] = "anthropic"
+            _llm_provider = _ProviderClass(**_llm_provider_kwargs)
         else:
             _llm_provider = _ProviderClass()  # Anthropic doesn't need ssl_verify
         _llm_model = _scratchpad_model

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -174,6 +174,31 @@ def _translate_user_blocks(blocks: list[dict], supports_vision: bool = True, vis
                             "image_url": {"url": f"data:{media_type};base64,{data}"},
                         }
                     )
+        elif block.get("type") == "image_url" and supports_vision:
+            # Inbound OpenAI-format image (e.g. scratchpad code that built the
+            # message in OpenAI shape). Translate to the configured outbound
+            # format so it actually reaches the model.
+            url = (block.get("image_url") or {}).get("url", "")
+            if vision_format == "anthropic" and url.startswith("data:"):
+                # data:<media_type>;base64,<data>  ->  Anthropic image block
+                try:
+                    header, data = url.split(",", 1)
+                    media_type = header[len("data:") : header.index(";")]
+                except (ValueError, IndexError):
+                    media_type, data = "image/png", ""
+                content_parts.append(
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": data,
+                        },
+                    }
+                )
+            else:
+                # Already OpenAI format — pass through.
+                content_parts.append(block)
 
     if content_parts:
         # If only text parts, flatten to a simple string for compatibility


### PR DESCRIPTION
Images passed to `get_llm()` from scratchpad code were being silently dropped or rejected when the endpoint was a proxy (MindsHub / MDB.AI). Two issues, both fixed:

 - In `scratchpad_boot.py`, the OpenAIProvider used by `get_llm()` was instantiated without `vision_format`, so it defaulted to "openai" (data-URL image_url blocks). The main process's LLMClient.from_settings already overrides this to "anthropic" for openai-compatible, but the scratchpad subprocess never mirrored that — so image blocks went out in the wrong shape and got 400'd by mdb.ai.

 - `_translate_user_blocks` in `anton/core/llm/openai.py` only recognised Anthropic-shaped image blocks `({type: "image", source: {...}})`. If scratchpad code constructed the message in OpenAI shape `({type: "image_url", image_url: {url: "data:..."}})` — which is intuitive given the provider name — the block was silently dropped from the content list, and the model just answered "I don't see any image."