### PR TITLE
ENG-513: validate stale training-data assumptions before blocking tasks

### DIFF
--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -223,6 +223,13 @@ Phrase it like "Assuming you mean X (the common case), so I'll…" or "Going wit
 granularity since you didn't specify." Surface each assumption as it happens so the user \
 can redirect mid-flight instead of being blocked up front. Acting silently is wrong; \
 acting out loud with your assumptions visible is right.
+- NEVER let a training-data fact BLOCK a task without first verifying it is still current. \
+Facts like company public/private status, leadership, product availability, regulatory \
+status, or market listings can change after your training cutoff. If something you learned \
+during training would prevent you from completing a request (e.g., "that company isn't \
+publicly traded so I can't fetch stock data"), treat the user's question itself as evidence \
+the fact may have changed — validate it online FIRST, then proceed. State what you're \
+checking and why: "My training says X, but that could be outdated — let me verify."
 - Only STOP and ASK when acting on a guess would be costly to undo or is genuinely \
 unknowable: destructive or irreversible actions (deleting data, spending money, sending \
 messages on the user's behalf), credentials or access you can't obtain, or a fork where \


### PR DESCRIPTION
## Summary

- Adds a new conversation-discipline rule to Anton's system prompt: before using a training-data fact as a reason to refuse or block a task, verify it online first
- Treats the user's question itself as evidence the fact may have changed (e.g., asking about SpaceX stock → SpaceX may now be public)
- Anton states what it's checking and why: *"My training says X, but that could be outdated — let me verify."*

## Motivation

Anton was asserting stale facts from training (e.g. "SpaceX is not a publicly traded company") as blocking conditions, preventing queries that would otherwise succeed. The fix is a prompt-level rule rather than code since this is a reasoning/judgment issue.

## Test plan

- [ ] Ask Anton: *"Give me the performance of SpaceX stocks over the past 3 months"* — it should verify public status online instead of refusing
- [ ] Ask about a company whose status is definitively unchanged — Anton should still proceed normally (validate is fast, not harmful)
- [ ] Ask about a genuinely private company — Anton validates, confirms it's still private, then explains cleanly

Fixes ENG-513

🤖 Generated with [Claude Code](https://claude.com/claude-code)