### PR TITLE
chore: normalize CoWork casing to Cowork

### DIFF
--- a/anton/core/runtime.py
+++ b/anton/core/runtime.py
@@ -1,4 +1,4 @@
-"""Shared ChatSession builder for any host (CoWork desktop, dispatch, CLI integrations).
+"""Shared ChatSession builder for any host (Cowork desktop, dispatch, CLI integrations).
 
 Wraps the boilerplate that used to live inline in `anton-cowork/server/routes/anton_bridge.py`
 so the same workspace + memory + vault wiring is reused by every host. Hosts customize
@@ -12,6 +12,7 @@ Public API:
     AntonConfigurationError        — raise when setup is missing/invalid
     AntonRuntimeError              — raise when an Anton call fails after configuration is OK
 """
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Description

Normalize product name casing from "CoWork" to "Cowork" per updated branding guidance.

## Type of change

- [ ] 📄 This change requires a documentation update

## Testing / Verification

Text-only change in a comment/docstring. No behavioral impact.

Steps to verify:
1. Grep for "CoWork" — should return no results in modified files
2. Grep for "Cowork" — should match the updated references

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)