### PR TITLE
ENG-747: read status-error codes from the shape the SDK actually stores — revives the dead model-403 card

### DIFF
--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -38,16 +38,28 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     Mapping policy:
       - 401 → ConnectionError with the invalid-key copy (cowork-server's
         provider_auth detection keys on this exact phrase).
-      - 403 with a structured gateway code (``error.code`` of
-        ``model_access_denied`` / ``model_disabled``) → ModelUnavailableError
-        carrying the code + model, with actionable copy. Detection is
-        code-exact on purpose: BYOK OpenAI 403s (region blocks), Anthropic
-        permission errors, and Cloudflare HTML 403s carry no such code and
-        must fall through to the generic message, never the plan copy.
+      - 403 with a structured gateway code (``model_access_denied`` /
+        ``model_disabled``) → ModelUnavailableError carrying the code +
+        model, with actionable copy. Detection is code-exact on purpose:
+        BYOK OpenAI 403s (region blocks), Anthropic permission errors, and
+        Cloudflare HTML 403s carry no such code and must fall through to
+        the generic message, never the plan copy.
       - 429 with a quota detail → TokenLimitExceeded, checked first so a body
-        carrying both ``detail`` and ``error.code`` stays token_limit (quota
-        keeps its own card downstream).
+        carrying both ``detail`` and a structured code stays token_limit
+        (quota keeps its own card downstream).
       - anything else → the generic "temporarily unavailable" ConnectionError.
