### PR TITLE
feat: support restricted (email/org) access on publish

### DIFF
--- a/anton/publisher.py
+++ b/anton/publisher.py
@@ -60,6 +60,54 @@ def hash_access_password(password: str) -> str:
     b64 = lambda b: base64.b64encode(b).decode("ascii")
     return f"pbkdf2_sha256${_PBKDF2_ITERATIONS}${b64(salt)}${b64(dk)}"
 
+
+def _normalize_emails(values) -> list[str]:
+    """Strip + lowercase + de-dupe, preserving first-seen order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in values or []:
+        email = str(raw).strip().lower()
+        if email and email not in seen:
+            seen.add(email)
+            out.append(email)
+    return out
+
+
+def build_access_payload(access: dict | None, *, pwd_version: int = 1, access_version: int = 1) -> dict:
+    """Translate the inbound access spec into the `/upload` ``access`` block.
+
+    Input (from cowork-server, the caller) is one of::
+
+        {"mode": "public"}                                          # or None
+        {"mode": "password", "password": "plaintext"}
+        {"mode": "restricted", "emails": [...], "org_allowed": bool}
+
+    Output (what travels to anton-services):
+
+        {"mode": "public"}
+        {"mode": "password", "password_hash": "pbkdf2_sha256$...", "pwd_version": N}
+        {"mode": "restricted", "allowed_emails": [...], "org_allowed": bool, "access_version": N}
+
+    The plaintext password is hashed here and never forwarded. Emails are
+    normalized and forwarded as-is (auth compares them server-side) and never
+    enter the zip bundle.
+    """
+    mode = (access or {}).get("mode", "public")
+    if mode == "password":
+        return {
+            "mode": "password",
+            "password_hash": hash_access_password(access["password"]),
+            "pwd_version": pwd_version,
+        }
+    if mode == "restricted":
+        return {
+            "mode": "restricted",
+            "allowed_emails": _normalize_emails(access.get("emails")),
+            "org_allowed": bool(access.get("org_allowed")),
+            "access_version": access_version,
+        }
+    return {"mode": "public"}
+
 # Patterns that capture relative paths from HTML attributes and CSS url()
 _REF_PATTERNS = [
     re.compile(r'(?:src|href)\s*=\s*"([^":#?]+)"', re.IGNORECASE),
@@ -213,6 +261,8 @@ def publish(
     ssl_verify: bool = True,
     password: str | None = None,
     pwd_version: int = 1,
+    access: dict | None = None,
+    access_version: int = 1,
     vault: DataVault | None = None,
 ) -> dict:
     """Zip and upload an HTML file/directory or a fullstack artifact directory.
