### PR TITLE
fix(llm): defer tool_result images to after all role:tool responses (ENG-568)

### DIFF
--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -135,6 +135,14 @@ def _translate_user_blocks(blocks: list[dict], supports_vision: bool = True, vis
     """
     result: list[dict] = []
     content_parts: list[dict] = []  # Accumulates text + image blocks
+    # Images extracted from tool_results are deferred here and flushed as a
+    # single role:user message AFTER all role:tool messages.  Emitting them
+    # inline (immediately after each role:tool) breaks the multi-tool case:
+    # when an assistant turn contains N tool_use blocks and a non-final one
+    # returns images, the inline role:user message lands between role:tool
+    # responses, leaving the remaining tool_use ids without a corresponding
+    # tool_result immediately after → Anthropic 400.
+    deferred_img_parts: list[dict] = []
 
     for block in blocks:
         if block.get("type") == "tool_result":
@@ -145,7 +153,8 @@ def _translate_user_blocks(blocks: list[dict], supports_vision: bool = True, vis
             # tool_result -> role:tool message. The Chat Completions API only
             # accepts a string in `tool` messages, so when the tool returned
             # multimodal blocks (image + text), we split them: text → tool
-            # message, image → a follow-up role:user message right after.
+            # message, images → a deferred role:user message emitted after
+            # ALL role:tool messages to keep tool responses contiguous.
             raw = block.get("content", "")
             extra_images: list[dict] = []
             if isinstance(raw, list):
@@ -173,21 +182,19 @@ def _translate_user_blocks(blocks: list[dict], supports_vision: bool = True, vis
             )
 
             if extra_images:
-                img_parts: list[dict] = [
-                    {
-                        "type": "text",
-                        "text": "Image(s) returned by previous tool call:",
-                    }
-                ]
+                if not deferred_img_parts:
+                    deferred_img_parts.append(
+                        {"type": "text", "text": "Image(s) returned by previous tool call:"}
+                    )
                 for img in extra_images:
                     if vision_format == "anthropic":
-                        img_parts.append(img)
+                        deferred_img_parts.append(img)
                         continue
                     source = img.get("source", {})
                     if source.get("type") == "base64":
                         media_type = source.get("media_type", "image/png")
                         data = source.get("data", "")
-                        img_parts.append(
+                        deferred_img_parts.append(
                             {
                                 "type": "image_url",
                                 "image_url": {
@@ -195,7 +202,6 @@ def _translate_user_blocks(blocks: list[dict], supports_vision: bool = True, vis
                                 },
                             }
                         )
-                result.append({"role": "user", "content": img_parts})
         elif block.get("type") == "text":
             content_parts.append({"type": "text", "text": block.get("text", "")})
         elif block.get("type") == "image" and supports_vision:
@@ -240,6 +246,10 @@ def _translate_user_blocks(blocks: list[dict], supports_vision: bool = True, vis
             else:
                 # Already OpenAI format — pass through.
                 content_parts.append(block)
+
+    # Flush deferred images after all role:tool messages.
+    if deferred_img_parts:
+        result.append({"role": "user", "content": deferred_img_parts})
 
     if content_parts:
         # If only text parts, flatten to a simple string for compatibility

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -220,6 +220,72 @@ class TestTranslateMessages:
         assert tool_msg["tool_call_id"] == "tool_1"
         assert tool_msg["content"] == "file contents here"
 
+    def test_multi_tool_with_image_result_keeps_tools_contiguous(self):
+        """Regression: when a non-final tool_result carries image content, the
+        extracted role:user image message must NOT be inserted between role:tool
+        messages — that breaks the Anthropic contract (every tool_use must have
+        a tool_result immediately after the assistant turn) and the OpenAI
+        contract (no role:user between tool responses).
+
+        Expected layout after translation:
+          system → assistant (2 tool_calls) → tool(toolu_RENDER) →
+          tool(toolu_FINDPATH) → user(images)
+        """
+        img_block = {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "abc123"},
+        }
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "toolu_RENDER", "name": "render_pdf", "input": {}},
+                    {"type": "tool_use", "id": "toolu_FINDPATH", "name": "find_path", "input": {}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_RENDER",
+                        "content": [
+                            {"type": "text", "text": "Rendered page 1."},
+                            img_block,
+                        ],
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_FINDPATH",
+                        "content": "path/to/file.pdf",
+                    },
+                ],
+            },
+        ]
+        result = _translate_messages("sys", msgs, supports_vision=True, vision_format="anthropic")
+
+        roles = [m["role"] for m in result]
+        # system, assistant, tool(RENDER), tool(FINDPATH), user(images)
+        assert roles == ["system", "assistant", "tool", "tool", "user"], (
+            f"Expected tools contiguous before image user-msg, got: {roles}"
+        )
+
+        # Both tool messages must appear before any user message
+        tool_indices = [i for i, m in enumerate(result) if m["role"] == "tool"]
+        user_indices = [i for i, m in enumerate(result) if m["role"] == "user"]
+        assert all(t < u for t in tool_indices for u in user_indices), (
+            "role:user image message must come after all role:tool messages"
+        )
+
+        # The tool responses map to the right call ids
+        assert result[2]["tool_call_id"] == "toolu_RENDER"
+        assert result[3]["tool_call_id"] == "toolu_FINDPATH"
+
+        # The trailing user message carries the image
+        img_user = result[4]
+        assert isinstance(img_user["content"], list)
+        assert any(p.get("type") == "image" for p in img_user["content"])
+
 
 class TestFromSettingsOpenAI:
     def test_from_settings_openai(self):


### PR DESCRIPTION
## Summary

- When an assistant turn has 2+ tool calls and a non-final `tool_result` returns image content, `_translate_user_blocks` was emitting a `role:user` image message inline — immediately after each `role:tool` — wedging it between tool responses
- The minds router then rebuilds Anthropic format with the second `tool_use` having no `tool_result` block immediately after → **Anthropic 400** ("tool_use ids were found without tool_result blocks")
- Fix: accumulate extracted images in `deferred_img_parts` and flush as a single `role:user` message **after all** `role:tool` messages

**Before (broken):**
```
assistant  [tool_calls: toolu_RENDER, toolu_FINDPATH]
tool       toolu_RENDER
user       <images>        ← wedged between tool responses
tool       toolu_FINDPATH  ← orphaned → 400
```

**After (fixed):**
```
assistant  [tool_calls: toolu_RENDER, toolu_FINDPATH]
tool       toolu_RENDER
tool       toolu_FINDPATH
user       <images>        ← after all tools
```

## Test plan

- [x] New regression test: `test_multi_tool_with_image_result_keeps_tools_contiguous` — covers a 2-tool round where the first tool returns `[text, image]` content; asserts role order and that images land after all tool messages
- [x] All 29 existing tests pass

Fixes: https://linear.app/mindsdb/issue/ENG-568

🤖 Generated with [Claude Code](https://claude.com/claude-code)