### PR TITLE
fix(scrub): redact provider API keys from tool output before it reaches the LLM (ENG-463)

### DIFF
--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -20,6 +20,31 @@ _DS_SECRET_VARS: set[str] = set()
 # DS_* var names for **ALL** fields of registered engines.
 _DS_KNOWN_VARS: set[str] = set()
 
+# Provider credential env vars injected into the scratchpad execution env for
+# the code to USE. Their values must never reach the LLM (ENG-463): a model can
+# only emit a secret it can see, and the agent was caught writing a raw `mdb_`
+# key into generated code. Scrubbed by exact value (labeled) from anything that
+# re-enters model context.
+_PROVIDER_SECRET_VARS: tuple[str, ...] = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "ANTON_OPENAI_API_KEY",
+    "ANTON_ANTHROPIC_API_KEY",
+    "ANTON_GEMINI_API_KEY",
+    "ANTON_MINDS_API_KEY",
+)
+
+# Well-known provider key formats — scrubbed by shape so a key is redacted even
+# when it didn't come from one of our env vars (e.g. the model already emitted
+# it, or it arrived via an unexpected path). Length floors keep this from
+# matching short incidental `sk-`/`mdb_` strings.
+_SECRET_KEY_PATTERN = re.compile(
+    r"mdb_[A-Za-z0-9._-]{10,}"   # MindsHub
+    r"|sk-[A-Za-z0-9_-]{20,}"    # OpenAI / Anthropic (sk-, sk-proj-, sk-ant-)
+    r"|AIza[A-Za-z0-9_-]{30,}"   # Google / Gemini
+)
+
 
 def _reset_registered_ds_vars() -> None:
     """Clear the DS_* var registries so they can be rebuilt from current vault state."""
