### PR TITLE
Fix: unexpected keyword argument 'when_to_use'

### DIFF
--- a/anton/core/memory/skills.py
+++ b/anton/core/memory/skills.py
@@ -90,6 +90,7 @@ class Skill:
     declarative_md: str
     created_at: str
     provenance: str  # "manual" | "consolidator"
+    when_to_use: str = ""
     stage_1_present: bool = True
     stage_2_present: bool = False
     stage_3_present: bool = False
@@ -406,9 +407,14 @@ class SkillStore:
             "created_at": skill.created_at,
         }.items() if v}
 
+        description = skill.description
+        if skill.when_to_use:
+            description = f"{description}. {skill.when_to_use}" if description else skill.when_to_use
+        description = description[:DESC_MAX]
+
         fm = AgentSkill.model_construct(
             name=skill.label,
-            description=skill.description,
+            description=description,
             instructions=skill.declarative_md,
             metadata=metadata,
         )


### PR DESCRIPTION
Fix for "Convert skill storage to Agentskills standard #186"

Rollback when_to_use for back compatibility with old cowork version

Using old cowork with a new anton results error:
```
File "/data/work/mindsdb/mindshub/cowork-server/cowork/handlers/responses.py", line 53, in handle
    await self.harness.sync_skills(SkillService(self.session).list_skills())
  File "/data/work/mindsdb/mindshub/cowork-server/cowork/harnesses/anton_harness/harness.py", line 128, in sync_skills
    anton_skill = AntonSkill(
                  ^^^^^^^^^^^
TypeError: Skill.__init__() got an unexpected keyword argument 'when_to_use'
```