### PR TITLE
fix(settings): host-aware minds→openai base URL derivation (ENG-436)

### DIFF
--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -139,7 +139,18 @@ class AntonSettings(CoreSettings):
         ):
             self.openai_api_key = self.minds_api_key
             if not self.openai_base_url:
-                self.openai_base_url = f"{self.minds_url.rstrip('/')}/api/v1"
+                # Host-aware base URL: api.mindshub.ai serves the
+                # OpenAI-compatible API at /v1, the legacy mdb.ai host at
+                # /api/v1. The previous hardcoded /api/v1 was correct only
+                # for mdb.ai and produced a wrong endpoint for mindshub
+                # (ENG-436). Mirrors cowork-server's minds_chat_base_url.
+                base = self.minds_url.rstrip("/")
+                if base.endswith("/v1"):
+                    self.openai_base_url = base
+                elif "mdb.ai" in base:
+                    self.openai_base_url = f"{base}/api/v1"
+                else:
+                    self.openai_base_url = f"{base}/v1"
 
     _workspace: Path = PrivateAttr(default=None)
 

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -352,7 +352,17 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
             and "ANTON_MINDS_URL" in env
             and self._coding_provider == "openai-compatible"
         ):
-            env["OPENAI_BASE_URL"] = f"{env['ANTON_MINDS_URL'].rstrip('/')}/api/v1"
+            # Host-aware (ENG-436): api.mindshub.ai serves /v1, legacy
+            # mdb.ai serves /api/v1. The previous hardcoded /api/v1 was
+            # wrong for mindshub. Mirrors config/settings.py +
+            # cowork-server minds_chat_base_url.
+            _minds_base = env["ANTON_MINDS_URL"].rstrip("/")
+            if _minds_base.endswith("/v1"):
+                env["OPENAI_BASE_URL"] = _minds_base
+            elif "mdb.ai" in _minds_base:
+                env["OPENAI_BASE_URL"] = f"{_minds_base}/api/v1"
+            else:
+                env["OPENAI_BASE_URL"] = f"{_minds_base}/v1"
         if self._coding_api_key:
             sdk_key = {
                 "anthropic": "ANTHROPIC_API_KEY",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -106,3 +106,56 @@ class TestWorkspaceResolution:
         s = AntonSettings(anthropic_api_key="test", _env_file=None)
         # Before resolve, workspace_path falls back to cwd
         assert s.workspace_path == tmp_path
+
+
+class TestMindsOpenAIBaseUrlDerivation:
+    """model_post_init derives a host-aware openai_base_url from minds_url.
+
+    Regression for the mdb.ai-era hardcoded /api/v1 (ENG-436): api.mindshub.ai
+    must derive /v1, mdb.ai keeps /api/v1, and an already-suffixed URL is
+    preserved. Derivation only fires for an openai-compatible provider when
+    no openai key/url is already set.
+    """
+
+    def _derive(self, minds_url, monkeypatch):
+        for k in _ANTON_MODEL_KEYS + [
+            "ANTON_OPENAI_API_KEY",
+            "ANTON_OPENAI_BASE_URL",
+            "ANTON_MINDS_API_KEY",
+            "ANTON_MINDS_URL",
+        ]:
+            monkeypatch.delenv(k, raising=False)
+        return AntonSettings(
+            minds_api_key="mdb_test",
+            minds_url=minds_url,
+            planning_provider="openai-compatible",
+            coding_provider="openai-compatible",
+            _env_file=None,
+        )
+
+    def test_mindshub_derives_v1(self, monkeypatch):
+        s = self._derive("https://api.mindshub.ai", monkeypatch)
+        assert s.openai_api_key == "mdb_test"
+        assert s.openai_base_url == "https://api.mindshub.ai/v1"
+
+    def test_legacy_mdb_ai_derives_api_v1(self, monkeypatch):
+        s = self._derive("https://mdb.ai", monkeypatch)
+        assert s.openai_base_url == "https://mdb.ai/api/v1"
+
+    def test_already_suffixed_url_preserved(self, monkeypatch):
+        s = self._derive("https://api.mindshub.ai/v1", monkeypatch)
+        assert s.openai_base_url == "https://api.mindshub.ai/v1"
+
+    def test_no_derivation_when_openai_key_present(self, monkeypatch):
+        for k in _ANTON_MODEL_KEYS + ["ANTON_OPENAI_BASE_URL"]:
+            monkeypatch.delenv(k, raising=False)
+        s = AntonSettings(
+            minds_api_key="mdb_test",
+            minds_url="https://api.mindshub.ai",
+            openai_api_key="sk-real-user-key",
+            planning_provider="openai-compatible",
+            _env_file=None,
+        )
+        # Derivation is skipped because openai_api_key is already set.
+        assert s.openai_api_key == "sk-real-user-key"
+        assert s.openai_base_url is None


### PR DESCRIPTION
Part 3 of 3 for **ENG-436** — the latent `mdb.ai`-era bug surfaced during the investigation. Base: `staging`. Independent of Parts 1/2 (can land any time).

## Problem
`AntonSettings.model_post_init` derives `openai_base_url` from `minds_url` with a **hardcoded `/api/v1`**:
```python
self.openai_base_url = f"{self.minds_url.rstrip('/')}/api/v1"
```
That's correct only for the legacy `mdb.ai` host. `api.mindshub.ai` serves the OpenAI-compatible API at **`/v1`**, so for the current product the derivation produces a wrong endpoint (`https://api.mindshub.ai/api/v1`). The rest of the stack already branches on host (cowork-server `minds_chat_base_url`, cowork `src/main/index.ts:166`) — this derivation was just missed in the rebrand.

## Fix
Make it host-aware (mirrors `minds_chat_base_url`):
- `api.mindshub.ai` → `/v1`
- `mdb.ai` → `/api/v1`
- already-suffixed URL → preserved

## Scope / safety
This only affects the `openai-compatible`-provider derivation path, and only when no `openai_base_url` is already set. It does **not** change behavior for `mdb.ai` users, and is masked today on the desktop app (which writes an explicit base URL) — but it's a real latent bug for any `openai-compatible` + mindshub config. Not required for the ENG-436 key-overwrite fix (that's Parts 1/2), but fixes the same root-era issue.

## Tests
`tests/test_settings.py::TestMindsOpenAIBaseUrlDerivation` — mindshub→`/v1`, mdb.ai→`/api/v1`, already-suffixed preserved, no derivation when an openai key is already set. Verified against real pydantic loading the edited source.

## Related PRs (ENG-436)
- cowork-server #90 — scratchpad resolves minds-cloud natively
- cowork #225 — stop overwriting the OpenAI slot on login

Refs ENG-436.