### PR TITLE
feat(select_path): inline file/folder picker for ambiguous paths

### DIFF
--- a/anton/core/interaction/__init__.py
+++ b/anton/core/interaction/__init__.py
@@ -1,0 +1,15 @@
+"""Mid-turn human interaction primitives for the agent loop.
+
+Currently this package hosts file/folder disambiguation (the ``select_path``
+tool). The agent depends only on the abstract :class:`SelectionElicitor`
+strategy; each host (CLI, cowork-server harness, …) supplies a concrete
+implementation, so the core never learns how the prompt is surfaced.
+"""
+
+from anton.core.interaction.selection import (
+    SelectionElicitor,
+    SelectionOption,
+    SelectionRequest,
+)
+
+__all__ = ["SelectionElicitor", "SelectionOption", "SelectionRequest"]

--- a/anton/core/interaction/cli.py
+++ b/anton/core/interaction/cli.py
@@ -21,6 +21,15 @@ class CLISelectionElicitor:
     async def elicit(self, request: SelectionRequest) -> str | None:
         from anton.utils.prompt import prompt_or_cancel
 
+        # Browse mode has no visual file tree on a terminal — fall back to a
+        # typed path (the GUI host gets a real navigable browser instead).
+        if request.mode == "browse":
+            self._console.print(f"\n[bold]{request.prompt}[/]")
+            if request.root:
+                self._console.print(f"  [dim]starting at {request.root}[/]")
+            chosen = await prompt_or_cancel("Enter a path (Esc to cancel)")
+            return (chosen or "").strip() or None
+
         options = request.options
         if not options:
             return None

--- a/anton/core/interaction/cli.py
+++ b/anton/core/interaction/cli.py
@@ -1,0 +1,44 @@
+"""Terminal implementation of :class:`SelectionElicitor` for standalone CLI runs.
+
+Renders a numbered picker to the console and reads the user's choice. The agent
+loop already pauses the escape watcher around interactive tools, so this only
+has to print the options and await a number.
+"""
+
+from __future__ import annotations
+
+from anton.core.interaction.selection import SelectionRequest
+
+__all__ = ["CLISelectionElicitor"]
+
+
+class CLISelectionElicitor:
+    """Picker that prompts on the terminal (standalone ``anton`` chat)."""
+
+    def __init__(self, console) -> None:
+        self._console = console
+
+    async def elicit(self, request: SelectionRequest) -> str | None:
+        from anton.utils.prompt import prompt_or_cancel
+
+        options = request.options
+        if not options:
+            return None
+
+        self._console.print(f"\n[bold]{request.prompt}[/]")
+        for index, option in enumerate(options, start=1):
+            icon = "📁" if option.kind == "folder" else "📄"
+            detail = f"  [dim]{option.detail}[/]" if option.detail else ""
+            self._console.print(f"  [bold]{index}[/]. {icon} {option.label}{detail}")
+
+        choice = await prompt_or_cancel(
+            "Select a number (Esc to cancel)",
+            choices=[str(i) for i in range(1, len(options) + 1)],
+        )
+        if choice is None:
+            return None
+        try:
+            selected = int(choice) - 1
+        except ValueError:
+            return None
+        return options[selected].value if 0 <= selected < len(options) else None

--- a/anton/core/interaction/selection.py
+++ b/anton/core/interaction/selection.py
@@ -41,11 +41,22 @@ class SelectionOption:
 
 @dataclass(frozen=True, slots=True)
 class SelectionRequest:
-    """A request for the user to disambiguate between candidate paths."""
+    """A request for the user to choose a file or folder.
+
+    Two modes:
+
+    * ``"pick"`` — disambiguate between the concrete ``options`` (e.g. several
+      files share a name). This is the default.
+    * ``"browse"`` — the target is unknown/unspecified; the host shows a
+      navigable browser rooted at ``root`` and the user locates the path
+      themselves. ``options`` is empty in this mode.
+    """
 
     prompt: str
-    options: tuple[SelectionOption, ...]
+    options: tuple[SelectionOption, ...] = ()
     kind: str = "any"  # "file" | "folder" | "any" — what is being chosen
+    mode: str = "pick"  # "pick" | "browse"
+    root: str = ""  # browse-mode start directory (absolute)
 
 
 @runtime_checkable

--- a/anton/core/interaction/selection.py
+++ b/anton/core/interaction/selection.py
@@ -19,7 +19,7 @@ transport — so the same disambiguation logic serves every host.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 
 __all__ = ["SelectionOption", "SelectionRequest", "SelectionElicitor"]
 
@@ -59,9 +59,13 @@ class SelectionRequest:
     root: str = ""  # browse-mode start directory (absolute)
 
 
-@runtime_checkable
 class SelectionElicitor(Protocol):
