### PR TITLE
Fix msg when invalid api key

### DIFF
--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -107,7 +107,10 @@ class AnthropicProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except anthropic.APIStatusError as exc:
-            if (
+            if exc.status_code == 401:
+                msg = "Invalid API key — check your ANTHROPIC_API_KEY environment variable."
+                raise ConnectionError(msg) from exc
+            elif (
                 exc.status_code == 429
                 and isinstance(exc.body, dict)
                 and exc.body.get("detail")
@@ -249,7 +252,10 @@ class AnthropicProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except anthropic.APIStatusError as exc:
-            if (
+            if exc.status_code == 401:
+                msg = "Invalid API key — check your ANTHROPIC_API_KEY environment variable."
+                raise ConnectionError(msg) from exc
+            elif (
                 exc.status_code == 429
                 and isinstance(exc.body, dict)
                 and exc.body.get("detail")

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -667,7 +667,10 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            if (
+            if exc.status_code == 401:
+                msg = "Invalid API key — check your OpenAI API key configuration."
+                raise ConnectionError(msg) from exc
+            elif (
                 exc.status_code == 429
                 and isinstance(exc.body, dict)
                 and exc.body.get("detail")
@@ -944,7 +947,10 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            if (
+            if exc.status_code == 401:
+                msg = "Invalid API key — check your OpenAI API key configuration."
+                raise ConnectionError(msg) from exc
+            elif (
                 exc.status_code == 429
                 and isinstance(exc.body, dict)
                 and exc.body.get("detail")

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -834,7 +834,10 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            if (
+            if exc.status_code == 401:
+                msg = "Invalid API key — check your OpenAI API key configuration."
+                raise ConnectionError(msg) from exc
+            elif (
                 exc.status_code == 429
                 and isinstance(exc.body, dict)
                 and exc.body.get("detail")
@@ -1076,7 +1079,10 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            if (
+            if exc.status_code == 401:
+                msg = "Invalid API key — check your OpenAI API key configuration."
+                raise ConnectionError(msg) from exc
+            elif (
                 exc.status_code == 429
                 and isinstance(exc.body, dict)
                 and exc.body.get("detail")

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1484,8 +1484,8 @@ class ChatSession:
                                 if isinstance(event, StreamTextDelta):
                                     assistant_text_parts.append(event.text)
                                 yield event
-                        except Exception:
-                            fallback = f"An unexpected error occurred: {_agent_exc}. Please try again or rephrase your request."
+                        except Exception as e:
+                            fallback = f"An unexpected error occurred: {e}. Please try again or rephrase your request."
                             assistant_text_parts.append(fallback)
                             yield StreamTextDelta(text=fallback)
                         break


### PR DESCRIPTION
Replace misleading "LLM endpoint may be temporarily unavailable" error message with specific "Invalid API key" errors when authentication fails (HTTP 401). Fixes #178 

Current flow:
```
you> oi
anton> An unexpected error occurred: Server returned 401 — the LLM endpoint  
may be temporarily unavailable. Try again in a moment.. Please try    
again or rephrase your request.   

```

