### PR TITLE
fix/ Reconcile artifact files[] against disk on read (ENG-372)

### DIFF
--- a/anton/core/artifacts/models.py
+++ b/anton/core/artifacts/models.py
@@ -56,9 +56,10 @@ ARTIFACT_TYPES: tuple[str, ...] = (
 class FileEntry(BaseModel):
     """One file inside the artifact folder.
 
-    Re-derived from disk on every save (`ArtifactStore.rescan_files`)
-    rather than mutated in place. The agent never writes here
-    directly — it just creates the files; the server records them.
+    Re-derived from disk on read (`ArtifactStore._reconcile_files`, called
+    by `open()` / `list()`) rather than mutated in place. The agent never
+    populates this directly — it writes the files into the folder via the
+    scratchpad, and the store reconciles `files[]` against disk on access.
     """
 
     path: str  # relative to the artifact folder (e.g. "dashboard.html", "data/prices.csv")

--- a/anton/core/artifacts/store.py
+++ b/anton/core/artifacts/store.py
@@ -38,6 +38,13 @@ logger = logging.getLogger(__name__)
 
 METADATA_FILENAME = "metadata.json"
 README_FILENAME = "README.md"
+PUBLISHED_FILENAME = ".published.json"
+
+# Files the store owns or that hold publish-state — not artifact content the
+# agent authored — so they're excluded from `files[]`. Mirrors cowork-server's
+# artifacts-service housekeeping set so the agent's view and the UI agree on
+# what counts as an artifact file.
+_HOUSEKEEPING_FILES = {METADATA_FILENAME, README_FILENAME, PUBLISHED_FILENAME}
 
 # Same character whitelist projects_store uses — keeps slug shapes
 # consistent across antontron's project names AND artifact slugs.
@@ -224,14 +231,24 @@ class ArtifactStore:
                 continue
             artifact = self._load_silent(child.name)
             if artifact is not None:
-                out.append(artifact)
+                # Reconcile against disk so file counts are accurate even
+                # though scratchpad writes bypass the store (see _reconcile_files).
+                out.append(self._reconcile_files(artifact))
         out.sort(key=lambda a: a.updatedAt, reverse=True)
         return out
 
     def open(self, slug: str) -> Artifact | None:
-        """Load an artifact by slug. None when the folder doesn't
-        exist or the metadata file is missing/corrupt."""
-        return self._load_silent(slug)
+        """Load an artifact by slug, reconciling `files[]` against disk.
+
+        None when the folder doesn't exist or the metadata file is
+        missing/corrupt. Reconciliation (see `_reconcile_files`) is what
+        makes scratchpad-written files show up in `files[]` — the agent
+        writes them directly to the folder, bypassing the store.
+        """
+        artifact = self._load_silent(slug)
+        if artifact is None:
+            return None
+        return self._reconcile_files(artifact)
 
     # ── Provenance + per-turn updates ───────────────────────────
 
@@ -287,18 +304,39 @@ class ArtifactStore:
         return artifact
 
     def rescan_files(self, slug: str) -> Artifact | None:
-        """Refresh `files[]` from disk. Skips `metadata.json` and
-        `README.md` — those are housekeeping, not artifact content."""
+        """Reconcile `files[]` with what's actually on disk, by slug.
+
+        Returns the (possibly refreshed) artifact, or None when the slug
+        is missing. See `_reconcile_files` for the why.
+        """
         artifact = self._load_silent(slug)
         if artifact is None:
             return None
-        folder = self.folder_for(slug)
+        return self._reconcile_files(artifact)
+
+    def _reconcile_files(self, artifact: Artifact) -> Artifact:
+        """Re-derive `files[]` from disk for an already-loaded artifact.
+
+        Scratchpad code writes artifact files straight into the folder via
+        plain ``open()``, bypassing the store — so without this, `files[]`
+        stays frozen at whatever ``create()``/``update()`` last set (usually
+        empty), and ``open()``/``list()`` report file_count 0 for artifacts
+        that are fully written on disk. The agent then concludes the file is
+        missing and burns turns in a recovery loop.
+
+        Persists (and bumps ``updatedAt``) ONLY when the on-disk file set
+        actually changed, so this is safe and cheap to call on every read —
+        no metadata/README churn and no spurious ``updatedAt`` bumps when
+        nothing moved. Skips housekeeping files (`metadata.json` /
+        `README.md` / `.published.json`).
+        """
+        folder = self.folder_for(artifact.slug)
         entries: list[FileEntry] = []
         for p in sorted(folder.rglob("*")):
             if not p.is_file() or p.is_symlink():
                 continue
             rel = str(p.relative_to(folder))
-            if rel in (METADATA_FILENAME, README_FILENAME):
+            if rel in _HOUSEKEEPING_FILES:
                 continue
             try:
                 stat = p.stat()
@@ -308,6 +346,13 @@ class ArtifactStore:
                 stat.st_mtime, timezone.utc
             ).isoformat(timespec="seconds")
             entries.append(FileEntry(path=rel, bytes=stat.st_size, modifiedAt=mtime_iso))
+
+        def _fingerprint(files: list[FileEntry]) -> list[tuple]:
+            return sorted((f.path, f.bytes, f.modifiedAt) for f in files)
+
+        if _fingerprint(entries) == _fingerprint(artifact.files):
+            return artifact  # nothing changed on disk — don't rewrite metadata
+
         artifact.files = entries
         artifact.updatedAt = _utc_now()
         self._save(artifact)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -264,6 +264,49 @@ def test_rescan_excludes_metadata_and_readme(store: ArtifactStore):
     assert paths == {"real-file.md"}
 
 
