### PR TITLE
fix(llm): back off + retry mid-stream provider failures; typed transient errors (ENG-673)

### DIFF
--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -236,8 +236,15 @@ class AnthropicProvider(LLMProvider):
         # Track content blocks by index for tool correlation
         blocks: dict[int, dict] = {}
 
+        # True once the 200 stream has been established. Anything that fails
+        # AFTER this point is mid-stream: the SDK's retry wrapper already
+        # returned, so it never retried — the session must (ENG-673). A failure
+        # BEFORE this (request establishment) was already SDK-retried → fail fast.
+        stream_started = False
+
         try:
             async with self._client.messages.stream(**kwargs) as stream:
+                stream_started = True
                 async for event in stream:
                     if event.type == "message_start":
                         usage = event.message.usage
@@ -306,13 +313,16 @@ class AnthropicProvider(LLMProvider):
         except anthropic.APIStatusError as exc:
             _raise_for_status_error(exc, model=model)
         except anthropic.APIConnectionError as exc:
-            # Connection dropped mid-stream — transient, but the SDK retries
-            # connection errors at the transport layer, so fail fast rather than
-            # adding the session budget on top (ENG-673).
+            # A connection error here is retryable. If it dropped mid-stream
+            # (after the 200), the SDK never retried it → the session must back
+            # off and retry. If it failed during request establishment, the SDK
+            # already retried → fail fast (no second budget on top). (ENG-673)
             raise TransientProviderError(
-                "Lost the connection to Anthropic mid-response — try again in a moment.",
-                provider="Anthropic", code="connection_error", session_backoff=False,
-                model=model,
+                "Lost the connection to Anthropic mid-response — try again in a moment."
+                if stream_started
+                else "Could not reach Anthropic — check your connection or try again in a moment.",
+                provider="Anthropic", code="connection_error",
+                session_backoff=stream_started, model=model,
             ) from exc
 
         # Missing stop_reason is a genuine truncation only when the stream
@@ -326,6 +336,14 @@ class AnthropicProvider(LLMProvider):
                                "passing through")
             else:
                 logger.warning("Anthropic stream ended empty with no stop_reason — treating as truncated")
