### PR TITLE
Browser Control M1 (read-only): stream browser_control per-action progress

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -1795,7 +1795,10 @@ async def _chat_loop(
                             display.on_tool_use_end(event.id)
                         elif isinstance(event, StreamTaskProgress):
                             display.update_progress(
-                                event.phase, event.message, event.eta_seconds
+                                event.phase,
+                                event.message,
+                                event.eta_seconds,
+                                id=event.id,
                             )
                         elif isinstance(event, StreamContextCompacted):
                             display.show_context_compacted(event.message)

--- a/anton/chat_ui.py
+++ b/anton/chat_ui.py
@@ -352,9 +352,19 @@ class StreamDisplay:
                 return
 
     def update_progress(
-        self, phase: str, message: str, eta: float | None = None
+        self,
+        phase: str,
+        message: str,
+        eta: float | None = None,
+        id: str | None = None,
     ) -> None:
-        """Update progress — manages spinner and activity lines."""
+        """Update progress — manages spinner and activity lines.
+
+        ``id`` optionally carries the originating tool_use id (session-side
+        ``StreamTaskProgress.id``) so phases that complete a specific activity
+        (currently ``browser_action``) can match it exactly instead of by
+        name. All other phases ignore it.
+        """
         if not self._active:
             return
 
@@ -422,6 +432,37 @@ class StreamDisplay:
                 if act.name == message and act.printed and not act.done:
                     act.done = True
                     act.work_elapsed = elapsed
+                    break
+            return
+
+        if phase == "browser_action":
+            # Browser control action — the session emits this phase instead of
+            # tool_start/tool_done, carrying the agent-supplied human-readable
+            # progress line (e.g. "Reading account list") rather than the tool
+            # name. eta is None while the action runs (status update); eta set
+            # means the action finished — mark the browser activity done, the
+            # same way tool_done does (which keys on the tool name; here the
+            # message is the human line, so key on the tool's fixed name).
+            if eta is None:
+                self._line2_status = message
+                self._line3_peek = ""
+                self._update_spinner()
+                return
+            # Prefer an exact tool_use-id match (the session forwards tc.id on
+            # browser_action events) — with multiple pending browser
+            # activities, a name-only reversed scan would mark the LAST
+            # pending one instead of the one that actually finished. Fall
+            # back to the name scan when no id is available (older callers).
+            if id is not None:
+                for act in self._activities:
+                    if act.tool_id == id and act.printed and not act.done:
+                        act.done = True
+                        act.work_elapsed = eta if eta else 0
+                        return
+            for act in reversed(self._activities):
+                if act.name == "browser_control" and act.printed and not act.done:
+                    act.done = True
+                    act.work_elapsed = eta if eta else 0
                     break
             return
 

--- a/anton/commands/goal.py
+++ b/anton/commands/goal.py
@@ -127,7 +127,10 @@ async def run_goal_loop(
                         elif isinstance(event, StreamToolUseEnd):
                             display.on_tool_use_end(event.id)
                         elif isinstance(event, StreamTaskProgress):
-                            display.update_progress(event.phase, event.message, event.eta_seconds)
+                            display.update_progress(
+                                event.phase, event.message, event.eta_seconds,
+                                id=event.id,
+                            )
                         elif isinstance(event, StreamContextCompacted):
                             display.show_context_compacted(event.message)
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2008,6 +2008,39 @@ class ChatSession:
                                 phase="analyzing",
                                 message="Analyzing results...",
                             )
+                        elif (
+                            tc.name == "browser_control"
+                            and isinstance(tc.input, dict)
+                            and tc.input.get("progress_message")
+                        ):
+                            # Browser control tool — surface the agent-supplied
+                            # human-readable progress line ("Reading account
+                            # list", "Opening July report", …) instead of the
+                            # raw tool name. The browser_control tool itself is
+                            # injected by the host (cowork-server); anton-core
+                            # stays host-agnostic and keys only on the tool name
+                            # plus the presence of a `progress_message` input
+                            # field, mirroring how scratchpad surfaces its
+                            # `one_line_description`.
+                            # The elif guard already requires a truthy
+                            # progress_message, so no tool-name fallback is
+                            # needed here.
+                            _browser_msg = tc.input["progress_message"]
+                            yield StreamTaskProgress(
+                                phase="browser_action",
+                                message=_browser_msg,
+                                id=tc.id,
+                            )
+                            result_text = await self.tool_registry.dispatch_tool(
+                                self, tc.name, tc.input
+                            )
+                            _tool_elapsed = _time.monotonic() - _tool_t0
+                            yield StreamTaskProgress(
+                                phase="browser_action",
+                                message=_browser_msg,
+                                eta_seconds=_tool_elapsed,
+                                id=tc.id,
+                            )
                         else:
                             # Non-scratchpad, non-interactive tool — track elapsed
                             yield StreamTaskProgress(

--- a/tests/e2e/scenarios/test_browser_tool.py
+++ b/tests/e2e/scenarios/test_browser_tool.py
@@ -1,0 +1,313 @@
+"""Scenario — Browser Control (read-only) tool driven through anton-core.
+
+These scenarios exercise WS3 of the Browser Control M1 plan against the local
+stub LLM server. Unlike the subprocess-based scenarios in this package, they
+drive ``ChatSession.turn_stream`` in-process for two reasons the subprocess
+harness cannot satisfy:
+
+1. The real ``browser_control`` tool is injected by the cowork-server host, not
+   by anton-core. Anton stays host-agnostic, so to exercise the engine path we
+   register our own FAKE ``browser_control`` ``ToolDef`` here (with a canned,
+   observed-data handler) via ``ChatSessionConfig.tools`` — exactly how a host
+   injects extra tools.
+2. The assertion is on the *streamed progress events* — that the per-action
+   ``StreamTaskProgress`` carries the human-readable ``progress_message`` the
+   agent supplied (e.g. "Reading account list"), not the raw ``browser_control``
+   tool name. Those events are only observable in-process.
+
+The stub LLM HTTP server (``tests/e2e/stub_server.py``) is still the driver: we
+queue scripted tool calls + final text the same way the subprocess scenarios
+do. anton-core connects to it over HTTP via a real ``OpenAIProvider`` pointed
+at ``stub.base_url``, so the whole turn loop (tool dispatch, progress
+streaming, completion verification) runs for real.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from anton.core.llm.client import LLMClient
+from anton.core.llm.openai import OpenAIProvider
+from anton.core.llm.provider import StreamTaskProgress
+from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.tools.tool_defs import ToolDef
+from tests.e2e.stub_server import StubServer
+
+# The whole point is to observe the in-process progress stream + a fake tool
+# handler, which the live provider path cannot script.
+pytestmark = pytest.mark.stub_only
+
+
+# Canned "observed" payloads a real bridge would return for each read-only
+# action. Content-free-ness is a WS4 concern; here we only need enough to let
+# the model cite an answer, mirroring the transient ``observed`` shape.
+_ACCOUNT_LIST_OBSERVED = {
+    "url": "https://reports.example.com/accounts",
+    "title": "Accounts",
+    "text": "Acme Inc, Globex, Initech. Monthly reports available.",
+    "links": [
+        {"text": "July report", "href": "https://reports.example.com/july"},
+        {"text": "June report", "href": "https://reports.example.com/june"},
+    ],
+}
+_JULY_REPORT_OBSERVED = {
+    "url": "https://reports.example.com/july",
+    "title": "July Report",
+    "text": "July total revenue: $1,234,567.",
+    "links": [],
+}
+
+
+class _FakeBrowserBridge:
+    """A fake bridge/tool handler returning canned observed data per action.
+
+    Records every call so a test can assert the sequence of actions the model
+    drove. Never raises — mirrors the anton tool-handler contract (handlers
+    return strings, error strings included).
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def handle(self, session, tc_input: dict) -> str:  # noqa: ANN001
+        del session  # host-agnostic fake; no session state needed
+        self.calls.append(dict(tc_input))
+        action = tc_input.get("action")
+        if action == "inspect" and not self.calls[:-1]:
+            observed = _ACCOUNT_LIST_OBSERVED
+        elif action == "follow_link":
+            observed = _JULY_REPORT_OBSERVED
+        elif action == "inspect":
+            # Second inspect (after the follow_link) reads the July report.
+            observed = _JULY_REPORT_OBSERVED
+        else:
+            return json.dumps(
+                {"status": "unsupported_action", "observed": None, "citations": []}
+            )
+        return json.dumps(
+            {
+                "status": "ok",
+                "observed": observed,
+                "citations": [{"url": observed["url"], "title": observed["title"]}],
+            }
+        )
+
+
+def _make_browser_tool(bridge: _FakeBrowserBridge) -> ToolDef:
+    """A fake ``browser_control`` ToolDef matching the WS3 tool contract shape.
+
+    Required fields ``action`` / ``reason`` / ``progress_message`` mirror the
+    real tool so anton-core's ``browser_control`` special-case (which keys on
+    the tool name + the presence of ``progress_message``) fires.
+    """
+    return ToolDef(
+        name="browser_control",
+        description=(
+            "Read-only browser control. Prefer a connector via lookup_connector "
+            "first; use this only when no connector satisfies the task."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["inspect", "follow_link", "scroll", "wait"],
+                },
+                "reason": {"type": "string"},
+                "progress_message": {"type": "string"},
+                "href": {"type": "string"},
+                "direction": {"type": "string"},
+            },
+            "required": ["action", "reason", "progress_message"],
+        },
+        handler=bridge.handle,
+    )
+
+
+def _lookup_connector_tool(calls: list[dict]) -> ToolDef:
+    """A minimal fake ``lookup_connector`` tool used by the connector-preferred
+    scenario, so the model has a connector-first path to take."""
+
+    async def handle(session, tc_input: dict) -> str:  # noqa: ANN001
+        del session
+        calls.append(dict(tc_input))
+        return json.dumps(
+            {
+                "match": "reports_api",
+                "confidence": 0.95,
+                "label": "Reports API",
+            }
+        )
+
+    return ToolDef(
+        name="lookup_connector",
+        description="Find a connector that satisfies the task.",
+        input_schema={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+        handler=handle,
+    )
+
+
+def _make_session(stub: StubServer, tools: list[ToolDef]) -> ChatSession:
+    """Build a real ChatSession wired to the stub LLM over HTTP.
+
+    Web tools are disabled so the only injected tools are the browser/connector
+    fakes — keeping the registry minimal and the assertions unambiguous.
+    """
+    provider = OpenAIProvider(
+        api_key="test-key-e2e",
+        base_url=stub.base_url,
+        flavor=OpenAIProvider.FLAVOR_OPENAI_COMPATIBLE_GENERIC,
+    )
+    llm = LLMClient(
+        planning_provider=provider,
+        planning_model="gpt-test",
+        coding_provider=provider,
+        coding_model="gpt-test",
+    )
+    return ChatSession(
+        ChatSessionConfig(
+            llm_client=llm,
+            tools=tools,
+            web_search_enabled=False,
+            web_fetch_enabled=False,
+        )
+    )
+
+
+async def _drain(session: ChatSession, user_input: str):
+    """Run a full turn, returning (all_events, task_progress_events)."""
+    events = []
+    progress: list[StreamTaskProgress] = []
+    async for event in session.turn_stream(user_input):
+        events.append(event)
+        if isinstance(event, StreamTaskProgress):
+            progress.append(event)
+    return events, progress
+
+
+async def test_three_step_read_only_task_streams_human_progress(cfg, stub):
+    """Scenario 1 — a three-step read-only browser task.
+
+    The model drives: inspect ("Reading account list") -> follow_link
+    ("Opening July report") -> inspect ("Reading July report") -> a cited
+    answer. Assert the streamed progress carries each human-readable
+    ``progress_message`` (NOT the raw "browser_control" tool name).
+    """
+    bridge = _FakeBrowserBridge()
+
+    # Script the stub: three browser_control tool calls, then a final cited
+    # answer, then the completion-verification "STATUS: COMPLETE".
+    stub.queue_tool_call(
+        "browser_control",
+        {
+            "action": "inspect",
+            "reason": "No connector exposes the accounts page.",
+            "progress_message": "Reading account list",
+        },
+    )
+    stub.queue_tool_call(
+        "browser_control",
+        {
+            "action": "follow_link",
+            "reason": "No connector exposes the July report.",
+            "progress_message": "Opening July report",
+            "href": "https://reports.example.com/july",
+        },
+    )
+    stub.queue_tool_call(
+        "browser_control",
+        {
+            "action": "inspect",
+            "reason": "No connector exposes the July report.",
+            "progress_message": "Reading July report",
+        },
+    )
+    stub.queue_text(
+        "July total revenue was $1,234,567 "
+        "(source: https://reports.example.com/july). ANSWER_DONE"
+    )
+    stub.queue_verification_ok()
+
+    session = _make_session(stub, [_make_browser_tool(bridge)])
+    _events, progress = await _drain(
+        session, "What was the July revenue on my reports site?"
+    )
+
+    # The fake bridge saw all three read-only actions in order.
+    assert [c["action"] for c in bridge.calls] == ["inspect", "follow_link", "inspect"]
+
+    browser_progress = [p for p in progress if p.phase == "browser_action"]
+    messages = [p.message for p in browser_progress]
+
+    # Every browser action surfaced the agent-supplied human message, and the
+    # raw tool name never leaked into the progress stream.
+    assert "Reading account list" in messages
+    assert "Opening July report" in messages
+    assert "Reading July report" in messages
+    assert "browser_control" not in messages, (
+        f"Progress must carry the human progress_message, not the raw tool "
+        f"name. Got: {messages}"
+    )
+
+    # Progress events correlate back to their originating tool_use id.
+    assert all(p.id is not None for p in browser_progress)
+
+    # Stream shape: each action yields exactly two browser_action events —
+    # a pre-dispatch one with no eta (running) and a post-dispatch completion
+    # one carrying the elapsed. Hosts (CLI display, cowork-server formatter)
+    # key completion off the eta-bearing event, so this shape is contractual.
+    assert len(browser_progress) == 6  # 3 actions x (start + done)
+    for start, done in zip(browser_progress[::2], browser_progress[1::2]):
+        assert start.message == done.message
+        assert start.id == done.id
+        assert start.eta_seconds is None
+        assert done.eta_seconds is not None
+    # The generic tool_start/tool_done phases never fire for browser_control.
+    assert not [
+        p
+        for p in progress
+        if p.phase in ("tool_start", "tool_done") and p.message == "browser_control"
+    ]
+
+    # The cited answer made it into the assistant reply.
+    reply = next(
+        (m["content"] for m in reversed(session._history) if m["role"] == "assistant"),
+        "",
+    )
+    assert "1,234,567" in str(reply)
+
+
+async def test_connector_preferred_never_emits_browser_control(cfg, stub):
+    """Scenario 2 — connector-first routing.
+
+    When a connector satisfies the task, the model calls ``lookup_connector``
+    and NEVER emits ``browser_control``. Assert no browser_action progress is
+    streamed and the fake browser bridge is never touched.
+    """
+    connector_calls: list[dict] = []
+    bridge = _FakeBrowserBridge()
+
+    stub.queue_tool_call("lookup_connector", {"query": "reports api"})
+    stub.queue_text(
+        "I can use the Reports API connector for this — no browser needed. "
+        "CONNECTOR_DONE"
+    )
+    stub.queue_verification_ok()
+
+    session = _make_session(
+        stub, [_lookup_connector_tool(connector_calls), _make_browser_tool(bridge)]
+    )
+    _events, progress = await _drain(session, "Pull the latest revenue numbers.")
+
+    # Connector path was taken; the browser bridge was never invoked.
+    assert connector_calls, "Expected lookup_connector to be called"
+    assert bridge.calls == [], "browser_control must not be called on the connector path"
+
+    # No browser progress was streamed.
+    assert not [p for p in progress if p.phase == "browser_action"]

--- a/tests/test_chat_browser_progress.py
+++ b/tests/test_chat_browser_progress.py
@@ -1,0 +1,205 @@
+"""Unit tests for the ``browser_control`` progress special-case in the
+``ChatSession`` streaming tool path (WS3-T3).
+
+The generic tool path yields ``StreamTaskProgress(phase="tool_start"/"tool_done",
+message=tc.name)`` for most tools. For ``browser_control`` (a host-injected
+tool) it instead yields ``phase="browser_action"`` with the agent-supplied
+``progress_message`` so the UI shows a human-readable per-action line.
+
+These tests drive ``turn_stream`` with a fully-mocked LLM (no HTTP), keeping
+them in the fast unit suite.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.conftest import make_mock_llm
+
+from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.tools.tool_defs import ToolDef
+from anton.core.llm.provider import (
+    LLMResponse,
+    StreamComplete,
+    StreamTaskProgress,
+    ToolCall,
+    Usage,
+)
+
+
+class _FakeAsyncIter:
+    def __init__(self, items):
+        self._items = items
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _text_response(text: str) -> LLMResponse:
+    return LLMResponse(
+        content=text,
+        tool_calls=[],
+        usage=Usage(input_tokens=10, output_tokens=20),
+        stop_reason="end_turn",
+    )
+
+
+def _tool_response(name: str, tc_input: dict, *, tool_id: str = "tc_1") -> LLMResponse:
+    return LLMResponse(
+        content="",
+        tool_calls=[ToolCall(id=tool_id, name=name, input=tc_input)],
+        usage=Usage(input_tokens=10, output_tokens=20),
+        stop_reason="tool_use",
+    )
+
+
+def _make_browser_tool(recorded: list[dict]) -> ToolDef:
+    async def handle(session, tc_input: dict) -> str:  # noqa: ANN001
+        del session
+        recorded.append(dict(tc_input))
+        return '{"status": "ok", "observed": {"text": "x"}, "citations": []}'
+
+    return ToolDef(
+        name="browser_control",
+        description="fake browser control",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "action": {"type": "string"},
+                "reason": {"type": "string"},
+                "progress_message": {"type": "string"},
+            },
+            "required": ["action", "reason", "progress_message"],
+        },
+        handler=handle,
+    )
+
+
+def _make_generic_tool(name: str, recorded: list[dict]) -> ToolDef:
+    async def handle(session, tc_input: dict) -> str:  # noqa: ANN001
+        del session
+        recorded.append(dict(tc_input))
+        return "generic-ok"
+
+    return ToolDef(
+        name=name,
+        description="generic tool",
+        input_schema={
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "required": [],
+        },
+        handler=handle,
+    )
+
+
+def _session_with_tool(tool: ToolDef, tool_call: LLMResponse) -> ChatSession:
+    mock_llm = make_mock_llm()
+    # Completion verifier uses plan(); keep it COMPLETE so the loop exits.
+    mock_llm.plan = AsyncMock(
+        return_value=_text_response("STATUS: COMPLETE — task done")
+    )
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([StreamComplete(response=tool_call)])
+        return _FakeAsyncIter([StreamComplete(response=_text_response("Done."))])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    return ChatSession(
+        ChatSessionConfig(
+            llm_client=mock_llm,
+            tools=[tool],
+            web_search_enabled=False,
+            web_fetch_enabled=False,
+        )
+    )
+
+
+async def _progress(session: ChatSession, user_input: str) -> list[StreamTaskProgress]:
+    out: list[StreamTaskProgress] = []
+    async for event in session.turn_stream(user_input):
+        if isinstance(event, StreamTaskProgress):
+            out.append(event)
+    return out
+
+
+class TestBrowserControlProgress:
+    async def test_browser_action_phase_carries_human_message(self):
+        recorded: list[dict] = []
+        tool = _make_browser_tool(recorded)
+        call = _tool_response(
+            "browser_control",
+            {
+                "action": "inspect",
+                "reason": "no connector",
+                "progress_message": "Reading account list",
+            },
+        )
+        session = _session_with_tool(tool, call)
+        progress = await _progress(session, "read my accounts")
+
+        browser = [p for p in progress if p.phase == "browser_action"]
+        # Both the pre- and post-dispatch progress events fire.
+        assert len(browser) == 2
+        messages = [p.message for p in browser]
+        assert messages == ["Reading account list", "Reading account list"]
+        # The pre-dispatch event has no eta (action running); the
+        # post-dispatch event carries the elapsed — this is the completion
+        # signal CLI/host displays use to mark the activity done.
+        assert browser[0].eta_seconds is None
+        assert browser[1].eta_seconds is not None
+        assert browser[1].eta_seconds >= 0
+        # The raw tool name is never surfaced as the message.
+        assert "browser_control" not in messages
+        # The generic tool_start/tool_done phases are NOT used for this tool.
+        assert not [p for p in progress if p.phase in ("tool_start", "tool_done")]
+        # Progress correlates to the originating tool_use id.
+        assert all(p.id == "tc_1" for p in browser)
+        assert recorded and recorded[0]["action"] == "inspect"
+
+    async def test_falls_back_to_tool_name_without_progress_message(self):
+        """When progress_message is absent, the tool takes the generic path
+        (tool_start/tool_done with the raw name) — the special-case keys on the
+        presence of a progress_message input field."""
+        recorded: list[dict] = []
+        tool = _make_browser_tool(recorded)
+        call = _tool_response(
+            "browser_control",
+            {"action": "inspect", "reason": "no connector"},
+        )
+        session = _session_with_tool(tool, call)
+        progress = await _progress(session, "read my accounts")
+
+        assert not [p for p in progress if p.phase == "browser_action"]
+        generic = [p for p in progress if p.phase in ("tool_start", "tool_done")]
+        assert generic, "Expected generic tool_start/tool_done fallback"
+        assert all(p.message == "browser_control" for p in generic)
+
+    async def test_other_tools_unaffected(self):
+        """A non-browser tool still uses the generic tool_start/tool_done path
+        even if it happens to carry a progress_message input."""
+        recorded: list[dict] = []
+        tool = _make_generic_tool("something_else", recorded)
+        call = _tool_response(
+            "something_else", {"progress_message": "should be ignored"}
+        )
+        session = _session_with_tool(tool, call)
+        progress = await _progress(session, "do a thing")
+
+        assert not [p for p in progress if p.phase == "browser_action"]
+        generic = [p for p in progress if p.phase in ("tool_start", "tool_done")]
+        assert generic
+        assert all(p.message == "something_else" for p in generic)

--- a/tests/test_chat_ui.py
+++ b/tests/test_chat_ui.py
@@ -224,3 +224,142 @@ class TestActivityTracking:
         assert display._initial_text == "Initial text"
         assert display._buffer == "Answer text"
         assert display._in_tool_phase
+
+
+class TestBrowserActionProgress:
+    """The browser_control streaming path emits phase="browser_action" instead
+    of tool_start/tool_done. update_progress must treat eta=None as a live
+    status update (surfacing the human progress_message) and eta-set as the
+    completion signal that marks the browser activity done with its elapsed —
+    mirroring tool_done, but keyed on the fixed "browser_control" name since
+    the message carries the human line, not the tool name."""
+
+    def _make_display(self):
+        console = MagicMock()
+        toolbar = {"stats": "", "status": ""}
+        return StreamDisplay(console, toolbar=toolbar), console
+
+    def _start_browser_activity(self, display):
+        display.on_tool_use_start("tool_b1", "browser_control")
+        display.on_tool_use_delta(
+            "tool_b1",
+            '{"action": "inspect", "reason": "no connector", '
+            '"progress_message": "Reading account list"}',
+        )
+        display.on_tool_use_end("tool_b1")  # prints the activity line
+
+    @patch("anton.chat_ui.Live")
+    def test_browser_action_without_eta_updates_status(self, MockLive):
+        display, _ = self._make_display()
+        display.start()
+        self._start_browser_activity(display)
+
+        display.update_progress("browser_action", "Reading account list")
+
+        act = display._activities[0]
+        assert not act.done
+        assert display._line2_status == "Reading account list"
+
+    @patch("anton.chat_ui.Live")
+    def test_browser_action_with_eta_marks_activity_done(self, MockLive):
+        display, _ = self._make_display()
+        display.start()
+        self._start_browser_activity(display)
+
+        display.update_progress("browser_action", "Reading account list")
+        display.update_progress("browser_action", "Reading account list", eta=2.5)
+
+        act = display._activities[0]
+        assert act.done
+        assert act.work_elapsed == 2.5
+
+    @patch("anton.chat_ui.Live")
+    def test_browser_action_done_line_printed_on_finish(self, MockLive):
+        """The completed browser activity gets its ✔ elapsed line (via
+        finish(), which flushes done-but-unprinted activities the same way
+        it does for tool_done-completed tools)."""
+        display, console = self._make_display()
+        display.start()
+        self._start_browser_activity(display)
+
+        display.update_progress("browser_action", "Reading account list", eta=1.9)
+        display.finish()
+
+        act = display._activities[0]
+        assert act.done
+        assert act.done_line_printed
+
+    @patch("anton.chat_ui.Live")
+    def test_browser_action_completion_via_reasoning_done(self, MockLive):
+        """reasoning_done after a completed browser action prints the combined
+        ✔ line, exactly as it does for tool_done-completed tools."""
+        display, _ = self._make_display()
+        display.start()
+        self._start_browser_activity(display)
+
+        display.update_progress("browser_action", "Reading account list", eta=1.2)
+        display.update_progress("reasoning_done", "", eta=3.4)
+
+        act = display._activities[0]
+        assert act.done
+        assert act.done_line_printed
+        assert act.reasoning_elapsed == 3.4
+
+    @patch("anton.chat_ui.Live")
+    def test_browser_action_does_not_complete_other_activities(self, MockLive):
+        """A browser_action completion only marks the browser_control
+        activity done — other pending tools are untouched."""
+        display, _ = self._make_display()
+        display.start()
+        display.on_tool_use_start("tool_x", "recall_skill")
+        display.on_tool_use_end("tool_x")
+        self._start_browser_activity(display)
+
+        display.update_progress("browser_action", "Reading account list", eta=2.0)
+
+        other = display._activities[0]
+        browser = display._activities[1]
+        assert not other.done
+        assert browser.done
+
+    @patch("anton.chat_ui.Live")
+    def test_browser_action_completion_matches_by_tool_use_id(self, MockLive):
+        """With two pending browser_control activities, a completion event
+        carrying the FIRST one's tool_use id marks that one done — not the
+        last pending one (which the name-only reversed scan would pick)."""
+        display, _ = self._make_display()
+        display.start()
+        # Two browser activities printed before either executes.
+        display.on_tool_use_start("tool_b1", "browser_control")
+        display.on_tool_use_end("tool_b1")
+        display.on_tool_use_start("tool_b2", "browser_control")
+        display.on_tool_use_end("tool_b2")
+
+        display.update_progress(
+            "browser_action", "Reading account list", eta=1.5, id="tool_b1"
+        )
+
+        first = next(a for a in display._activities if a.tool_id == "tool_b1")
+        second = next(a for a in display._activities if a.tool_id == "tool_b2")
+        assert first.done
+        assert first.work_elapsed == 1.5
+        assert not second.done
+
+    @patch("anton.chat_ui.Live")
+    def test_browser_action_completion_falls_back_to_name_without_id(self, MockLive):
+        """Without an id (older callers), completion falls back to the
+        reversed name scan — the last pending browser activity is marked."""
+        display, _ = self._make_display()
+        display.start()
+        display.on_tool_use_start("tool_b1", "browser_control")
+        display.on_tool_use_end("tool_b1")
+        display.on_tool_use_start("tool_b2", "browser_control")
+        display.on_tool_use_end("tool_b2")
+
+        display.update_progress("browser_action", "Reading account list", eta=2.0)
+
+        first = next(a for a in display._activities if a.tool_id == "tool_b1")
+        second = next(a for a in display._activities if a.tool_id == "tool_b2")
+        assert second.done
+        assert second.work_elapsed == 2.0
+        assert not first.done


### PR DESCRIPTION
Streams human-readable, per-action progress for the host-registered `browser_control` tool (Browser Control Milestone 1, read-only). When the LLM dispatches `browser_control`, the session now yields a `StreamTaskProgress(phase="browser_action")` event before and after tool execution, carrying the tool call's `progress_message` (e.g. "Opening the July report") so the host UI can show live "Browsing …" status with an ETA. Anton stays host-agnostic: the tool itself is defined and executed by the host (cowork-server); anton only surfaces its progress.

## Changes

- `anton/core/session.py`: special-case in `_stream_and_handle_tools` for tool calls named `browser_control` that carry a truthy `progress_message` argument — yields a pre-dispatch `StreamTaskProgress(phase="browser_action", message=<progress_message>, id=<tool_call_id>)` and a post-dispatch event with `eta_seconds`. All other tools fall through to the generic path unchanged.
- `tests/test_chat_browser_progress.py`: unit tests — phase carries the human message, fallback behavior without `progress_message`, other tools unaffected.
- **Review fixes (`06b5c4b`, `b79852d`, from PR review)**: `StreamDisplay.update_progress` (`anton/chat_ui.py`) gained an explicit `browser_action` branch so the CLI marks the browser activity done with its elapsed/✔ line on completion (previously `browser_action` fell through as a status update and the activity never completed). The tool_use `id` is now threaded through `update_progress` (call sites in `anton/chat.py`, `anton/commands/goal.py`) so completion matches the exact activity when multiple browser actions are pending, with a name-scan fallback.
- `tests/e2e/scenarios/test_browser_tool.py`: two e2e scenarios against the in-process `ChatSession.turn_stream` with a stub LLM server and a fake `browser_control` ToolDef — a three-step read-only task streams human progress; a connector-preferred task never emits `browser_control`.

## How to review

1. `anton/core/session.py` — the only behavioral change: the `browser_control` special-case in `_stream_and_handle_tools`. Check the pre/post `StreamTaskProgress(phase="browser_action")` pair and that every other tool falls through to the generic `tool_start`/`tool_done` path unchanged.
2. `anton/chat_ui.py` (`StreamDisplay.update_progress`) — the `browser_action` branch: `eta_seconds=None` = status update, `eta_seconds` set = mark the matching activity done; matching is by threaded tool_use `id` with a name-scan fallback.
3. `anton/chat.py` / `anton/commands/goal.py` — mechanical call-site updates threading the `id` through.
4. `tests/test_chat_browser_progress.py` + `tests/e2e/scenarios/test_browser_tool.py` — the e2e stream-shape guard pins exactly two `browser_action` events per action and no generic tool events for `browser_control`; this is the contract cowork-server's stream formatter depends on.

## Demo

[Desktop demo recording (mp4, ~5 min, 2.6 MB)](https://github.com/mindsdb/cowork/raw/vorflux/browser-control-m1-demo-assets/browser-control-m1-demo.mp4) — recorded on the final code of this stack against a real cowork-server, real Electron app, and a real Chrome window on a local fixture site. It shows: connect + one-tab approval (`awaiting-approval` → `connected`), the Browser Control connection card, real dispatched `inspect` → `follow_link` (Chrome visibly navigates to `july.html`) → `scroll` → `wait` through the live server command queue → Electron poller → CDP path with content-free observed digests, then Disconnect/revoke and a refused post-revoke dispatch ("The browser was stopped or handed back before this action ran."). The asset is hosted on the throwaway branch `vorflux/browser-control-m1-demo-assets` (cowork repo); safe to delete after the stack merges.

## Testing

Automated (all run by the testing subagent on this branch):

- `uv run --extra dev pytest tests/test_chat_browser_progress.py tests/e2e/scenarios/test_browser_tool.py -v` — 5 passed.
- `uv run --extra dev pytest tests/ --ignore=tests/e2e` — 1208 passed, 17 skipped on the `staging` base (branch rebased from `main` onto `staging`; feature diff unchanged).
- `uv run --extra dev pytest tests/e2e/` — 37 passed.
- The e2e stream-shape guard pins exactly two `browser_action` events per action (start with `eta_seconds=None`, done with elapsed) and no generic `tool_start`/`tool_done` for `browser_control`, protecting cowork-server's stream formatter.

Cross-repo integration (server↔Electron broker seam with a real headless Chrome and the real cowork-server) was exercised in the sibling PRs' testing; anton's contribution there is the streamed `browser_action` phase consumed by cowork-server's stream formatter.

Live real-LLM verification (added 2026-07-16 after `ANTHROPIC_API_KEY` became available): the previously-blocked connector-first + cited-answer acceptance check now PASSES with real Claude calls — a real chat turn streamed the `browser_action` progress phases while dispatching `inspect` then `follow_link` through the real cross-repo path, and the final answer correctly cited "July Total Revenue: $1,234,567" from the fixture; Stop during a live streaming turn completed in 13.7ms with in-flight calls refused cleanly. Full live evidence is in the sibling cowork/cowork-server PRs. Remaining caveat: no actual connector was configured in the dev env, so a live connector-vs-browser routing decision was not observable (the preference is confirmed via prompt/schema, unit test, and live `reason` usage).

Testing caveats (disclosed per policy):

- The end-to-end testing subagent hit six 3600s timeouts and one platform-internal error across its runs (the third during the demo-recording run, the fourth during the live-LLM round, the fifth and sixth during the Stop→resume verification round — in each case the round's work had completed and its results were recovered from the subagent's preserved report); it was resumed from its preserved transcripts each time and the suites above completed with the recorded results. See the sibling cowork/cowork-server PRs for the full integration/UI evidence and any remaining unverified cases.