+
+    Body-shape tolerance (ENG-747): the OpenAI SDK UNWRAPS the error
+    envelope before storing it — ``openai/_client.py`` does
+    ``data = body.get("error", body)`` — so for the gateway's OpenAI-style
+    403 (``{"error": {"code": …}}``), ``exc.body`` is the INNER dict and
+    ``code`` sits at top level. The gateway's 429 is FastAPI-style
+    (``{"detail": …}``, no envelope) and passes through untouched. Both
+    fields are therefore read from the top level first with an envelope
+    fallback, so the mapping survives either dialect (and a future gateway
+    standardization of the 429 shape). The originally shipped ENG-598
+    mapper read only ``body["error"]["code"]`` — a key the SDK had already
+    peeled off — which left the model-403 card dead in production.
     """
     if exc.status_code == 401:
         raise ConnectionError(
@@ -55,13 +67,14 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
         ) from exc
 
     body = exc.body if isinstance(exc.body, dict) else {}
-    if exc.status_code == 429 and body.get("detail"):
-        msg = f"Server returned 429 — {body['detail']}"
+    envelope = body.get("error") if isinstance(body.get("error"), dict) else {}
+    detail = body.get("detail") or envelope.get("detail")
+    if exc.status_code == 429 and detail:
+        msg = f"Server returned 429 — {detail}"
         msg += " Visit https://console.mindshub.ai to upgrade or top up your tokens."
         raise TokenLimitExceeded(msg) from exc
 
-    error = body.get("error") if isinstance(body.get("error"), dict) else {}
-    code = error.get("code")
+    code = body.get("code") or envelope.get("code")
     if exc.status_code == 403 and code in ("model_access_denied", "model_disabled"):
         if code == "model_access_denied":
             msg = (

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -55,11 +55,20 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     403 (``{"error": {"code": …}}``), ``exc.body`` is the INNER dict and
     ``code`` sits at top level. The gateway's 429 is FastAPI-style
     (``{"detail": …}``, no envelope) and passes through untouched. Both
-    fields are therefore read from the top level first with an envelope
-    fallback, so the mapping survives either dialect (and a future gateway
-    standardization of the 429 shape). The originally shipped ENG-598
-    mapper read only ``body["error"]["code"]`` — a key the SDK had already
-    peeled off — which left the model-403 card dead in production.
+    fields are therefore read from the top level first, with an envelope
+    fallback for clients that deliver the wire shape unmodified (anton's
+    pyproject allows ``openai>=1.0``, and proxies exist that re-wrap).
+    The originally shipped ENG-598 mapper read only
+    ``body["error"]["code"]`` — a key the SDK had already peeled off —
+    which left the model-403 card dead in production.
+
+    Known limits, on purpose: a wire body carrying BOTH a top-level
+    ``detail`` and an ``error`` envelope loses the detail inside the SDK
+    (the unwrap discards siblings of ``error``) — unrecoverable from
+    ``exc.body``, and no real dialect emits that shape. And a 429 whose
+    envelope carries only ``message`` (OpenAI's own quota dialect, e.g.
+    ``insufficient_quota``) stays generic: classifying arbitrary provider
+    messages as MindsHub quota would put an upsell CTA on BYOK errors.
     """
     if exc.status_code == 401:
         raise ConnectionError(
@@ -69,7 +78,9 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     body = exc.body if isinstance(exc.body, dict) else {}
     envelope = body.get("error") if isinstance(body.get("error"), dict) else {}
     detail = body.get("detail") or envelope.get("detail")
-    if exc.status_code == 429 and detail:
+    # str-only: FastAPI validation errors put a LIST in detail — rendering
+    # its repr into user-facing copy (with an upgrade CTA!) helps nobody.
+    if exc.status_code == 429 and isinstance(detail, str) and detail:
         msg = f"Server returned 429 — {detail}"
         msg += " Visit https://console.mindshub.ai to upgrade or top up your tokens."
         raise TokenLimitExceeded(msg) from exc

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -1,8 +1,7 @@
-"""The shared provider status-error mapper (ENG-598).
+"""The shared provider status-error mapper (ENG-598, fixed in ENG-747).
 
-One mapper (`openai._raise_for_status_error`) now serves all four call paths
-(chat/stream × completions/responses) — previously four copy-pasted blocks
-that had already drifted in wording. These tests pin the mapping policy:
+One mapper (`openai._raise_for_status_error`) serves all four call paths
+(chat/stream × completions/responses). These tests pin the mapping policy:
 
 - 401 → ConnectionError with the exact invalid-key copy (cowork-server's
   provider_auth detection string-matches it).
@@ -11,25 +10,55 @@ that had already drifted in wording. These tests pin the mapping policy:
   with actionable copy per code.
 - Any other 403 (BYOK region blocks, Anthropic permission errors, Cloudflare
   HTML) → the generic message, NEVER the plan copy.
+
+ENG-747: every exception here is constructed by the REAL pinned OpenAI SDK
+from a raw HTTP response (`httpx.MockTransport`), never hand-built. The
+original suite duck-typed `exc.body` as the wire envelope
+(``{"error": {...}}``) — but the SDK UNWRAPS that envelope
+(``openai/_client.py``: ``data = body.get("error", body)``), so the tests
+passed against a shape production never produces and the model-403 card
+shipped dead. If the SDK's behavior ever changes, these tests notice;
+hand-built fixtures cannot.
 """
 
+import httpx
+import openai
 import pytest
 
 from anton.core.llm.openai import _raise_for_status_error
 from anton.core.llm.provider import ModelUnavailableError, TokenLimitExceeded
 
 
-class _FakeStatusError(Exception):
-    """Duck-typed stand-in for openai.APIStatusError (status_code + body)."""
+def _sdk_error(status_code, json_body=None, text_body=None):
+    """Real `openai.APIStatusError`, built by the pinned SDK from a raw HTTP
+    response — exactly what production call sites catch and hand to the
+    mapper. This is the load-bearing difference from the original suite."""
 
-    def __init__(self, status_code, body=None):
-        super().__init__(f"HTTP {status_code}")
-        self.status_code = status_code
-        self.body = body
+    def handler(request: httpx.Request) -> httpx.Response:
+        if text_body is not None:
+            return httpx.Response(status_code, text=text_body)
+        return httpx.Response(status_code, json=json_body if json_body is not None else {})
+
+    client = openai.OpenAI(
+        base_url="http://gateway.test/v1",
+        api_key="test-key",
+        max_retries=0,
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        client.chat.completions.create(
+            model="latest:sonnet", max_tokens=1,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    except openai.APIStatusError as exc:
+        return exc
+    raise AssertionError(f"SDK did not raise for HTTP {status_code}")
 
 
 def _gateway_403(code, model="sonnet"):
-    return _FakeStatusError(403, body={"error": {
+    """The gateway's OpenAI-style 403 envelope, byte-shaped like the live
+    body captured from prod on 2026-07-13 (ENG-747)."""
+    return _sdk_error(403, json_body={"error": {
         "message": f"The model '{model}' is rejected.",
         "type": "invalid_request_error",
         "param": "model",
@@ -37,29 +66,63 @@ def _gateway_403(code, model="sonnet"):
     }})
 
 
+# ── the SDK-unwrap regression itself ──────────────────────────────────
+
+def test_sdk_unwraps_error_envelope():
+    """Documents the SDK behavior that broke ENG-598: `exc.body` is the
+    INNER error object, not the wire envelope. If this ever fails, the SDK
+    changed its parsing and the mapper's shape assumptions need re-auditing."""
+    exc = _gateway_403("model_access_denied")
+    assert isinstance(exc.body, dict)
+    assert "error" not in exc.body
+    assert exc.body["code"] == "model_access_denied"
+
+
 # ── 401 ───────────────────────────────────────────────────────────────
 
 def test_401_maps_to_invalid_key_connection_error():
+    exc = _sdk_error(401, json_body={"error": {"message": "bad key"}})
     with pytest.raises(ConnectionError) as err:
-        _raise_for_status_error(_FakeStatusError(401), "sonnet")
+        _raise_for_status_error(exc, "sonnet")
     # cowork-server's provider_auth detection keys on this exact phrase.
     assert "Invalid API key" in str(err.value)
     assert not isinstance(err.value, ModelUnavailableError)
 
 
+def test_401_html_body_maps_to_invalid_key():
+    # nginx auth walls return HTML — the 401 branch must not need a body.
+    exc = _sdk_error(401, text_body="<html>401 Authorization Required</html>")
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert "Invalid API key" in str(err.value)
+
+
 # ── 429 (quota) ───────────────────────────────────────────────────────
 
-def test_429_with_detail_maps_to_token_limit():
-    exc = _FakeStatusError(429, body={"detail": "Monthly limit exceeded for tokens: 5/5"})
+def test_429_fastapi_detail_maps_to_token_limit():
+    # The gateway's CURRENT dialect: FastAPI HTTPException → {"detail": ...},
+    # no envelope, so the SDK's unwrap is a no-op.
+    exc = _sdk_error(429, json_body={"detail": "Monthly limit exceeded for tokens: 5/5"})
     with pytest.raises(TokenLimitExceeded) as err:
         _raise_for_status_error(exc, "sonnet")
     assert "Monthly limit exceeded" in str(err.value)
     assert "console.mindshub.ai" in str(err.value)
 
 
+def test_429_enveloped_detail_also_maps_to_token_limit():
+    # The time bomb (ENG-747): if the gateway ever standardizes its 429 onto
+    # the OpenAI envelope, the SDK will unwrap it — the card must survive
+    # both dialects.
+    exc = _sdk_error(429, json_body={"error": {"detail": "Monthly limit exceeded for tokens: 5/5"}})
+    with pytest.raises(TokenLimitExceeded) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert "Monthly limit exceeded" in str(err.value)
+
+
 def test_bare_429_stays_generic():
+    exc = _sdk_error(429, json_body={})
     with pytest.raises(ConnectionError) as err:
-        _raise_for_status_error(_FakeStatusError(429), "sonnet")
+        _raise_for_status_error(exc, "sonnet")
     assert "temporarily unavailable" in str(err.value)
 
 
@@ -95,11 +158,19 @@ def test_model_unavailable_is_a_connection_error():
         _raise_for_status_error(_gateway_403("model_disabled"), "sonnet")
 
 
+def test_unwrapped_403_shape_also_maps():
+    # Defensive: a proxy or SDK version that does NOT unwrap would hand the
+    # mapper a top-level-code body directly; both shapes must classify.
+    exc = _sdk_error(403, json_body={"code": "model_access_denied", "message": "no"})
+    with pytest.raises(ModelUnavailableError):
+        _raise_for_status_error(exc, "sonnet")
+
+
 # ── 403 WITHOUT the gateway codes: never the plan copy ────────────────
 
 def test_byok_openai_403_falls_through_to_generic():
     # e.g. OpenAI region block — different error code.
-    exc = _FakeStatusError(403, body={"error": {
+    exc = _sdk_error(403, json_body={"error": {
         "code": "unsupported_country_region_territory",
         "message": "Country not supported.",
     }})
@@ -111,13 +182,14 @@ def test_byok_openai_403_falls_through_to_generic():
 
 def test_html_403_falls_through_to_generic():
     # Cloudflare/WAF blocks have no JSON body at all.
+    exc = _sdk_error(403, text_body="<html>blocked</html>")
     with pytest.raises(ConnectionError) as err:
-        _raise_for_status_error(_FakeStatusError(403, body="<html>blocked</html>"), "sonnet")
+        _raise_for_status_error(exc, "sonnet")
     assert not isinstance(err.value, ModelUnavailableError)
 
 
 def test_403_with_no_code_falls_through_to_generic():
-    exc = _FakeStatusError(403, body={"error": {"message": "forbidden"}})
+    exc = _sdk_error(403, json_body={"error": {"message": "forbidden"}})
     with pytest.raises(ConnectionError) as err:
         _raise_for_status_error(exc, "sonnet")
     assert not isinstance(err.value, ModelUnavailableError)
@@ -127,9 +199,11 @@ def test_403_with_no_code_falls_through_to_generic():
 
 def test_429_with_detail_wins_even_if_error_code_present():
     # A quota failure must stay token_limit, never be misread as model-403.
-    exc = _FakeStatusError(429, body={
-        "detail": "Monthly limit exceeded for tokens: 5/5",
-        "error": {"code": "model_disabled"},
+    # (The SDK unwraps this body to its "error" member, which carries both
+    # fields — precedence must hold on the unwrapped shape too.)
+    exc = _sdk_error(429, json_body={
+        "error": {"detail": "Monthly limit exceeded for tokens: 5/5",
+                  "code": "model_disabled"},
     })
     with pytest.raises(TokenLimitExceeded):
         _raise_for_status_error(exc, "sonnet")
@@ -138,6 +212,7 @@ def test_429_with_detail_wins_even_if_error_code_present():
 # ── other statuses stay generic ───────────────────────────────────────
 
 def test_500_stays_generic():
+    exc = _sdk_error(500, json_body={"error": {"message": "boom"}})
     with pytest.raises(ConnectionError) as err:
-        _raise_for_status_error(_FakeStatusError(500), "sonnet")
+        _raise_for_status_error(exc, "sonnet")
     assert "Server returned 500" in str(err.value)

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -110,9 +110,10 @@ def test_429_fastapi_detail_maps_to_token_limit():
 
 
 def test_429_enveloped_detail_also_maps_to_token_limit():
-    # The time bomb (ENG-747): if the gateway ever standardizes its 429 onto
-    # the OpenAI envelope, the SDK will unwrap it — the card must survive
-    # both dialects.
+    # If the gateway ever moves its 429 into the OpenAI envelope while keeping
+    # the `detail` field, the SDK unwraps it to top level — still classified.
+    # (An envelope carrying only `message` — OpenAI's own quota dialect —
+    # deliberately stays generic; see the mapper docstring's known limits.)
     exc = _sdk_error(429, json_body={"error": {"detail": "Monthly limit exceeded for tokens: 5/5"}})
     with pytest.raises(TokenLimitExceeded) as err:
         _raise_for_status_error(exc, "sonnet")
@@ -124,6 +125,16 @@ def test_bare_429_stays_generic():
     with pytest.raises(ConnectionError) as err:
         _raise_for_status_error(exc, "sonnet")
     assert "temporarily unavailable" in str(err.value)
+
+
+def test_429_list_detail_stays_generic():
+    # FastAPI validation errors put a LIST in detail — its Python repr must
+    # never reach user-facing copy with an upgrade CTA attached.
+    exc = _sdk_error(429, json_body={"detail": [{"loc": ["body", "x"], "msg": "field required"}]})
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert "field required" not in str(err.value)
+    assert not isinstance(err.value, TokenLimitExceeded)
 
 
 # ── 403 with structured gateway codes ────────────────────────────────
@@ -158,11 +169,30 @@ def test_model_unavailable_is_a_connection_error():
         _raise_for_status_error(_gateway_403("model_disabled"), "sonnet")
 
 
-def test_unwrapped_403_shape_also_maps():
-    # Defensive: a proxy or SDK version that does NOT unwrap would hand the
-    # mapper a top-level-code body directly; both shapes must classify.
-    exc = _sdk_error(403, json_body={"code": "model_access_denied", "message": "no"})
+def _wire_shaped_error(status_code, body):
+    """Real `openai.APIStatusError` constructed DIRECTLY with an explicit
+    body — bypassing the SDK's parse-and-unwrap on purpose. This is the only
+    way to hand the mapper an envelope-shaped ``exc.body``: the pinned SDK
+    always peels ``error`` (see test_sdk_unwraps_error_envelope), but
+    anton's pyproject allows ``openai>=1.0`` and proxies exist that re-wrap,
+    so the mapper's envelope fallback must stay pinned by a test that the
+    MockTransport route physically cannot produce."""
+    request = httpx.Request("POST", "http://gateway.test/v1/chat/completions")
+    response = httpx.Response(status_code, json=body if isinstance(body, dict) else None, request=request)
+    return openai.APIStatusError("wire-shaped", response=response, body=body)
+
+
+def test_envelope_shaped_403_maps_via_fallback():
+    # A client that does NOT unwrap delivers the wire envelope verbatim —
+    # the mapper's `envelope.get("code")` fallback is what classifies it.
+    exc = _wire_shaped_error(403, {"error": {"code": "model_access_denied", "message": "no"}})
     with pytest.raises(ModelUnavailableError):
+        _raise_for_status_error(exc, "sonnet")
+
+
+def test_envelope_shaped_429_detail_maps_via_fallback():
+    exc = _wire_shaped_error(429, {"error": {"detail": "Monthly limit exceeded for tokens: 5/5"}})
+    with pytest.raises(TokenLimitExceeded):
         _raise_for_status_error(exc, "sonnet")
 
 


### PR DESCRIPTION
## Summary

Fixes [ENG-747](https://linear.app/mindsdb/issue/ENG-747/model-403-error-card-is-dead-in-prod-the-openai-sdk-unwraps-the-error): the ENG-598 model-unavailable card has been **dead in production** since it shipped — observed live on a fully-updated free-tier machine (2026-07-13) and reproduced deterministically.

**Root cause:** the OpenAI SDK unwraps the error envelope before storing it (`openai/_client.py:416`, `data = body.get("error", body)`), so the gateway's 403 `{"error": {"code": "model_access_denied", …}}` reaches the mapper as the **inner** dict with `code` at top level. The mapper read `body["error"]["code"]` — a key the SDK had already peeled — so every model-403 fell to the generic *"temporarily unavailable"* path: no typed error, no turn error, no card.

**Why 429 worked all along:** the gateway's 429 is FastAPI-style (`{"detail": …}`, no envelope) — the SDK's unwrap is a no-op for it. The working token-limit card was load-bearing on the gateway's dialect inconsistency.

## Fix

- `_raise_for_status_error`: read `code` and `detail` from the top level first, envelope fallback second — correct for both gateway dialects today, and the 429 card now survives a future gateway standardization onto the OpenAI envelope (previously a silent time bomb).
- **Tests rebuilt on the real SDK**: every `APIStatusError` is now constructed by the pinned SDK (`openai 2.21.0`) from a raw HTTP response via `httpx.MockTransport` — the duck-typed `_FakeStatusError` (which hand-built the wire shape the SDK never stores, letting the suite validate the spec against itself) is gone from the status-error path. A dedicated `test_sdk_unwraps_error_envelope` documents the SDK behavior so any future SDK parsing change fails loudly. Coverage: 403 envelope × both codes, 403 pre-unwrapped, 429 both dialects, 429-beats-403 precedence on the unwrapped shape, 401 JSON + 401 nginx-HTML, WAF HTML 403, code-less 403, 500.

## Verification

- Mapper suite: 15 passed. Full suite: **1170 passed, 17 skipped**.
- Repro chain (SDK source line, MockTransport assert-proof with the live-captured prod gateway body, field observation) documented on the ticket.
- End-to-end confirmation available: the live free-tier repro machine — fresh message on a locked model should show the ModelUnavailableCard after this ships.

## Security pass

Reviewed the changed surface: no credentials or user content in error messages beyond the model alias; the HTML-body cases confirm non-JSON error pages can't inject into curated copy (fall through to the generic string); no logging added.

## Notes

- No cowork-server / renderer changes — verified correct in `v2.26.7.13.1`; they were starved of input, not broken.
- `uv.lock` intentionally untouched (the `rich <15` resync drift is pre-existing and already flagged on #244).

🤖 Generated with [Claude Code](https://claude.com/claude-code)