-    """Strategy for surfacing a :class:`SelectionRequest` and awaiting a choice."""
+    """Strategy for surfacing a :class:`SelectionRequest` and awaiting a choice.
+
+    A Protocol (not an ABC) on purpose: hosts satisfy it by shape, so the
+    cowork-server streaming picker implements ``elicit`` without importing or
+    inheriting this class. The tool depends only on the shape.
+    """
 
     async def elicit(self, request: SelectionRequest) -> str | None:
         """Present *request*, block until the user responds.

--- a/anton/core/interaction/selection.py
+++ b/anton/core/interaction/selection.py
@@ -1,0 +1,61 @@
+"""File/folder disambiguation: value types and the elicitor strategy.
+
+When the agent cannot tell which file or folder the user means, the
+``select_path`` tool offers the candidates and asks the user to pick one
+*within the current turn* — the choice comes back as the tool result, so the
+agent simply keeps going (no separate "I picked X" user message).
+
+How the prompt is surfaced is a host concern, isolated behind
+:class:`SelectionElicitor`:
+
+* standalone CLI injects a terminal picker;
+* the cowork-server harness injects a streaming picker that emits a GUI event
+  and awaits the reply.
+
+The tool and the agent loop depend only on the protocol — never on a concrete
+transport — so the same disambiguation logic serves every host.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+__all__ = ["SelectionOption", "SelectionRequest", "SelectionElicitor"]
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionOption:
+    """One selectable candidate offered to the user.
+
+    ``value`` is the absolute path handed back to the model on selection;
+    ``label`` is what the user sees (typically the path relative to the
+    project root).
+    """
+
+    value: str
+    label: str
+    kind: str  # "file" | "folder"
+    detail: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionRequest:
+    """A request for the user to disambiguate between candidate paths."""
+
+    prompt: str
+    options: tuple[SelectionOption, ...]
+    kind: str = "any"  # "file" | "folder" | "any" — what is being chosen
+
+
+@runtime_checkable
+class SelectionElicitor(Protocol):
+    """Strategy for surfacing a :class:`SelectionRequest` and awaiting a choice."""
+
+    async def elicit(self, request: SelectionRequest) -> str | None:
+        """Present *request*, block until the user responds.
+
+        Returns the chosen option's ``value``, or ``None`` if the user
+        cancelled / dismissed the picker without choosing.
+        """
+        ...

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -50,9 +50,11 @@ from anton.core.tools.tool_defs import (
     READ_IMAGE_TOOL,
     RECALL_TOOL,
     SCRATCHPAD_TOOL,
+    SELECT_PATH_TOOL,
     UPDATE_ARTIFACT_METADATA_TOOL,
     ToolDef,
 )
+from anton.core.interaction.selection import SelectionElicitor
 from anton.core.utils.scratchpad import (
     prepare_scratchpad_exec,
     format_cell_result,
@@ -195,6 +197,11 @@ class ChatSession:
         self._cancel_event = asyncio.Event()
         self._escape_watcher: EscapeWatcher | None = None
         self._active_datasource: str | None = None
+        # Strategy for mid-turn file/folder disambiguation (the `select_path`
+        # tool). Hosts inject a concrete elicitor — a streaming GUI picker in
+        # cowork-server, a terminal picker on the CLI. None falls back to the
+        # console picker (CLI) or a graceful no-op (headless).
+        self.selection_elicitor: SelectionElicitor | None = None
 
         coding_provider = config.llm_client.coding_provider
         coding_conn = coding_provider.export_connection_info()
@@ -724,6 +731,9 @@ class ChatSession:
 
         self.tool_registry.register_tool(scratchpad_tool)
         self.tool_registry.register_tool(READ_IMAGE_TOOL)
+        # Interactive file/folder disambiguation — always available; degrades
+        # to a plain-text prompt when no elicitor/console is present.
+        self.tool_registry.register_tool(SELECT_PATH_TOOL)
 
         if self._cortex is not None or self._self_awareness is not None:
             self.tool_registry.register_tool(MEMORIZE_TOOL)
@@ -1922,9 +1932,13 @@ class ChatSession:
                                         (cell.stdout or ""),
                                         description=description,
                                     )