+# ─── Reconcile-on-read (ENG-372) ────────────────────────────────────────────
+# Scratchpad code writes artifact files straight into the folder via plain
+# open(), bypassing the store. open()/list() must reconcile files[] against
+# disk so the agent never sees file_count 0 for a fully-written artifact.
+
+
+def test_open_reflects_scratchpad_written_files(store: ArtifactStore):
+    artifact = store.create(name="Dash", description="x", type="html-app")
+    assert artifact.files == []  # create starts empty
+    folder = store.folder_for(artifact.slug)
+    (folder / "dashboard.html").write_text("<html>" + "x" * 1000 + "</html>")
+    opened = store.open(artifact.slug)
+    assert [f.path for f in opened.files] == ["dashboard.html"]
+    assert opened.files[0].bytes > 1000
+
+
+def test_list_reflects_scratchpad_written_files(store: ArtifactStore):
+    artifact = store.create(name="Dash", description="x", type="html-app")
+    (store.folder_for(artifact.slug) / "dashboard.html").write_text("<html></html>")
+    match = next(a for a in store.list() if a.slug == artifact.slug)
+    assert {f.path for f in match.files} == {"dashboard.html"}
+
+
+def test_reconcile_excludes_published_json(store: ArtifactStore):
+    """.published.json is publish-state housekeeping, not artifact content."""
+    artifact = store.create(name="Dash", description="x", type="html-app")
+    folder = store.folder_for(artifact.slug)
+    (folder / "dashboard.html").write_text("<html></html>")
+    (folder / ".published.json").write_text("{}")
+    opened = store.open(artifact.slug)
+    assert {f.path for f in opened.files} == {"dashboard.html"}
+
+
+def test_reconcile_on_read_is_idempotent(store: ArtifactStore):
+    """A read with no on-disk change must not re-save or bump updatedAt."""
+    artifact = store.create(name="Dash", description="x", type="html-app")
+    (store.folder_for(artifact.slug) / "dashboard.html").write_text("<html></html>")
+    first = store.open(artifact.slug)   # reconciles + persists
+    second = store.open(artifact.slug)  # no disk change → no re-save
+    assert {f.path for f in second.files} == {"dashboard.html"}
+    assert second.updatedAt == first.updatedAt
+
+
 # ─── README rendering ───────────────────────────────────────────────────────
 
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -307,6 +307,19 @@ def test_reconcile_on_read_is_idempotent(store: ArtifactStore):
     assert second.updatedAt == first.updatedAt
 
 
+def test_reconcile_re_saves_and_persists_when_files_change(store: ArtifactStore):
+    """A changed on-disk file set must reconcile AND persist to metadata.json."""
+    artifact = store.create(name="Dash", description="x", type="html-app")
+    folder = store.folder_for(artifact.slug)
+    (folder / "a.html").write_text("<html></html>")
+    assert {f.path for f in store.open(artifact.slug).files} == {"a.html"}
+    # A second file lands on disk → next read reconciles and persists it.
+    (folder / "b.html").write_text("<html></html>")
+    assert {f.path for f in store.open(artifact.slug).files} == {"a.html", "b.html"}
+    on_disk = json.loads(store.metadata_path(artifact.slug).read_text())
+    assert {f["path"] for f in on_disk["files"]} == {"a.html", "b.html"}
+
+
 # ─── README rendering ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes ENG-372 — https://linear.app/mindsdb/issue/ENG-372

## What

When Anton creates an artifact and then writes its files via scratchpad `open()`, the artifact's `metadata.json` `files[]` was **never updated** — it stayed frozen at the empty state `create_artifact` wrote. So `open_artifact()` / `list_artifacts()` reported `file_count: 0` for artifacts that were fully written on disk. The agent read that as "the file is missing" and burned turns in a search/recovery loop (32 cells in the reported session) even though the file was at the correct path the whole time.

Surfaced by an Anton self-generated post-mortem (artifact `mooresville-home-finder-enhanced`: `dashboard.html` 278 KB on disk, registry `files: []`).

## Root cause

- Scratchpad `open(path, 'w')` writes straight into the artifact folder, **bypassing the store** — there's no write→store notification hook.
- The store already had a reconciliation primitive, `ArtifactStore.rescan_files()`, **but it had zero callers** (dead code — only a docstring reference).
- `store.open()` / `store.list()` read `files[]` straight from the frozen metadata with no disk reconciliation.

(Related dead code, left as a follow-up: `record_turn()` — the provenance hook — also has zero callers, so `provenance[]` is always `[]`. Out of scope here.)

## Fix

Reconcile `files[]` against disk on read, using the primitive that already existed:
- Wire a new `_reconcile_files()` into `open()` and `list()` so both agent tools self-heal (and existing stale artifacts heal on next access).
- **Save-on-change only** — compares the on-disk file set to `files[]` and only rewrites `metadata.json` / bumps `updatedAt` when it actually changed, so calling it on every read is idempotent and cheap (no churn, no spurious `updatedAt` bumps).
- Add `.published.json` to the housekeeping skip set (was `metadata.json` / `README.md` only) to match cowork-server's artifacts service — otherwise publish-state would be miscounted as an artifact file.

## Scope

**Agent-facing only.** cowork-server's artifact service (`_user_files`) already scans the folder from disk directly, so the **user-facing UI/preview was never affected** — this fixes the agent's view (the recovery loops and wrong "file missing" messages).

## Testing

`tests/test_artifacts.py` — 40 passing, incl. 4 new: `open()`/`list()` reflect a scratchpad-written file, `.published.json` is excluded, and reconcile-on-read is idempotent (no re-save when nothing changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)