### PR TITLE
feat(llm): shared status-error mapper + typed model-403s (ENG-598)

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -23,6 +23,7 @@ from anton.clipboard import (
 from anton.core.session import ChatSession, ChatSessionConfig
 from anton.core.llm.prompt_builder import SystemPromptContext
 from anton.core.llm.provider import (
+    ModelUnavailableError,
     TokenLimitExceeded,
     StreamComplete,
     StreamContextCompacted,
@@ -1886,7 +1887,15 @@ async def _chat_loop(
                     "  (anton) Switch LLM provider, update API key, or retry?",
                     choices=["setup", "retry", "s", "r"],
                     choices_display="setup/retry",
-                    default="retry" if isinstance(exc, ConnectionError) else "setup",
+                    # A ModelUnavailableError is a deterministic plan/kill-switch
+                    # gate — retrying re-sends the same doomed request — so steer
+                    # the default to "setup" (switch model / provider). Other
+                    # ConnectionErrors (transient) keep retry as the default.
+                    default=(
+                        "setup"
+                        if isinstance(exc, ModelUnavailableError)
+                        else ("retry" if isinstance(exc, ConnectionError) else "setup")
+                    ),
                 )
                 if choice in ("setup", "s"):
                     session = await handle_setup_models(

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -12,6 +12,7 @@ from .provider import (
     ContextOverflowError,
     LLMProvider,
     LLMResponse,
+    ModelUnavailableError,
     ProviderConnectionInfo,
     StreamComplete,
     StreamEvent,
@@ -19,10 +20,67 @@ from .provider import (
     StreamToolUseDelta,
     StreamToolUseEnd,
     StreamToolUseStart,
+    TokenLimitExceeded,
     ToolCall,
     Usage,
     compute_context_pressure,
 )
+
+
+def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> None:
+    """Map a provider HTTP error onto anton's typed/curated exceptions.
+
+    The single mapper shared by all four call paths (chat/stream ×
+    completions/responses) so the mapping can't drift between them — the
+    previous four copy-pasted blocks had already diverged in wording.
+
+    Mapping policy:
+      - 401 → ConnectionError with the invalid-key copy (cowork-server's
+        provider_auth detection keys on this exact phrase).
+      - 403 with a structured gateway code (``error.code`` of
+        ``model_access_denied`` / ``model_disabled``) → ModelUnavailableError
+        carrying the code + model, with actionable copy. Detection is
+        code-exact on purpose: BYOK OpenAI 403s (region blocks), Anthropic
+        permission errors, and Cloudflare HTML 403s carry no such code and
+        must fall through to the generic message, never the plan copy.
+      - 429 with a quota detail → TokenLimitExceeded (checked before the 403
+        branch can't shadow it — quota keeps its own card downstream).
+      - anything else → the generic "temporarily unavailable" ConnectionError.
+    """
+    if exc.status_code == 401:
+        raise ConnectionError(
+            "Invalid API key — check your OpenAI API key configuration."
+        ) from exc
+
+    body = exc.body if isinstance(exc.body, dict) else {}
+    if exc.status_code == 429 and body.get("detail"):
+        msg = f"Server returned 429 — {body['detail']}"
+        msg += " Visit https://console.mindshub.ai to upgrade or top up your tokens."
+        raise TokenLimitExceeded(msg) from exc
+
+    error = body.get("error") if isinstance(body.get("error"), dict) else {}
+    code = error.get("code")
+    if exc.status_code == 403 and code in ("model_access_denied", "model_disabled"):
+        if code == "model_access_denied":
+            msg = (
+                f"The model '{model}' isn't included in your current MindsHub plan. "
+                "Visit https://console.mindshub.ai to upgrade, or switch models in Settings."
+            )
+        else:
+            # Hedged: until the gateway distinguishes tier locks from admin
+            # kill switches everywhere (ENG-596), model_disabled can mean
+            # either — don't promise that an upgrade fixes it.
+            msg = (
+                f"The model '{model}' isn't available right now — it may not be included "
+                "in your plan, or it's temporarily disabled. Switch models in Settings; "
+                "upgrading your plan may enable it."
+            )
+        raise ModelUnavailableError(msg, code=code, model=model) from exc
+
+    raise ConnectionError(
+        f"Server returned {exc.status_code} — the LLM endpoint may be "
+        "temporarily unavailable. Try again in a moment."
+    ) from exc
 
 
 def _translate_tools(tools: list[dict]) -> list[dict]:
@@ -709,22 +767,7 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            if exc.status_code == 401:
-                msg = "Invalid API key — check your OpenAI API key configuration."
-                raise ConnectionError(msg) from exc
-            elif (
-                exc.status_code == 429
-                and isinstance(exc.body, dict)
-                and exc.body.get("detail")
-            ):
-                msg = f"Server returned 429 — {exc.body['detail']}"
-                msg += " Visit https://console.mindshub.ai to upgrade or to top up your tokens."
-                from .provider import TokenLimitExceeded
-
-                raise TokenLimitExceeded(msg) from exc
-            else:
-                msg = f"Server returned {exc.status_code} — the LLM endpoint may be temporarily unavailable. Try again in a moment."
-            raise ConnectionError(msg) from exc
+            _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
             raise ConnectionError(
                 "Could not reach the LLM server — check your connection or try again in a moment."
@@ -878,22 +921,7 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            if exc.status_code == 401:
-                msg = "Invalid API key — check your OpenAI API key configuration."
-                raise ConnectionError(msg) from exc
-            elif (
-                exc.status_code == 429
-                and isinstance(exc.body, dict)
-                and exc.body.get("detail")
-            ):
-                msg = f"Server returned 429 — {exc.body['detail']}"
-                msg += " Visit https://console.mindshub.ai to upgrade or top up your tokens."
-                from .provider import TokenLimitExceeded
-
-                raise TokenLimitExceeded(msg) from exc
-            else:
-                msg = f"Server returned {exc.status_code} — the LLM endpoint may be temporarily unavailable. Try again in a moment."
-            raise ConnectionError(msg) from exc
+            _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
             raise ConnectionError(
                 "Could not reach the LLM server — check your connection or try again in a moment."
@@ -996,22 +1024,7 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            if exc.status_code == 401:
-                msg = "Invalid API key — check your OpenAI API key configuration."
-                raise ConnectionError(msg) from exc
-            elif (
-                exc.status_code == 429
-                and isinstance(exc.body, dict)
-                and exc.body.get("detail")
-            ):
-                msg = f"Server returned 429 — {exc.body['detail']}"
-                msg += " Visit https://console.mindshub.ai to upgrade or to top up your tokens."
-                from .provider import TokenLimitExceeded
-
-                raise TokenLimitExceeded(msg) from exc
-            else:
-                msg = f"Server returned {exc.status_code} — the LLM endpoint may be temporarily unavailable. Try again in a moment."
-            raise ConnectionError(msg) from exc
+            _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
             raise ConnectionError(
                 "Could not reach the LLM server — check your connection or try again in a moment."
@@ -1125,22 +1138,7 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            if exc.status_code == 401:
-                msg = "Invalid API key — check your OpenAI API key configuration."
-                raise ConnectionError(msg) from exc
-            elif (
-                exc.status_code == 429
-                and isinstance(exc.body, dict)
-                and exc.body.get("detail")
-            ):
-                msg = f"Server returned 429 — {exc.body['detail']}"
-                msg += " Visit https://console.mindshub.ai to upgrade or top up your tokens."
-                from .provider import TokenLimitExceeded
-
-                raise TokenLimitExceeded(msg) from exc
-            else:
-                msg = f"Server returned {exc.status_code} — the LLM endpoint may be temporarily unavailable. Try again in a moment."
-            raise ConnectionError(msg) from exc
+            _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
             raise ConnectionError(
                 "Could not reach the LLM server — check your connection or try again in a moment."

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import AsyncIterator
+from typing import NoReturn
 
 import openai
 from openai import AsyncAzureOpenAI
@@ -27,7 +28,7 @@ from .provider import (
 )
 
 
-def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> None:
+def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoReturn:
     """Map a provider HTTP error onto anton's typed/curated exceptions.
 
     The single mapper shared by all four call paths (chat/stream ×
@@ -43,8 +44,9 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> None:
         code-exact on purpose: BYOK OpenAI 403s (region blocks), Anthropic
         permission errors, and Cloudflare HTML 403s carry no such code and
         must fall through to the generic message, never the plan copy.
-      - 429 with a quota detail → TokenLimitExceeded (checked before the 403
-        branch can't shadow it — quota keeps its own card downstream).
+      - 429 with a quota detail → TokenLimitExceeded, checked first so a body
+        carrying both ``detail`` and ``error.code`` stays token_limit (quota
+        keeps its own card downstream).
       - anything else → the generic "temporarily unavailable" ConnectionError.
     """
     if exc.status_code == 401:

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -312,6 +312,27 @@ class TokenLimitExceeded(Exception):
     """Raised when the LLM returns 429 due to billing/token limits."""
 
 
+class ModelUnavailableError(ConnectionError):
+    """Raised when the gateway rejects the requested model with a structured 403.
+
+    The MindsHub gateway distinguishes two cases via ``error.code``:
+
+    - ``model_access_denied`` — the caller's plan tier doesn't include the
+      model (an upgrade fixes it).
+    - ``model_disabled`` — an admin kill switch (an upgrade does NOT fix it).
+
+    Subclasses ConnectionError so call sites that only know the legacy
+    ConnectionError mapping keep working unchanged; typed consumers
+    (cowork-server's turn-error mapping) read ``code``/``model`` to pick the
+    right user-facing remedy instead of string-matching.
+    """
+
+    def __init__(self, message: str, *, code: str, model: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.model = model
+
+
 @dataclass
 class ProviderConnectionInfo:
     """Serializable provider connection details.

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1591,8 +1591,12 @@ class ChatSession:
                         yield event
                     break  # completed successfully
                 except Exception as _agent_exc:
-                    # Token/billing limit — don't retry, let the chat loop handle it
-                    if isinstance(_agent_exc, TokenLimitExceeded):
+                    # Token/billing limits and model-gate 403s are
+                    # deterministic — the auto-retry below would just re-send
+                    # the same doomed request (and burn its budget) before
+                    # failing anyway. Don't retry; let the chat loop / server
+                    # map them to their cards.
+                    if isinstance(_agent_exc, (TokenLimitExceeded, ModelUnavailableError)):
                         raise
                     _retry_count += 1
                     # Anthropic's API rejects any history where the

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -25,6 +25,7 @@ from anton.core.llm.prompts import (
 )
 from anton.core.llm.provider import (
     ContextOverflowError,
+    ModelUnavailableError,
     StreamComplete,
     StreamContextCompacted,
     StreamEvent,
@@ -1646,6 +1647,15 @@ class ChatSession:
                                 if isinstance(event, StreamTextDelta):
                                     assistant_text_parts.append(event.text)
                                 yield event
+                        except (TokenLimitExceeded, ModelUnavailableError):
+                            # Curated provider failures must FAIL the turn, not
+                            # get wrapped into assistant prose: the server maps
+                            # them to actionable error cards (token_limit /
+                            # model-unavailable), which can only fire when the
+                            # exception propagates. Wrapping them as text is
+                            # how "Server returned 403" ended up mid-chat with
+                            # "please rephrase your request" advice.
+                            raise
                         except Exception as e:
                             fallback = f"An unexpected error occurred: {e}. Please try again or rephrase your request."
                             assistant_text_parts.append(fallback)

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -1,0 +1,143 @@
+"""The shared provider status-error mapper (ENG-598).
+
+One mapper (`openai._raise_for_status_error`) now serves all four call paths
+(chat/stream × completions/responses) — previously four copy-pasted blocks
+that had already drifted in wording. These tests pin the mapping policy:
+
+- 401 → ConnectionError with the exact invalid-key copy (cowork-server's
+  provider_auth detection string-matches it).
+- 429 + quota detail → TokenLimitExceeded (and it outranks any 403 logic).
+- 403 + structured gateway code → ModelUnavailableError carrying code+model,
+  with actionable copy per code.
+- Any other 403 (BYOK region blocks, Anthropic permission errors, Cloudflare
+  HTML) → the generic message, NEVER the plan copy.
+"""
+
+import pytest
+
+from anton.core.llm.openai import _raise_for_status_error
+from anton.core.llm.provider import ModelUnavailableError, TokenLimitExceeded
+
+
+class _FakeStatusError(Exception):
+    """Duck-typed stand-in for openai.APIStatusError (status_code + body)."""
+
+    def __init__(self, status_code, body=None):
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = status_code
+        self.body = body
+
+
+def _gateway_403(code, model="sonnet"):
+    return _FakeStatusError(403, body={"error": {
+        "message": f"The model '{model}' is rejected.",
+        "type": "invalid_request_error",
+        "param": "model",
+        "code": code,
+    }})
+
+
+# ── 401 ───────────────────────────────────────────────────────────────
+
+def test_401_maps_to_invalid_key_connection_error():
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(_FakeStatusError(401), "sonnet")
+    # cowork-server's provider_auth detection keys on this exact phrase.
+    assert "Invalid API key" in str(err.value)
+    assert not isinstance(err.value, ModelUnavailableError)
+
+
+# ── 429 (quota) ───────────────────────────────────────────────────────
+
+def test_429_with_detail_maps_to_token_limit():
+    exc = _FakeStatusError(429, body={"detail": "Monthly limit exceeded for tokens: 5/5"})
+    with pytest.raises(TokenLimitExceeded) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert "Monthly limit exceeded" in str(err.value)
+    assert "console.mindshub.ai" in str(err.value)
+
+
+def test_bare_429_stays_generic():
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(_FakeStatusError(429), "sonnet")
+    assert "temporarily unavailable" in str(err.value)
+
+
+# ── 403 with structured gateway codes ────────────────────────────────
+
+def test_model_access_denied_maps_to_plan_copy():
+    with pytest.raises(ModelUnavailableError) as err:
+        _raise_for_status_error(_gateway_403("model_access_denied"), "sonnet")
+    e = err.value
+    assert e.code == "model_access_denied"
+    assert e.model == "sonnet"
+    assert "isn't included in your current MindsHub plan" in str(e)
+    assert "upgrade" in str(e).lower()
+
+
+def test_model_disabled_maps_to_hedged_copy():
+    # Hedged until ENG-596's config lands everywhere: model_disabled can be
+    # either a tier lock or an admin kill switch, so don't promise an upgrade
+    # fixes it — but don't claim a transient outage either.
+    with pytest.raises(ModelUnavailableError) as err:
+        _raise_for_status_error(_gateway_403("model_disabled", model="opus"), "opus")
+    e = err.value
+    assert e.code == "model_disabled"
+    assert e.model == "opus"
+    assert "Switch models in Settings" in str(e)
+    assert "temporarily unavailable. Try again" not in str(e)
+
+
+def test_model_unavailable_is_a_connection_error():
+    # Legacy call sites only know ConnectionError — the typed error must keep
+    # flowing through them unchanged.
+    with pytest.raises(ConnectionError):
+        _raise_for_status_error(_gateway_403("model_disabled"), "sonnet")
+
+
+# ── 403 WITHOUT the gateway codes: never the plan copy ────────────────
+
+def test_byok_openai_403_falls_through_to_generic():
+    # e.g. OpenAI region block — different error code.
+    exc = _FakeStatusError(403, body={"error": {
+        "code": "unsupported_country_region_territory",
+        "message": "Country not supported.",
+    }})
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(exc, "gpt-4o")
+    assert not isinstance(err.value, ModelUnavailableError)
+    assert "temporarily unavailable" in str(err.value)
+
+
+def test_html_403_falls_through_to_generic():
+    # Cloudflare/WAF blocks have no JSON body at all.
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(_FakeStatusError(403, body="<html>blocked</html>"), "sonnet")
+    assert not isinstance(err.value, ModelUnavailableError)
+
+
+def test_403_with_no_code_falls_through_to_generic():
+    exc = _FakeStatusError(403, body={"error": {"message": "forbidden"}})
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert not isinstance(err.value, ModelUnavailableError)
+
+
+# ── precedence: quota beats model-403 logic ───────────────────────────
+
+def test_429_with_detail_wins_even_if_error_code_present():
+    # A quota failure must stay token_limit, never be misread as model-403.
+    exc = _FakeStatusError(429, body={
+        "detail": "Monthly limit exceeded for tokens: 5/5",
+        "error": {"code": "model_disabled"},
+    })
+    with pytest.raises(TokenLimitExceeded):
+        _raise_for_status_error(exc, "sonnet")
+
+
+# ── other statuses stay generic ───────────────────────────────────────
+
+def test_500_stays_generic():
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(_FakeStatusError(500), "sonnet")
+    assert "Server returned 500" in str(err.value)


### PR DESCRIPTION
Part 1 of 3 for ENG-598 (with cowork-server and cowork companion PRs).

## Problem

A gateway 403 for a tier-locked/disabled model surfaced in chat as:

> "An unexpected error occurred: Server returned 403 — the LLM endpoint may be temporarily unavailable. Try again in a moment.. Please try again or rephrase your request."

Wrong cause, useless advice, double-wrapped. Two layers: (1) `openai.py` mapped every non-401/429 `APIStatusError` to the generic copy, in **four copy-pasted blocks** that had already drifted in wording; (2) `session.py`'s plan_stream fallback **swallowed the exception into assistant text**, so the turn "succeeded" and cowork-server's error-card machinery never ran.

## Fix

- **One shared `_raise_for_status_error(exc, model)`** used by all four call paths (chat/stream × completions/responses) — the mapping can't drift again. 401 and 429 behavior byte-compatible (same copy the downstream `provider_auth` / `token_limit` detections key on).
- **New `ModelUnavailableError(ConnectionError)`** carrying `{code, model}` for the gateway's structured 403s (`error.code` of `model_access_denied` / `model_disabled`):
  - `model_access_denied` → "isn't included in your current MindsHub plan — upgrade or switch models in Settings"
  - `model_disabled` → hedged copy (can be tier lock or admin kill switch until mindshub-inference#335 / ENG-596 lands)
  - Detection is **code-exact**: BYOK OpenAI 403s (region blocks), Anthropic permission errors, and Cloudflare HTML 403s carry no such code and fall through to the generic message — never the plan copy. Subclassing `ConnectionError` keeps every legacy call site working unchanged.
- **`session.py`**: `TokenLimitExceeded` / `ModelUnavailableError` now **propagate** from the plan_stream fallback instead of being wrapped into prose — the turn fails, so the server can render an actionable card. All other exceptions keep the existing text fallback.

## Tests

11 new in `tests/test_status_error_mapper.py`: 401 copy pin, 429 quota (+ precedence over model-403), both gateway codes (attrs + copy), ConnectionError compatibility, BYOK/HTML/code-less 403 fall-through, 500 generic.

Suite: **1147 passed**. The 2 `test_chat_scratchpad` failures **pre-exist on clean staging** (verified via stash — environment-dependent, fail identically without this diff).

Ticket: ENG-535's sibling — ENG-598. Related: ENG-516 (this introduces the typed-exception pattern it asked for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)