-                        elif tc.name == "connect_new_datasource" or (
-                            tc.name == "publish_or_preview"
-                            and tc.input.get("action") == "publish"
+                        elif (
+                            tc.name == "connect_new_datasource"
+                            or tc.name == "select_path"
+                            or (
+                                tc.name == "publish_or_preview"
+                                and tc.input.get("action") == "publish"
+                            )
                         ):
                             # Interactive tool — pause spinner AND escape watcher
                             yield StreamTaskProgress(

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -147,6 +147,7 @@ class ChatSessionConfig:
     # so resuming a conversation days later still reports the real "now".
     # None → fall back to today.
     started_at: datetime | None = None
+    selection_elicitor: SelectionElicitor | None = None
 
 
 class ChatSession:
@@ -201,7 +202,7 @@ class ChatSession:
         # tool). Hosts inject a concrete elicitor — a streaming GUI picker in
         # cowork-server, a terminal picker on the CLI. None falls back to the
         # console picker (CLI) or a graceful no-op (headless).
-        self.selection_elicitor: SelectionElicitor | None = None
+        self.selection_elicitor: SelectionElicitor | None = config.selection_elicitor
 
         coding_provider = config.llm_client.coding_provider
         coding_conn = coding_provider.export_connection_info()
@@ -1947,11 +1948,13 @@ class ChatSession:
                             )
                             if self._escape_watcher:
                                 self._escape_watcher.pause()
-                            result_text = await self.tool_registry.dispatch_tool(
-                                self, tc.name, tc.input
-                            )
-                            if self._escape_watcher:
-                                self._escape_watcher.resume()
+                            try:
+                                result_text = await self.tool_registry.dispatch_tool(
+                                    self, tc.name, tc.input
+                                )
+                            finally:
+                                if self._escape_watcher:
+                                    self._escape_watcher.resume()
                             yield StreamTaskProgress(
                                 phase="analyzing",
                                 message="Analyzing results...",

--- a/anton/core/tools/tool_defs.py
+++ b/anton/core/tools/tool_defs.py
@@ -7,6 +7,7 @@ from anton.core.tools.tool_handlers import (
     handle_read_image,
     handle_recall,
     handle_scratchpad,
+    handle_select_path,
     handle_update_artifact_metadata,
 )
 
@@ -421,4 +422,58 @@ READ_IMAGE_TOOL = ToolDef(
         "required": ["file_path"],
     },
     handler=handle_read_image,
+)
+
+
+SELECT_PATH_TOOL = ToolDef(
+    name="select_path",
+    description=(
+        "Ask the user to pick the exact file or folder they meant, via an inline "
+        "picker. Use this ONLY when a path is genuinely ambiguous and you cannot "
+        "safely resolve it yourself — e.g. several files share the name the user "
+        "mentioned, or the reference is vague. Do NOT use it for a path you already "
+        "know, and do NOT use it to browse: it is a disambiguator, not a file "
+        "explorer.\n\n"
+        "Provide EITHER an explicit `candidates` list (paths you already found), OR "
+        "a glob `pattern` (optionally under `base_dir`) and the tool finds matches "
+        "within the project. If exactly one candidate matches it is returned "
+        "immediately with no prompt; if none match you are told to refine or ask in "
+        "text. On selection the tool returns JSON "
+        '{"status":"resolved","path":"<absolute path>"} — use that path directly and '
+        "continue; never re-ask the user in plain text after a resolved selection."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "One short line telling the user what to choose, "
+                'e.g. \'Which "report.csv" did you mean?\'.',
+            },
+            "candidates": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Explicit candidate paths (absolute, or relative to the "
+                "project root). Preferred when you already know the options.",
+            },
+            "pattern": {
+                "type": "string",
+                "description": "Glob to find candidates within the project "
+                "(e.g. '**/config.json'). Used when `candidates` is omitted.",
+            },
+            "base_dir": {
+                "type": "string",
+                "description": "Directory to resolve `pattern` against, relative to the "
+                "project root. Defaults to the project root.",
+            },
+            "kind": {
+                "type": "string",
+                "enum": ["file", "folder", "any"],
+                "description": "Restrict candidates to files, folders, or allow both. "
+                "Default 'any'.",
+            },
+        },
+        "required": ["prompt"],
+    },
+    handler=handle_select_path,
 )