@@ -231,6 +281,14 @@ def publish(
                   responsible for storing the plaintext owner-side.
         pwd_version: Monotonic version bumped whenever the password
                   changes, so previously issued access cookies invalidate.
+        access: Structured access spec, mutually exclusive with `password`:
+                  {"mode": "public"} |
+                  {"mode": "password", "password": "..."} |
+                  {"mode": "restricted", "emails": [...], "org_allowed": bool}.
+                  When omitted, a bare `password=` is mapped to password mode.
+                  See `build_access_payload` for the outbound shape.
+        access_version: Monotonic version bumped whenever the restricted list/
+                  org flag changes, invalidating previously issued grants.
         vault: Credential store to resolve datasource secrets from. Defaults
                   to anton's local vault (`~/.anton/data_vault`); cowork-server
                   passes its own vault so published secrets match where the
@@ -259,17 +317,16 @@ def publish(
     payload_dict["file_payload"] = base64.b64encode(zipped).decode()
     if report_id:
         payload_dict["report_id"] = report_id
-    # Access control: send the hash (never the plaintext). Omitting the
-    # key entirely on a public publish lets the server clear any prior
-    # protection on re-publish.
-    payload_dict["access"] = (
-        {
-            "requires_password": True,
-            "password_hash": hash_access_password(password),
-            "pwd_version": pwd_version,
-        }
-        if password
-        else {"requires_password": False}
+    # Access control: send the hash (never the plaintext) and, for restricted
+    # mode, the normalized email list + org flag (auth is the source of truth;
+    # neither the list nor the password plaintext enters the zip bundle). A
+    # `public` mode clears any prior protection on re-publish.
+    #
+    # Backward-compat: a bare `password=` (no `access=`) maps to password mode.
+    if access is None and password:
+        access = {"mode": "password", "password": password}
+    payload_dict["access"] = build_access_payload(
+        access, pwd_version=pwd_version, access_version=access_version
     )
     payload = json.dumps(payload_dict).encode()
 

--- a/tests/test_publish_access.py
+++ b/tests/test_publish_access.py
@@ -1,0 +1,103 @@
+"""Tests for the publish access spec (ENG-322): build_access_payload + publish()."""
+
+import base64
+import json
+from pathlib import Path
+from unittest import mock
+
+from anton import publisher
+from anton.publisher import build_access_payload, publish
+
+
+# ---------------------------------------------------------------------------
+# build_access_payload
+# ---------------------------------------------------------------------------
+
+
+def test_public_mode():
+    assert build_access_payload(None) == {"mode": "public"}
+    assert build_access_payload({"mode": "public"}) == {"mode": "public"}
+
+
+def test_password_mode_hashes_and_drops_plaintext():
+    out = build_access_payload({"mode": "password", "password": "hunter2"}, pwd_version=2)
+    assert out["mode"] == "password"
+    assert out["pwd_version"] == 2
+    assert out["password_hash"].startswith("pbkdf2_sha256$")
+    assert "password" not in out  # plaintext never leaves
+
+
+def test_restricted_mode_normalizes_and_excludes_secrets():
+    out = build_access_payload(
+        {"mode": "restricted", "emails": [" A@X.com ", "a@x.com", "B@Y.com"], "org_allowed": True},
+        access_version=4,
+    )
+    assert out == {
+        "mode": "restricted",
+        "allowed_emails": ["a@x.com", "b@y.com"],
+        "org_allowed": True,
+        "access_version": 4,
+    }
+
+
+def test_restricted_mode_defaults():
+    out = build_access_payload({"mode": "restricted"}, access_version=1)
+    assert out == {"mode": "restricted", "allowed_emails": [], "org_allowed": False, "access_version": 1}
+
+
+# ---------------------------------------------------------------------------
+# publish() wiring
+# ---------------------------------------------------------------------------
+
+
+def _capture_publish(tmp_path: Path, **publish_kwargs) -> dict:
+    f = tmp_path / "index.html"
+    f.write_text("<html>hi</html>", encoding="utf-8")
+    captured: dict = {}
+
+    def fake_request(url, api_key, *, method="POST", payload=None, verify=True, timeout=30):
+        captured["payload"] = json.loads(payload.decode())
+        return json.dumps(
+            {"user_prefix": "u", "report_id": "r", "md5": "m", "view_url": "url", "version": 1, "files": []}
+        )
+
+    with mock.patch.object(publisher, "minds_request", fake_request):
+        publish(f, api_key="k", **publish_kwargs)
+    return captured["payload"]
+
+
+def test_publish_sends_restricted_access(tmp_path: Path):
+    payload = _capture_publish(
+        tmp_path,
+        access={"mode": "restricted", "emails": ["a@x.com"], "org_allowed": True},
+        access_version=2,
+    )
+    assert payload["access"] == {
+        "mode": "restricted",
+        "allowed_emails": ["a@x.com"],
+        "org_allowed": True,
+        "access_version": 2,
+    }
+
+
+def test_publish_restricted_emails_do_not_enter_bundle(tmp_path: Path):
+    payload = _capture_publish(
+        tmp_path,
+        access={"mode": "restricted", "emails": ["secret@x.com"], "org_allowed": False},
+        access_version=1,
+    )
+    zip_bytes = base64.b64decode(payload["file_payload"])
+    assert b"secret@x.com" not in zip_bytes
+
+
+def test_publish_public_by_default(tmp_path: Path):
+    payload = _capture_publish(tmp_path)
+    assert payload["access"] == {"mode": "public"}
+
+
+def test_publish_back_compat_password(tmp_path: Path):
+    payload = _capture_publish(tmp_path, password="hunter2", pwd_version=3)
+    assert payload["access"]["mode"] == "password"
+    assert payload["access"]["pwd_version"] == 3
+    assert payload["access"]["password_hash"].startswith("pbkdf2_sha256$")
+    assert "password" not in payload["access"]


### PR DESCRIPTION
## Summary

Extends `publish()` to accept a structured `access` spec, adding **restricted** access (allow-list of emails + optional org-wide flag) alongside the existing public/password modes. This unblocks ENG-322 (artifact access by email).

## What changed

- **New `build_access_payload()` helper** in `anton/publisher.py` translates the inbound access spec from cowork-server into the outbound `/upload` `access` block:
  - `{"mode": "public"}` → `{"mode": "public"}`
  - `{"mode": "password", "password": "..."}` → `{"mode": "password", "password_hash": "pbkdf2_sha256$...", "pwd_version": N}`
  - `{"mode": "restricted", "emails": [...], "org_allowed": bool}` → `{"mode": "restricted", "allowed_emails": [...], "org_allowed": bool, "access_version": N}`
- **`publish()` gains `access` and `access_version` params.** Emails are normalized (strip / lowercase / de-dupe, first-seen order preserved) and forwarded to anton-services, which is the source of truth for auth.
- **Security:** the plaintext password is hashed before leaving and never forwarded; the allowed-email list is forwarded out-of-band and **never enters the zip bundle**.
- **Backward compatible:** a bare `password=` with no `access=` is still mapped to password mode. Public mode clears any prior protection on re-publish.
