### PR TITLE
feat(publish): add access modes (password/restricted) to /publish and…

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -869,6 +869,41 @@ async def _handle_unpublish(
     console.print(f"  [anton.success]Removed:[/] {title}")
     console.print()
 
+    # 6. Drop the local owner-side record for this report so a later /publish
+    # treats it as a fresh publish instead of offering to "update" (and reusing
+    # the report_id of) a report that no longer exists.
+    import json as _json
+    from pathlib import Path as _Path
+
+    removed_report_id = selected.get("report_id") or ""
+    removed_md5 = selected.get("md5") or ""
+    artifacts_root = _Path(settings.artifacts_dir)
+    for pub_file in artifacts_root.rglob(".published.json"):
+        try:
+            data = _json.loads(pub_file.read_text())
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        changed = False
+        for key in list(data.keys()):
+            entry = data.get(key)
+            if not isinstance(entry, dict):
+                continue
+            entry_report_id = entry.get("report_id") or ""
+            matches = (
+                (removed_report_id and entry_report_id == removed_report_id)
+                or (not entry_report_id and removed_md5 and entry.get("last_md5") == removed_md5)
+            )
+            if matches:
+                del data[key]
+                changed = True
+        if changed:
+            try:
+                pub_file.write_text(_json.dumps(data, indent=2))
+            except Exception:
+                pass
+
 
 async def _agent_zero(console: Console, session: "ChatSession", settings) -> str | None:
     """First-run staged demo. Runs the backup script in a real scratchpad cell.

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -426,6 +426,11 @@ async def _handle_publish(
     import webbrowser
     from pathlib import Path
 
+    from anton.publish_access import (
+        prompt_access,
+        resolve_access,
+        resolve_publish_target,
+    )
     from anton.publisher import publish
 
     console.print()
@@ -475,7 +480,6 @@ async def _handle_publish(
     # directory is no longer scanned; users move old files into a
     # proper artifact subfolder if they still want them publishable.
     artifacts_root = Path(settings.artifacts_dir)
-    publish_index_dir = artifacts_root  # `.published.json` lives at the root
     store = ArtifactStore(artifacts_root)
 
     def _make_candidate(path: Path) -> tuple[str, Path, str, str] | None:
@@ -630,20 +634,34 @@ async def _handle_publish(
         console.print()
         return
 
-    # 3. Check if this artifact was previously published
-    published_json = publish_index_dir / ".published.json"
+    # 3. Resolve where .published.json lives (unified convention) + read prev.
+    _t, published_dir, published_key, _fs = resolve_publish_target(target, [artifacts_root])
+    published_json = published_dir / ".published.json"
     published_map = {}
     try:
         if published_json.is_file():
             published_map = json.loads(published_json.read_text())
     except Exception:
         pass
+    prev = published_map.get(published_key)
+
+    # Back-compat: legacy /publish wrote a single root map keyed by relative path.
+    if not prev:
+        legacy_json = artifacts_root / ".published.json"
+        try:
+            if legacy_json.is_file():
+                legacy_map = json.loads(legacy_json.read_text())
+                legacy_entry = legacy_map.get(file_key)
+                if isinstance(legacy_entry, dict) and legacy_entry.get("report_id"):
+                    prev = legacy_entry  # carry over report_id/url/last_md5/access
+        except Exception:
+            pass
 
     report_id = None
-    prev = published_map.get(file_key)
-
     if prev and prev.get("report_id"):
-        console.print(f"  [anton.muted]Previously published: {prev.get('url', '')}[/]")
+        _mode = prev.get("mode", "public")
+        _badge = {"password": " 🔒 password", "restricted": " 👥 restricted"}.get(_mode, "")
+        console.print(f"  [anton.muted]Previously published: {prev.get('url', '')}{_badge}[/]")
         update_choice = await prompt_or_cancel(
             "  Update existing report, or publish as new?",
             choices=["update", "new", "u", "n"],
@@ -655,6 +673,18 @@ async def _handle_publish(
             return
         if update_choice in ("update", "u"):
             report_id = prev["report_id"]
+        else:
+            prev = None  # publish as new → do not inherit versions/access
+
+    # 3b. Collect access mode from the user.
+    access = await prompt_access(
+        prompt_or_cancel, previous=prev, allow_keep=bool(report_id and prev),
+    )
+    if access is None:
+        console.print()
+        return
+
+    eff_access, pwd_version, access_version, owner_side = resolve_access(None, access, prev)
 
     # 4. Publish
     from rich.live import Live
@@ -669,6 +699,9 @@ async def _handle_publish(
                 report_id=report_id,
                 publish_url=settings.publish_url,
                 ssl_verify=settings.minds_ssl_verify,
+                access=eff_access,
+                pwd_version=pwd_version,
+                access_version=access_version,
             )
         except Exception as e:
             import urllib.error
@@ -698,15 +731,25 @@ async def _handle_publish(
     else:
         console.print(f"  [anton.success]Published![/]")
     console.print(f"  [link={view_url}]{view_url}[/link]")
+
+    _mode = owner_side.get("mode", "public")
+    if _mode == "password":
+        console.print("  [anton.muted]🔒 Password-protected[/]")
+    elif _mode == "restricted":
+        _n = len(owner_side.get("emails", []))
+        _org = " · org allowed" if owner_side.get("org_allowed") else ""
+        console.print(f"  [anton.muted]👥 Restricted · {_n} emails{_org}[/]")
     console.print()
 
-    # 5. Save mapping
+    # 5. Save mapping (owner-side; new unified location + key).
     if returned_report_id:
-        published_map[file_key] = {
+        entry = dict(owner_side)
+        entry.update({
             "report_id": returned_report_id,
             "url": view_url,
             "last_md5": result.get("md5", ""),
-        }
+        })
+        published_map[published_key] = entry
         try:
             published_json.write_text(json.dumps(published_map, indent=2))
         except Exception:

--- a/anton/publish_access.py
+++ b/anton/publish_access.py
@@ -1,0 +1,308 @@
+"""Single source of truth for publish access resolution + target resolution.
+
+Ported verbatim (behaviour-preserving) from cowork-server so that anton's
+`/publish`, anton's `publish_or_preview` tool, and cowork-server all resolve
+access, versioning, and `.published.json` location the same way.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+_EMAIL_SPLIT_RE = re.compile(r"[\s,;]+")
+
+# Keep in sync with anton.publisher._FULLSTACK_EXCLUDED (publisher.py:42):
+# backend.log is the running backend's runtime log — excluded from the
+# published bundle there, so it must not count as user content here either.
+_HOUSEKEEPING_FILES = {"metadata.json", "README.md", "backend.log", ".published.json"}
+
+
+def normalize_emails(values) -> list[str]:
+    """Strip + lowercase + de-dupe, preserving first-seen order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in values or []:
+        email = str(raw).strip().lower()
+        if email and email not in seen:
+            seen.add(email)
+            out.append(email)
+    return out
+
+
+def resolve_access(
+    password: str | None, access: dict | None, previous: Any
+) -> tuple[dict, int, int, dict]:
+    """Resolve effective publish access from request + prior state.
+
+    Returns ``(effective_access, pwd_version, access_version, owner_side)``.
+    A request with no usable selection (empty password, or restricted with no
+    emails and no org) degrades to ``public`` — a server-side safety net for
+    programmatic callers; interactive callers must gate empty input earlier.
+    NOTE: with ``access=None`` and ``password=None`` the mode defaults to
+    ``public`` — the prior mode is NOT inherited (``previous`` only feeds the
+    version counters). Callers that want to preserve a prior non-public mode
+    must reconstruct it via ``access_from_owner_side`` first.
+    """
+    prev = previous if isinstance(previous, dict) else {}
+    password = (password or "").strip() or None
+
+    mode = (access or {}).get("mode") if access else None
+    if not mode:
+        mode = "password" if password else "public"
+
+    prev_pwd_version = prev.get("pwd_version", 0) or 0
+    prev_access_version = prev.get("access_version", 0) or 0
+    pwd_version = prev_pwd_version or 1
+    access_version = prev_access_version or 1
+
+    if mode == "password":
+        pw = ((access or {}).get("password") or password or "").strip() or None
+        if pw:
+            prev_password = prev.get("access_password")
+            pwd_version = (prev_pwd_version + 1) if pw != prev_password else (prev_pwd_version or 1)
+            owner_side = {
+                "mode": "password",
+                "requires_password": True,
+                "access_password": pw,
+                "pwd_version": pwd_version,
+            }
+            return {"mode": "password", "password": pw}, pwd_version, access_version, owner_side
+        mode = "public"  # empty password → public
+
+    if mode == "restricted":
+        emails = normalize_emails((access or {}).get("emails"))
+        org_allowed = bool((access or {}).get("org_allowed"))
+        if emails or org_allowed:
+            prev_restricted = prev.get("mode") == "restricted"
+            prev_emails = prev.get("emails") if prev_restricted else None
+            prev_org = prev.get("org_allowed") if prev_restricted else None
+            changed = (emails != prev_emails) or (org_allowed != prev_org)
+            access_version = (prev_access_version + 1) if changed else (prev_access_version or 1)
+            owner_side = {
+                "mode": "restricted",
+                "requires_password": False,
+                "emails": emails,
+                "org_allowed": org_allowed,
+                "access_version": access_version,
+            }
+            return (
+                {"mode": "restricted", "emails": emails, "org_allowed": org_allowed},
+                pwd_version,
+                access_version,
+                owner_side,
+            )
+        mode = "public"  # nothing selected → public
+
+    return {"mode": "public"}, pwd_version, access_version, {"mode": "public", "requires_password": False}
+
+
+def parse_emails(text_or_list) -> tuple[list[str], list[str]]:
+    """Split + validate emails (mirrors AccessChooser.jsx parseEmailList).
+
+    Accepts a raw string ("a@x.com, b@x.com") or a list. Returns
+    ``(valid, invalid)`` — valid are stripped/lowercased/de-duped, invalid
+    keep their original text (for a "Skipped invalid: ..." warning).
+    """
+    if isinstance(text_or_list, str):
+        tokens = _EMAIL_SPLIT_RE.split(text_or_list)
+    else:
+        tokens = [str(t) for t in (text_or_list or [])]
+    valid: list[str] = []
+    invalid: list[str] = []
+    seen: set[str] = set()
+    for tok in tokens:
+        tok = tok.strip()
+        if not tok:
+            continue
+        low = tok.lower()
+        if _EMAIL_RE.match(low):
+            if low not in seen:
+                seen.add(low)
+                valid.append(low)
+        else:
+            invalid.append(tok)
+    return valid, invalid
+
+
+def access_from_owner_side(entry: Any) -> dict:
+    """Rebuild the input access shape from a stored `.published.json` entry.
+
+    Canonicalises the inline reconstruction that used to live in
+    cowork-server's ``update_artifact``. Used by: /publish "keep", the tool's
+    "preserve previous" default, and cowork-server's update_artifact.
+    """
+    entry = entry if isinstance(entry, dict) else {}
+    mode = entry.get("mode") or ("password" if entry.get("requires_password") else "public")
+    if mode == "password":
+        return {"mode": "password", "password": entry.get("access_password", "") or ""}
+    if mode == "restricted":
+        return {
+            "mode": "restricted",
+            "emails": entry.get("emails", []) or [],
+            "org_allowed": bool(entry.get("org_allowed")),
+        }
+    return {"mode": "public"}
+
+
+def _fullstack_types() -> frozenset[str]:
+    """Artifact types anton's publisher bundles as fullstack apps.
+
+    Imported lazily to avoid a publish_access ↔ publisher import cycle."""
+    from anton.publisher import FULLSTACK_ARTIFACT_TYPES
+    return FULLSTACK_ARTIFACT_TYPES
+
+
+def _load_metadata(folder: Path) -> dict | None:
+    path = folder / "metadata.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Skipping artifact with unreadable metadata: %s", path, exc_info=True)
+        return None
+
+
+def _user_files(folder: Path) -> list[Path]:
+    """All non-housekeeping files inside an artifact folder, mtime desc."""
+    out: list[Path] = []
+    try:
+        for p in folder.rglob("*"):
+            if not p.is_file() or p.is_symlink():
+                continue
+            rel = p.relative_to(folder)
+            top = rel.parts[0] if rel.parts else ""
+            if top in _HOUSEKEEPING_FILES:
+                continue
+            out.append(p)
+    except OSError:
+        return []
+    try:
+        out.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    except OSError:
+        pass
+    return out
+
+
+def _pick_primary(folder: Path, files: list[Path], primary_hint: str | None = None) -> Path | None:
+    """The "open this" file for an artifact."""
+    if primary_hint:
+        try:
+            target = (folder / primary_hint).resolve()
+            target.relative_to(folder.resolve())
+            if target.is_file():
+                return target
+        except (ValueError, OSError):
+            pass
+    if not files:
+        return None
+    index = next((f for f in files if f.name == "index.html"), None)
+    if index is not None:
+        return index
+    html = next((f for f in files if f.suffix.lower() == ".html"), None)
+    if html is not None:
+        return html
+    return files[0]
+
+
+def _artifact_root_for(path: Path, container_dirs: list[Path]) -> Path:
+    """Climb from an artifact file to the folder holding its metadata.json,
+    bounded by the given container dirs (anton: [artifacts_dir]; cowork:
+    _scan_artifact_dirs()). Falls back to path.parent."""
+    containers = {str(Path(d).resolve()) for d in container_dirs}
+    current = path.parent.resolve()
+    while True:
+        if (current / "metadata.json").is_file():
+            return current
+        if str(current) in containers or current.parent == current:
+            return path.parent.resolve()
+        current = current.parent
+
+
+def resolve_publish_target(
+    artifact: Path, container_dirs: list[Path]
+) -> tuple[Path, Path, str, bool]:
+    """Decide what to publish + where `.published.json` lives + its key.
+
+    Returns (publish_target, published_dir, published_key, is_fullstack).
+    - fullstack → publish the artifact *directory*; `.published.json` at root;
+    - static → publish the single primary *file*; `.published.json` in its parent.
+    Always keyed by the primary file name.
+    """
+    if artifact.is_dir():
+        artifact_root = artifact
+        meta = _load_metadata(artifact_root) or {}
+        primary = _pick_primary(artifact_root, _user_files(artifact_root), primary_hint=meta.get("primary"))
+    else:
+        artifact_root = _artifact_root_for(artifact, container_dirs)
+        meta = _load_metadata(artifact_root) if (artifact_root / "metadata.json").is_file() else None
+        primary = artifact
+
+    if (meta or {}).get("type") in _fullstack_types():
+        key = primary.name if primary else "index.html"
+        return artifact_root, artifact_root, key, True
+    if primary:
+        return primary, primary.parent, primary.name, False
+    return artifact_root, artifact_root, "index.html", False
+
+
+async def prompt_access(prompt_fn, *, previous=None, allow_keep=False) -> dict | None:
+    """Interactively collect an access spec via a prompt_or_cancel-like coro.
+
+    Returns an input access dict ({"mode": ...}) or None if the user cancels
+    (Esc at any step). Empty password / empty restricted selection re-prompt
+    rather than silently degrading to public — parity with cowork's
+    isAccessDraftValid(). ``prompt_fn`` is injected so this is unit-testable
+    without a TTY.
+    """
+    choices = ["public", "password", "restricted"]
+    if allow_keep:
+        choices = ["keep"] + choices
+    mode = await prompt_fn(
+        "  Access",
+        choices=choices,
+        choices_display="/".join(choices),
+        default=("keep" if allow_keep else "public"),
+    )
+    if mode is None:
+        return None
+    mode = (mode or "").strip().lower() or ("keep" if allow_keep else "public")
+
+    if mode == "keep":
+        return access_from_owner_side(previous) if previous else {"mode": "public"}
+    if mode == "public":
+        return {"mode": "public"}
+
+    if mode == "password":
+        while True:
+            pw = await prompt_fn("  Password", password=True)
+            if pw is None:
+                return None
+            pw = pw.strip()
+            if pw:
+                return {"mode": "password", "password": pw}
+            # empty → re-prompt (do NOT degrade to public silently)
+
+    if mode == "restricted":
+        while True:
+            raw = await prompt_fn("  Allowed emails (comma or space separated)")
+            if raw is None:
+                return None
+            valid, _invalid = parse_emails(raw)
+            org_ans = await prompt_fn(
+                "  Allow everyone in your organization?",
+                choices=["y", "n"], choices_display="y/n", default="n",
+            )
+            if org_ans is None:
+                return None
+            org_allowed = org_ans.strip().lower() in ("y", "yes")
+            if valid or org_allowed:
+                return {"mode": "restricted", "emails": valid, "org_allowed": org_allowed}
+            # nothing selected → re-prompt
+
+    return {"mode": "public"}

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -376,35 +376,84 @@ CONNECT_DATASOURCE_TOOL = ToolDef(
 )
 
 
+def _previewable_html(path: "Path"):
+    """Best-effort HTML file to open for local preview.
+
+    For a file, returns it as-is; for a folder (e.g. a fullstack artifact),
+    prefers index.html / static/index.html, else the first ``*.html`` found."""
+    from pathlib import Path
+
+    path = Path(path)
+    if path.is_file():
+        return path
+    for cand in (path / "index.html", path / "static" / "index.html"):
+        if cand.is_file():
+            return cand
+    try:
+        htmls = sorted(path.rglob("*.html"))
+    except OSError:
+        htmls = []
+    return htmls[0] if htmls else None
+
+
 async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str:
-    """Interactive preview/publish flow after dashboard creation."""
+    """Interactive preview/publish flow after dashboard creation.
+
+    Accepts the **artifact folder** (preferred) or any file inside it. The
+    artifact type is read from its ``metadata.json`` via
+    ``resolve_publish_target`` — fullstack apps publish the whole folder, static
+    reports publish the primary file — so callers never need to know the type."""
     import os
     import webbrowser
     from pathlib import Path
+
+    from anton.config.settings import AntonSettings
+    from anton.publish_access import (
+        access_from_owner_side,
+        resolve_access,
+        resolve_publish_target,
+    )
 
     console = session._console
 
     raw_path = tc_input.get("file_path", "")
     title = tc_input.get("title", "Dashboard")
     action = tc_input.get("action", "ask")
-    file_path = Path(raw_path)
-    if not file_path.is_absolute() and session._workspace:
-        file_path = Path(session._workspace.base) / raw_path
-
-    if not file_path.exists():
-        return f"File not found: {file_path}"
-
-    # Direct preview — just open and return, no prompts
-    if action in ("preview", "ask"):
-        abs_path = os.path.abspath(str(file_path))
-        webbrowser.open(f"file://{abs_path}")
-        return f"Opened {title} in browser. The user can ask for changes or say /publish to publish it to the web."
-
-    # Publish flow
-    from anton.config.settings import AntonSettings
-    from anton.publisher import publish
 
     settings = AntonSettings()
+    artifacts_root = Path(settings.artifacts_dir)
+
+    # Accept the artifact folder (preferred) or any file inside it. Resolve a
+    # relative path against the artifacts dir first (so "my-app" works), then
+    # the workspace base.
+    file_path = Path(raw_path)
+    if not file_path.is_absolute():
+        base = Path(session._workspace.base) if session._workspace else artifacts_root
+        file_path = next(
+            (c for c in (artifacts_root / raw_path, base / raw_path) if c.exists()),
+            base / raw_path,
+        )
+
+    if not file_path.exists():
+        return f"Path not found: {file_path}"
+
+    # Decide WHAT to publish from the artifact's metadata.json: fullstack → the
+    # whole folder, static → the primary file. Also yields the canonical
+    # .published.json location + key (shared with /publish and cowork-server).
+    publish_target, published_dir, published_key, _is_fullstack = resolve_publish_target(
+        file_path, [artifacts_root]
+    )
+
+    # Direct preview — open a previewable HTML and return, no prompts.
+    if action in ("preview", "ask"):
+        preview_file = _previewable_html(publish_target)
+        if preview_file is not None:
+            webbrowser.open(f"file://{os.path.abspath(str(preview_file))}")
+            return f"Opened {title} in browser. The user can ask for changes or say /publish to publish it to the web."
+        return f"{title} is at {file_path} but no previewable HTML was found."
+
+    # Publish flow
+    from anton.publisher import publish
 
     if not settings.minds_api_key:
         console.print()
@@ -423,19 +472,12 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
     from rich.live import Live
     from rich.spinner import Spinner
 
-    from anton.publish_access import (
-        access_from_owner_side,
-        resolve_access,
-        resolve_publish_target,
-    )
     from anton.utils.prompt import prompt_or_cancel
 
-    # Check if this file was previously published — reuse report_id to
-    # update instead of creating a new report every time. Resolve the
-    # .published.json location with the unified convention (shared with
-    # /publish and cowork-server) so the two entry points never disagree.
-    artifacts_root = Path(settings.artifacts_dir)
-    _t, published_dir, published_key, _fs = resolve_publish_target(file_path, [artifacts_root])
+    # Check if this artifact was previously published — reuse report_id to
+    # update instead of creating a new report every time. published_dir /
+    # published_key were resolved above via the unified convention (shared with
+    # /publish and cowork-server) so the entry points never disagree.
     published_json = published_dir / ".published.json"
     published_map: dict = {}
     try:
@@ -485,7 +527,7 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
     with Live(Spinner("dots", text=action_text, style="anton.cyan"), console=console, transient=True):
         try:
             result = publish(
-                file_path,
+                publish_target,
                 api_key=settings.minds_api_key,
                 report_id=report_id,
                 publish_url=settings.publish_url,
@@ -500,7 +542,7 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
                 # without report_id to create a fresh one.
                 try:
                     result = publish(
-                        file_path,
+                        publish_target,
                         api_key=settings.minds_api_key,
                         publish_url=settings.publish_url,
                         ssl_verify=settings.minds_ssl_verify,
@@ -556,19 +598,27 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
 PUBLISH_TOOL = ToolDef(
     name = "publish_or_preview",
     description = (
-        "Call this after generating an HTML dashboard or report in .anton/output/. "
+        "Call this after generating a dashboard/report/app to preview or publish it. "
+        "Pass the artifact FOLDER as file_path — the tool reads metadata.json and picks "
+        "the right thing to publish (whole folder for fullstack apps, primary file for "
+        "static reports). "
         "Actions: 'ask' (default) prompts the user to preview/publish/skip interactively. "
-        "'preview' opens the file in the browser immediately. "
+        "'preview' opens it in the browser immediately. "
         "'publish' publishes to the web immediately. "
         "Use 'preview' or 'publish' when the user has already stated their intent. "
-        "Use 'ask' after generating a new dashboard to let the user choose."
+        "Use 'ask' after generating a new artifact to let the user choose."
     ),
     input_schema = {
         "type": "object",
         "properties": {
             "file_path": {
                 "type": "string",
-                "description": "Path to the HTML file (e.g. .anton/output/dashboard.html)",
+                "description": (
+                    "Path to the artifact FOLDER (e.g. artifacts/<slug>). The tool reads "
+                    "the folder's metadata.json to decide how to publish: fullstack apps "
+                    "publish the whole folder, static reports publish their primary file. "
+                    "A path to a file inside the artifact also works."
+                ),
             },
             "title": {
                 "type": "string",

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -632,7 +632,7 @@ PUBLISH_TOOL = ToolDef(
             "access_mode": {
                 "type": "string",
                 "enum": ["public", "password", "restricted"],
-                "description": "Access level. ONLY set when the user explicitly asked for it.",
+                "description": "Access level the user chose. If the user hasn't said which access they want, ASK them first (see the tool guidance) rather than guessing; only set this once you know.",
             },
             "password": {
                 "type": "string",
@@ -660,11 +660,17 @@ PUBLISH_TOOL = ToolDef(
         "- user's connected datasources (databases, CRMs, etc.) is fine — this rule only applies to \n"
         "- sharing generated output with the public internet.\n"
         "ACCESS MODE:\n"
-        "- Pass access_mode/password/emails/org_allowed ONLY if the user explicitly asked "
-        "(e.g. 'publish with password', 'share only with a@x.com').\n"
-        "- NEVER invent a password. If the user wants a password but didn't state it, set "
+        "- Before publishing you MUST know the access mode. If the user stated it "
+        "(e.g. 'publish with password', 'share only with a@x.com', 'make it public'), use it: "
+        "set access_mode (+ password/emails/org_allowed) accordingly.\n"
+        "- If the user did NOT specify an access mode, ASK them in chat which one they want — "
+        "public (anyone with the link), password-protected, or restricted to specific emails / "
+        "the whole organization — and wait for their answer before calling this tool with "
+        "action='publish'. Do NOT silently default to public.\n"
+        "- NEVER invent a password. If the user chooses password but gives no value, set "
         "access_mode='password' and leave password empty — the app will prompt them.\n"
-        "- If the user says nothing about access, omit these fields (public, or the artifact's "
-        "previous access is preserved on re-publish)."
+        "- Exception: when re-publishing an artifact that already has access on record and the "
+        "user says nothing new about access, omit these fields to keep its previous access "
+        "(no need to ask again)."
     ),
 )

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -423,10 +423,20 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
     from rich.live import Live
     from rich.spinner import Spinner
 
+    from anton.publish_access import (
+        access_from_owner_side,
+        resolve_access,
+        resolve_publish_target,
+    )
+    from anton.utils.prompt import prompt_or_cancel
+
     # Check if this file was previously published — reuse report_id to
-    # update instead of creating a new report every time.
-    output_dir = file_path.parent
-    published_json = output_dir / ".published.json"
+    # update instead of creating a new report every time. Resolve the
+    # .published.json location with the unified convention (shared with
+    # /publish and cowork-server) so the two entry points never disagree.
+    artifacts_root = Path(settings.artifacts_dir)
+    _t, published_dir, published_key, _fs = resolve_publish_target(file_path, [artifacts_root])
+    published_json = published_dir / ".published.json"
     published_map: dict = {}
     try:
         if published_json.is_file():
@@ -434,9 +444,42 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
     except Exception:
         pass
 
-    file_key = file_path.name
-    prev = published_map.get(file_key)
+    prev = published_map.get(published_key)
     report_id = prev.get("report_id") if isinstance(prev, dict) else None
+
+    # Resolve the access spec: explicit tool fields > preserve previous >
+    # public. NB: password input (when the user asked for a password but gave
+    # no value) is collected BEFORE the Live spinner below — prompt_toolkit
+    # and rich.Live must not run at the same time.
+    access_mode = tc_input.get("access_mode")
+    if access_mode:
+        req_access = {"mode": access_mode}
+        if access_mode == "password":
+            pw = (tc_input.get("password") or "").strip()
+            if not pw:
+                import sys
+                if sys.stdin.isatty():
+                    entered = await prompt_or_cancel("  Set a password for this report", password=True)
+                    if entered is None or not entered.strip():
+                        return "CANCELLED: publish aborted by user (no password entered)."
+                    pw = entered.strip()
+                else:
+                    return (
+                        "CANCELLED: password required but no TTY. Ask the user to run "
+                        "/publish to set a password interactively."
+                    )
+            req_access["password"] = pw
+        elif access_mode == "restricted":
+            from anton.publish_access import parse_emails
+            valid, _invalid = parse_emails(tc_input.get("emails") or [])
+            req_access["emails"] = valid
+            req_access["org_allowed"] = bool(tc_input.get("org_allowed"))
+    elif isinstance(prev, dict) and prev.get("report_id"):
+        req_access = access_from_owner_side(prev)  # preserve previous, do NOT reset to public
+    else:
+        req_access = {"mode": "public"}
+
+    eff_access, pwd_version, access_version, owner_side = resolve_access(None, req_access, prev)
 
     action_text = "  Updating..." if report_id else "  Publishing..."
     with Live(Spinner("dots", text=action_text, style="anton.cyan"), console=console, transient=True):
@@ -447,6 +490,9 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
                 report_id=report_id,
                 publish_url=settings.publish_url,
                 ssl_verify=settings.minds_ssl_verify,
+                access=eff_access,
+                pwd_version=pwd_version,
+                access_version=access_version,
             )
         except Exception as e:
             if report_id:
@@ -458,6 +504,9 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
                         api_key=settings.minds_api_key,
                         publish_url=settings.publish_url,
                         ssl_verify=settings.minds_ssl_verify,
+                        access=eff_access,
+                        pwd_version=pwd_version,
+                        access_version=access_version,
                     )
                 except Exception as e2:
                     console.print(f"  [anton.error]Publish failed: {e2}[/]")
@@ -483,13 +532,15 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
     console.print()
 
     # Persist the mapping so future publishes of the same file update
-    # instead of creating a new report.
+    # instead of creating a new report (owner-side; unified location + key).
     if returned_report_id:
-        published_map[file_key] = {
+        entry = dict(owner_side)
+        entry.update({
             "report_id": returned_report_id,
             "url": view_url,
             "last_md5": result.get("md5", ""),
-        }
+        })
+        published_map[published_key] = entry
         try:
             published_json.write_text(_json.dumps(published_map, indent=2))
         except Exception:
@@ -528,6 +579,24 @@ PUBLISH_TOOL = ToolDef(
                 "enum": ["ask", "preview", "publish"],
                 "description": "What to do: 'ask' prompts user, 'preview' opens locally, 'publish' publishes to web",
             },
+            "access_mode": {
+                "type": "string",
+                "enum": ["public", "password", "restricted"],
+                "description": "Access level. ONLY set when the user explicitly asked for it.",
+            },
+            "password": {
+                "type": "string",
+                "description": "Password for access_mode='password'. ONLY if the user stated it verbatim; otherwise leave empty and it will be asked interactively. NEVER invent one.",
+            },
+            "emails": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Allowed viewer emails for access_mode='restricted'.",
+            },
+            "org_allowed": {
+                "type": "boolean",
+                "description": "Whether the whole organization may view (access_mode='restricted').",
+            },
         },
         "required": ["file_path"],
     },
@@ -539,6 +608,13 @@ PUBLISH_TOOL = ToolDef(
         "- services (paste sites, gists, CDNs, file hosts) via scratchpad code — unless the user \n"
         "- explicitly names the service and confirms. Reading from public APIs and writing to the \n"
         "- user's connected datasources (databases, CRMs, etc.) is fine — this rule only applies to \n"
-        "- sharing generated output with the public internet."
+        "- sharing generated output with the public internet.\n"
+        "ACCESS MODE:\n"
+        "- Pass access_mode/password/emails/org_allowed ONLY if the user explicitly asked "
+        "(e.g. 'publish with password', 'share only with a@x.com').\n"
+        "- NEVER invent a password. If the user wants a password but didn't state it, set "
+        "access_mode='password' and leave password empty — the app will prompt them.\n"
+        "- If the user says nothing about access, omit these fields (public, or the artifact's "
+        "previous access is preserved on re-publish)."
     ),
 )

--- a/tests/test_publish_access_resolve.py
+++ b/tests/test_publish_access_resolve.py
@@ -1,0 +1,197 @@
+"""Tests for anton.publish_access — access resolution ported from cowork-server."""
+
+from pathlib import Path
+
+import pytest
+
+from anton.publish_access import (
+    access_from_owner_side,
+    normalize_emails,
+    parse_emails,
+    prompt_access,
+    resolve_access,
+    resolve_publish_target,
+)
+
+
+def _write(p: Path, text: str = "x") -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_normalize_emails_strips_lowers_dedupes():
+    assert normalize_emails([" A@x.com ", "a@x.com", "B@x.com"]) == ["a@x.com", "b@x.com"]
+    assert normalize_emails(None) == []
+
+
+def test_resolve_public_default():
+    eff, pwd_v, acc_v, owner = resolve_access(None, None, None)
+    assert eff == {"mode": "public"}
+    assert owner == {"mode": "public", "requires_password": False}
+
+
+def test_resolve_legacy_password():
+    eff, pwd_v, acc_v, owner = resolve_access("hunter2", None, None)
+    assert eff == {"mode": "password", "password": "hunter2"}
+    assert pwd_v == 1
+    assert owner["mode"] == "password"
+    assert owner["requires_password"] is True
+    assert owner["access_password"] == "hunter2"
+    assert owner["pwd_version"] == 1
+
+
+def test_resolve_empty_password_degrades_to_public():
+    eff, *_ = resolve_access("   ", None, None)
+    assert eff == {"mode": "public"}
+
+
+def test_resolve_password_change_bumps_pwd_version():
+    prev = {"mode": "password", "access_password": "old", "pwd_version": 2}
+    _, pwd_v, _, owner = resolve_access("new", None, prev)
+    assert pwd_v == 3
+    assert owner["pwd_version"] == 3
+
+
+def test_resolve_password_unchanged_keeps_pwd_version():
+    prev = {"mode": "password", "access_password": "same", "pwd_version": 2}
+    _, pwd_v, _, _ = resolve_access("same", None, prev)
+    assert pwd_v == 2
+
+
+def test_resolve_restricted_normalizes():
+    eff, _, acc_v, owner = resolve_access(
+        None, {"mode": "restricted", "emails": [" A@x.com ", "a@x.com"], "org_allowed": True}, None
+    )
+    assert eff == {"mode": "restricted", "emails": ["a@x.com"], "org_allowed": True}
+    assert acc_v == 1
+    assert owner["mode"] == "restricted"
+    assert owner["emails"] == ["a@x.com"]
+    assert owner["org_allowed"] is True
+    assert owner["access_version"] == 1
+
+
+def test_resolve_restricted_change_bumps_access_version():
+    prev = {"mode": "restricted", "emails": ["a@x.com"], "org_allowed": False, "access_version": 2}
+    _, _, acc_v, _ = resolve_access(
+        None, {"mode": "restricted", "emails": ["a@x.com", "b@x.com"], "org_allowed": False}, prev
+    )
+    assert acc_v == 3
+
+
+def test_resolve_restricted_empty_degrades_to_public():
+    eff, *_ = resolve_access(None, {"mode": "restricted", "emails": [], "org_allowed": False}, None)
+    assert eff == {"mode": "public"}
+
+
+def test_parse_emails_splits_and_validates():
+    valid, invalid = parse_emails("a@x.com, b@x.com foo@ ; c@y.io")
+    assert valid == ["a@x.com", "b@x.com", "c@y.io"]
+    assert invalid == ["foo@"]
+
+
+def test_parse_emails_accepts_list():
+    valid, invalid = parse_emails(["A@x.com", "bad"])
+    assert valid == ["a@x.com"]
+    assert invalid == ["bad"]
+
+
+def test_access_from_owner_side_password():
+    entry = {"mode": "password", "requires_password": True, "access_password": "s3cret"}
+    assert access_from_owner_side(entry) == {"mode": "password", "password": "s3cret"}
+
+
+def test_access_from_owner_side_restricted():
+    entry = {"mode": "restricted", "emails": ["a@x.com"], "org_allowed": True}
+    assert access_from_owner_side(entry) == {
+        "mode": "restricted", "emails": ["a@x.com"], "org_allowed": True,
+    }
+
+
+def test_access_from_owner_side_public_and_legacy():
+    assert access_from_owner_side({"mode": "public"}) == {"mode": "public"}
+    assert access_from_owner_side({"requires_password": True, "access_password": "p"}) == {
+        "mode": "password", "password": "p",
+    }
+    assert access_from_owner_side({}) == {"mode": "public"}
+
+
+def test_resolve_target_static_html(tmp_path):
+    root = tmp_path / "artifacts"
+    art = root / "sales"
+    _write(art / "metadata.json", '{"type": "html-report", "primary": "report.html"}')
+    _write(art / "report.html", "<html></html>")
+    target, pub_dir, key, is_fs = resolve_publish_target(art, [root])
+    assert is_fs is False
+    assert target == (art / "report.html")
+    assert pub_dir == art
+    assert key == "report.html"
+
+
+def test_resolve_target_static_addressed_by_file(tmp_path):
+    root = tmp_path / "artifacts"
+    art = root / "sales"
+    _write(art / "metadata.json", '{"type": "html-report", "primary": "report.html"}')
+    f = _write(art / "report.html", "<html></html>")
+    target, pub_dir, key, is_fs = resolve_publish_target(f, [root])
+    assert is_fs is False
+    assert key == "report.html"
+    assert pub_dir == art
+
+
+def test_resolve_target_fullstack(tmp_path):
+    root = tmp_path / "artifacts"
+    art = root / "app"
+    _write(art / "metadata.json", '{"type": "fullstack-stateless-app", "primary": "static/index.html"}')
+    _write(art / "backend.py", "print(1)")
+    _write(art / "static" / "index.html", "<html></html>")
+    target, pub_dir, key, is_fs = resolve_publish_target(art, [root])
+    assert is_fs is True
+    assert target == art
+    assert pub_dir == art
+    assert key == "index.html"
+
+
+class _FakePrompt:
+    """Feeds scripted answers to a prompt_or_cancel-compatible callable."""
+
+    def __init__(self, answers):
+        self._answers = list(answers)
+        self.asked = []
+
+    async def __call__(self, label, *, default="", password=False,
+                       choices=None, choices_display="", allow_cancel=True, default_text=""):
+        self.asked.append(label)
+        return self._answers.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_public():
+    fp = _FakePrompt(["public"])
+    assert await prompt_access(fp) == {"mode": "public"}
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_password():
+    fp = _FakePrompt(["password", "hunter2"])
+    assert await prompt_access(fp) == {"mode": "password", "password": "hunter2"}
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_password_empty_reprompts_then_cancel():
+    fp = _FakePrompt(["password", "", None])
+    assert await prompt_access(fp) is None
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_restricted():
+    fp = _FakePrompt(["restricted", "a@x.com, b@x.com", "y"])
+    assert await prompt_access(fp) == {
+        "mode": "restricted", "emails": ["a@x.com", "b@x.com"], "org_allowed": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_cancel_at_mode():
+    fp = _FakePrompt([None])
+    assert await prompt_access(fp) is None

--- a/tests/test_publish_api_key.py
+++ b/tests/test_publish_api_key.py
@@ -58,7 +58,7 @@ async def test_401_clears_api_key(tmp_path):
     )
 
     with (
-        patch("anton.chat.prompt_or_cancel", new=AsyncMock(side_effect=["y", "wrongkey", "1"])),
+        patch("anton.chat.prompt_or_cancel", new=AsyncMock(side_effect=["y", "wrongkey", "public"])),
         patch("anton.publisher.publish", side_effect=http_401),
     ):
         await _handle_publish(console, settings, workspace, file_arg=str(html))
@@ -91,7 +91,7 @@ async def test_successful_publish_persists_key(tmp_path):
     }
 
     with (
-        patch("anton.chat.prompt_or_cancel", new=AsyncMock(side_effect=["y", "goodkey", "1"])),
+        patch("anton.chat.prompt_or_cancel", new=AsyncMock(side_effect=["y", "goodkey", "public"])),
         patch("anton.publisher.publish", return_value=publish_result),
         patch("webbrowser.open"),
     ):
@@ -117,6 +117,9 @@ async def test_401_with_existing_key_clears_it(tmp_path):
     )
 
     with (
+        # /publish now asks for an access mode before publishing; the key is
+        # already set so no key prompts fire — just answer the Access prompt.
+        patch("anton.chat.prompt_or_cancel", new=AsyncMock(side_effect=["public"])),
         patch("anton.publisher.publish", side_effect=http_401),
     ):
         await _handle_publish(console, settings, workspace, file_arg=str(html))

--- a/tests/test_publish_chat_access.py
+++ b/tests/test_publish_chat_access.py
@@ -48,14 +48,14 @@ async def test_publish_passes_password_access(tmp_path):
     async def fake_prompt_access(*a, **k):
         return {"mode": "password", "password": "hunter2"}
 
-    # publish и prompt_access импортируются в _handle_publish на уровне функции,
-    # поэтому патчим ИСХОДНЫЕ модули — function-level импорт резолвит имя в
-    # момент вызова и подхватит патч.
+    # publish and prompt_access are imported inside _handle_publish at the
+    # function level, so we patch the SOURCE modules — a function-level import
+    # resolves the name at call time and picks up the patch.
     with mock.patch("anton.publisher.publish", fake_publish), \
          mock.patch("anton.publish_access.prompt_access", side_effect=fake_prompt_access), \
          mock.patch("webbrowser.open"):
-        # Директорию _make_candidate публикует только для fullstack; для
-        # html-report адресуем файл (файловая ветка _make_candidate).
+        # _make_candidate only publishes a directory for fullstack artifacts;
+        # for an html-report we address the file (the file branch of _make_candidate).
         await chat._handle_publish(Console(), settings, mock.Mock(), file_arg="sales/report.html")
 
     _, kwargs = fake_publish.call_args

--- a/tests/test_publish_chat_access.py
+++ b/tests/test_publish_chat_access.py
@@ -1,0 +1,67 @@
+"""_handle_publish passes the selected access through to publisher.publish."""
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from rich.console import Console
+
+import anton.chat as chat
+
+
+def _make_artifact(tmp_path: Path) -> Path:
+    root = tmp_path / "artifacts"
+    art = root / "sales"
+    art.mkdir(parents=True)
+    (art / "metadata.json").write_text(json.dumps({
+        "schemaVersion": 1,
+        "id": "abcd1234",
+        "slug": "sales",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "name": "Sales",
+        "description": "Sales report",
+        "type": "html-app",
+        "primary": "report.html",
+    }))
+    (art / "report.html").write_text("<html><title>Sales</title></html>")
+    return root
+
+
+@pytest.mark.asyncio
+async def test_publish_passes_password_access(tmp_path):
+    root = _make_artifact(tmp_path)
+
+    settings = mock.Mock()
+    settings.minds_api_key = "key"
+    settings.artifacts_dir = str(root)
+    settings.workspace_path = str(tmp_path)
+    settings.publish_url = "https://view.test"
+    settings.minds_ssl_verify = True
+
+    fake_publish = mock.Mock(return_value={
+        "view_url": "https://view.test/r/abc", "report_id": "abc",
+        "md5": "m", "version": 1,
+    })
+
+    async def fake_prompt_access(*a, **k):
+        return {"mode": "password", "password": "hunter2"}
+
+    # publish и prompt_access импортируются в _handle_publish на уровне функции,
+    # поэтому патчим ИСХОДНЫЕ модули — function-level импорт резолвит имя в
+    # момент вызова и подхватит патч.
+    with mock.patch("anton.publisher.publish", fake_publish), \
+         mock.patch("anton.publish_access.prompt_access", side_effect=fake_prompt_access), \
+         mock.patch("webbrowser.open"):
+        # Директорию _make_candidate публикует только для fullstack; для
+        # html-report адресуем файл (файловая ветка _make_candidate).
+        await chat._handle_publish(Console(), settings, mock.Mock(), file_arg="sales/report.html")
+
+    _, kwargs = fake_publish.call_args
+    assert kwargs["access"] == {"mode": "password", "password": "hunter2"}
+
+    # owner-side persisted next to the primary, keyed by file name
+    published = json.loads((root / "sales" / ".published.json").read_text())
+    assert published["report.html"]["mode"] == "password"
+    assert published["report.html"]["access_password"] == "hunter2"

--- a/tests/test_publish_tool_access.py
+++ b/tests/test_publish_tool_access.py
@@ -20,6 +20,18 @@ def _artifact(tmp_path: Path) -> Path:
     return f
 
 
+def _fullstack_artifact(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "artifacts"
+    art = root / "server-time-display-2"
+    (art / "static").mkdir(parents=True)
+    (art / "metadata.json").write_text(
+        '{"type": "fullstack-stateless-app", "primary": "static/index.html"}'
+    )
+    (art / "backend.py").write_text("print(1)")
+    (art / "static" / "index.html").write_text("<html></html>")
+    return root, art
+
+
 def _session(tmp_path):
     s = mock.Mock()
     s._console = Console()
@@ -88,3 +100,34 @@ async def test_tool_password_no_value_non_tty_cancels(tmp_path):
         )
     assert "CANCELLED" in out
     fake_publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tool_fullstack_publishes_folder(tmp_path):
+    """Given the artifact folder, publish() receives the folder (fullstack bundle)."""
+    root, art = _fullstack_artifact(tmp_path)
+    fake_publish = mock.Mock(return_value={"view_url": "u", "report_id": "r", "md5": "m", "version": 1})
+    with mock.patch("anton.publisher.publish", fake_publish), \
+         mock.patch("anton.config.settings.AntonSettings", return_value=_settings(root)), \
+         mock.patch("webbrowser.open"):
+        await tools.handle_publish_or_preview(
+            _session(tmp_path), {"file_path": str(art), "action": "publish"},
+        )
+    args, _ = fake_publish.call_args
+    assert Path(args[0]) == art  # the folder, not an inner file
+
+
+@pytest.mark.asyncio
+async def test_tool_fullstack_from_inner_file_publishes_folder(tmp_path):
+    """Even if the model points at an inner HTML file, publish() gets the folder."""
+    root, art = _fullstack_artifact(tmp_path)
+    fake_publish = mock.Mock(return_value={"view_url": "u", "report_id": "r", "md5": "m", "version": 1})
+    with mock.patch("anton.publisher.publish", fake_publish), \
+         mock.patch("anton.config.settings.AntonSettings", return_value=_settings(root)), \
+         mock.patch("webbrowser.open"):
+        await tools.handle_publish_or_preview(
+            _session(tmp_path),
+            {"file_path": str(art / "static" / "index.html"), "action": "publish"},
+        )
+    args, _ = fake_publish.call_args
+    assert Path(args[0]) == art  # normalized up to the fullstack folder

--- a/tests/test_publish_tool_access.py
+++ b/tests/test_publish_tool_access.py
@@ -1,0 +1,90 @@
+"""publish_or_preview tool: access fields + preserve-previous default."""
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from rich.console import Console
+
+import anton.tools as tools
+
+
+def _artifact(tmp_path: Path) -> Path:
+    root = tmp_path / "artifacts"
+    art = root / "sales"
+    art.mkdir(parents=True)
+    (art / "metadata.json").write_text('{"type": "html-report", "primary": "report.html"}')
+    f = art / "report.html"
+    f.write_text("<html></html>")
+    return f
+
+
+def _session(tmp_path):
+    s = mock.Mock()
+    s._console = Console()
+    ws = mock.Mock()
+    ws.base = str(tmp_path)
+    s._workspace = ws
+    return s
+
+
+def _settings(root):
+    s = mock.Mock()
+    s.minds_api_key = "key"
+    s.publish_url = "https://view.test"
+    s.minds_ssl_verify = True
+    s.artifacts_dir = str(root)
+    return s
+
+
+@pytest.mark.asyncio
+async def test_tool_explicit_password(tmp_path):
+    f = _artifact(tmp_path)
+    fake_publish = mock.Mock(return_value={"view_url": "u", "report_id": "r", "md5": "m", "version": 1})
+    with mock.patch("anton.publisher.publish", fake_publish), \
+         mock.patch("anton.config.settings.AntonSettings", return_value=_settings(f.parent.parent)), \
+         mock.patch("webbrowser.open"):
+        out = await tools.handle_publish_or_preview(
+            _session(tmp_path),
+            {"file_path": str(f), "action": "publish",
+             "access_mode": "password", "password": "hunter2"},
+        )
+    _, kwargs = fake_publish.call_args
+    assert kwargs["access"] == {"mode": "password", "password": "hunter2"}
+    assert "Published" in out
+
+
+@pytest.mark.asyncio
+async def test_tool_preserves_previous_when_no_fields(tmp_path):
+    f = _artifact(tmp_path)
+    (f.parent / ".published.json").write_text(json.dumps({
+        "report.html": {"report_id": "r", "url": "u", "last_md5": "m",
+                          "mode": "password", "requires_password": True,
+                          "access_password": "old", "pwd_version": 1},
+    }))
+    fake_publish = mock.Mock(return_value={"view_url": "u", "report_id": "r", "md5": "m2", "version": 2})
+    with mock.patch("anton.publisher.publish", fake_publish), \
+         mock.patch("anton.config.settings.AntonSettings", return_value=_settings(f.parent.parent)), \
+         mock.patch("webbrowser.open"):
+        await tools.handle_publish_or_preview(
+            _session(tmp_path), {"file_path": str(f), "action": "publish"},
+        )
+    _, kwargs = fake_publish.call_args
+    assert kwargs["access"] == {"mode": "password", "password": "old"}  # NOT public
+
+
+@pytest.mark.asyncio
+async def test_tool_password_no_value_non_tty_cancels(tmp_path):
+    f = _artifact(tmp_path)
+    fake_publish = mock.Mock()
+    with mock.patch("anton.publisher.publish", fake_publish), \
+         mock.patch("anton.config.settings.AntonSettings", return_value=_settings(f.parent.parent)), \
+         mock.patch("sys.stdin") as stdin:
+        stdin.isatty.return_value = False
+        out = await tools.handle_publish_or_preview(
+            _session(tmp_path),
+            {"file_path": str(f), "action": "publish", "access_mode": "password"},
+        )
+    assert "CANCELLED" in out
+    fake_publish.assert_not_called()

--- a/tests/test_unpublish_clears_local.py
+++ b/tests/test_unpublish_clears_local.py
@@ -1,0 +1,51 @@
+"""/unpublish must drop the local .published.json entry so a later /publish
+does not offer to 'update' a report that no longer exists."""
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from rich.console import Console
+
+import anton.chat as chat
+
+
+def _make_published_artifact(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "artifacts"
+    art = root / "server-time-display-2"
+    art.mkdir(parents=True)
+    (art / "report.html").write_text("<html></html>")
+    pub = art / ".published.json"
+    pub.write_text(json.dumps({
+        "report.html": {
+            "report_id": "247c4983", "url": "https://view/a/247c4983",
+            "last_md5": "m", "mode": "password", "requires_password": True,
+            "access_password": "s3cret", "pwd_version": 1,
+        },
+    }))
+    return root, pub
+
+
+@pytest.mark.asyncio
+async def test_unpublish_removes_local_entry(tmp_path):
+    root, pub = _make_published_artifact(tmp_path)
+
+    settings = mock.Mock()
+    settings.minds_api_key = "key"
+    settings.artifacts_dir = str(root)
+    settings.publish_url = "https://view.test"
+    settings.minds_ssl_verify = True
+
+    reports = [{"title": "server-time-display-2", "report_id": "247c4983",
+                "md5": "m", "view_url": "https://view/a/247c4983"}]
+
+    with mock.patch("anton.publisher.list_published", return_value=reports), \
+         mock.patch("anton.publisher.unpublish", return_value={}), \
+         mock.patch("anton.chat.prompt_or_cancel",
+                    new=mock.AsyncMock(side_effect=["1", "y"])):
+        await chat._handle_unpublish(Console(), settings, mock.Mock())
+
+    # The stale entry must be gone so /publish treats it as fresh.
+    data = json.loads(pub.read_text())
+    assert "report.html" not in data


### PR DESCRIPTION
## TL/DR
1. changed `/publish` command to support different publish options
<img width="383" height="309" alt="image" src="https://github.com/user-attachments/assets/8d5d7533-f459-4f3c-bffb-caf54363d2c4" />
2. If you request to publish an artifact in the chat, you will be offered a choice of publication type, instead of the previously hidden use of public publication.

## What & why

anton could only publish artifacts **publicly**. The access-control protocol
(`public` / `password` / `restricted`) has been fully implemented and tested in
`publisher.py` for a while, but neither user-facing entry point wired it up —
both `/publish` (chat REPL) and the `publish_or_preview` LLM tool always called
`publish()` without `access`, i.e. public.

This PR brings anton to parity with cowork: users can now choose the access mode
when publishing from the CLI or from chat. It also extracts the access-resolution
logic into a shared module that cowork-server consumes, so there's a single source
of truth.

## Changes

- **New `anton/publish_access.py`** — single source of truth for:
  - `resolve_access()` — merges the request with prior state and bumps
    `pwd_version`/`access_version` only when the password / email-list / org flag
    actually changes (so stale viewer grants invalidate). Ported verbatim from
    cowork-server.
  - `normalize_emails()` / `parse_emails()` — canonical email normalization +
    format validation (mirrors cowork's `AccessChooser`).
  - `access_from_owner_side()` — reconstructs the access spec from a stored
    `.published.json` entry (used to preserve access on re-publish).
  - `resolve_publish_target()` — where `.published.json` lives + its key; ported
    from cowork-server with container dirs passed as a parameter.
  - `prompt_access()` — interactive terminal access chooser.
- **`/publish` (`chat.py`)** — prompts for access mode; `keep`/`change` on
  re-publish; empty password/empty restricted **re-prompts** instead of silently
  degrading to public; unified `.published.json` convention with back-compat read
  of the legacy root map; access-mode badge in output.
- **`publish_or_preview` tool (`tools.py`)** — new optional fields
  `access_mode` / `password` / `emails` / `org_allowed`. The model only sets them
  when the user explicitly asked and **never invents a password**. If a password
  is required but not stated: interactive hidden prompt on a TTY, otherwise the
  tool returns `CANCELLED` (no hang). When no access is given on re-publish, the
  **prior access is preserved** rather than reset to public.

## Behaviour notes

- Password plaintext is stored owner-side only (`.published.json`); the server
  receives only the PBKDF2 hash — unchanged, handled by `publisher.build_access_payload()`.
- `publisher.py` (the publish protocol) is **not** touched.

## Testing

- New: `tests/test_publish_access_resolve.py`, `tests/test_publish_chat_access.py`,
  `tests/test_publish_tool_access.py`.
- Updated `tests/test_publish_api_key.py` for the new access step.
- All publish tests green: `39 passed`.
- Manual smoke still recommended before merge: real `/publish` with a password →
  re-publish shows the lock badge; “publish with a password” (no value) in a TTY
  chat session raises the hidden prompt without breaking the live spinner.

## Coordination / deploy order

`resolve_access` / `normalize_emails` / `resolve_publish_target` now live here and
are imported by **cowork-server**. Deploy order:

1. cowork-server harness forward-compat PR (already tolerates the new tool schema);
2. **this anton release**;
3. cowork-server swap PR (bumps the `anton-agent` dependency and imports from
   `anton.publish_access`).
   
  Linear ENG-727