--- a/anton/core/tools/tool_defs.py
+++ b/anton/core/tools/tool_defs.py
@@ -428,19 +428,29 @@ READ_IMAGE_TOOL = ToolDef(
 SELECT_PATH_TOOL = ToolDef(
     name="select_path",
     description=(
-        "Ask the user to pick the exact file or folder they meant, via an inline "
-        "picker. Use this ONLY when a path is genuinely ambiguous and you cannot "
-        "safely resolve it yourself — e.g. several files share the name the user "
-        "mentioned, or the reference is vague. Do NOT use it for a path you already "
-        "know, and do NOT use it to browse: it is a disambiguator, not a file "
-        "explorer.\n\n"
-        "Provide EITHER an explicit `candidates` list (paths you already found), OR "
-        "a glob `pattern` (optionally under `base_dir`) and the tool finds matches "
-        "within the project. If exactly one candidate matches it is returned "
-        "immediately with no prompt; if none match you are told to refine or ask in "
-        "text. On selection the tool returns JSON "
-        '{"status":"resolved","path":"<absolute path>"} — use that path directly and '
-        "continue; never re-ask the user in plain text after a resolved selection."
+        "Show the user an inline picker to choose a file or folder, and get back "
+        "the absolute path. Two modes, chosen by what you pass:\n\n"
+        "• BROWSE — the location is unknown or the user only referred to it vaguely "
+        "(e.g. 'a folder somewhere', 'my downloads', 'the project I mentioned'). Call "
+        "with just a `prompt` (and `kind`); the user navigates a picker to locate it. "
+        "Use this INSTEAD of asking the user to type or paste a path. Optionally set "
+        "`start_dir` to seed the starting folder.\n"
+        "• PICK — you already found several matches and need the user to disambiguate. "
+        "Pass an explicit `candidates` list, OR a glob `pattern` (optionally under "
+        "`base_dir`) to find matches within the project. Exactly one match resolves "
+        "immediately with no prompt; zero matches tells you to refine.\n\n"
+        'On selection the tool returns {"status":"resolved","path":"<absolute path>"} '
+        "— use that path directly and keep going. Other statuses: 'cancelled' (user "
+        "dismissed), 'no_matches', 'invalid'. Never re-ask in plain text after a "
+        "resolved selection."
+    ),
+    # Injected into the system prompt: bias the model toward the picker over a
+    # type-the-path request, which is the whole point of the tool.
+    prompt=(
+        "When the user refers to a file or folder without giving a path you can "
+        "confidently resolve, call the `select_path` tool to let them pick it — do "
+        "NOT ask them to paste or type a path, and do not guess. Browse mode (no "
+        "candidates/pattern) is the right choice when you don't know where it is."
     ),
     input_schema={
         "type": "object",
@@ -448,29 +458,33 @@ SELECT_PATH_TOOL = ToolDef(
             "prompt": {
                 "type": "string",
                 "description": "One short line telling the user what to choose, "
-                'e.g. \'Which "report.csv" did you mean?\'.',
-            },
-            "candidates": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "Explicit candidate paths (absolute, or relative to the "
-                "project root). Preferred when you already know the options.",
-            },
-            "pattern": {
-                "type": "string",
-                "description": "Glob to find candidates within the project "
-                "(e.g. '**/config.json'). Used when `candidates` is omitted.",
-            },
-            "base_dir": {
-                "type": "string",
-                "description": "Directory to resolve `pattern` against, relative to the "
-                "project root. Defaults to the project root.",
+                "e.g. 'Pick the folder to check' or 'Which \"report.csv\" did you mean?'.",
             },
             "kind": {
                 "type": "string",
                 "enum": ["file", "folder", "any"],
-                "description": "Restrict candidates to files, folders, or allow both. "
-                "Default 'any'.",
+                "description": "What the user should choose. Default 'any'.",
+            },
+            "start_dir": {
+                "type": "string",
+                "description": "BROWSE mode only: directory to open the picker at "
+                "(absolute, or relative to the project root). Defaults to the project root.",
+            },
+            "candidates": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "PICK mode: explicit candidate paths (absolute, or "
+                "relative to the project root) you have already identified.",
+            },
+            "pattern": {
+                "type": "string",
+                "description": "PICK mode: glob to find candidates within the project "
+                "(e.g. '**/config.json'). Used when `candidates` is omitted.",
+            },
+            "base_dir": {
+                "type": "string",
+                "description": "PICK mode: directory to resolve `pattern` against, "
+                "relative to the project root. Defaults to the project root.",
             },
         },
         "required": ["prompt"],

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -692,13 +692,66 @@ def _resolve_selection_elicitor(session: "ChatSession"):
     return CLISelectionElicitor(console)
 
 
-async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
-    """Ask the user to disambiguate a file/folder; return the chosen path as JSON.
+def _browse_start_dir(tc_input: dict, root: "Path") -> "Path":
+    """Resolve the browse-mode starting directory (defaults to the project root)."""
+    from pathlib import Path
 
-    Auto-resolves when exactly one candidate matches and reports "no matches"
-    when none do, so the picker is shown only when the choice is genuinely
-    ambiguous (≥2 candidates). The result is fed back as the tool result, so the
-    agent continues without a separate user message.
+    raw = (tc_input.get("start_dir") or "").strip()
+    if not raw:
+        return root
+    start = Path(raw).expanduser()
+    if not start.is_absolute():
+        start = root / start
+    start = start.resolve()
+    return start if start.is_dir() else root
+
+
+async def _run_elicitor(elicitor, request):
+    """Run the elicitor, returning (chosen, error_json). error_json is None on success."""
+    import json
+
+    try:
+        return await elicitor.elicit(request), None
+    except Exception as exc:
+        _log.warning("select_path elicitor failed: %s", exc, exc_info=True)
+        return None, json.dumps({"status": "error", "message": f"Selection failed: {exc}"})
+
+
+def _finalize_browse_choice(chosen: "str | None", kind: str) -> str:
+    """Validate a browse-mode pick: any existing path of the requested kind."""
+    import json
+    from pathlib import Path
+
+    if chosen is None:
+        return json.dumps({
+            "status": "cancelled",
+            "message": "The user dismissed the picker without choosing. Ask how they would like to proceed.",
+        })
+    path = Path(chosen).expanduser()
+    if not path.exists():
+        return json.dumps({"status": "invalid", "message": "The selected path no longer exists."})
+    if kind == "file" and not path.is_file():
+        return json.dumps({"status": "invalid", "message": "A folder was selected but a file was expected."})
+    if kind == "folder" and not path.is_dir():
+        return json.dumps({"status": "invalid", "message": "A file was selected but a folder was expected."})
+    return json.dumps({"status": "resolved", "path": str(path.resolve())})
+
+
+async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
+    """Have the user choose a file/folder; return the chosen path as JSON.
+
+    Two modes, chosen automatically from the inputs:
+
+    * **browse** — no ``candidates``/``pattern`` given: the location is unknown,
+      so the user navigates a picker to locate it. Use this instead of asking
+      the user to type or paste a path.
+    * **pick** — ``candidates`` or ``pattern`` given: disambiguate concrete
+      matches within the project. Auto-resolves a single match and reports
+      "no matches" for none, so the picker appears only for a genuine (≥2)
+      ambiguity.
+
+    The result is fed back as the tool result, so the agent continues without a
+    separate user message.
     """
     import json
 
@@ -710,18 +763,32 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
         kind = "any"
 
     root = _selection_root(session)
-    candidates = _collect_selection_candidates(session, tc_input, root, kind)
+    elicitor = _resolve_selection_elicitor(session)
+    has_candidates = isinstance(tc_input.get("candidates"), list) and bool(tc_input.get("candidates"))
+    has_pattern = bool((tc_input.get("pattern") or "").strip())
 
+    # ── browse — locate an unspecified path ──────────────────────────────
+    if not has_candidates and not has_pattern:
+        if elicitor is None:
+            return json.dumps({
+                "status": "picker_unavailable",
+                "message": "An interactive picker is unavailable here; ask the user for the path in plain text.",
+            })
+        request = SelectionRequest(
+            prompt=prompt, kind=kind, mode="browse", root=str(_browse_start_dir(tc_input, root))
+        )
+        chosen, error = await _run_elicitor(elicitor, request)
+        return error or _finalize_browse_choice(chosen, kind)
+
+    # ── pick — disambiguate concrete candidates within the project ───────
+    candidates = _collect_selection_candidates(session, tc_input, root, kind)
     if not candidates:
         return json.dumps({
             "status": "no_matches",
-            "message": "No matching file or folder was found. Refine the pattern, or ask the user to clarify the path in plain text.",
+            "message": "No match found. Refine the pattern, omit candidates/pattern to let the user browse, or ask in plain text.",
         })
-
     if len(candidates) == 1:
         return json.dumps({"status": "resolved", "auto_resolved": True, "path": str(candidates[0])})
-
-    elicitor = _resolve_selection_elicitor(session)
     if elicitor is None:
         return json.dumps({
             "status": "picker_unavailable",
@@ -730,12 +797,9 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
         })
 
     options = tuple(_selection_option(p, root) for p in candidates)
-    try:
-        chosen = await elicitor.elicit(SelectionRequest(prompt=prompt, options=options, kind=kind))
-    except Exception as exc:
-        _log.warning("select_path elicitor failed: %s", exc, exc_info=True)
-        return json.dumps({"status": "error", "message": f"Selection failed: {exc}"})
-
+    chosen, error = await _run_elicitor(elicitor, SelectionRequest(prompt=prompt, options=options, kind=kind))
+    if error:
+        return error
     if chosen is None:
         return json.dumps({
             "status": "cancelled",
@@ -743,5 +807,4 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
         })
     if chosen not in {option.value for option in options}:
         return json.dumps({"status": "invalid", "message": "The returned selection was not one of the offered options."})
-
     return json.dumps({"status": "resolved", "path": chosen})

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -717,7 +717,7 @@ async def _run_elicitor(elicitor, request):
         return None, json.dumps({"status": "error", "message": f"Selection failed: {exc}"})
 
 
-def _finalize_browse_choice(chosen: "str | None", kind: str) -> str:
+def _finalize_browse_choice(chosen: "str | None", kind: str, root: "Path") -> str:
     """Validate a browse-mode pick: any existing path of the requested kind."""
     import json
     from pathlib import Path
@@ -728,6 +728,8 @@ def _finalize_browse_choice(chosen: "str | None", kind: str) -> str:
             "message": "The user dismissed the picker without choosing. Ask how they would like to proceed.",
         })
     path = Path(chosen).expanduser()
+    if not path.is_absolute():
+        path = root / path
     if not path.exists():
         return json.dumps({"status": "invalid", "message": "The selected path no longer exists."})
     if kind == "file" and not path.is_file():
@@ -754,6 +756,7 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
     separate user message.
     """
     import json
+    from pathlib import Path
 
     from anton.core.interaction.selection import SelectionRequest
 
@@ -778,7 +781,8 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
             prompt=prompt, kind=kind, mode="browse", root=str(_browse_start_dir(tc_input, root))
         )
         chosen, error = await _run_elicitor(elicitor, request)
