### PR TITLE
read_image: resolve relative paths against the workspace, not cwd

### DIFF
--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -517,7 +517,15 @@ async def handle_read_image(
     try:
         path = Path(file_path).expanduser()
         if not path.is_absolute():
-            path = (Path.cwd() / path).resolve()
+            # Resolve relative paths against the project workspace (where
+            # artifacts/decks live), not the process cwd. Under the desktop
+            # app the agent's cwd is NOT the project, so a project-relative
+            # image path would otherwise land in the wrong directory and
+            # come back "file not found". Mirrors publish_or_preview. Falls
+            # back to cwd for the CLI, where cwd already is the project.
+            base = getattr(getattr(session, "_workspace", None), "base", None)
+            root = Path(base) if base else Path.cwd()
+            path = (root / path).resolve()
     except OSError as exc:
         return f"Error: invalid path '{file_path}': {exc}"
 


### PR DESCRIPTION
## Bug
`read_image` resolved **relative** paths against `Path.cwd()`. Under the desktop app the agent's `cwd` is **not** the project, so a project-relative image path (a rendered deck/chart/screenshot in the artifacts folder) resolved to the wrong directory → **"file not found"** — which forced the agent to copy a downsized contact sheet into a cwd-reachable dir just to see anything. (Absolute paths already worked.)

## Fix
Resolve relative paths against the **session workspace base** (where artifacts live), mirroring `publish_or_preview`; fall back to `cwd` for the CLI (where `cwd` already is the project). Absolute paths unchanged.

```python
if not path.is_absolute():
    base = getattr(getattr(session, "_workspace", None), "base", None)
    path = ((Path(base) if base else Path.cwd()) / path).resolve()
```

## Together with the gateway fix
This is orthogonal to the image-block format issue fixed in `mindshub_inference#302` (which translates OpenAI `image_url` → Anthropic `image` so a Claude-backed model can *receive* the picture). #302 lets the model *see* an image once it's loaded; this lets `read_image` *find* it by a project-relative path. With both, Anton can read project/artifact images by absolute **or** relative path — no contact-sheet workaround.

anton (`core_agent`) only. Syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)