@@ -80,14 +105,19 @@ def register_secret_vars(
 
 
 def scrub_credentials(text: str) -> str:
-    """Remove secret DS_* values from scratchpad output before it reaches the LLM.
+    """Remove secret values from scratchpad/tool output before it reaches the LLM.
 
-    Only redacts vars registered as secret via _register_secret_vars (driven by
-    DatasourceField.secret=true in datasources.md).  Non-secret fields of known
-    engines (DS_HOST, DS_PORT, DS_BASE_URL, …) are left readable so the LLM can
-    reason about connection errors.  For truly unknown DS_* vars (custom engines
-    not yet in the registry) the fallback scrubs any long value — conservative
-    but safe.
+    Redacts, in order:
+      * DS_* values registered as secret via register_secret_vars (driven by
+        DatasourceField.secret=true). Non-secret fields of known engines
+        (DS_HOST, DS_PORT, DS_BASE_URL, …) stay readable so the LLM can reason
+        about connection errors.
+      * Unknown DS_* vars (custom engines not yet in the registry) — any long
+        value, conservatively.
+      * Provider credentials (ENG-463): the values of _PROVIDER_SECRET_VARS,
+        then anything matching a well-known key shape (_SECRET_KEY_PATTERN), so
+        a raw `mdb_`/`sk-`/`AIza` key can't reach model context via a tool
+        result, traceback, or settings echo.
     """
     for key in _DS_SECRET_VARS:
         value = os.environ.get(key, "")
@@ -104,6 +134,14 @@ def scrub_credentials(text: str) -> str:
         if not value or len(value) <= 8:
             continue
         text = text.replace(value, f"[{key}]")
+    # Provider keys: exact-value first (informative label), then by shape to
+    # catch any that didn't originate from one of our env vars.
+    for key in _PROVIDER_SECRET_VARS:
+        value = os.environ.get(key, "")
+        if not value or len(value) <= 8:
+            continue
+        text = re.sub(r'(?<!\w)' + re.escape(value) + r'(?!\w)', f'[{key}]', text)
+    text = _SECRET_KEY_PATTERN.sub("[REDACTED_API_KEY]", text)
     return text
 
 

--- a/tests/test_scrubbing.py
+++ b/tests/test_scrubbing.py
@@ -66,3 +66,42 @@ class TestScrubCredentials:
         monkeypatch.setenv("DS_ENABLE_FEATURE", "on")
         result = scrub_credentials("flag=on active")
         assert "on" in result
+
+
+class TestScrubProviderKeys:
+    """Provider API keys must never reach model context (ENG-463)."""
+
+    MINDS_KEY = "mdb_dI2OzIgO.5t7QUxqGPdgrdg2wNwvFFDTUHPyYUZRH"
+
+    def test_provider_key_value_scrubbed_with_label(self, monkeypatch):
+        """A live provider key present in env is redacted with its var label."""
+        monkeypatch.setenv("ANTON_MINDS_API_KEY", self.MINDS_KEY)
+        result = scrub_credentials(f'api_key = "{self.MINDS_KEY}"')
+        assert self.MINDS_KEY not in result
+        assert "[ANTON_MINDS_API_KEY]" in result
+
+    def test_openai_key_value_scrubbed(self, monkeypatch):
+        key = "sk-proj-abcDEF1234567890abcDEF1234567890"
+        monkeypatch.setenv("OPENAI_API_KEY", key)
+        result = scrub_credentials(f"OPENAI_API_KEY={key}")
+        assert key not in result
+        assert "[OPENAI_API_KEY]" in result
+
+    def test_mdb_key_scrubbed_by_pattern_without_env(self):
+        """A key the model already emitted (not in any env var) is caught by shape."""
+        result = scrub_credentials("here it is: mdb_AAAAAAAAAA.BBBBBBBBBBBBCCCC")
+        assert "mdb_AAAAAAAAAA" not in result
+        assert "[REDACTED_API_KEY]" in result
+
+    def test_sk_and_gemini_keys_scrubbed_by_pattern(self):
+        text = "k1=sk-ant-api03-abcdefghij1234567890XYZ k2=AIzaSyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q"
+        result = scrub_credentials(text)
+        assert "sk-ant-api03" not in result
+        assert "AIzaSy" not in result
+
+    def test_short_sk_and_base_url_left_readable(self, monkeypatch):
+        """Short `sk-` strings and non-secret base URLs are not over-redacted."""
+        monkeypatch.setenv("ANTON_OPENAI_BASE_URL", "https://api.openai.com/v1")
+        result = scrub_credentials("sk-abc connecting to https://api.openai.com/v1")
+        assert "sk-abc" in result
+        assert "https://api.openai.com/v1" in result


### PR DESCRIPTION
## Summary

Fixes [ENG-463](https://linear.app/mindsdb/issue/ENG-463) — a raw provider API key reached the LLM's context (the agent was caught writing a live `mdb_` key into generated scratchpad code). *A model can only emit a secret it can see.*

**Root cause:** `scrub_credentials()` (anton) is already applied to every tool result before it's appended to history (`session.py:1472` for strings, `:1464` for multimodal text blocks) — but it only redacted `DS_*` datasource secrets. Provider keys (`mdb_`/`sk-`/`AIza`) never start with `DS_`, so a key surfaced via a tool result, a scratchpad traceback (env values appear in frame locals), or a settings echo passed straight through into model context — and was re-sent to the provider as prompt text on every subsequent turn.

## Change (anton, `anton/utils/datasources.py`)
Extend `scrub_credentials` to also redact, after the existing `DS_*` logic:
1. **By value** — the values of `_PROVIDER_SECRET_VARS` (`OPENAI/ANTHROPIC/GEMINI/ANTON_*_API_KEY`, `ANTON_MINDS_API_KEY`) present in `os.environ`, with an informative `[VAR]` label (mirrors the `DS_*` secret handling). Precise, no false positives.
2. **By shape** — `_SECRET_KEY_PATTERN` (`mdb_…`, `sk-…`/`sk-proj-`/`sk-ant-`, `AIza…`, with length floors) → `[REDACTED_API_KEY]`, so a key that didn't originate from one of our env vars (e.g. one the model already emitted) is still caught.

No change to `scratchpad_boot.py` needed: the scratchpad result/traceback is returned as the tool-result string, which already flows through `scrub_credentials`. Base URLs and short `sk-`/`mdb_` fragments are deliberately left readable to avoid over-redaction.

## Testing
`uv run pytest tests/test_scrubbing.py` → **10 passed** (5 new: value-redaction with label for minds/openai keys; pattern-redaction of `mdb_`/`sk-ant-`/`AIza` keys with no env var set; base-URL + short-`sk-` left intact). Existing `DS_*` scrub tests in `test_datasource.py` still green (23 passed).

## Scope / follow-up (NOT in this PR)
This closes the **model-visible** path (the core of ENG-463 — what the model sees and re-emits). The issue also notes the key lands in the **SSE `/responses` stream, `cowork.db`, and the HTTP cache**. Those persistence paths are emitted in `cowork-server` (`harnesses/anton_harness/stream_formatter.py` `StreamToolResult`) independently of anton's history scrub, and overlap ENG-462 (cache mitigation already shipped). A defense-in-depth follow-up could redact at that stream layer too (pattern-based, since cowork-server's process may not hold the provider env values). Flagging rather than bundling — happy to do it next if you want full coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