-        return error or _finalize_browse_choice(chosen, kind)
+        browse_root = Path(request.root) if request.root else root
+        return error or _finalize_browse_choice(chosen, kind, browse_root)
 
     # ── pick — disambiguate concrete candidates within the project ───────
     candidates = _collect_selection_candidates(session, tc_input, root, kind)

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from anton.core.backends.base import Cell
@@ -593,8 +595,6 @@ _SELECTION_SCAN_LIMIT = 5000
 
 def _selection_root(session: "ChatSession") -> "Path":
     """The directory candidates are confined to: the project root (or cwd)."""
-    from pathlib import Path
-
     workspace = getattr(session, "_workspace", None)
     return (workspace.base if workspace is not None else Path.cwd()).resolve()
 
@@ -608,17 +608,13 @@ def _is_within(root: "Path", candidate: "Path") -> bool:
         return False
 
 
-def _collect_selection_candidates(
-    session: "ChatSession", tc_input: dict, root: "Path", kind: str
-) -> "list[Path]":
+def _collect_selection_candidates(tc_input: dict, root: "Path", kind: str) -> "list[Path]":
     """Resolve candidate paths: confined to *root*, deduped, kind-filtered, capped.
 
     Prefers the model's explicit ``candidates`` list; otherwise globs
     ``pattern`` (under an optional ``base_dir``). The private ``.anton``
     workspace is never exposed.
     """
