### PR TITLE
gdrive connector with google picker api

### DIFF
--- a/anton/core/runtime.py
+++ b/anton/core/runtime.py
@@ -173,7 +173,10 @@ async def build_chat_session(
         episodic=episodic,
         system_prompt_context=SystemPromptContext(
             runtime_context=build_runtime_context(settings),
-            suffix=system_prompt_suffix,
+            # SystemPromptContext.suffix is typed str (default ""), not
+            # Optional — pass "" rather than None when no suffix was given,
+            # or ChatSystemPromptBuilder.build()'s suffix.strip() crashes.
+            suffix=system_prompt_suffix or "",
         ),
         output_dir=str(output_dir),
         workspace=workspace,

--- a/anton/core/runtime.py
+++ b/anton/core/runtime.py
@@ -14,6 +14,7 @@ Public API:
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 from pathlib import Path
@@ -142,6 +143,13 @@ async def build_chat_session(
 
     data_vault = LocalDataVault() if LocalDataVault is not None else None
     google_drive_oauth_connected = False
+    # {connection_name: [{"id": ..., "name": ...}, ...]} — files the user
+    # explicitly granted access to via the Google Picker. drive.file scope
+    # only covers files the app created itself, so without calling these
+    # out by name the agent has no way to know they're reachable at all;
+    # it isn't enough to just leave PICKED_FILES sitting in the env like
+    # any other DS_ credential field.
+    google_drive_picked_files: dict[str, list[dict]] = {}
     if data_vault is not None:
         try:
             for conn in data_vault.list_connections():
@@ -154,6 +162,14 @@ async def build_chat_session(
                     fields = data_vault.load(engine, name) or {}
                     if fields.get("auth_type") == "oauth":
                         google_drive_oauth_connected = True
+                    raw_picked = fields.get("picked_files")
+                    if raw_picked:
+                        try:
+                            files = json.loads(raw_picked)
+                        except (json.JSONDecodeError, TypeError):
+                            files = []
+                        if files:
+                            google_drive_picked_files[name] = files
         except Exception:
             logger.debug("Could not inject Anton data vault env", exc_info=True)
 
@@ -164,6 +180,29 @@ async def build_chat_session(
             "in the injected `DS_GOOGLE_DRIVE_<CONNECTION>__...` environment variables. "
             "Only claim Google Drive access if you can actually use those credentials successfully."
         )
+        if google_drive_picked_files:
+            picked_lines = [
+                f"- {f.get('name', 'untitled')} (id: {f.get('id')}, connection: {conn_name})"
+                for conn_name, files in google_drive_picked_files.items()
+                for f in files
+            ]
+            # Deliberately imperative and structurally separate from the
+            # paragraph above — a soft prose mention was tested and the
+            # agent silently dropped these files whenever a user asked to
+            # "list" Drive files, because it just reported files.list()'s
+            # output verbatim without cross-referencing earlier context.
+            integration_guidance += (
+                "\n\nIMPORTANT — additional Drive files the user has explicitly granted access to "
+                "via the Google Picker, which a plain files.list() or files.search() call will NOT "
+                "return (the google_drive scope only covers files this app created itself, plus "
+                "these specifically granted ones):\n"
+                + "\n".join(picked_lines)
+                + "\nWhenever you list, search, or enumerate Drive files for the user, you MUST "
+                "include every file above IN ADDITION to whatever files.list()/files.search() "
+                "returns — do not report only the API call's results. To read one of these files' "
+                "content, call files.get(fileId=...) directly with its id above; do not expect it "
+                "to appear in a files.list() response first."
+            )
 
     suffix_parts = [s for s in (system_prompt_suffix, integration_guidance) if s]
     final_suffix = "".join(suffix_parts) if suffix_parts else None

--- a/anton/core/runtime.py
+++ b/anton/core/runtime.py
@@ -152,7 +152,21 @@ async def build_chat_session(
     google_drive_picked_files: dict[str, list[dict]] = {}
     if data_vault is not None:
         try:
-            for conn in data_vault.list_connections():
+            connections = data_vault.list_connections()
+        except Exception:
+            logger.debug("Could not list Anton data vault connections", exc_info=True)
+            connections = []
+        for conn in connections:
+            # Per-connection try/except — one bad record (a load() error, a
+            # malformed field) must not abort inject_env/picked_files
+            # processing for every connection after it in the list.
+            # engine/name are initialized before the try so the except
+            # handler's logging never re-calls conn.get(...) itself — if
+            # `conn` isn't a plain dict, that would raise a second,
+            # uncaught exception right here and abort the whole loop again.
+            engine = None
+            name = None
+            try:
                 engine = conn.get("engine")
                 name = conn.get("name")
                 if not (engine and name):
@@ -162,47 +176,74 @@ async def build_chat_session(
                     fields = data_vault.load(engine, name) or {}
                     if fields.get("auth_type") == "oauth":
                         google_drive_oauth_connected = True
-                    raw_picked = fields.get("picked_files")
+                    # Fall back to the pre-rename key so a vault record
+                    # written before the _picked_files rename doesn't
+                    # silently lose its guidance.
+                    raw_picked = fields.get("_picked_files") or fields.get("picked_files")
                     if raw_picked:
                         try:
-                            files = json.loads(raw_picked)
+                            parsed = json.loads(raw_picked)
                         except (json.JSONDecodeError, TypeError):
-                            files = []
+                            parsed = []
+                        # Only keep well-formed entries — anything else (a
+                        # bare string, a dict instead of a list, an entry
+                        # missing "id") would crash the f.get(...) calls
+                        # below or embed a literal "None" fileId in the
+                        # prompt instructions.
+                        files = (
+                            [f for f in parsed if isinstance(f, dict) and f.get("id")]
+                            if isinstance(parsed, list) else []
+                        )
                         if files:
                             google_drive_picked_files[name] = files
-        except Exception:
-            logger.debug("Could not inject Anton data vault env", exc_info=True)
+            except Exception:
+                logger.debug(
+                    "Could not inject Anton data vault env for %s/%s",
+                    engine, name, exc_info=True,
+                )
 
     integration_guidance = ""
-    if google_drive_oauth_connected:
+    # Also shown whenever picked_files exist even if google_drive_oauth_connected
+    # is somehow False (fragile single-connection heuristic) — a connection
+    # can only have picked_files at all via the OAuth-based Picker flow, so
+    # its DS_ credentials necessarily exist; otherwise the IMPORTANT block
+    # below would tell the agent to fetch specific file IDs without ever
+    # mentioning the env vars that authenticate those calls.
+    if google_drive_oauth_connected or google_drive_picked_files:
         integration_guidance = (
             " Connected Google Drive accounts are available through Google OAuth credentials "
             "in the injected `DS_GOOGLE_DRIVE_<CONNECTION>__...` environment variables. "
             "Only claim Google Drive access if you can actually use those credentials successfully."
         )
-        if google_drive_picked_files:
-            picked_lines = [
-                f"- {f.get('name', 'untitled')} (id: {f.get('id')}, connection: {conn_name})"
-                for conn_name, files in google_drive_picked_files.items()
-                for f in files
-            ]
-            # Deliberately imperative and structurally separate from the
-            # paragraph above — a soft prose mention was tested and the
-            # agent silently dropped these files whenever a user asked to
-            # "list" Drive files, because it just reported files.list()'s
-            # output verbatim without cross-referencing earlier context.
-            integration_guidance += (
-                "\n\nIMPORTANT — additional Drive files the user has explicitly granted access to "
-                "via the Google Picker, which a plain files.list() or files.search() call will NOT "
-                "return (the google_drive scope only covers files this app created itself, plus "
-                "these specifically granted ones):\n"
-                + "\n".join(picked_lines)
-                + "\nWhenever you list, search, or enumerate Drive files for the user, you MUST "
-                "include every file above IN ADDITION to whatever files.list()/files.search() "
-                "returns — do not report only the API call's results. To read one of these files' "
-                "content, call files.get(fileId=...) directly with its id above; do not expect it "
-                "to appear in a files.list() response first."
-            )
+    # Deliberately NOT gated behind google_drive_oauth_connected — that flag
+    # is a fragile, single-source heuristic (fields.get("auth_type") ==
+    # "oauth" on SOME connection). A connection whose record predates that
+    # field, or uses a different auth_type value, would otherwise have real
+    # picked_files data but no guidance telling the agent it exists —
+    # reproducing the exact bug this block was added to fix.
+    if google_drive_picked_files:
+        picked_lines = [
+            f"- {f.get('name', 'untitled')} (id: {f.get('id')}, connection: {conn_name})"
+            for conn_name, files in google_drive_picked_files.items()
+            for f in files
+        ]
+        # Deliberately imperative and structurally separate from the
+        # paragraph above — a soft prose mention was tested and the
+        # agent silently dropped these files whenever a user asked to
+        # "list" Drive files, because it just reported files.list()'s
+        # output verbatim without cross-referencing earlier context.
+        integration_guidance += (
+            "\n\nIMPORTANT — additional Drive files the user has explicitly granted access to "
+            "via the Google Picker, which a plain files.list() or files.search() call will NOT "
+            "return (the google_drive scope only covers files this app created itself, plus "
+            "these specifically granted ones):\n"
+            + "\n".join(picked_lines)
+            + "\nWhenever you list, search, or enumerate Drive files for the user, you MUST "
+            "include every file above IN ADDITION to whatever files.list()/files.search() "
+            "returns — do not report only the API call's results. To read one of these files' "
+            "content, call files.get(fileId=...) directly with its id above; do not expect it "
+            "to appear in a files.list() response first."
+        )
 
     suffix_parts = [s for s in (system_prompt_suffix, integration_guidance) if s]
     final_suffix = "".join(suffix_parts) if suffix_parts else None

--- a/anton/core/runtime.py
+++ b/anton/core/runtime.py
@@ -14,7 +14,6 @@ Public API:
 """
 from __future__ import annotations
 
-import json
 import logging
 import os
 from pathlib import Path
@@ -142,14 +141,6 @@ async def build_chat_session(
     initial_history = history_store.load(session_id)
 
     data_vault = LocalDataVault() if LocalDataVault is not None else None
-    google_drive_oauth_connected = False
-    # {connection_name: [{"id": ..., "name": ...}, ...]} — files the user
-    # explicitly granted access to via the Google Picker. drive.file scope
-    # only covers files the app created itself, so without calling these
-    # out by name the agent has no way to know they're reachable at all;
-    # it isn't enough to just leave PICKED_FILES sitting in the env like
-    # any other DS_ credential field.
-    google_drive_picked_files: dict[str, list[dict]] = {}
     if data_vault is not None:
         try:
             connections = data_vault.list_connections()
@@ -157,13 +148,9 @@ async def build_chat_session(
             logger.debug("Could not list Anton data vault connections", exc_info=True)
             connections = []
         for conn in connections:
-            # Per-connection try/except — one bad record (a load() error, a
-            # malformed field) must not abort inject_env/picked_files
-            # processing for every connection after it in the list.
-            # engine/name are initialized before the try so the except
-            # handler's logging never re-calls conn.get(...) itself — if
-            # `conn` isn't a plain dict, that would raise a second,
-            # uncaught exception right here and abort the whole loop again.
+            # Per-connection try/except so one bad record can't abort
+            # injecting env for the rest; engine/name are set before the try
+            # so the except's own logging can't itself raise.
             engine = None
             name = None
             try:
@@ -172,81 +159,11 @@ async def build_chat_session(
                 if not (engine and name):
                     continue
                 data_vault.inject_env(engine, name)
-                if engine == "google_drive":
-                    fields = data_vault.load(engine, name) or {}
-                    if fields.get("auth_type") == "oauth":
-                        google_drive_oauth_connected = True
-                    # Fall back to the pre-rename key so a vault record
-                    # written before the _picked_files rename doesn't
-                    # silently lose its guidance.
-                    raw_picked = fields.get("_picked_files") or fields.get("picked_files")
-                    if raw_picked:
-                        try:
-                            parsed = json.loads(raw_picked)
-                        except (json.JSONDecodeError, TypeError):
-                            parsed = []
-                        # Only keep well-formed entries — anything else (a
-                        # bare string, a dict instead of a list, an entry
-                        # missing "id") would crash the f.get(...) calls
-                        # below or embed a literal "None" fileId in the
-                        # prompt instructions.
-                        files = (
-                            [f for f in parsed if isinstance(f, dict) and f.get("id")]
-                            if isinstance(parsed, list) else []
-                        )
-                        if files:
-                            google_drive_picked_files[name] = files
             except Exception:
                 logger.debug(
                     "Could not inject Anton data vault env for %s/%s",
                     engine, name, exc_info=True,
                 )
-
-    integration_guidance = ""
-    # Also shown whenever picked_files exist even if google_drive_oauth_connected
-    # is somehow False (fragile single-connection heuristic) — a connection
-    # can only have picked_files at all via the OAuth-based Picker flow, so
-    # its DS_ credentials necessarily exist; otherwise the IMPORTANT block
-    # below would tell the agent to fetch specific file IDs without ever
-    # mentioning the env vars that authenticate those calls.
-    if google_drive_oauth_connected or google_drive_picked_files:
-        integration_guidance = (
-            " Connected Google Drive accounts are available through Google OAuth credentials "
-            "in the injected `DS_GOOGLE_DRIVE_<CONNECTION>__...` environment variables. "
-            "Only claim Google Drive access if you can actually use those credentials successfully."
-        )
-    # Deliberately NOT gated behind google_drive_oauth_connected — that flag
-    # is a fragile, single-source heuristic (fields.get("auth_type") ==
-    # "oauth" on SOME connection). A connection whose record predates that
-    # field, or uses a different auth_type value, would otherwise have real
-    # picked_files data but no guidance telling the agent it exists —
-    # reproducing the exact bug this block was added to fix.
-    if google_drive_picked_files:
-        picked_lines = [
-            f"- {f.get('name', 'untitled')} (id: {f.get('id')}, connection: {conn_name})"
-            for conn_name, files in google_drive_picked_files.items()
-            for f in files
-        ]
-        # Deliberately imperative and structurally separate from the
-        # paragraph above — a soft prose mention was tested and the
-        # agent silently dropped these files whenever a user asked to
-        # "list" Drive files, because it just reported files.list()'s
-        # output verbatim without cross-referencing earlier context.
-        integration_guidance += (
-            "\n\nIMPORTANT — additional Drive files the user has explicitly granted access to "
-            "via the Google Picker, which a plain files.list() or files.search() call will NOT "
-            "return (the google_drive scope only covers files this app created itself, plus "
-            "these specifically granted ones):\n"
-            + "\n".join(picked_lines)
-            + "\nWhenever you list, search, or enumerate Drive files for the user, you MUST "
-            "include every file above IN ADDITION to whatever files.list()/files.search() "
-            "returns — do not report only the API call's results. To read one of these files' "
-            "content, call files.get(fileId=...) directly with its id above; do not expect it "
-            "to appear in a files.list() response first."
-        )
-
-    suffix_parts = [s for s in (system_prompt_suffix, integration_guidance) if s]
-    final_suffix = "".join(suffix_parts) if suffix_parts else None
 
     config = ChatSessionConfig(
         llm_client=llm_client,
@@ -256,7 +173,7 @@ async def build_chat_session(
         episodic=episodic,
         system_prompt_context=SystemPromptContext(
             runtime_context=build_runtime_context(settings),
-            suffix=final_suffix,
+            suffix=system_prompt_suffix,
         ),
         output_dir=str(output_dir),
         workspace=workspace,

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -145,6 +146,20 @@ def scrub_credentials(text: str) -> str:
     return text
 
 
+def _parse_picked_files(raw: str | None) -> list[dict]:
+    """Parse a `_picked_files` JSON field, dropping malformed entries so they
+    can't crash a later f.get(...) call or embed "None" as a fileId."""
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [f for f in parsed if isinstance(f, dict) and f.get("id")]
+
+
 def build_datasource_context(vault: DataVault, active_only: str | None = None) -> str:
     """Build a system-prompt section listing available DS_* env vars by name.
 
@@ -172,6 +187,12 @@ def build_datasource_context(vault: DataVault, active_only: str | None = None) -
         "it by name; never treat the bracket form as a literal credential "
         "or pass it back as a value to any tool.\n"
     )
+    # Google Drive's drive.file OAuth scope only covers files the app created
+    # itself, plus files explicitly granted via the Google Picker (persisted
+    # as a `_picked_files` vault field) — these must be named explicitly here
+    # since a plain files.list()/files.search() call won't return them.
+    google_drive_oauth_connected = False
+    google_drive_picked_files: dict[str, list[dict]] = {}
     for c in conns:
         slug = f"{c['engine']}-{c['name']}"
         if active_only and slug != active_only:
@@ -200,6 +221,39 @@ def build_datasource_context(vault: DataVault, active_only: str | None = None) -
         if identity:
             head += f" — {identity}"
         lines.append(f"- {head} → {var_names}")
+        if c["engine"] == "google_drive":
+            if fields.get("auth_type") == "oauth":
+                google_drive_oauth_connected = True
+            picked = _parse_picked_files(fields.get("_picked_files"))
+            if picked:
+                google_drive_picked_files[c["name"]] = picked
+    if google_drive_oauth_connected or google_drive_picked_files:
+        lines.append(
+            "\nConnected Google Drive accounts are available through Google OAuth credentials "
+            "in the injected `DS_GOOGLE_DRIVE_<CONNECTION>__...` environment variables. "
+            "Only claim Google Drive access if you can actually use those credentials successfully."
+        )
+    if google_drive_picked_files:
+        picked_lines = [
+            f"- {f.get('name', 'untitled')} (id: {f.get('id')}, connection: {conn_name})"
+            for conn_name, files in google_drive_picked_files.items()
+            for f in files
+        ]
+        # Imperative and structurally separate from the paragraph above — a
+        # softer prose mention got silently dropped by the agent when
+        # reporting files.list() results verbatim.
+        lines.append(
+            "\nIMPORTANT — additional Drive files the user has explicitly granted access to "
+            "via the Google Picker, which a plain files.list() or files.search() call will NOT "
+            "return (the google_drive scope only covers files this app created itself, plus "
+            "these specifically granted ones):\n"
+            + "\n".join(picked_lines)
+            + "\nWhenever you list, search, or enumerate Drive files for the user, you MUST "
+            "include every file above IN ADDITION to whatever files.list()/files.search() "
+            "returns — do not report only the API call's results. To read one of these files' "
+            "content, call files.get(fileId=...) directly with its id above; do not expect it "
+            "to appear in a files.list() response first."
+        )
     return "\n".join(lines)
 
 

--- a/tests/test_build_chat_session_google_drive.py
+++ b/tests/test_build_chat_session_google_drive.py
@@ -1,0 +1,84 @@
+"""End-to-end: build_chat_session() -> ChatSession._build_system_prompt() actually
+surfaces Google Drive Picker guidance in the real assembled system prompt.
+
+ENG-687 review (PR #241): the picked-files/OAuth guidance moved out of
+build_chat_session (anton/core/runtime.py) into build_datasource_context
+(anton/utils/datasources.py), which ChatSession already calls fresh every
+turn. This exercises the real integration point end-to-end rather than just
+the relocated function in isolation, and guards a real crash the move
+uncovered: SystemPromptContext.suffix is typed str (default ""), but
+build_chat_session could pass suffix=None when no system_prompt_suffix was
+given, and ChatSystemPromptBuilder.build() calls suffix.strip() unconditionally.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """LocalDataVault() with no args resolves under $HOME — isolate it so this
+    test never touches the real ~/.anton/data_vault or ~/.anton/memory."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    # build_chat_session constructs a real LLMClient; a syntactically-plausible
+    # dummy key is enough since this test never calls the LLM (no turn_stream()).
+    monkeypatch.setenv("ANTON_ANTHROPIC_API_KEY", "sk-ant-test-00000000000000000000000000")
+    return home
+
+
+@pytest.fixture()
+def workspace_path(tmp_path):
+    p = tmp_path / "workspace"
+    p.mkdir()
+    return p
+
+
+async def test_picked_files_reach_the_real_system_prompt(workspace_path):
+    from anton.core.datasources.data_vault import LocalDataVault
+    from anton.core.runtime import build_chat_session
+
+    vault = LocalDataVault()
+    vault.save("google_drive", "work", {
+        "auth_type": "oauth",
+        "account_email": "user@example.com",
+        "_picked_files": json.dumps([{"id": "f1", "name": "Roadmap.gdoc"}]),
+    })
+
+    session = await build_chat_session(session_id="test-picked-files", workspace_path=str(workspace_path))
+    prompt = await session._build_system_prompt()
+
+    assert "Connected Google Drive accounts are available" in prompt
+    assert "IMPORTANT — additional Drive files" in prompt
+    assert "Roadmap.gdoc" in prompt
+
+
+async def test_no_connections_and_no_suffix_does_not_crash(workspace_path):
+    """Regression: on staging, build_chat_session could pass suffix=None to
+    SystemPromptContext (typed str) whenever there was nothing to add,
+    crashing ChatSystemPromptBuilder.build()'s suffix.strip() call. Any
+    session with zero connections and no explicit system_prompt_suffix hits
+    this — verifying it explicitly rather than relying on it being masked by
+    an unrelated google_drive connection existing in the vault."""
+    from anton.core.runtime import build_chat_session
+
+    session = await build_chat_session(session_id="test-empty", workspace_path=str(workspace_path))
+    prompt = await session._build_system_prompt()  # must not raise
+
+    assert "Google Drive" not in prompt
+
+
+async def test_explicit_system_prompt_suffix_still_appended(workspace_path):
+    from anton.core.runtime import build_chat_session
+
+    session = await build_chat_session(
+        session_id="test-suffix",
+        workspace_path=str(workspace_path),
+        system_prompt_suffix="Host-specific note: reply in French.",
+    )
+    prompt = await session._build_system_prompt()
+
+    assert "Host-specific note: reply in French." in prompt

--- a/tests/test_datasource_context_identity.py
+++ b/tests/test_datasource_context_identity.py
@@ -5,8 +5,10 @@ without exposing secrets — so the system-prompt section shows the account emai
 or the DB host/name, never the credential, and never a dump of opaque/config
 fields.
 """
+import json
+
 from anton.core.datasources.data_vault import LocalDataVault
-from anton.utils.datasources import _connection_identity, build_datasource_context
+from anton.utils.datasources import _connection_identity, _parse_picked_files, build_datasource_context
 
 
 class TestConnectionIdentity:
@@ -82,3 +84,106 @@ class TestBuildContext:
         ctx = build_datasource_context(v)
         assert "Support" in ctx       # the human label is shown
         assert "regtr@mail.com" not in ctx  # label preferred over the opaque email
+
+
+class TestParsePickedFiles:
+    def test_valid_list(self):
+        raw = json.dumps([{"id": "1", "name": "a"}, {"id": "2", "name": "b"}])
+        assert _parse_picked_files(raw) == [{"id": "1", "name": "a"}, {"id": "2", "name": "b"}]
+
+    def test_drops_malformed_entries(self):
+        raw = json.dumps([
+            {"id": "1", "name": "keep"},
+            "not-a-dict",
+            {"name": "missing-id"},
+            {"id": None, "name": "null-id"},
+        ])
+        assert _parse_picked_files(raw) == [{"id": "1", "name": "keep"}]
+
+    def test_non_list_json_returns_empty(self):
+        assert _parse_picked_files(json.dumps({"id": "1"})) == []
+
+    def test_invalid_json_returns_empty(self):
+        assert _parse_picked_files("not json") == []
+
+    def test_empty_or_none_returns_empty(self):
+        assert _parse_picked_files(None) == []
+        assert _parse_picked_files("") == []
+
+
+class TestGoogleDrivePickerContext:
+    """ENG-687: google_drive's drive.file OAuth scope only covers files the
+    app created itself, plus files explicitly granted via the Google
+    Picker — the agent needs those named by id or a plain files.list()/
+    files.search() call won't surface them at all."""
+
+    def test_oauth_connection_without_picked_files_shows_availability_only(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("google_drive", "work", {"auth_type": "oauth", "account_email": "u@x.com"})
+        ctx = build_datasource_context(v)
+        assert "Connected Google Drive accounts are available" in ctx
+        assert "IMPORTANT" not in ctx
+
+    def test_picked_files_surfaced_with_id_and_connection(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("google_drive", "work", {
+            "auth_type": "oauth",
+            "_picked_files": json.dumps([{"id": "f1", "name": "Roadmap.gdoc"}]),
+        })
+        ctx = build_datasource_context(v)
+        assert "IMPORTANT — additional Drive files" in ctx
+        assert "Roadmap.gdoc" in ctx
+        assert "id: f1" in ctx
+        assert "connection: work" in ctx
+
+    def test_resource_key_not_required_but_included_when_present(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("google_drive", "work", {
+            "_picked_files": json.dumps([{"id": "f1", "name": "Shared.gdoc", "resourceKey": "rk123"}]),
+        })
+        ctx = build_datasource_context(v)
+        assert "Roadmap.gdoc" not in ctx  # sanity: not leaking the other test's fixture
+        assert "Shared.gdoc" in ctx
+
+    def test_malformed_picked_file_entries_are_dropped_not_crashed(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("google_drive", "work", {
+            "_picked_files": json.dumps(["not-a-dict", {"name": "missing-id"}]),
+        })
+        ctx = build_datasource_context(v)  # must not raise
+        assert "IMPORTANT" not in ctx  # nothing well-formed survived, so no block at all
+
+    def test_no_google_drive_connection_no_guidance(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("postgres", "prod", {"host": "db.acme.com"})
+        ctx = build_datasource_context(v)
+        assert "Google Drive" not in ctx
+        assert "IMPORTANT" not in ctx
+
+    def test_multiple_google_drive_connections_each_listed_separately(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("google_drive", "work", {"_picked_files": json.dumps([{"id": "1", "name": "Work.gdoc"}])})
+        v.save("google_drive", "personal", {"_picked_files": json.dumps([{"id": "2", "name": "Personal.gdoc"}])})
+        ctx = build_datasource_context(v)
+        assert "Work.gdoc" in ctx and "connection: work" in ctx
+        assert "Personal.gdoc" in ctx and "connection: personal" in ctx
+
+    def test_active_only_suppresses_other_connections_guidance(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("google_drive", "work", {
+            "auth_type": "oauth",
+            "_picked_files": json.dumps([{"id": "1", "name": "Roadmap.gdoc"}]),
+        })
+        v.save("postgres", "prod", {"host": "db.acme.com"})
+        # A different connection is active — Drive guidance must not leak in.
+        ctx = build_datasource_context(v, active_only="postgres-prod")
+        assert "Google Drive" not in ctx
+        assert "Roadmap.gdoc" not in ctx
+
+    def test_active_only_on_google_drive_still_shows_its_guidance(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("google_drive", "work", {
+            "_picked_files": json.dumps([{"id": "1", "name": "Roadmap.gdoc"}]),
+        })
+        ctx = build_datasource_context(v, active_only="google_drive-work")
+        assert "Roadmap.gdoc" in ctx

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "rich", specifier = ">=13.0" },
+    { name = "rich", specifier = ">=13.0,<15" },
     { name = "typer", specifier = ">=0.12.4" },
 ]
 provides-extras = ["clipboard", "dev"]


### PR DESCRIPTION
Linear ticket: https://linear.app/mindsdb/issue/ENG-687/google-drive-google-picker-api
___

Demo video: https://www.loom.com/share/6c689e3708664779aa13900ae20e4e49
___

Adds Google Drive Picker guidance to `build_chat_session`—the function backing Anton's own dispatch/CLI runtime—so that files a user explicitly granted access to via the Picker are surfaced to the agent by name. A plain `files.list()`/`files.search()` call won't return them because the `drive.file` scope only covers files created by the app itself.

Since this logic runs on every chat turn and touches every connection in the vault, it also hardens the surrounding loop against malformed records and partial failures so one bad connection can't prevent guidance from being generated for every other connection.

| File | What & why |
|------|------------|
| `anton/core/runtime.py` | Added picked-files extraction and an **IMPORTANT** guidance block telling the agent which files it can access directly via `files.get()` (mirrors `cowork-server`'s `harness.py`, used by a different, non-`cowork-server` call path). Moved the per-connection `try/except` inside the loop so one bad record doesn't abort processing for subsequent connections. Initialized `engine` and `name` before the `try` block so the exception handler's own logging can't fail on malformed connection records. Validated picked-file data after JSON parsing by dropping non-dictionary entries and entries missing an `id`, preventing malformed data from crashing `f.get(...)` or embedding a literal `"None"` file ID in the prompt. Decoupled the guidance block from the `auth_type == "oauth"` heuristic, since gating the entire block behind that fragile check could silently suppress the guidance. Reads the renamed `_picked_files` field while maintaining backward compatibility with the legacy `picked_files` key. |
| `uv.lock` | Lockfile bump. |