### PR TITLE
Fix web_search crash on None input_tokens from Responses API (ENG-349)

### DIFF
--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -1133,8 +1133,11 @@ def _parse_response_object(response, model: str) -> LLMResponse:
         # the model's output_text already incorporates their effects.
 
     usage = getattr(response, "usage", None)
-    input_tokens = getattr(usage, "input_tokens", 0) if usage else 0
-    output_tokens = getattr(usage, "output_tokens", 0) if usage else 0
+    # `or 0` guards an explicit None (the attr is present but null) — the
+    # Responses API returns usage.input_tokens=None on web-search responses,
+    # which a bare getattr default does NOT catch. Mirrors the streaming path.
+    input_tokens = (getattr(usage, "input_tokens", 0) or 0) if usage else 0
+    output_tokens = (getattr(usage, "output_tokens", 0) or 0) if usage else 0
 
     return LLMResponse(
         content=content_text,

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -281,8 +281,16 @@ _CONTEXT_WINDOWS: list[tuple[str, int]] = [
 _DEFAULT_CONTEXT_WINDOW = 128_000
 
 
-def compute_context_pressure(model: str, input_tokens: int) -> float:
-    """Return input_tokens / context_window as a 0.0–1.0 float."""
+def compute_context_pressure(model: str, input_tokens: int | None) -> float:
+    """Return input_tokens / context_window as a 0.0–1.0 float.
+
+    ``input_tokens`` may be ``None``: some providers omit a usage count for
+    tool-augmented responses (e.g. the MindsHub passthrough returns
+    ``usage.input_tokens = None`` on web-search responses). Treat a missing
+    count as no measurable pressure rather than crashing on ``None / int``.
+    """
+    if not input_tokens:  # None or 0 → no measurable pressure
+        return 0.0
     window = _DEFAULT_CONTEXT_WINDOW
     for prefix, size in _CONTEXT_WINDOWS:
         if model.startswith(prefix):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from anton.core.llm.anthropic import AnthropicProvider
+from anton.core.llm.openai import _parse_response_object
 from anton.core.llm.provider import LLMResponse, ToolCall, compute_context_pressure
 
 
@@ -22,6 +24,31 @@ class TestComputeContextPressure:
 
     def test_clamps_at_one(self):
         assert compute_context_pressure("claude-3", 10_000_000) == 1.0
+
+    def test_parse_response_object_coerces_none_usage_tokens(self):
+        # End-to-end at the crash site: a web-search Responses object comes
+        # back with usage.input_tokens/output_tokens = None. _parse_response_object
+        # must coerce them to 0 (not pass None into compute_context_pressure)
+        # and must not raise.
+        response = SimpleNamespace(
+            output=[],
+            usage=SimpleNamespace(input_tokens=None, output_tokens=None),
+        )
+        result = _parse_response_object(response, "claude-sonnet-4-6")
+        assert result.usage.input_tokens == 0
+        assert result.usage.output_tokens == 0
+        assert result.usage.context_pressure == 0.0
+
+    def test_parse_response_object_keeps_real_usage_tokens(self):
+        # Sanity: valid counts are preserved unchanged.
+        response = SimpleNamespace(
+            output=[],
+            usage=SimpleNamespace(input_tokens=100_000, output_tokens=250),
+        )
+        result = _parse_response_object(response, "claude-sonnet-4-6")
+        assert result.usage.input_tokens == 100_000
+        assert result.usage.output_tokens == 250
+        assert result.usage.context_pressure == 0.5
 
 
 class TestDataclasses:

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -3,7 +3,25 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from anton.core.llm.anthropic import AnthropicProvider
-from anton.core.llm.provider import LLMResponse, ToolCall
+from anton.core.llm.provider import LLMResponse, ToolCall, compute_context_pressure
+
+
+class TestComputeContextPressure:
+    def test_none_input_tokens_is_zero_not_crash(self):
+        # The MindsHub passthrough returns usage.input_tokens=None on
+        # web-search responses; compute_context_pressure must not raise
+        # `unsupported operand type(s) for /: 'NoneType' and 'int'`.
+        assert compute_context_pressure("claude-sonnet-4-6", None) == 0.0
+
+    def test_zero_input_tokens_is_zero(self):
+        assert compute_context_pressure("claude-sonnet-4-6", 0) == 0.0
+
+    def test_normal_ratio(self):
+        # 100k tokens against a 200k window → 0.5.
+        assert compute_context_pressure("claude-sonnet-4-6", 100_000) == 0.5
+
+    def test_clamps_at_one(self):
+        assert compute_context_pressure("claude-3", 10_000_000) == 1.0
 
 
 class TestDataclasses:


### PR DESCRIPTION
Fixes ENG-349 — https://linear.app/mindsdb/issue/ENG-349

## What

`web_search()` (the scratchpad helper) crashes on **every call** on the hub agents with:

```
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
  File "anton/core/llm/provider.py", line 291, in compute_context_pressure
    return min(input_tokens / window, 1.0)
```

## Why

The scratchpad `web_search()` helper routes through `/v1/responses`. The MindsHub passthrough returns `usage.input_tokens = None` on web-search (tool-augmented) responses. `_parse_response_object` (`openai.py:1136`) read it with `getattr(usage, "input_tokens", 0)` — but a `getattr` default only fires when the attribute is **absent**, not when it's present-but-`None`. So `None` flowed into `compute_context_pressure`, which did `None / window` → `TypeError`.

The **streaming** Responses path already guards this exact case (`openai.py:1064`, `getattr(...) or 0`); the **non-streaming** `_parse_response_object` never got the same treatment. This is a one-line oversight.

Discovered via an Anton self-generated post-mortem (Nate Herk / MindsHub dashboard session) — `web_search` failed on every call, forcing the agent onto slower direct-HTTP fetching.

## Impact

`web_search` is effectively **100% non-functional on the hub agents** today (Responses path). Research tasks silently degrade to "fetch URLs I can already guess" — no discovery.

## Not a billing issue

`compute_context_pressure` is a **client-side** context-fullness gauge (`input_tokens / context_window`) used only to decide when to compact history on the instance. It is **not** part of any billing path — billing is metered server-side in mindshub-inference from the provider's real reported usage (`usage_box.value` ← Anthropic's actual `usage.input_tokens`), independent of what the client receives. So this fix has **no billing implications**.

## Fix (defense in depth)

- `compute_context_pressure` — treat `None`/`0` input tokens as `0.0` pressure instead of crashing. Guarding the shared helper covers **every** call path (streaming, non-streaming, Anthropic, OpenAI).
- `_parse_response_object` — coerce `None → 0` to match the already-guarded streaming path.
- Tests — `TestComputeContextPressure` covers the `None` regression case, zero, a normal ratio, and the clamp-at-1.0 boundary.

## Testing

`tests/test_provider.py` (15 passed locally, incl. the 4 new cases). `test_openai_provider.py` couldn't run in my local venv due to an unrelated missing-dep (`pydantic_settings`) — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)