-    from pathlib import Path
-
     seen: set[Path] = set()
     found: list[Path] = []
 
@@ -694,8 +690,6 @@ def _resolve_selection_elicitor(session: "ChatSession"):
 
 def _browse_start_dir(tc_input: dict, root: "Path") -> "Path":
     """Resolve the browse-mode starting directory (defaults to the project root)."""
-    from pathlib import Path
-
     raw = (tc_input.get("start_dir") or "").strip()
     if not raw:
         return root
@@ -706,37 +700,34 @@ def _browse_start_dir(tc_input: dict, root: "Path") -> "Path":
     return start if start.is_dir() else root
 
 
+def _status(status: str, message: str = "", **extra) -> str:
+    """Serialize a select_path tool result, omitting an empty message."""
+    return json.dumps({"status": status, **({"message": message} if message else {}), **extra})
+
+
 async def _run_elicitor(elicitor, request):
     """Run the elicitor, returning (chosen, error_json). error_json is None on success."""
-    import json
-
     try:
         return await elicitor.elicit(request), None
     except Exception as exc:
         _log.warning("select_path elicitor failed: %s", exc, exc_info=True)
-        return None, json.dumps({"status": "error", "message": f"Selection failed: {exc}"})
+        return None, _status("error", f"Selection failed: {exc}")
 
 
 def _finalize_browse_choice(chosen: "str | None", kind: str, root: "Path") -> str:
     """Validate a browse-mode pick: any existing path of the requested kind."""
-    import json
-    from pathlib import Path
-
     if chosen is None:
-        return json.dumps({
-            "status": "cancelled",
-            "message": "The user dismissed the picker without choosing. Ask how they would like to proceed.",
-        })
+        return _status("cancelled", "The user dismissed the picker without choosing. Ask how they would like to proceed.")
     path = Path(chosen).expanduser()
     if not path.is_absolute():
         path = root / path
     if not path.exists():
-        return json.dumps({"status": "invalid", "message": "The selected path no longer exists."})
+        return _status("invalid", "The selected path no longer exists.")
     if kind == "file" and not path.is_file():
-        return json.dumps({"status": "invalid", "message": "A folder was selected but a file was expected."})
+        return _status("invalid", "A folder was selected but a file was expected.")
     if kind == "folder" and not path.is_dir():
-        return json.dumps({"status": "invalid", "message": "A file was selected but a folder was expected."})
-    return json.dumps({"status": "resolved", "path": str(path.resolve())})
+        return _status("invalid", "A file was selected but a folder was expected.")
+    return _status("resolved", path=str(path.resolve()))
 
 
 async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