+                # Deliberate carve-out (ENG-673): this branch fires ONLY when the
+                # stream produced NOTHING (a content-bearing stream with no
+                # stop_reason passes through above). An empty-from-start 200 is a
+                # weak incident signal and a strong broken/misconfigured-endpoint
+                # signal, so it fails fast rather than looping the 30s budget on an
+                # endpoint that never emits. Genuine mid-incident silence surfaces
+                # instead as a connection drop / read timeout / SSE error event —
+                # all of which DO back off (session_backoff=True) above.
                 raise TransientProviderError(
                     "Anthropic ended the response early — try again in a moment.",
                     provider="Anthropic", code="truncated_stream",

--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -31,7 +31,9 @@ from .provider import (
 logger = logging.getLogger(__name__)
 
 
-def _raise_for_status_error(exc: anthropic.APIStatusError, *, provider: str = "Anthropic") -> NoReturn:
+def _raise_for_status_error(
+    exc: anthropic.APIStatusError, *, provider: str = "Anthropic", model: str = "",
+) -> NoReturn:
     """Map an Anthropic HTTP error onto anton's typed/curated exceptions.
 
     Shared by ``complete`` and ``stream`` so the mapping can't drift (the two
@@ -56,7 +58,7 @@ def _raise_for_status_error(exc: anthropic.APIStatusError, *, provider: str = "A
         msg += " Visit https://console.mindshub.ai to upgrade or to top up your tokens."
         raise TokenLimitExceeded(msg) from exc
 
-    transient = classify_transient(exc.status_code, body, provider=provider)
+    transient = classify_transient(exc.status_code, body, provider=provider, model=model)
     if transient is not None:
         logger.warning(
             "transient provider error (%s): status=%s body=%s",
@@ -165,7 +167,7 @@ class AnthropicProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except anthropic.APIStatusError as exc:
-            _raise_for_status_error(exc)
+            _raise_for_status_error(exc, model=model)
         except anthropic.APIConnectionError as exc:
             # Transient, but the SDK already retries connection errors at the
             # transport layer — so classify honestly and fail fast rather than
@@ -173,6 +175,7 @@ class AnthropicProvider(LLMProvider):
             raise TransientProviderError(
                 "Could not reach Anthropic — check your connection or try again in a moment.",
                 provider="Anthropic", code="connection_error", session_backoff=False,
+                model=model,
             ) from exc
 
         content_text = ""
@@ -301,7 +304,7 @@ class AnthropicProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except anthropic.APIStatusError as exc:
-            _raise_for_status_error(exc)
+            _raise_for_status_error(exc, model=model)
         except anthropic.APIConnectionError as exc:
             # Connection dropped mid-stream — transient, but the SDK retries
             # connection errors at the transport layer, so fail fast rather than
@@ -309,20 +312,25 @@ class AnthropicProvider(LLMProvider):
             raise TransientProviderError(
                 "Lost the connection to Anthropic mid-response — try again in a moment.",
                 provider="Anthropic", code="connection_error", session_backoff=False,
+                model=model,
             ) from exc
 
-        # A stream that ended without a stop_reason was cut off before the model
-        # finished (a silent truncation — no error event, no message_stop). Raise
-        # rather than yield a partial answer as if complete; classify transient so
-        # the honest message surfaces and the turn retries quickly, but NOT with
-        # the session budget — a persistently-malformed endpoint must fail fast,
-        # not loop for 30s (ENG-673).
+        # Missing stop_reason is a genuine truncation only when the stream
+        # produced NOTHING. A content/tool-bearing stream that lacks it is almost
+        # always a provider that doesn't report one — treating THAT as truncated
+        # would discard a complete, good answer, so we log and pass it through.
+        # Only the truly-empty case is transient (fail-fast). (ENG-673)
         if stop_reason is None:
-            logger.warning("Anthropic stream ended with no stop_reason — treating as truncated")
-            raise TransientProviderError(
-                "Anthropic ended the response early — try again in a moment.",
-                provider="Anthropic", code="truncated_stream", session_backoff=False,
-            )
+            if content_text or tool_calls:
+                logger.warning("Anthropic stream ended with no stop_reason but produced output — "
+                               "passing through")
+            else:
+                logger.warning("Anthropic stream ended empty with no stop_reason — treating as truncated")
+                raise TransientProviderError(
+                    "Anthropic ended the response early — try again in a moment.",
+                    provider="Anthropic", code="truncated_stream",
+                    session_backoff=False, model=model,
+                )
 
         yield StreamComplete(
             response=LLMResponse(

--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-import json
+import logging
 from collections.abc import AsyncIterator
+from typing import NoReturn
 
 import anthropic
+
+from anton.utils.datasources import scrub_credentials
 
 from .provider import safe_parse_tool_input
 from .provider import (
@@ -17,10 +20,54 @@ from .provider import (
     StreamToolUseDelta,
     StreamToolUseEnd,
     StreamToolUseStart,
+    TokenLimitExceeded,
     ToolCall,
+    TransientProviderError,
     Usage,
+    classify_transient,
     compute_context_pressure,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _raise_for_status_error(exc: anthropic.APIStatusError, *, provider: str = "Anthropic") -> NoReturn:
+    """Map an Anthropic HTTP error onto anton's typed/curated exceptions.
+
+    Shared by ``complete`` and ``stream`` so the mapping can't drift (the two
+    were byte-identical copy-paste before ENG-673). Order matters — permanent
+    failures are classified first; only what's left is offered to the transient
+    classifier, and the generic "unavailable" copy is the last resort.
+
+    - 401 → ConnectionError (invalid-key copy; cowork-server keys on this phrase).
+    - 429 WITH a quota ``detail`` → TokenLimitExceeded (keeps its own card).
+    - overloaded/api_error (incl. the mid-stream HTTP-200 case), 5xx, plain 429
+      → TransientProviderError (retryable — see ENG-673).
+    - anything else → the generic "temporarily unavailable" ConnectionError.
+    """
+    if exc.status_code == 401:
+        raise ConnectionError(
+            "Invalid API key — check your ANTHROPIC_API_KEY environment variable."
+        ) from exc
+
+    body = exc.body if isinstance(exc.body, dict) else {}
+    if exc.status_code == 429 and body.get("detail"):
+        msg = f"Server returned 429 — {body['detail']}"
+        msg += " Visit https://console.mindshub.ai to upgrade or to top up your tokens."
+        raise TokenLimitExceeded(msg) from exc
+
+    transient = classify_transient(exc.status_code, body, provider=provider)
+    if transient is not None:
+        logger.warning(
+            "transient provider error (%s): status=%s body=%s",
+            transient.code, exc.status_code, scrub_credentials(str(exc.body))[:500],
+        )
+        raise transient from exc
+
+    raise ConnectionError(
+        f"Server returned {exc.status_code} — the LLM endpoint may be "
+        "temporarily unavailable. Try again in a moment."
+    ) from exc
 
 # Native server-side web tool type strings exposed by the Anthropic Messages API.
 # The model invokes these inside the provider — Anton's tool-dispatch loop never
@@ -118,25 +165,14 @@ class AnthropicProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except anthropic.APIStatusError as exc:
-            if exc.status_code == 401:
-                msg = "Invalid API key — check your ANTHROPIC_API_KEY environment variable."
-                raise ConnectionError(msg) from exc
-            elif (
-                exc.status_code == 429
-                and isinstance(exc.body, dict)
-                and exc.body.get("detail")
-            ):
-                msg = f"Server returned 429 — {exc.body['detail']}"
-                msg += " Visit https://console.mindshub.ai to upgrade or to top up your tokens."
-                from .provider import TokenLimitExceeded
-
-                raise TokenLimitExceeded(msg) from exc
-            else:
-                msg = f"Server returned {exc.status_code} — the LLM endpoint may be temporarily unavailable. Try again in a moment."
-            raise ConnectionError(msg) from exc
+            _raise_for_status_error(exc)
         except anthropic.APIConnectionError as exc:
-            raise ConnectionError(
-                "Could not reach the LLM server — check your connection or try again in a moment."
+            # Transient, but the SDK already retries connection errors at the
+            # transport layer — so classify honestly and fail fast rather than
+            # stacking the session budget on top (ENG-673).
+            raise TransientProviderError(
+                "Could not reach Anthropic — check your connection or try again in a moment.",
+                provider="Anthropic", code="connection_error", session_backoff=False,
             ) from exc
 
         content_text = ""
@@ -265,26 +301,28 @@ class AnthropicProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except anthropic.APIStatusError as exc:
-            if exc.status_code == 401:
-                msg = "Invalid API key — check your ANTHROPIC_API_KEY environment variable."
-                raise ConnectionError(msg) from exc
-            elif (
-                exc.status_code == 429
-                and isinstance(exc.body, dict)
-                and exc.body.get("detail")
-            ):
-                msg = f"Server returned 429 — {exc.body['detail']}"
-                msg += " Visit https://console.mindshub.ai to upgrade or to top up your tokens."
-                from .provider import TokenLimitExceeded
-
-                raise TokenLimitExceeded(msg) from exc
-            else:
-                msg = f"Server returned {exc.status_code} — the LLM endpoint may be temporarily unavailable. Try again in a moment."
-            raise ConnectionError(msg) from exc
+            _raise_for_status_error(exc)
         except anthropic.APIConnectionError as exc:
-            raise ConnectionError(
-                "Could not reach the LLM server — check your connection or try again in a moment."
+            # Connection dropped mid-stream — transient, but the SDK retries
+            # connection errors at the transport layer, so fail fast rather than
+            # adding the session budget on top (ENG-673).
+            raise TransientProviderError(
+                "Lost the connection to Anthropic mid-response — try again in a moment.",
+                provider="Anthropic", code="connection_error", session_backoff=False,
             ) from exc
+
+        # A stream that ended without a stop_reason was cut off before the model
+        # finished (a silent truncation — no error event, no message_stop). Raise
+        # rather than yield a partial answer as if complete; classify transient so
+        # the honest message surfaces and the turn retries quickly, but NOT with
+        # the session budget — a persistently-malformed endpoint must fail fast,
+        # not loop for 30s (ENG-673).
+        if stop_reason is None:
+            logger.warning("Anthropic stream ended with no stop_reason — treating as truncated")
+            raise TransientProviderError(
+                "Anthropic ended the response early — try again in a moment.",
+                provider="Anthropic", code="truncated_stream", session_backoff=False,
+            )
 
         yield StreamComplete(
             response=LLMResponse(

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from collections.abc import AsyncIterator
 from typing import NoReturn
 
 import openai
 from openai import AsyncAzureOpenAI
+
+from anton.utils.datasources import scrub_credentials
 
 from .provider import safe_parse_tool_input
 from .provider import (
@@ -23,9 +26,13 @@ from .provider import (
     StreamToolUseStart,
     TokenLimitExceeded,
     ToolCall,
+    TransientProviderError,
     Usage,
+    classify_transient,
     compute_context_pressure,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoReturn:
@@ -102,6 +109,17 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
                 "upgrading your plan may enable it."
             )
         raise ModelUnavailableError(msg, code=code, model=model) from exc
+
+    # Retryable provider/infra failures — overload/api_error (incl. the mid-stream
+    # HTTP-200 case), 5xx, or a plain 429 — get backed off and retried by the
+    # session loop rather than surfacing an instant, misleading failure (ENG-673).
+    transient = classify_transient(exc.status_code, body, provider="The model provider")
+    if transient is not None:
+        logger.warning(
+            "transient provider error (%s): status=%s body=%s",
+            transient.code, exc.status_code, scrub_credentials(str(exc.body))[:500],
+        )
+        raise transient from exc
 
     raise ConnectionError(
         f"Server returned {exc.status_code} — the LLM endpoint may be "
@@ -795,8 +813,12 @@ class OpenAIProvider(LLMProvider):
         except openai.APIStatusError as exc:
             _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
-            raise ConnectionError(
-                "Could not reach the LLM server — check your connection or try again in a moment."
+            # Transient, but the SDK already retries connection errors at the
+            # transport layer — classify honestly and fail fast rather than
+            # stacking the session budget on top (ENG-673).
+            raise TransientProviderError(
+                "Could not reach the model provider — check your connection or try again in a moment.",
+                provider="The model provider", code="connection_error", session_backoff=False,
             ) from exc
 
         choice = response.choices[0]
@@ -949,8 +971,12 @@ class OpenAIProvider(LLMProvider):
         except openai.APIStatusError as exc:
             _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
-            raise ConnectionError(
-                "Could not reach the LLM server — check your connection or try again in a moment."
+            # Transient, but the SDK already retries connection errors at the
+            # transport layer — classify honestly and fail fast rather than
+            # stacking the session budget on top (ENG-673).
+            raise TransientProviderError(
+                "Could not reach the model provider — check your connection or try again in a moment.",
+                provider="The model provider", code="connection_error", session_backoff=False,
             ) from exc
 
         # Finalize tool calls. Same safe-parse protection as the
@@ -968,6 +994,19 @@ class OpenAIProvider(LLMProvider):
                 parse_error=parse_error,
             ))
             yield StreamToolUseEnd(id=info["id"])
+
+        # A stream that ended with no finish_reason was cut off before the model
+        # finished (silent truncation — no error chunk, no [DONE]). Raise rather
+        # than yield a partial answer as if complete; classify transient so the
+        # honest message surfaces and the turn retries quickly, but NOT with the
+        # session budget — a persistently-malformed endpoint must fail fast, not
+        # loop for 30s (ENG-673).
+        if stop_reason is None:
+            logger.warning("stream ended with no finish_reason — treating as truncated")
+            raise TransientProviderError(
+                "The model provider ended the response early — try again in a moment.",
+                provider="The model provider", code="truncated_stream", session_backoff=False,
+            )
 
         yield StreamComplete(
             response=LLMResponse(
@@ -1052,8 +1091,12 @@ class OpenAIProvider(LLMProvider):
         except openai.APIStatusError as exc:
             _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
-            raise ConnectionError(
-                "Could not reach the LLM server — check your connection or try again in a moment."
+            # Transient, but the SDK already retries connection errors at the
+            # transport layer — classify honestly and fail fast rather than
+            # stacking the session budget on top (ENG-673).
+            raise TransientProviderError(
+                "Could not reach the model provider — check your connection or try again in a moment.",
+                provider="The model provider", code="connection_error", session_backoff=False,
             ) from exc
 
         return _parse_response_object(response, model)
@@ -1166,8 +1209,12 @@ class OpenAIProvider(LLMProvider):
         except openai.APIStatusError as exc:
             _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
-            raise ConnectionError(
-                "Could not reach the LLM server — check your connection or try again in a moment."
+            # Transient, but the SDK already retries connection errors at the
+            # transport layer — classify honestly and fail fast rather than
+            # stacking the session budget on top (ENG-673).
+            raise TransientProviderError(
+                "Could not reach the model provider — check your connection or try again in a moment.",
+                provider="The model provider", code="connection_error", session_backoff=False,
             ) from exc
 
         yield StreamComplete(

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -909,8 +909,15 @@ class OpenAIProvider(LLMProvider):
         # Track tool call deltas by index
         tc_state: dict[int, dict] = {}
 
+        # True once the 200 stream has been established. Anything that fails
+        # AFTER this point is mid-stream: the SDK's retry wrapper already
+        # returned, so it never retried — the session must (ENG-673). A failure
+        # BEFORE this (request establishment) was already SDK-retried → fail fast.
+        stream_started = False
+
         try:
             stream = await self._client.chat.completions.create(**kwargs)
+            stream_started = True
             async for chunk in stream:
                 if chunk.usage:
                     input_tokens = chunk.usage.prompt_tokens
@@ -972,13 +979,39 @@ class OpenAIProvider(LLMProvider):
         except openai.APIStatusError as exc:
             _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
-            # Transient, but the SDK already retries connection errors at the
-            # transport layer — classify honestly and fail fast rather than
-            # stacking the session budget on top (ENG-673).
+            # A connection error here is retryable. If it dropped mid-stream
+            # (after the 200), the SDK never retried it → the session must back
+            # off and retry. If it failed during request establishment, the SDK
+            # already retried → fail fast (no second budget on top). (ENG-673)
             raise TransientProviderError(
-                "Could not reach the model provider — check your connection or try again in a moment.",
-                provider="The model provider", code="connection_error", session_backoff=False,
-                model=model,
+                "Lost the connection to the model provider mid-response — try again in a moment."
+                if stream_started
+                else "Could not reach the model provider — check your connection or try again in a moment.",
+                provider="The model provider", code="connection_error",
+                session_backoff=stream_started, model=model,
+            ) from exc
+        except openai.APIError as exc:
+            # A mid-stream SSE `error` event (server_error / overloaded) arrives
+            # as a BARE APIError with no status_code — NOT an APIStatusError — so
+            # it slips past the handlers above. The SDK already consumed the 200,
+            # so it never retried it → the session must back off and retry, and we
+            # must classify it here or it surfaces as an opaque generic error on
+            # the OpenAI/MindsHub path (ENG-673, Sam's review). Body type sits at
+            # the top level (SDK-unwrapped); classify_transient handles that shape.
+            transient = classify_transient(
+                getattr(exc, "status_code", None), getattr(exc, "body", None),
+                provider="The model provider", model=model,
+            )
+            if transient is not None:
+                logger.warning(
+                    "transient mid-stream provider error (%s): %s",
+                    transient.code, scrub_credentials(str(getattr(exc, "body", "")))[:500],
+                )
+                raise transient from exc
+            raise TransientProviderError(
+                "The model provider failed mid-response — try again in a moment.",
+                provider="The model provider", code="stream_error",
+                session_backoff=True, model=model,
             ) from exc
 
         # Finalize tool calls. Same safe-parse protection as the
@@ -1010,6 +1043,13 @@ class OpenAIProvider(LLMProvider):
                                "passing through (provider likely omits finish_reason)")
             else:
                 logger.warning("stream ended empty with no finish_reason — treating as truncated")
+                # Deliberate carve-out (ENG-673): fires ONLY on a stream that
+                # produced NOTHING. An empty-from-start 200 is a weak incident
+                # signal and a strong broken/misconfigured-endpoint signal, so it
+                # fails fast rather than looping the 30s budget on an endpoint that
+                # never emits. Genuine mid-incident silence surfaces instead as a
+                # connection drop / read timeout / SSE error — all of which DO back
+                # off above. Keeps a persistently-malformed endpoint from looping.
                 raise TransientProviderError(
                     "The model provider ended the response early — try again in a moment.",
                     provider="The model provider", code="truncated_stream",
@@ -1141,8 +1181,13 @@ class OpenAIProvider(LLMProvider):
         # a per-output_index stable handle for streaming arguments.
         fc_state: dict[int, dict] = {}
 
+        # See the chat-completions path: True once the 200 stream is established;
+        # a failure after this is mid-stream and was never SDK-retried (ENG-673).
+        stream_started = False
+
         try:
             stream = await self._client.responses.create(**kwargs)
+            stream_started = True
             async for event in stream:
                 etype = getattr(event, "type", "")
 
@@ -1218,13 +1263,34 @@ class OpenAIProvider(LLMProvider):
         except openai.APIStatusError as exc:
             _raise_for_status_error(exc, model)
         except openai.APIConnectionError as exc:
-            # Transient, but the SDK already retries connection errors at the
-            # transport layer — classify honestly and fail fast rather than
-            # stacking the session budget on top (ENG-673).
+            # A connection error here is retryable. Mid-stream (after the 200) was
+            # never SDK-retried → session backs off; request-establishment was
+            # already SDK-retried → fail fast (ENG-673).
             raise TransientProviderError(
-                "Could not reach the model provider — check your connection or try again in a moment.",
-                provider="The model provider", code="connection_error", session_backoff=False,
-                model=model,
+                "Lost the connection to the model provider mid-response — try again in a moment."
+                if stream_started
+                else "Could not reach the model provider — check your connection or try again in a moment.",
+                provider="The model provider", code="connection_error",
+                session_backoff=stream_started, model=model,
+            ) from exc
+        except openai.APIError as exc:
+            # Bare mid-stream SSE error (no status_code) — not an APIStatusError,
+            # so it slips past the handlers above; the SDK already consumed the
+            # 200 and never retried it → the session must back off (ENG-673).
+            transient = classify_transient(
+                getattr(exc, "status_code", None), getattr(exc, "body", None),
+                provider="The model provider", model=model,
+            )
+            if transient is not None:
+                logger.warning(
+                    "transient mid-stream provider error (%s): %s",
+                    transient.code, scrub_credentials(str(getattr(exc, "body", "")))[:500],
+                )
+                raise transient from exc
+            raise TransientProviderError(
+                "The model provider failed mid-response — try again in a moment.",
+                provider="The model provider", code="stream_error",
+                session_backoff=True, model=model,
             ) from exc
 
         yield StreamComplete(

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -113,7 +113,7 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     # Retryable provider/infra failures — overload/api_error (incl. the mid-stream
     # HTTP-200 case), 5xx, or a plain 429 — get backed off and retried by the
     # session loop rather than surfacing an instant, misleading failure (ENG-673).
-    transient = classify_transient(exc.status_code, body, provider="The model provider")
+    transient = classify_transient(exc.status_code, body, provider="The model provider", model=model)
     if transient is not None:
         logger.warning(
             "transient provider error (%s): status=%s body=%s",
@@ -819,6 +819,7 @@ class OpenAIProvider(LLMProvider):
             raise TransientProviderError(
                 "Could not reach the model provider — check your connection or try again in a moment.",
                 provider="The model provider", code="connection_error", session_backoff=False,
+                model=model,
             ) from exc
 
         choice = response.choices[0]
@@ -977,6 +978,7 @@ class OpenAIProvider(LLMProvider):
             raise TransientProviderError(
                 "Could not reach the model provider — check your connection or try again in a moment.",
                 provider="The model provider", code="connection_error", session_backoff=False,
+                model=model,
             ) from exc
 
         # Finalize tool calls. Same safe-parse protection as the
@@ -995,18 +997,24 @@ class OpenAIProvider(LLMProvider):
             ))
             yield StreamToolUseEnd(id=info["id"])
 
-        # A stream that ended with no finish_reason was cut off before the model
-        # finished (silent truncation — no error chunk, no [DONE]). Raise rather
-        # than yield a partial answer as if complete; classify transient so the
-        # honest message surfaces and the turn retries quickly, but NOT with the
-        # session budget — a persistently-malformed endpoint must fail fast, not
-        # loop for 30s (ENG-673).
+        # Missing finish_reason is ambiguous: it's a genuine truncation only when
+        # the stream produced NOTHING (empty + no terminal marker). A stream that
+        # produced content/tool_calls but no finish_reason is almost always a
+        # provider that just doesn't report one (many OpenAI-compatible endpoints)
+        # — treating THAT as truncated would discard a complete, good answer, so
+        # we log and pass it through. Only the truly-empty case is transient
+        # (fail-fast: a persistently-malformed endpoint must not loop). (ENG-673)
         if stop_reason is None:
-            logger.warning("stream ended with no finish_reason — treating as truncated")
-            raise TransientProviderError(
-                "The model provider ended the response early — try again in a moment.",
-                provider="The model provider", code="truncated_stream", session_backoff=False,
-            )
+            if content_text or tool_calls:
+                logger.warning("stream ended with no finish_reason but produced output — "
+                               "passing through (provider likely omits finish_reason)")
+            else:
+                logger.warning("stream ended empty with no finish_reason — treating as truncated")
+                raise TransientProviderError(
+                    "The model provider ended the response early — try again in a moment.",
+                    provider="The model provider", code="truncated_stream",
+                    session_backoff=False, model=model,
+                )
 
         yield StreamComplete(
             response=LLMResponse(
@@ -1097,6 +1105,7 @@ class OpenAIProvider(LLMProvider):
             raise TransientProviderError(
                 "Could not reach the model provider — check your connection or try again in a moment.",
                 provider="The model provider", code="connection_error", session_backoff=False,
+                model=model,
             ) from exc
 
         return _parse_response_object(response, model)
@@ -1215,6 +1224,7 @@ class OpenAIProvider(LLMProvider):
             raise TransientProviderError(
                 "Could not reach the model provider — check your connection or try again in a moment.",
                 provider="The model provider", code="connection_error", session_backoff=False,
+                model=model,
             ) from exc
 
         yield StreamComplete(

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -329,11 +329,16 @@ class TransientProviderError(ConnectionError):
     def __init__(
         self, message: str, *, provider: str = "", code: str | None = None,
         retry_after: float | None = None, session_backoff: bool = True,
+        model: str = "",
     ) -> None:
         super().__init__(message)
         self.provider = provider
         self.code = code
         self.retry_after = retry_after
+        # The model that was in flight when this failed — so a downstream
+        # ProviderOverloadedError names the ACTUAL model (planning OR coding),
+        # not whatever the session defaults to (ENG-673).
+        self.model = model
         # Whether the SESSION should spend its backoff budget on this (ENG-673).
         # True for failures that had NO prior retry — a mid-stream error (arrives
         # inside an HTTP-200 stream), a dropped connection, or a truncated stream.
@@ -371,7 +376,7 @@ _TRANSIENT_ERROR_TYPES = frozenset(
 
 
 def classify_transient(
-    status_code: int | None, body: Any, *, provider: str = ""
+    status_code: int | None, body: Any, *, provider: str = "", model: str = ""
 ) -> "TransientProviderError | None":
     """Arm A of the transient classifier (see ENG-673): inspect an
     ``APIStatusError``'s status + body and return a ``TransientProviderError`` if
@@ -394,19 +399,19 @@ def classify_transient(
         # a misleading 200 mid-stream, or a real 529 at request time).
         return TransientProviderError(
             f"{provider or 'The model provider'} is momentarily overloaded.",
-            provider=provider, code=etype, session_backoff=session_backoff,
+            provider=provider, code=etype, session_backoff=session_backoff, model=model,
         )
     if isinstance(status_code, int) and 500 <= status_code < 600:
         return TransientProviderError(
             f"{provider or 'The model provider'} returned {status_code}.",
-            provider=provider, code=f"http_{status_code}", session_backoff=False,
+            provider=provider, code=f"http_{status_code}", session_backoff=False, model=model,
         )
     if status_code == 429 and not b.get("detail"):
         # Plain rate-limit ("slow down"), NOT an out-of-quota 429 (that carries a
         # `detail` and is mapped to TokenLimitExceeded upstream of this call).
         return TransientProviderError(
             f"{provider or 'The model provider'} is rate-limiting requests.",
-            provider=provider, code="rate_limited", session_backoff=False,
+            provider=provider, code="rate_limited", session_backoff=False, model=model,
         )
     return None
 

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -387,7 +387,12 @@ def classify_transient(
     out — this decides between "retryable transient" and "generic unavailable".
     """
     b = body if isinstance(body, dict) else {}
-    err = b.get("error") if isinstance(b.get("error"), dict) else {}
+    # Two body dialects: Anthropic nests the error under `error` ({"error":
+    # {"type": ...}}); the OpenAI SDK unwraps its envelope (`body.get("error",
+    # body)`) so the type sits at the TOP level. Read the nested object when
+    # present, otherwise treat the body itself as the error object — so the
+    # mid-stream case classifies on BOTH providers (ENG-673, Sam's review).
+    err = b.get("error") if isinstance(b.get("error"), dict) else b
     etype = err.get("type") or err.get("code")
     # A mid-stream failure has no real HTTP error status (it's smuggled into an
     # already-sent 200, or there's no status at all), so the SDK never retried it

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -312,6 +312,105 @@ class TokenLimitExceeded(Exception):
     """Raised when the LLM returns 429 due to billing/token limits."""
 
 
+class TransientProviderError(ConnectionError):
+    """Raised when the provider fails in a way that a retry might fix.
+
+    Covers provider/infra-side hiccups — an ``overloaded_error``/``api_error``
+    event (including the mid-stream case that arrives inside an HTTP-200 stream,
+    see ENG-673), a 5xx, a plain 429 (no quota detail), a dropped connection, or
+    a truncated stream. The session loop backs off and retries these within a
+    bounded budget; distinct from auth/quota/model-gate failures, which are
+    permanent for the identical request and must fail fast.
+
+    Subclasses ConnectionError so legacy call sites that only know the
+    ConnectionError mapping keep working unchanged.
+    """
+
+    def __init__(
+        self, message: str, *, provider: str = "", code: str | None = None,
+        retry_after: float | None = None, session_backoff: bool = True,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.code = code
+        self.retry_after = retry_after
+        # Whether the SESSION should spend its backoff budget on this (ENG-673).
+        # True for failures that had NO prior retry — a mid-stream error (arrives
+        # inside an HTTP-200 stream), a dropped connection, or a truncated stream.
+        # False for request-time HTTP errors (real 4xx/5xx): the SDK already
+        # retried those with backoff, so the session fails fast (still with the
+        # honest typed message) instead of stacking another 30s on top.
+        self.session_backoff = session_backoff
+
+
+class ProviderOverloadedError(ConnectionError):
+    """Terminal form of a transient failure: the retry budget was exhausted.
+
+    Carries the failing ``model`` + ``provider`` so cowork-server can render the
+    ``provider_overloaded`` card (the MindsHub cross-provider-failover nudge).
+    Typed consumers read ``code``/``model``/``provider``; it subclasses
+    ConnectionError for legacy call sites.
+    """
+
+    def __init__(
+        self, message: str, *, provider: str = "", model: str = "",
+        code: str = "provider_overloaded",
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.model = model
+        self.code = code
+
+
+# Body ``error.type``/``error.code`` values that mean "provider is momentarily
+# failing" — retryable. The mid-stream overload arrives with one of these inside
+# an HTTP-200 stream (ENG-673), so classification must read the body, not status.
+_TRANSIENT_ERROR_TYPES = frozenset(
+    {"overloaded_error", "overloaded", "api_error", "server_error", "service_unavailable"}
+)
+
+
+def classify_transient(
+    status_code: int | None, body: Any, *, provider: str = ""
+) -> "TransientProviderError | None":
+    """Arm A of the transient classifier (see ENG-673): inspect an
+    ``APIStatusError``'s status + body and return a ``TransientProviderError`` if
+    it's a retryable provider/infra failure, else ``None``.
+
+    Shared by both providers so the mapping can't drift. Call this only AFTER the
+    permanent classifications (401 / 429-quota / 403 model-gate) have been ruled
+    out — this decides between "retryable transient" and "generic unavailable".
+    """
+    b = body if isinstance(body, dict) else {}
+    err = b.get("error") if isinstance(b.get("error"), dict) else {}
+    etype = err.get("type") or err.get("code")
+    # A mid-stream failure has no real HTTP error status (it's smuggled into an
+    # already-sent 200, or there's no status at all), so the SDK never retried it
+    # → the session must. A request-time error carries a real 4xx/5xx → the SDK
+    # already retried → fail fast.
+    session_backoff = status_code is None or status_code == 200
+    if isinstance(etype, str) and etype in _TRANSIENT_ERROR_TYPES:
+        # Explicit overload/api_error — the body is authoritative (status may be
+        # a misleading 200 mid-stream, or a real 529 at request time).
+        return TransientProviderError(
+            f"{provider or 'The model provider'} is momentarily overloaded.",
+            provider=provider, code=etype, session_backoff=session_backoff,
+        )
+    if isinstance(status_code, int) and 500 <= status_code < 600:
+        return TransientProviderError(
+            f"{provider or 'The model provider'} returned {status_code}.",
+            provider=provider, code=f"http_{status_code}", session_backoff=False,
+        )
+    if status_code == 429 and not b.get("detail"):
+        # Plain rate-limit ("slow down"), NOT an out-of-quota 429 (that carries a
+        # `detail` and is mapped to TokenLimitExceeded upstream of this call).
+        return TransientProviderError(
+            f"{provider or 'The model provider'} is rate-limiting requests.",
+            provider=provider, code="rate_limited", session_backoff=False,
+        )
+    return None
+
+
 class ModelUnavailableError(ConnectionError):
     """Raised when the gateway rejects the requested model with a structured 403.
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1696,15 +1696,20 @@ class ChatSession:
                             )
                             _transient_attempt += 1
                             if await self._backoff_sleep(delay):
-                                raise  # cancelled during backoff — abort the turn
+                                # User cancelled during backoff — stop cleanly
+                                # (like a normal stop), not with an error card.
+                                break
                             continue
                         # Budget exhausted — fail with an actionable, honest error
                         # the server renders as the provider_overloaded card.
+                        # Name the model that actually failed (planning OR coding),
+                        # falling back to the session's planning model.
                         raise ProviderOverloadedError(
                             f"{_agent_exc.provider or 'The model provider'} is experiencing an "
                             "incident and didn't recover in time.",
                             provider=getattr(_agent_exc, "provider", "") or "",
-                            model=getattr(self._llm, "planning_model", "") or "",
+                            model=(getattr(_agent_exc, "model", "") or "")
+                            or getattr(self._llm, "planning_model", "") or "",
                         ) from _agent_exc
 
                     _retry_count += 1

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1725,18 +1725,27 @@ class ChatSession:
                     # and we get the same 400 forever.
                     self._seal_dangling_tool_uses("interrupted by error")
                     if _retry_count <= _max_auto_retries:
-                        # Inject the error into history and let the LLM try to recover
-                        self._append_history(
-                            {
-                                "role": "user",
-                                "content": (
-                                    f"SYSTEM: An error interrupted execution: {_agent_exc}\n\n"
-                                    "If you can diagnose and fix the issue, continue working on the task. "
-                                    "Adjust your approach to avoid the same error. "
-                                    "If this is unrecoverable, summarize what you accomplished and suggest next steps."
-                                ),
-                            }
-                        )
+                        # Inject the error into history and let the LLM try to
+                        # recover. A TransientProviderError reaching here is a
+                        # request-time provider blip (5xx / rate-limit / dropped
+                        # connection) — NOT the model's fault, so don't tell it to
+                        # "adjust your approach" (that misattributes the failure
+                        # and can degrade the next attempt during an incident);
+                        # just note it was transient and continue as planned (ENG-673).
+                        if isinstance(_agent_exc, TransientProviderError):
+                            recovery_note = (
+                                f"SYSTEM: A temporary provider error interrupted execution: {_agent_exc}\n\n"
+                                "This was a transient service issue, not a problem with your approach — "
+                                "continue the task as planned."
+                            )
+                        else:
+                            recovery_note = (
+                                f"SYSTEM: An error interrupted execution: {_agent_exc}\n\n"
+                                "If you can diagnose and fix the issue, continue working on the task. "
+                                "Adjust your approach to avoid the same error. "
+                                "If this is unrecoverable, summarize what you accomplished and suggest next steps."
+                            )
+                        self._append_history({"role": "user", "content": recovery_note})
                         # Continue the while loop — _stream_and_handle_tools will be called
                         # again with the error context now in history
                         continue

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import random
 from collections.abc import AsyncIterator, Callable
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime
@@ -26,6 +27,7 @@ from anton.core.llm.prompts import (
 from anton.core.llm.provider import (
     ContextOverflowError,
     ModelUnavailableError,
+    ProviderOverloadedError,
     StreamComplete,
     StreamContextCompacted,
     StreamEvent,
@@ -34,6 +36,7 @@ from anton.core.llm.provider import (
     StreamToolResult,
     TokenLimitExceeded,
     ToolCall,
+    TransientProviderError,
 )
 from anton.core.llm.tracing import (
     TraceContext,
@@ -173,6 +176,11 @@ class ChatSessionConfig:
 
 class ChatSession:
     """Manages a multi-turn conversation with tool-call delegation."""
+
+    # ENG-673: wall-clock budget for backing off + retrying transient provider
+    # failures within a single turn. Class attribute so it's tunable (a future
+    # per-surface / config knob) and injectable in tests.
+    _transient_budget_s: float = 30.0
 
     def __init__(self, config: ChatSessionConfig) -> None:
         s = config.settings or CoreSettings()
@@ -975,6 +983,34 @@ class ChatSession:
                 compacted = True
         return compacted
 
+    @staticmethod
+    def _transient_backoff_delay(attempt: int, retry_after: float | None = None) -> float:
+        """Backoff for a transient-provider retry (ENG-673).
+
+        Honors a provider `retry_after` when present (usually only on
+        request-time 429/529 — the mid-stream 200 case carries none). Otherwise
+        ~2s → ~10s → ~18s with ±20% jitter, so a fleet recovering from the same
+        incident doesn't retry in lockstep against an already-struggling provider.
+        """
+        if retry_after is not None and retry_after > 0:
+            return min(float(retry_after), 30.0)
+        base = (2.0, 10.0, 18.0)
+        d = base[attempt] if attempt < len(base) else base[-1]
+        return d * (0.8 + 0.4 * random.random())
+
+    async def _backoff_sleep(self, delay: float) -> bool:
+        """Sleep `delay` seconds, waking early if the turn is cancelled.
+
+        Returns True if cancelled during the wait, False if the full delay
+        elapsed — so a user hitting stop during backoff aborts immediately
+        instead of waiting out the incident (ENG-673).
+        """
+        try:
+            await asyncio.wait_for(self._cancel_event.wait(), timeout=delay)
+            return True  # _cancel_event fired
+        except asyncio.TimeoutError:
+            return False  # slept the full delay
+
     def _seal_dangling_tool_uses(self, reason: str = "interrupted") -> int:
         """Append synthetic `tool_result` blocks for any unmatched
         `tool_use` blocks in the last assistant message.
@@ -1584,6 +1620,14 @@ class ChatSession:
         assistant_text_parts: list[str] = []
         _max_auto_retries = 2
         _retry_count = 0
+        # ENG-673: a mid-stream provider failure that had NO prior retry (an
+        # overload smuggled into an HTTP-200 stream) gets budget-bounded
+        # backoff-and-retry — separate from the instant, count-bounded recovery
+        # used for genuine errors. The clock starts on the first such error and
+        # is measured across the turn. Request-time transients (real 5xx/429,
+        # connection errors) carry session_backoff=False and skip this path.
+        _transient_deadline: float | None = None
+        _transient_attempt = 0
         self._active_explainability = ExplainabilityCollector(
             self._explainability_store,
             turn=self._turn_count + 1,
@@ -1623,6 +1667,46 @@ class ChatSession:
                     # map them to their cards.
                     if isinstance(_agent_exc, (TokenLimitExceeded, ModelUnavailableError)):
                         raise
+
+                    # ENG-673: a mid-stream transient failure that had NO prior
+                    # retry (overload smuggled into a 200, or a truncated stream).
+                    # Back off and retry the SAME step within a per-turn budget —
+                    # do NOT inject a "you errored, change approach" note (it was
+                    # a provider blip, not the model's fault) and do NOT spend the
+                    # count-based retry budget reserved for genuine errors.
+                    # Completed tool_results already sit in history and are never
+                    # re-executed on retry (idempotency); we only seal any
+                    # tool_use the interrupted stream left dangling so the retried
+                    # request is valid. Request-time transients (real 5xx/429,
+                    # connection errors) set session_backoff=False — the SDK
+                    # already retried them, so they fall through to the fast
+                    # count-based path below with their honest typed message.
+                    if isinstance(_agent_exc, TransientProviderError) and _agent_exc.session_backoff:
+                        now = asyncio.get_running_loop().time()
+                        if _transient_deadline is None:
+                            _transient_deadline = now + self._transient_budget_s
+                        self._seal_dangling_tool_uses("interrupted by a transient provider error")
+                        remaining = _transient_deadline - now
+                        if remaining > 0.5:
+                            delay = min(
+                                self._transient_backoff_delay(
+                                    _transient_attempt, _agent_exc.retry_after
+                                ),
+                                remaining,
+                            )
+                            _transient_attempt += 1
+                            if await self._backoff_sleep(delay):
+                                raise  # cancelled during backoff — abort the turn
+                            continue
+                        # Budget exhausted — fail with an actionable, honest error
+                        # the server renders as the provider_overloaded card.
+                        raise ProviderOverloadedError(
+                            f"{_agent_exc.provider or 'The model provider'} is experiencing an "
+                            "incident and didn't recover in time.",
+                            provider=getattr(_agent_exc, "provider", "") or "",
+                            model=getattr(self._llm, "planning_model", "") or "",
+                        ) from _agent_exc
+
                     _retry_count += 1
                     # Anthropic's API rejects any history where the
                     # message after a `tool_use` lacks matching

--- a/tests/e2e/scenarios/test_error_handling.py
+++ b/tests/e2e/scenarios/test_error_handling.py
@@ -47,8 +47,10 @@ def test_http_500_handled_gracefully(cfg, tmp_path):
 
     assert_exit_ok(result)
     assert_not_output(result, "Traceback (most recent call last)")
-    # After 3 retries the fallback text surfaces the ConnectionError message (openai.py:364)
-    assert_output(result, "Server returned 500")
+    # ENG-673: a request-time 5xx is now classified as a transient provider error
+    # and (since the SDK already retried it) fails fast with the honest typed
+    # message rather than the old "Server returned 500" phrasing.
+    assert_output(result, "returned 500")
 
 
 @pytest.mark.stub_only

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -26,7 +26,11 @@ import openai
 import pytest
 
 from anton.core.llm.openai import _raise_for_status_error
-from anton.core.llm.provider import ModelUnavailableError, TokenLimitExceeded
+from anton.core.llm.provider import (
+    ModelUnavailableError,
+    TokenLimitExceeded,
+    TransientProviderError,
+)
 
 
 def _sdk_error(status_code, json_body=None, text_body=None):
@@ -114,17 +118,23 @@ def test_429_enveloped_detail_also_maps_to_token_limit():
     # the `detail` field, the SDK unwraps it to top level — still classified.
     # (An envelope carrying only `message` — OpenAI's own quota dialect —
     # deliberately stays generic; see the mapper docstring's known limits.)
+    # Classified before the transient path (429+detail → quota), so ENG-673's
+    # bare-429-is-transient change leaves this untouched.
     exc = _sdk_error(429, json_body={"error": {"detail": "Monthly limit exceeded for tokens: 5/5"}})
     with pytest.raises(TokenLimitExceeded) as err:
         _raise_for_status_error(exc, "sonnet")
     assert "Monthly limit exceeded" in str(err.value)
 
 
-def test_bare_429_stays_generic():
+def test_bare_429_is_transient_fail_fast():
+    # ENG-673: a plain 429 (no quota detail) is a retryable rate-limit, but the
+    # SDK already retried it at request time → fail fast (no session backoff).
+    # Replaces the old test_bare_429_stays_generic — this path is now typed.
     exc = _sdk_error(429, json_body={})
-    with pytest.raises(ConnectionError) as err:
+    with pytest.raises(TransientProviderError) as err:
         _raise_for_status_error(exc, "sonnet")
-    assert "temporarily unavailable" in str(err.value)
+    assert err.value.session_backoff is False
+    assert "rate-limiting" in str(err.value).lower()
 
 
 def test_429_list_detail_stays_generic():
@@ -239,10 +249,13 @@ def test_429_with_detail_wins_even_if_error_code_present():
         _raise_for_status_error(exc, "sonnet")
 
 
-# ── other statuses stay generic ───────────────────────────────────────
+# ── 5xx / infra failures are transient (ENG-673) ──────────────────────
 
-def test_500_stays_generic():
-    exc = _sdk_error(500, json_body={"error": {"message": "boom"}})
-    with pytest.raises(ConnectionError) as err:
+def test_500_is_transient_fail_fast():
+    # ENG-673: a request-time 5xx is transient (retryable), but SDK-retried
+    # already → fail fast with the honest typed message, no session backoff.
+    exc = _sdk_error(500, json_body={})
+    with pytest.raises(TransientProviderError) as err:
         _raise_for_status_error(exc, "sonnet")
-    assert "Server returned 500" in str(err.value)
+    assert err.value.session_backoff is False
+    assert "returned 500" in str(err.value)

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -6,10 +6,10 @@ Covers the anton-side of the fix without a live provider:
     right typed exception for each failure, incl. the mid-stream HTTP-200 case.
   * the session backoff helpers — cadence, `retry_after`, and cancel-awareness.
 
-The end-to-end turn behavior (retry recovers, budget exhausts to a
-`provider_overloaded` card, completed tools aren't re-run) is exercised by the
-mock-provider harness in `test_transient_retry_e2e` / the fixture under
-`tests/fixtures/`.
+The real-SDK wire path (a genuine SSE `error` inside a 200 is parsed and
+classified on BOTH providers) is exercised by the mock-provider harness in
+`test_transient_retry_e2e.py`, which drives the real anthropic/openai SDKs
+against an `httpx.MockTransport`.
 """
 
 from __future__ import annotations
@@ -189,6 +189,9 @@ def test_provider_overloaded_error_carries_model_and_provider():
 
 from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
 
+import httpx  # noqa: E402
+import openai  # noqa: E402
+
 from anton.chat import ChatSession  # noqa: E402
 from anton.core.llm.openai import OpenAIProvider  # noqa: E402
 from anton.core.llm.provider import StreamComplete, StreamTextDelta  # noqa: E402
@@ -244,7 +247,75 @@ async def test_stream_empty_without_finish_reason_is_truncated():
     with pytest.raises(TransientProviderError) as ei:
         await _run_openai_stream([])
     assert ei.value.code == "truncated_stream"
+    # Deliberate carve-out (ENG-673): an empty-from-start 200 is a broken-endpoint
+    # signal, not a mid-incident blip — it fails fast rather than looping the
+    # backoff budget. Genuine mid-incident silence arrives as a connection drop /
+    # read timeout / SSE error, which DO back off (tested above/below).
     assert ei.value.session_backoff is False
+
+
+# --------------------------------------------------------------------------- #
+# mid-stream vs request-time boundary — the ENG-673 session_backoff flag
+# (Sam's review): a failure AFTER the 200 was never SDK-retried → session backs
+# off; a failure DURING establishment was already SDK-retried → fail fast.
+# Drive a REAL OpenAIProvider whose client we replace, so the genuine openai.*
+# exception classes match the provider's except clauses (no module patching).
+# --------------------------------------------------------------------------- #
+
+def _req() -> httpx.Request:
+    return httpx.Request("POST", "http://mock/v1/chat/completions")
+
+
+async def _drain_openai_with_create(create_mock) -> TransientProviderError:
+    prov = OpenAIProvider(api_key="k")
+    prov._client = AsyncMock()
+    prov._client.chat.completions.create = create_mock
+    with pytest.raises(TransientProviderError) as ei:
+        _ = [
+            ev async for ev in prov.stream(
+                model="latest:sonnet", system="s",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+    return ei.value
+
+
+async def test_stream_connection_drop_during_establishment_is_fail_fast():
+    # create() itself raises → the SDK already retried at the transport layer.
+    exc = await _drain_openai_with_create(
+        AsyncMock(side_effect=openai.APIConnectionError(request=_req()))
+    )
+    assert exc.code == "connection_error"
+    assert exc.session_backoff is False
+
+
+async def test_stream_connection_drop_midstream_backs_off():
+    # A 200 was established (first chunk arrived) then the connection dropped —
+    # the SDK never retried this, so the session must.
+    async def _aiter():
+        yield _chunk(content="partial")
+        raise openai.APIConnectionError(request=_req())
+
+    exc = await _drain_openai_with_create(AsyncMock(return_value=_aiter()))
+    assert exc.code == "connection_error"
+    assert exc.session_backoff is True
+
+
+async def test_stream_midstream_bare_apierror_is_classified_and_backs_off():
+    # The OpenAI-shaped gap: a mid-stream SSE `error` surfaces as a bare
+    # openai.APIError (no status_code, body type at top level), which is NOT an
+    # APIStatusError. It must still be caught, classified from the body, and
+    # backed off — otherwise it escapes as an opaque generic error (ENG-673).
+    async def _aiter():
+        yield _chunk(content="Hel")
+        raise openai.APIError(
+            "overloaded", request=_req(),
+            body={"type": "server_error", "message": "overloaded"},
+        )
+
+    exc = await _drain_openai_with_create(AsyncMock(return_value=_aiter()))
+    assert exc.session_backoff is True
+    assert exc.code in ("server_error", "stream_error")
 
 
 def _session() -> ChatSession:

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -338,6 +338,30 @@ async def test_provider_overloaded_names_the_failing_model_not_planning():
     assert ei.value.model == "latest:haiku"   # the failing model, not planning
 
 
+async def test_request_time_transient_does_not_tell_model_to_adjust_approach():
+    # ENG-673 #6: a request-time provider blip (session_backoff=False) recovers
+    # via the count-based path, but must NOT inject "adjust your approach" — that
+    # misattributes a service hiccup to the model.
+    s = _session()
+    calls = {"n": 0}
+
+    async def _gen(user_msg):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TransientProviderError(
+                "Server returned 500.", provider="X", code="http_500", session_backoff=False,
+            )
+        yield StreamTextDelta(text="ok done")
+
+    s._stream_and_handle_tools = _gen
+    events = [e async for e in s.turn_stream("do it")]
+
+    assert "ok done" in "".join(e.text for e in events if isinstance(e, StreamTextDelta))
+    history = json.dumps(s._history).lower()
+    assert "transient service issue" in history
+    assert "adjust your approach" not in history
+
+
 def test_classify_transient_propagates_model():
     err = classify_transient(200, {"error": {"type": "overloaded_error"}}, provider="X", model="latest:opus")
     assert err.model == "latest:opus"

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -187,12 +187,64 @@ def test_provider_overloaded_error_carries_model_and_provider():
 # session turn loop — recovery, budget exhaustion, no-replay (idempotency)
 # --------------------------------------------------------------------------- #
 
-from unittest.mock import AsyncMock  # noqa: E402
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
 
 from anton.chat import ChatSession  # noqa: E402
-from anton.core.llm.provider import StreamTextDelta  # noqa: E402
+from anton.core.llm.openai import OpenAIProvider  # noqa: E402
+from anton.core.llm.provider import StreamComplete, StreamTextDelta  # noqa: E402
 from anton.core.session import ChatSessionConfig  # noqa: E402
 from tests.conftest import make_mock_llm  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# provider-level truncation — #1 fix regression guard
+# --------------------------------------------------------------------------- #
+
+def _chunk(content=None, finish_reason=None):
+    delta = MagicMock()
+    delta.content = content
+    delta.tool_calls = None
+    choice = MagicMock()
+    choice.delta = delta
+    choice.finish_reason = finish_reason
+    ch = MagicMock()
+    ch.choices = [choice]
+    ch.usage = None
+    return ch
+
+
+async def _run_openai_stream(chunks):
+    async def _aiter():
+        for c in chunks:
+            yield c
+    with patch("anton.core.llm.openai.openai") as mock_openai:
+        client = AsyncMock()
+        mock_openai.AsyncOpenAI.return_value = client
+        client.chat.completions.create = AsyncMock(return_value=_aiter())
+        prov = OpenAIProvider(api_key="k")
+        return [
+            ev async for ev in prov.stream(
+                model="latest:sonnet", system="s",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        ]
+
+
+async def test_stream_content_without_finish_reason_passes_through():
+    # #1 regression: a COMPLETE answer with no finish_reason (common on
+    # OpenAI-compatible endpoints) must complete, NOT be discarded as truncated.
+    events = await _run_openai_stream([_chunk(content="Hello "), _chunk(content="world")])
+    completes = [e for e in events if isinstance(e, StreamComplete)]
+    assert len(completes) == 1
+    assert completes[0].response.content == "Hello world"
+
+
+async def test_stream_empty_without_finish_reason_is_truncated():
+    # Only the truly-empty no-terminal-marker stream is a genuine truncation.
+    with pytest.raises(TransientProviderError) as ei:
+        await _run_openai_stream([])
+    assert ei.value.code == "truncated_stream"
+    assert ei.value.session_backoff is False
 
 
 def _session() -> ChatSession:

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -1,0 +1,283 @@
+"""ENG-673 — transient mid-stream provider errors: classification + backoff.
+
+Covers the anton-side of the fix without a live provider:
+  * `classify_transient` (Arm A) — the shared body/status classifier.
+  * both provider mappers (`anthropic`/`openai` `_raise_for_status_error`) — the
+    right typed exception for each failure, incl. the mid-stream HTTP-200 case.
+  * the session backoff helpers — cadence, `retry_after`, and cancel-awareness.
+
+The end-to-end turn behavior (retry recovers, budget exhausts to a
+`provider_overloaded` card, completed tools aren't re-run) is exercised by the
+mock-provider harness in `test_transient_retry_e2e` / the fixture under
+`tests/fixtures/`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import types
+
+import pytest
+
+from anton.core.llm.provider import (
+    ModelUnavailableError,
+    ProviderOverloadedError,
+    TokenLimitExceeded,
+    TransientProviderError,
+    classify_transient,
+)
+
+
+class _FakeStatusError(Exception):
+    """Minimal stand-in for anthropic/openai APIStatusError — the mappers only
+    read `.status_code` and `.body`, and `raise X from exc` needs a real exc."""
+
+    def __init__(self, status_code, body):
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = status_code
+        self.body = body
+
+
+# --------------------------------------------------------------------------- #
+# classify_transient (Arm A)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        (200, {"type": "error", "error": {"type": "overloaded_error"}}),  # mid-stream
+        (200, {"error": {"code": "api_error"}}),
+        (503, {}),
+        (500, {}),
+        (429, {}),                       # plain rate-limit (no quota detail)
+    ],
+)
+def test_classify_transient_retryable(status, body):
+    result = classify_transient(status, body, provider="Anthropic")
+    assert isinstance(result, TransientProviderError)
+    assert result.provider == "Anthropic"
+
+
+def test_session_backoff_flag_splits_midstream_from_requesttime():
+    # Mid-stream (overload smuggled into a 200) had NO prior retry → session
+    # backs off. Request-time errors (real 5xx/429/529) were SDK-retried already
+    # → fail fast, no extra session budget.
+    assert classify_transient(
+        200, {"error": {"type": "overloaded_error"}}, provider="X"
+    ).session_backoff is True
+    assert classify_transient(503, {}, provider="X").session_backoff is False
+    assert classify_transient(429, {}, provider="X").session_backoff is False
+    assert classify_transient(
+        529, {"error": {"type": "overloaded_error"}}, provider="X"
+    ).session_backoff is False
+
+
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        (200, {}),                                   # clean stream, no error
+        (401, {}),                                   # auth
+        (403, {"error": {"code": "model_disabled"}}),      # model gate
+        (403, {"error": {"code": "model_access_denied"}}),
+        (429, {"detail": "out of tokens"}),          # quota → TokenLimitExceeded upstream
+        (400, {"error": {"type": "invalid_request_error"}}),
+    ],
+)
+def test_classify_transient_not_retryable(status, body):
+    assert classify_transient(status, body, provider="X") is None
+
+
+# --------------------------------------------------------------------------- #
+# provider mappers — the same input must map identically on both providers
+# --------------------------------------------------------------------------- #
+
+def _anthropic_map(status, body):
+    from anton.core.llm.anthropic import _raise_for_status_error
+    _raise_for_status_error(_FakeStatusError(status, body))
+
+
+def _openai_map(status, body):
+    from anton.core.llm.openai import _raise_for_status_error
+    _raise_for_status_error(_FakeStatusError(status, body), "latest:sonnet")
+
+
+@pytest.mark.parametrize("mapper", [_anthropic_map, _openai_map])
+def test_mapper_midstream_200_is_transient_not_confusing_200(mapper):
+    """The core ENG-673 fix: a mid-stream overload arriving inside an HTTP-200
+    stream must become TransientProviderError, never 'Server returned 200'."""
+    with pytest.raises(TransientProviderError) as ei:
+        mapper(200, {"type": "error", "error": {"type": "overloaded_error"}})
+    assert "200" not in str(ei.value)          # no misleading status echo
+    assert "overloaded" in str(ei.value).lower()
+
+
+@pytest.mark.parametrize("mapper", [_anthropic_map, _openai_map])
+def test_mapper_5xx_is_transient(mapper):
+    with pytest.raises(TransientProviderError):
+        mapper(503, {})
+
+
+@pytest.mark.parametrize("mapper", [_anthropic_map, _openai_map])
+def test_mapper_quota_429_is_token_limit_not_transient(mapper):
+    with pytest.raises(TokenLimitExceeded):
+        mapper(429, {"detail": "You have run out of tokens."})
+
+
+@pytest.mark.parametrize("mapper", [_anthropic_map, _openai_map])
+def test_mapper_401_stays_connectionerror_fail_fast(mapper):
+    # 401 must NOT be transient — retrying resends the same bad key forever.
+    with pytest.raises(ConnectionError) as ei:
+        mapper(401, {})
+    assert not isinstance(ei.value, TransientProviderError)
+
+
+def test_openai_mapper_model_gate_still_model_unavailable():
+    # ENG-598 behavior must be preserved: structured 403 → ModelUnavailableError.
+    with pytest.raises(ModelUnavailableError):
+        _openai_map(403, {"error": {"code": "model_access_denied"}})
+
+
+# --------------------------------------------------------------------------- #
+# session backoff helpers
+# --------------------------------------------------------------------------- #
+
+def _delay(attempt, retry_after=None):
+    from anton.core.session import ChatSession
+    return ChatSession._transient_backoff_delay(attempt, retry_after)
+
+
+def test_backoff_cadence_grows_and_jitters():
+    # Monotone-ish base cadence ~2 → ~10 → ~18, each within its ±20% jitter band.
+    assert 1.6 <= _delay(0) <= 2.4
+    assert 8.0 <= _delay(1) <= 12.0
+    assert 14.4 <= _delay(2) <= 21.6
+    # Beyond the table, clamps to the last step (still jittered).
+    assert 14.4 <= _delay(9) <= 21.6
+
+
+def test_backoff_honors_retry_after():
+    assert _delay(0, retry_after=5) == 5.0
+    assert _delay(0, retry_after=999) == 30.0   # capped at the budget
+
+
+async def test_backoff_sleep_returns_false_on_full_delay():
+    from anton.core.session import ChatSession
+    ns = types.SimpleNamespace(_cancel_event=asyncio.Event())
+    assert await ChatSession._backoff_sleep(ns, 0.01) is False
+
+
+async def test_backoff_sleep_wakes_on_cancel():
+    from anton.core.session import ChatSession
+    ev = asyncio.Event()
+    ns = types.SimpleNamespace(_cancel_event=ev)
+    ev.set()  # already cancelled → must return immediately, not wait out the delay
+    assert await asyncio.wait_for(ChatSession._backoff_sleep(ns, 30.0), timeout=1.0) is True
+
+
+def test_provider_overloaded_error_carries_model_and_provider():
+    exc = ProviderOverloadedError("boom", provider="Anthropic", model="latest:sonnet")
+    assert exc.code == "provider_overloaded"
+    assert exc.provider == "Anthropic"
+    assert exc.model == "latest:sonnet"
+    assert isinstance(exc, ConnectionError)  # legacy call sites still catch it
+
+
+# --------------------------------------------------------------------------- #
+# session turn loop — recovery, budget exhaustion, no-replay (idempotency)
+# --------------------------------------------------------------------------- #
+
+from unittest.mock import AsyncMock  # noqa: E402
+
+from anton.chat import ChatSession  # noqa: E402
+from anton.core.llm.provider import StreamTextDelta  # noqa: E402
+from anton.core.session import ChatSessionConfig  # noqa: E402
+from tests.conftest import make_mock_llm  # noqa: E402
+
+
+def _session() -> ChatSession:
+    s = ChatSession(ChatSessionConfig(llm_client=make_mock_llm()))
+    s._llm.planning_model = "latest:sonnet"
+    return s
+
+
+def _stream_that_fails_then_succeeds(fail_n: int, calls: dict):
+    """Async-generator factory: raise a transient error `fail_n` times, then
+    yield a successful text delta."""
+    async def _gen(user_msg):
+        calls["n"] += 1
+        if calls["n"] <= fail_n:
+            raise TransientProviderError(
+                "Anthropic is momentarily overloaded.",
+                provider="Anthropic", code="overloaded_error",
+            )
+        yield StreamTextDelta(text="recovered-and-done")
+    return _gen
+
+
+async def test_turn_recovers_after_transient_retries():
+    s = _session()
+    calls = {"n": 0}
+    s._stream_and_handle_tools = _stream_that_fails_then_succeeds(2, calls)
+    s._backoff_sleep = AsyncMock(return_value=False)  # don't really sleep
+
+    events = [e async for e in s.turn_stream("build me a dashboard")]
+
+    text = "".join(e.text for e in events if isinstance(e, StreamTextDelta))
+    assert "recovered-and-done" in text          # turn completed
+    assert calls["n"] == 3                        # 2 failures + 1 success
+    assert s._backoff_sleep.await_count == 2      # backed off before each retry
+
+
+async def test_turn_transient_retry_does_not_inject_recovery_note():
+    """Idempotency/no-replay: a transient blip must NOT inject a 'you errored,
+    change approach' SYSTEM note (which would alter behavior / prompt a replay);
+    it simply retries the same step from unchanged history."""
+    s = _session()
+    calls = {"n": 0}
+    s._stream_and_handle_tools = _stream_that_fails_then_succeeds(2, calls)
+    s._backoff_sleep = AsyncMock(return_value=False)
+
+    _ = [e async for e in s.turn_stream("do it")]
+
+    joined = json.dumps(s._history)
+    assert "An error interrupted execution" not in joined
+    assert "transient provider error" not in joined  # seal reason not injected either
+
+
+async def test_turn_exhausts_budget_to_provider_overloaded():
+    s = _session()
+    s._transient_budget_s = 0.05   # exhaust almost immediately
+    calls = {"n": 0}
+
+    async def _always_fail(user_msg):
+        calls["n"] += 1
+        raise TransientProviderError(
+            "Anthropic is momentarily overloaded.",
+            provider="Anthropic", code="overloaded_error",
+        )
+        yield  # pragma: no cover  (makes this an async generator)
+
+    s._stream_and_handle_tools = _always_fail
+
+    with pytest.raises(ProviderOverloadedError) as ei:
+        _ = [e async for e in s.turn_stream("do it")]
+
+    assert ei.value.code == "provider_overloaded"
+    assert ei.value.provider == "Anthropic"
+    assert ei.value.model == "latest:sonnet"
+
+
+async def test_turn_transient_backoff_cancels_on_stop():
+    """User-stop during backoff aborts immediately rather than waiting out the
+    incident: _backoff_sleep reports cancellation and the turn stops retrying."""
+    s = _session()
+    calls = {"n": 0}
+    s._stream_and_handle_tools = _stream_that_fails_then_succeeds(5, calls)
+    s._backoff_sleep = AsyncMock(return_value=True)  # cancelled during backoff
+
+    with pytest.raises(TransientProviderError):
+        _ = [e async for e in s.turn_stream("do it")]
+
+    assert calls["n"] == 1                    # failed once, then cancelled — no further retries
+    assert s._backoff_sleep.await_count == 1

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -268,16 +268,42 @@ async def test_turn_exhausts_budget_to_provider_overloaded():
     assert ei.value.model == "latest:sonnet"
 
 
+async def test_provider_overloaded_names_the_failing_model_not_planning():
+    # ENG-673 #4: the card must name the model that actually failed (which may be
+    # the coding model), not always the session's planning model.
+    s = _session()  # planning_model = latest:sonnet
+    s._transient_budget_s = 0.05
+
+    async def _always_fail(user_msg):
+        raise TransientProviderError(
+            "overloaded", provider="Anthropic", code="overloaded_error", model="latest:haiku",
+        )
+        yield  # pragma: no cover
+
+    s._stream_and_handle_tools = _always_fail
+    with pytest.raises(ProviderOverloadedError) as ei:
+        _ = [e async for e in s.turn_stream("do it")]
+    assert ei.value.model == "latest:haiku"   # the failing model, not planning
+
+
+def test_classify_transient_propagates_model():
+    err = classify_transient(200, {"error": {"type": "overloaded_error"}}, provider="X", model="latest:opus")
+    assert err.model == "latest:opus"
+
+
 async def test_turn_transient_backoff_cancels_on_stop():
     """User-stop during backoff aborts immediately rather than waiting out the
-    incident: _backoff_sleep reports cancellation and the turn stops retrying."""
+    incident — and stops CLEANLY (like a normal stop), not with a provider-error
+    card surfaced to the user."""
     s = _session()
     calls = {"n": 0}
     s._stream_and_handle_tools = _stream_that_fails_then_succeeds(5, calls)
     s._backoff_sleep = AsyncMock(return_value=True)  # cancelled during backoff
 
-    with pytest.raises(TransientProviderError):
-        _ = [e async for e in s.turn_stream("do it")]
+    events = [e async for e in s.turn_stream("do it")]  # no exception raised
 
     assert calls["n"] == 1                    # failed once, then cancelled — no further retries
     assert s._backoff_sleep.await_count == 1
+    # Clean cancel: no transient-error prose leaks into the transcript.
+    text = "".join(e.text for e in events if isinstance(e, StreamTextDelta))
+    assert "overloaded" not in text.lower()

--- a/tests/test_transient_retry_e2e.py
+++ b/tests/test_transient_retry_e2e.py
@@ -1,0 +1,189 @@
+"""ENG-673 e2e — deterministic mock-provider harness.
+
+Drives the **real** anthropic / openai SDK stream parsers against an
+``httpx.MockTransport`` so we exercise the genuine wire path, not a hand-built
+exception. Proves the core fix on BOTH providers: a provider failure arriving
+*mid-stream inside an HTTP-200 stream* is classified as a retryable
+``TransientProviderError`` (``session_backoff=True``), never the misleading
+"Server returned 200".
+
+Complements ``test_transient_retry.py`` (unit-level classifier + session
+backoff/budget). The turn-level cadence/budget/idempotency behavior lives there
+against a faked stream; here we prove the classification the real SDK produces
+is the input those session tests assume.
+
+No network, no sleeping, no waiting for a real incident — the transport returns
+canned SSE bytes.
+"""
+
+from __future__ import annotations
+
+import anthropic
+import httpx
+import openai
+import pytest
+
+from anton.core.llm.anthropic import AnthropicProvider
+from anton.core.llm.openai import OpenAIProvider
+from anton.core.llm.provider import (
+    StreamComplete,
+    StreamTextDelta,
+    TransientProviderError,
+)
+
+
+# --------------------------------------------------------------------------- #
+# wire payloads
+# --------------------------------------------------------------------------- #
+
+def _sse(*lines: str) -> bytes:
+    return ("".join(lines)).encode()
+
+
+# Anthropic Messages API: a 200 stream that emits message_start then an SSE
+# `error` event carrying overloaded_error — the exact BUG-CM-001 shape.
+_ANTH_MIDSTREAM_OVERLOAD = _sse(
+    'event: message_start\n',
+    'data: {"type":"message_start","message":{"id":"msg_1","type":"message",'
+    '"role":"assistant","model":"claude","content":[],"stop_reason":null,'
+    '"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+    'event: error\n',
+    'data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
+)
+
+# Anthropic: a clean, complete stream (sanity — the harness itself is honest).
+_ANTH_GOOD = _sse(
+    'event: message_start\n',
+    'data: {"type":"message_start","message":{"id":"msg_2","type":"message",'
+    '"role":"assistant","model":"claude","content":[],"stop_reason":null,'
+    '"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+    'event: content_block_start\n',
+    'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+    'event: content_block_delta\n',
+    'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello world"}}\n\n',
+    'event: content_block_stop\n',
+    'data: {"type":"content_block_stop","index":0}\n\n',
+    'event: message_delta\n',
+    'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},'
+    '"usage":{"output_tokens":3}}\n\n',
+    'event: message_stop\n',
+    'data: {"type":"message_stop"}\n\n',
+)
+
+# OpenAI chat.completions: a 200 stream that emits one good chunk then an SSE
+# `error` — the SDK surfaces this as a BARE openai.APIError (status_code=None).
+_OAI_MIDSTREAM_ERROR = _sse(
+    'data: {"id":"1","object":"chat.completion.chunk","choices":'
+    '[{"index":0,"delta":{"content":"Hel"},"finish_reason":null}]}\n\n',
+    'data: {"error":{"message":"The server is overloaded","type":"server_error","code":null}}\n\n',
+)
+
+
+# --------------------------------------------------------------------------- #
+# provider factories wired to a MockTransport
+# --------------------------------------------------------------------------- #
+
+def _anthropic_provider(handler) -> AnthropicProvider:
+    prov = AnthropicProvider(api_key="test")
+    prov._client = anthropic.AsyncAnthropic(
+        api_key="test",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    return prov
+
+
+def _openai_provider(handler) -> OpenAIProvider:
+    # Default flavor is openai-compatible-generic → the chat.completions path
+    # (the MindsHub-passthrough dialect), which is what MindsHub routing uses.
+    prov = OpenAIProvider(api_key="test", base_url="http://mock/v1")
+    prov._client = openai.AsyncOpenAI(
+        api_key="test", base_url="http://mock/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    return prov
+
+
+def _static(body: bytes):
+    def handler(_req):
+        return httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=body
+        )
+    return handler
+
+
+async def _drain(prov):
+    return [
+        ev
+        async for ev in prov.stream(
+            model="latest:sonnet", system="s",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Anthropic
+# --------------------------------------------------------------------------- #
+
+async def test_e2e_anthropic_midstream_overload_is_transient_not_confusing_200():
+    prov = _anthropic_provider(_static(_ANTH_MIDSTREAM_OVERLOAD))
+    with pytest.raises(TransientProviderError) as ei:
+        await _drain(prov)
+    exc = ei.value
+    assert exc.code == "overloaded_error"
+    # The whole point of ENG-673: the 200 must NOT leak into the message, and
+    # the session must be allowed to back off (mid-stream had no SDK retry).
+    assert "200" not in str(exc)
+    assert exc.session_backoff is True
+
+
+async def test_e2e_anthropic_clean_stream_completes():
+    prov = _anthropic_provider(_static(_ANTH_GOOD))
+    events = await _drain(prov)
+    text = "".join(e.text for e in events if isinstance(e, StreamTextDelta))
+    completes = [e for e in events if isinstance(e, StreamComplete)]
+    assert text == "Hello world"
+    assert len(completes) == 1
+    assert completes[0].response.stop_reason == "end_turn"
+
+
+async def test_e2e_anthropic_recovers_after_n_failures():
+    """Attempt log verifies the fail-N-then-succeed shape at the SDK layer:
+    the same request resent after transient failures eventually completes."""
+    state = {"n": 0}
+
+    def handler(_req):
+        state["n"] += 1
+        body = _ANTH_MIDSTREAM_OVERLOAD if state["n"] <= 2 else _ANTH_GOOD
+        return httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, content=body
+        )
+
+    prov = _anthropic_provider(handler)
+    # First two calls fail transiently...
+    for _ in range(2):
+        with pytest.raises(TransientProviderError):
+            await _drain(prov)
+    # ...the third (identical) request succeeds — exactly what the session's
+    # backoff loop replays.
+    events = await _drain(prov)
+    assert "".join(e.text for e in events if isinstance(e, StreamTextDelta)) == "Hello world"
+    assert state["n"] == 3
+
+
+# --------------------------------------------------------------------------- #
+# OpenAI / MindsHub (chat.completions dialect)
+# --------------------------------------------------------------------------- #
+
+async def test_e2e_openai_midstream_error_is_transient():
+    """The OpenAI-shaped gap: a mid-stream SSE error is a bare openai.APIError
+    (no status_code), which must still classify as transient + backoff-able —
+    'the fix is not tested if only Anthropic is mocked' (Sam's review)."""
+    prov = _openai_provider(_static(_OAI_MIDSTREAM_ERROR))
+    with pytest.raises(TransientProviderError) as ei:
+        await _drain(prov)
+    exc = ei.value
+    assert "200" not in str(exc)
+    assert exc.session_backoff is True
+    # server_error is in the transient set → classified by type, not a fallback.
+    assert exc.code in ("server_error", "stream_error")


### PR DESCRIPTION
Part **1 of 3** for ENG-673 (cowork-server + cowork companions to follow — this is the upstream that raises the typed error). Fixes the anton-side of BUG-CM-001.

## Problem

A mid-stream provider overload arrives *inside* an HTTP-200 stream — the status was already sent, so the error is smuggled into the body as an SSE `error` event, and the SDK raises `APIStatusError(status_code=200, body=…)`. anton's status-only classifier turned that into the nonsensical **"Server returned 200 — the LLM endpoint may be temporarily unavailable"**, and the session loop retried it **instantly with zero backoff** — burning all attempts within seconds of a minutes-long incident (Anthropic "elevated errors", 2026-07-08). BYOK/direct users hit this; MindsHub-routed users are shielded by the router's failover.

## What changed

- **Typed errors + shared classifier** (`provider.py`): new `TransientProviderError` / `ProviderOverloadedError`, and `classify_transient()` that reads the **body, not the status** — `overloaded_error`/`api_error`, 5xx, plain-429, connection drops, truncated streams.
- **`anthropic.py`**: the two byte-identical status-only blocks refactored into a shared `_raise_for_status_error` (mirrors the ENG-598 openai mapper). **`openai.py`**: that mapper extended with the transient branch (covers all four call paths).
- **`session.py`**: budget-bounded **backoff-and-retry** (30s/turn, cancellation-aware, jittered ~2/10/18s) for the mid-stream case; on exhaustion raise `ProviderOverloadedError` (carries `model`+`provider`) for the downstream `provider_overloaded` card. Completed `tool_result`s are **never re-executed** on retry — only dangling `tool_use` is sealed.
- **Scrubbed logging** of the error body on every transient occurrence (via ENG-583 `scrub_credentials`).

## Design decisions (aligned on the ticket)

- **Classify by body, not status** — the only way to see the truth once a 200 is on the wire.
- **Split by prior-retry** — the 30s budget is spent **only** on the mid-stream case that had *no* prior retry (overload in a 200). Request-time 5xx/429, connection errors, and truncated streams were already retried by the SDK (or would loop on a hard-bad endpoint), so they carry `session_backoff=False`: honest typed message, but **fail fast** instead of stacking another 30s. This is what keeps a persistently-broken endpoint from hanging 30s (and the e2e error tests fast).
- **Idempotency** — retry re-issues only the failed LLM call; history (with completed tool_results) is unchanged, so a tool that already published/sent can't fire twice.
- **Per-turn 30s budget** from the first transient error; cancellation aborts the backoff immediately.

## Tests

`tests/test_transient_retry.py` (new, 30 cases): the classifier matrix, both provider mappers (incl. the mid-stream-200 → *not* "Server returned 200"), the `session_backoff` split, backoff cadence + `retry_after` + cancel-awareness, and turn-level behavior — recovers after N transient retries, exhausts the budget to `ProviderOverloadedError`, cancels on stop, and does **not** inject a recovery note (no-replay). Updated the two ENG-598 mapper tests (429/500 are now typed-transient) and the two e2e error-handling tests (honest message + fast fail).

**Full suite green** except the 2 pre-existing environmental `test_chat_scratchpad` failures (scratchpad subprocess can't spawn in the sandbox — documented in the ENG-655 PR, unrelated here).

## Security pass (convention #8)

- Logged error body is run through `scrub_credentials` (ENG-583) before hitting logs — no `mdb_`/`sk-`/`AIza` keys leak via a traceback/body echo.
- No new external input is trusted; classification reads only structured `status`/`body.error.type`.
- `ProviderOverloadedError` carries only `model`+`provider` (no keys/PII).

## Self-review notes (for the reviewer)

- **Truncation detection** (`stop_reason is None` after a clean stream iteration) is new and conservative — it raises transient with `session_backoff=False` (fail-fast), so a false-positive costs a quick retry, not a 30s loop. The `_stream_via_responses` path is intentionally **not** truncation-checked (its `status` semantics are less clear); flagging in case we want it later.
- **What triggers the 30s budget is deliberately narrow** — only the evidenced mid-stream-overload-in-a-200 case. If we later see real truncation/connection incidents that would benefit, flipping their `session_backoff` is a one-liner.
- Punted (tracked on the ticket): scheduled/channel auto-fallback, cross-provider switch suggestion, a config kill-switch for the budget.

## Merge order

**Land this before / with cowork-server #186** (or together). The core fix — surviving the incident via backoff-retry — works standalone. But on *budget exhaustion* the honest message only reaches the user once cowork-server maps the code: with an old cowork-server, `ProviderOverloadedError` is unrecognized and degrades to the generic *"An unexpected error occurred"* (still not misleading, and never the old "Server returned 200" — but NOT the curated provider text until #186 lands). Full sequence: anton (this) → cowork-server #186 (map `provider_overloaded` → code + extras) → cowork #388 (the card). Each degrades gracefully; no branch stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
