### PR TITLE
feat(datasources): surface non-secret connection identity in the agent prompt (ENG-508)

### DIFF
--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -148,7 +148,11 @@ def build_datasource_context(vault: DataVault, active_only: str | None = None) -
             fields = vault.load(c["engine"], c["name"]) or {}
             secure_keys = None
         prefix = _slug_env_prefix(c["engine"], c["name"])
-        var_names = ", ".join(f"{prefix}__{k.upper()}" for k in fields)
+        # Skip `_`-prefixed bookkeeping (`_connector_id`, `_method`, `_label`) —
+        # they're not credential env vars the agent should reference.
+        var_names = ", ".join(
+            f"{prefix}__{k.upper()}" for k in fields if not k.startswith("_")
+        )
         # Prefer a user/agent-assigned label ("Support"); otherwise the derived
         # non-secret identity (email / host).
         identity = str(fields.get("_label", "")).strip() or _connection_identity(

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -138,11 +138,54 @@ def build_datasource_context(vault: DataVault, active_only: str | None = None) -
         slug = f"{c['engine']}-{c['name']}"
         if active_only and slug != active_only:
             continue
-        fields = vault.load(c["engine"], c["name"]) or {}
+        # read_record gives fields + secure_keys in one call; fall back to load
+        # for any vault backend that doesn't implement it.
+        if hasattr(vault, "read_record"):
+            record = vault.read_record(c["engine"], c["name"]) or {}
+            fields = record.get("fields", {}) or {}
+            secure_keys = record.get("secure_keys")
+        else:
+            fields = vault.load(c["engine"], c["name"]) or {}
+            secure_keys = None
         prefix = _slug_env_prefix(c["engine"], c["name"])
         var_names = ", ".join(f"{prefix}__{k.upper()}" for k in fields)
-        lines.append(f"- `{slug}` ({c['engine']}) → {var_names}")
+        # Prefer a user/agent-assigned label ("Support"); otherwise the derived
+        # non-secret identity (email / host).
+        identity = str(fields.get("_label", "")).strip() or _connection_identity(
+            fields, secure_keys
+        )
+        head = f"`{slug}` ({c['engine']})"
+        if identity:
+            head += f" — {identity}"
+        lines.append(f"- {head} → {var_names}")
     return "\n".join(lines)
+
+
+def _connection_identity(fields: dict, secure_keys: list | None = None) -> str | None:
+    """A short, non-secret label so the LLM can tell connections apart — the
+    account email, or the database host (+ name).
+
+    Scoped to these inherently non-secret fields on purpose: it is NOT a dump of
+    every field (which would surface opaque ``client_id`` / config like
+    ``ssl_mode``) and never a secret. Lets the agent pick the right account
+    ("send from my support email") even when the connection slug is an old random
+    one. Any field a record explicitly marks secret via ``secure_keys`` is
+    skipped, defensively, even though email/host are not normally secret.
+    """
+    secure = set(secure_keys or [])
+    # `email` is collected by credential forms; `account_email` is stored by the
+    # OAuth flows (from userinfo). Either identifies the account.
+    for key in ("email", "account_email"):
+        val = str(fields.get(key, "")).strip()
+        if val and key not in secure:
+            return val
+    host = str(fields.get("host", "")).strip()
+    if host and "host" not in secure:
+        database = str(fields.get("database", "")).strip()
+        if database and "database" not in secure:
+            return f"{host}/{database}"
+        return host
+    return None
 
 
 def restore_namespaced_env(vault: DataVault) -> None:

--- a/tests/test_datasource_context_identity.py
+++ b/tests/test_datasource_context_identity.py
@@ -1,0 +1,70 @@
+"""build_datasource_context surfaces a non-secret identity per connection.
+
+ENG-508: the LLM must be able to tell connections apart (which Gmail, which DB)
+without exposing secrets — so the system-prompt section shows the account email
+or the DB host/name, never the credential, and never a dump of opaque/config
+fields.
+"""
+from anton.core.datasources.data_vault import LocalDataVault
+from anton.utils.datasources import _connection_identity, build_datasource_context
+
+
+class TestConnectionIdentity:
+    def test_email_wins(self):
+        assert _connection_identity({"email": "support@acme.com"}) == "support@acme.com"
+
+    def test_host_and_database(self):
+        assert _connection_identity({"host": "db.acme.com", "database": "sales"}) == "db.acme.com/sales"
+
+    def test_host_only(self):
+        assert _connection_identity({"host": "db.acme.com"}) == "db.acme.com"
+
+    def test_no_identity_field(self):
+        assert _connection_identity({"client_id": "opaque", "ssl_mode": "require"}) is None
+        assert _connection_identity({}) is None
+
+    def test_respects_secure_keys(self):
+        # Defensive: a field a record marks secret is never surfaced as identity.
+        assert _connection_identity({"email": "u@x.com"}, ["email"]) is None
+        assert _connection_identity({"email": "u@x.com"}, []) == "u@x.com"
+        assert _connection_identity({"host": "h", "database": "d"}, ["database"]) == "h"
+        assert _connection_identity({"host": "h"}, ["host"]) is None
+
+    def test_oauth_account_email(self):
+        # OAuth flows store the address under `account_email`.
+        assert _connection_identity({"account_email": "u@acme.com"}) == "u@acme.com"
+        assert _connection_identity({"account_email": "u@acme.com"}, ["account_email"]) is None
+
+
+class TestBuildContext:
+    def test_shows_identity_not_secrets_or_opaque(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("gmail", "support", {"email": "support@acme.com", "app_password": "SECRETVAL123"})
+        v.save("postgres", "prod", {"host": "db.acme.com", "database": "sales", "password": "PGSECRET"})
+        v.save("asana", "team", {"client_id": "opaque-guid", "access_token": "TOKSECRET"})
+
+        ctx = build_datasource_context(v)
+
+        # Identity is shown so the agent can pick the right account.
+        assert "support@acme.com" in ctx
+        assert "db.acme.com/sales" in ctx
+        # Secrets are never in the prompt (only their DS_* var name).
+        assert "SECRETVAL123" not in ctx
+        assert "PGSECRET" not in ctx
+        assert "TOKSECRET" not in ctx
+        assert "DS_GMAIL_SUPPORT__APP_PASSWORD" in ctx
+        # Opaque/config field values are not surfaced as identity.
+        assert "opaque-guid" not in ctx
+
+    def test_empty_vault_returns_empty(self, tmp_path):
+        assert build_datasource_context(LocalDataVault(tmp_path)) == ""
+
+    def test_label_preferred_over_email(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save(
+            "gmail", "support",
+            {"email": "regtr@mail.com", "app_password": "x", "_label": "Support"},
+        )
+        ctx = build_datasource_context(v)
+        assert "Support" in ctx       # the human label is shown
+        assert "regtr@mail.com" not in ctx  # label preferred over the opaque email

--- a/tests/test_datasource_context_identity.py
+++ b/tests/test_datasource_context_identity.py
@@ -59,6 +59,20 @@ class TestBuildContext:
     def test_empty_vault_returns_empty(self, tmp_path):
         assert build_datasource_context(LocalDataVault(tmp_path)) == ""
 
+    def test_meta_fields_not_listed_as_env_vars(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save(
+            "gmail", "support",
+            {"email": "u@x.com", "app_password": "p", "_connector_id": "gmail",
+             "_method": "app-password", "_label": "Support"},
+        )
+        ctx = build_datasource_context(v)
+        # `_`-prefixed bookkeeping must not appear as DS_* env vars.
+        assert "__CONNECTOR_ID" not in ctx
+        assert "__METHOD" not in ctx
+        assert "__LABEL" not in ctx
+        assert "DS_GMAIL_SUPPORT__EMAIL" in ctx  # real fields still listed
+
     def test_label_preferred_over_email(self, tmp_path):
         v = LocalDataVault(tmp_path)
         v.save(


### PR DESCRIPTION
## What

`build_datasource_context` (the "## Connected Data Sources" system-prompt section) listed only `DS_*` **var names**, so the agent could see *that* a Gmail was connected but not **which account** — and with several connected it couldn't pick the right one ("send from my support email"). Asked the address directly, it can't read it back either: the scrubber redacts any `DS_*` value > 8 chars for unregistered connectors.

This adds a short **non-secret identity** to each line — the account `email`, or the DB `host` (+ `database`):

```
## Connected Data Sources
- `gmail-support` (gmail) — support@acme.com → DS_GMAIL_SUPPORT__EMAIL, DS_GMAIL_SUPPORT__APP_PASSWORD
- `postgres-prod` (postgres) — db.acme.com/sales → DS_POSTGRES_PROD__HOST, DS_POSTGRES_PROD__PASSWORD, ...
```

The identity comes from the **prompt** (read from the vault), which isn't scrubbed — so the agent can finally tell connections apart and select among them.

## Scope / safety

- **Scoped, not a dump.** Only `email` / `host` / `database` are shown — inherently non-secret, account-identifying fields. It deliberately does **not** print every non-secret field (which would surface opaque `client_id` or config like `ssl_mode`), and never a secret.
- **Helps existing connections too.** Because it reads the stored `fields`, it labels connections saved under an old random slug (`gmail-548bdb`), not just newly-named ones.
- The scrubber is unchanged; this routes identity via the prompt rather than via scratchpad output.

## Tests

`tests/test_datasource_context_identity.py` — identity selection (email/host/host+db), and that secrets and opaque field *values* never reach the prompt. `uv run --with pytest python -m pytest tests/test_data_vault.py tests/test_datasource.py tests/test_datasource_context_identity.py` → **221 passed**.

## Coordination

Pairs with the cowork-server side ([cowork-server#144](https://github.com/mindsdb/cowork-server/pull/144), ENG-508): readable identity-derived slugs + non-destructive save + secure_keys. This anton change reaches a deployed cowork-server via the usual PyPI/`main` path (release + `anton-agent` pin), so it lands after merge → release. Part of ENG-508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