@@ -755,9 +746,6 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
     The result is fed back as the tool result, so the agent continues without a
     separate user message.
     """
-    import json
-    from pathlib import Path
-
     from anton.core.interaction.selection import SelectionRequest
 
     prompt = (tc_input.get("prompt") or "Select a file or folder.").strip()
@@ -773,10 +761,10 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
     # ── browse — locate an unspecified path ──────────────────────────────
     if not has_candidates and not has_pattern:
         if elicitor is None:
-            return json.dumps({
-                "status": "picker_unavailable",
-                "message": "An interactive picker is unavailable here; ask the user for the path in plain text.",
-            })
+            return _status(
+                "picker_unavailable",
+                "An interactive picker is unavailable here; ask the user for the path in plain text.",
+            )
         request = SelectionRequest(
             prompt=prompt, kind=kind, mode="browse", root=str(_browse_start_dir(tc_input, root))
         )
@@ -785,30 +773,27 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
         return error or _finalize_browse_choice(chosen, kind, browse_root)
 
     # ── pick — disambiguate concrete candidates within the project ───────
-    candidates = _collect_selection_candidates(session, tc_input, root, kind)
+    candidates = _collect_selection_candidates(tc_input, root, kind)
     if not candidates:
-        return json.dumps({
-            "status": "no_matches",
-            "message": "No match found. Refine the pattern, omit candidates/pattern to let the user browse, or ask in plain text.",
-        })
+        return _status(
+            "no_matches",
+            "No match found. Refine the pattern, omit candidates/pattern to let the user browse, or ask in plain text.",
+        )
     if len(candidates) == 1:
-        return json.dumps({"status": "resolved", "auto_resolved": True, "path": str(candidates[0])})
+        return _status("resolved", auto_resolved=True, path=str(candidates[0]))
     if elicitor is None:
-        return json.dumps({
-            "status": "picker_unavailable",
-            "candidates": [str(p) for p in candidates],
-            "message": "An interactive picker is unavailable here; ask the user which of these paths they meant.",
-        })
+        return _status(
+            "picker_unavailable",
+            "An interactive picker is unavailable here; ask the user which of these paths they meant.",
+            candidates=[str(p) for p in candidates],
+        )
 
     options = tuple(_selection_option(p, root) for p in candidates)
     chosen, error = await _run_elicitor(elicitor, SelectionRequest(prompt=prompt, options=options, kind=kind))
     if error:
         return error
     if chosen is None:
-        return json.dumps({
-            "status": "cancelled",
-            "message": "The user dismissed the picker without choosing. Ask how they would like to proceed.",
-        })
+        return _status("cancelled", "The user dismissed the picker without choosing. Ask how they would like to proceed.")
     if chosen not in {option.value for option in options}:
-        return json.dumps({"status": "invalid", "message": "The returned selection was not one of the offered options."})
-    return json.dumps({"status": "resolved", "path": chosen})
+        return _status("invalid", "The returned selection was not one of the offered options.")
+    return _status("resolved", path=chosen)

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -578,3 +578,170 @@ async def handle_read_image(
         },
         {"type": "text", "text": summary},
     ]
+
+
+# ---------------------------------------------------------------------------
+# select_path — interactive file/folder disambiguation
+# ---------------------------------------------------------------------------
+
+# Hard caps keep the picker fast and the prompt readable: never offer more
+# than _SELECTION_MAX_CANDIDATES options, and stop walking a glob after
+# _SELECTION_SCAN_LIMIT entries so a `**` pattern on a huge tree can't stall.
+_SELECTION_MAX_CANDIDATES = 50
+_SELECTION_SCAN_LIMIT = 5000
+
+
+def _selection_root(session: "ChatSession") -> "Path":
+    """The directory candidates are confined to: the project root (or cwd)."""
+    from pathlib import Path
+
+    workspace = getattr(session, "_workspace", None)
+    return (workspace.base if workspace is not None else Path.cwd()).resolve()
+
+
+def _is_within(root: "Path", candidate: "Path") -> bool:
+    """True when *candidate* is inside *root* — the path-traversal guard."""
+    try:
+        candidate.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _collect_selection_candidates(
+    session: "ChatSession", tc_input: dict, root: "Path", kind: str
+) -> "list[Path]":
+    """Resolve candidate paths: confined to *root*, deduped, kind-filtered, capped.
+
+    Prefers the model's explicit ``candidates`` list; otherwise globs
+    ``pattern`` (under an optional ``base_dir``). The private ``.anton``
+    workspace is never exposed.
+    """
+    from pathlib import Path
+
+    seen: set[Path] = set()
+    found: list[Path] = []
+
+    def consider(path: Path) -> bool:
+        """Add *path* if it qualifies. Returns False once the cap is hit."""
+        if len(found) >= _SELECTION_MAX_CANDIDATES:
+            return False
+        resolved = path.resolve()
+        if resolved in seen or not _is_within(root, resolved) or not resolved.exists():
+            return True
+        if ".anton" in resolved.relative_to(root).parts:
+            return True
+        if (kind == "file" and not resolved.is_file()) or (kind == "folder" and not resolved.is_dir()):
+            return True
+        seen.add(resolved)
+        found.append(resolved)
+        return True
+
+    explicit = tc_input.get("candidates")
+    if isinstance(explicit, list) and explicit:
+        for raw in explicit:
+            if not isinstance(raw, str) or not raw.strip():
+                continue
+            candidate = Path(raw).expanduser()
+            if not candidate.is_absolute():
+                candidate = root / candidate
+            if not consider(candidate):
+                break
+    else:
+        pattern = (tc_input.get("pattern") or "").strip()
+        if pattern:
+            base_dir = (tc_input.get("base_dir") or "").strip()
+            search_root = root
+            if base_dir:
+                rel = Path(base_dir).expanduser()
+                search_root = (rel if rel.is_absolute() else root / rel).resolve()
+            if _is_within(root, search_root):
+                for scanned, match in enumerate(search_root.glob(pattern)):
+                    if scanned >= _SELECTION_SCAN_LIMIT or not consider(match):
+                        break
+
+    found.sort(key=lambda p: str(p).lower())
+    return found
+
+
+def _selection_option(path: "Path", root: "Path"):
+    """Build a display option for *path* (label = path relative to the root)."""
+    from anton.core.interaction.selection import SelectionOption
+
+    try:
+        label = str(path.relative_to(root))
+    except ValueError:
+        label = str(path)
+    return SelectionOption(
+        value=str(path),
+        label=label,
+        kind="folder" if path.is_dir() else "file",
+    )
+
+
+def _resolve_selection_elicitor(session: "ChatSession"):
+    """The host-injected elicitor, falling back to a terminal picker on the CLI."""
+    elicitor = getattr(session, "selection_elicitor", None)
+    if elicitor is not None:
+        return elicitor
+    console = getattr(session, "_console", None)
+    if console is None:
+        return None
+    from anton.core.interaction.cli import CLISelectionElicitor
+
+    return CLISelectionElicitor(console)
+
+
+async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
+    """Ask the user to disambiguate a file/folder; return the chosen path as JSON.
+
+    Auto-resolves when exactly one candidate matches and reports "no matches"
+    when none do, so the picker is shown only when the choice is genuinely
+    ambiguous (≥2 candidates). The result is fed back as the tool result, so the
+    agent continues without a separate user message.
+    """
+    import json
+
+    from anton.core.interaction.selection import SelectionRequest
+
+    prompt = (tc_input.get("prompt") or "Select a file or folder.").strip()
+    kind = (tc_input.get("kind") or "any").strip().lower()
+    if kind not in ("file", "folder", "any"):
+        kind = "any"
+
+    root = _selection_root(session)
+    candidates = _collect_selection_candidates(session, tc_input, root, kind)
+
+    if not candidates:
+        return json.dumps({
+            "status": "no_matches",
+            "message": "No matching file or folder was found. Refine the pattern, or ask the user to clarify the path in plain text.",
+        })
+
+    if len(candidates) == 1:
+        return json.dumps({"status": "resolved", "auto_resolved": True, "path": str(candidates[0])})
+
+    elicitor = _resolve_selection_elicitor(session)
+    if elicitor is None:
+        return json.dumps({
+            "status": "picker_unavailable",
+            "candidates": [str(p) for p in candidates],
+            "message": "An interactive picker is unavailable here; ask the user which of these paths they meant.",
+        })
+
+    options = tuple(_selection_option(p, root) for p in candidates)
+    try:
+        chosen = await elicitor.elicit(SelectionRequest(prompt=prompt, options=options, kind=kind))
+    except Exception as exc:
+        _log.warning("select_path elicitor failed: %s", exc, exc_info=True)
+        return json.dumps({"status": "error", "message": f"Selection failed: {exc}"})
+
+    if chosen is None:
+        return json.dumps({
+            "status": "cancelled",
+            "message": "The user dismissed the picker without choosing. Ask how they would like to proceed.",
+        })
+    if chosen not in {option.value for option in options}:
+        return json.dumps({"status": "invalid", "message": "The returned selection was not one of the offered options."})
+
+    return json.dumps({"status": "resolved", "path": chosen})


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-325/cowork-file-access

When the agent can't tell which file or folder the user meant, it had two bad options: guess and risk acting on the wrong path, or stop and ask in plain text and break its own flow. This adds a third. The agent calls a `select_path` tool, the user picks, and the same turn keeps going. No extra user message, no restart. It only fires when the path is genuinely ambiguous, so normal requests are untouched.

## Before
<img width="2638" height="1554" alt="image" src="https://github.com/user-attachments/assets/b50a5c4d-4dd5-4a1e-8e8c-022e3c840645" />


## After 
<img width="861" height="480" alt="Screenshot 2026-06-22 at 2 16 27 AM" src="https://github.com/user-attachments/assets/f6f1a783-70a1-4568-850f-db1377feb99b" />

https://www.loom.com/share/5495d1aff1a7488db532fbdbd0f55926

What's in here:
- `select_path` tool definition and handler with two modes. Pick mode disambiguates between concrete candidates that already exist in the project. Browse mode is for when there's nothing concrete to offer, so the host opens a picker rooted at a sensible directory.
- A small `SelectionElicitor` protocol (`core/interaction/selection.py`) so the core stays transport agnostic. It only knows "ask for a selection, get a path back" and does not care whether that's a terminal prompt or a GUI.
- A CLI elicitor for the terminal, plus a console fallback and a graceful no-op when running headless.
- Hosts inject their elicitor through `ChatSessionConfig`, and browse picks that come back relative are resolved against the request root.

This is the bottom of a three-repo stack. The picker is useless without a host to drive it, so the other two build on this:
- cowork-server streams the request to the client and feeds the pick back into the paused turn.
- cowork renders the card and opens the native OS picker.

Tested both modes locally through the full cowork stack.

---

Part of the inline path picker stack. Merge bottom up:
1. anton: https://github.com/mindsdb/anton/pull/197 (this PR, the select_path tool and elicitor protocol)
2. cowork-server: https://github.com/mindsdb/cowork-server/pull/77 (streams the request, resolves the pick)
3. cowork: https://github.com/mindsdb/cowork/pull/212 (the native OS picker UI)

Related but independent: mindshub_inference #302 (https://github.com/mindsdb/mindshub_inference/pull/302) is the image side of the same multimodal and file effort. It translates image_url blocks for every provider and transcodes unsupported image types to PNG. It does not depend on this stack and this stack does not depend on it.
