### PR TITLE
Add published artifact collaboration

### DIFF
--- a/anton/publisher.py
+++ b/anton/publisher.py
@@ -294,7 +294,7 @@ def publish(
                   passes its own vault so published secrets match where the
                   connection credentials were actually saved.
 
-    Response keys (HTML path): user_prefix, report_id, md5, view_url, version, files
+    Response keys (HTML path): user_prefix, report_id, md5, view_url, edit_url, version, files
     """
     if not file_path.exists():
         raise FileNotFoundError(f"Path not found: {file_path}")


### PR DESCRIPTION
## Summary

Adds the published artifact collaboration/commenting flow for MindsHub Cowork.

## What changed

- Adds collaboration URLs alongside published artifact URLs.
- Adds service/auth support for authenticated collaboration access context.
- Adds service-side collaboration shell/API/storage plumbing for comments, replies, resolve/reopen, and soft delete.
- Adds Cowork UI affordances for opening/copying collaboration links.

## Validation

- cowork: `npm run build:web`
- cowork-server: `python3 -m py_compile ...` and `pytest tests/test_publish_markdown.py tests/test_stable_publish_url.py` (`29 passed`)
- auth: focused artifact access serializer/view tests (`33 passed`)
- service repos: collaboration/html upload modules compile; local pytest unavailable in those repos (`python3.14: No module named pytest`)
