### PR TITLE
ENG-824: force UTF-8 in the scratchpad so non-UTF-8 host locales (GBK/CJK Windows) don't crash

### DIFF
--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -704,6 +704,9 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            # Same UTF-8 mode as the scratchpad process, so pip/uv output on a
+            # non-UTF-8 host locale doesn't come back as mojibake (ENG-824).
+            env=_utf8_env(os.environ),
         )
         try:
             stdout, _ = await asyncio.wait_for(

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -33,10 +33,15 @@ def _utf8_env(base: "os._Environ[str] | dict[str, str]") -> dict[str, str]:
     page and every ``open()``/``print()``/stdio defaults to it — so reading the
     boot script or emitting non-ASCII output crashes (ENG-824). ``setdefault``
     so an explicit operator override still wins.
+
+    Only ``PYTHONUTF8`` is set: UTF-8 mode already makes open()/filesystem/stdio
+    UTF-8 with the lenient ``surrogateescape`` stdio handler. We deliberately do
+    NOT also set ``PYTHONIOENCODING`` — a bare value downgrades the stdio error
+    handler back to ``strict`` (verified), which would re-introduce a crash on
+    exotic output rather than round-tripping it.
     """
     env = dict(base)
     env.setdefault("PYTHONUTF8", "1")
-    env.setdefault("PYTHONIOENCODING", "utf-8")
     return env
 
 

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -24,6 +24,16 @@ from anton.core.backends.utils import compute_timeouts
 _BOOT_SCRIPT_PATH = Path(__file__).parent / "scratchpad_boot.py"
 
 
+def _read_boot_script() -> str:
+    """Read the boot script as UTF-8 explicitly.
+
+    It contains non-ASCII (…, —), so a host-locale-default read (e.g. GBK on
+    Chinese Windows) crashes with a codec error before the scratchpad can start
+    (ENG-824). Kept as a helper so the explicit encoding is pinned by a test.
+    """
+    return _BOOT_SCRIPT_PATH.read_text(encoding="utf-8")
+
+
 def _utf8_env(base: "os._Environ[str] | dict[str, str]") -> dict[str, str]:
     """A copy of ``base`` with Python UTF-8 mode forced for the scratchpad
     subprocess.
@@ -273,7 +283,12 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                     break
             if child_site and parent_site:
                 pth_path = os.path.join(child_site, "_parent_venv.pth")
-                with open(pth_path, "w") as f:
+                # UTF-8 explicitly: a plain open() encodes with the host locale
+                # (e.g. GBK on Chinese Windows), but the child reads .pth files
+                # as UTF-8 under UTF-8 mode — a mismatch corrupts non-ASCII
+                # site-packages paths (same class of bug as the boot script,
+                # ENG-824).
+                with open(pth_path, "w", encoding="utf-8") as f:
                     for sp in parent_site:
                         f.write(sp + "\n")
 
@@ -347,10 +362,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         """Write the boot script to a temp file and launch the subprocess."""
         self._ensure_venv()
 
-        # Read/write the boot script as UTF-8 explicitly: it contains non-ASCII
-        # (…, —), so a host-locale-default read (e.g. GBK on Chinese Windows)
-        # crashes with a codec error before the scratchpad can start (ENG-824).
-        boot_code = _BOOT_SCRIPT_PATH.read_text(encoding="utf-8")
+        boot_code = _read_boot_script()
         fd, path = tempfile.mkstemp(suffix=".py", prefix="anton_scratchpad_")
         os.write(fd, boot_code.encode("utf-8"))
         os.close(fd)

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -22,6 +22,24 @@ from anton.core.settings import CoreSettings
 from anton.core.backends.utils import compute_timeouts
 
 _BOOT_SCRIPT_PATH = Path(__file__).parent / "scratchpad_boot.py"
+
+
+def _utf8_env(base: "os._Environ[str] | dict[str, str]") -> dict[str, str]:
+    """A copy of ``base`` with Python UTF-8 mode forced for the scratchpad
+    subprocess.
+
+    The parent may run under a non-UTF-8 host locale (e.g. GBK/cp936 on
+    Chinese Windows). Without this, the child interpreter inherits that code
+    page and every ``open()``/``print()``/stdio defaults to it — so reading the
+    boot script or emitting non-ASCII output crashes (ENG-824). ``setdefault``
+    so an explicit operator override still wins.
+    """
+    env = dict(base)
+    env.setdefault("PYTHONUTF8", "1")
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    return env
+
+
 _MAX_OUTPUT = 10_000
 
 
@@ -199,7 +217,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 capture_output=True,
                 timeout=5,
             )
-            return result.returncode == 0 and "ok" in result.stdout.decode()
+            return result.returncode == 0 and "ok" in result.stdout.decode("utf-8", errors="replace")
         except Exception:
             return False
 
@@ -324,13 +342,18 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         """Write the boot script to a temp file and launch the subprocess."""
         self._ensure_venv()
 
-        boot_code = _BOOT_SCRIPT_PATH.read_text()
+        # Read/write the boot script as UTF-8 explicitly: it contains non-ASCII
+        # (…, —), so a host-locale-default read (e.g. GBK on Chinese Windows)
+        # crashes with a codec error before the scratchpad can start (ENG-824).
+        boot_code = _BOOT_SCRIPT_PATH.read_text(encoding="utf-8")
         fd, path = tempfile.mkstemp(suffix=".py", prefix="anton_scratchpad_")
-        os.write(fd, boot_code.encode())
+        os.write(fd, boot_code.encode("utf-8"))
         os.close(fd)
         self._boot_path = path
 
-        env = os.environ.copy()
+        # Force UTF-8 mode in the child so its I/O never depends on the host
+        # code page (ENG-824).
+        env = _utf8_env(os.environ)
         if self._coding_model:
             env["ANTON_SCRATCHPAD_MODEL"] = self._coding_model
         if self._coding_provider:
@@ -490,7 +513,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
             return
 
         payload = code + "\n" + CELL_DELIM + "\n"
-        self._proc.stdin.write(payload.encode())  # type: ignore[union-attr]
+        self._proc.stdin.write(payload.encode("utf-8"))  # type: ignore[union-attr]
         await self._proc.stdin.drain()  # type: ignore[union-attr]
 
         total_timeout, inactivity_timeout = compute_timeouts(estimated_seconds)
@@ -622,7 +645,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 }
                 return
 
-            line = raw.decode().rstrip("\r\n")
+            line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
 
             if line.startswith(PROGRESS_MARKER):
                 current_inactivity = max(
@@ -685,7 +708,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
             proc.kill()
             await proc.wait()
             return f"Install timed out after {_install_timeout}s."
-        output = stdout.decode()
+        output = stdout.decode("utf-8", errors="replace")
         if proc.returncode != 0:
             return f"Install failed (exit {proc.returncode}):\n{output}"
         for p in needed:

--- a/tests/test_scratchpad_utf8.py
+++ b/tests/test_scratchpad_utf8.py
@@ -11,15 +11,16 @@ import anton.core.backends.local as local
 def test_utf8_env_forces_utf8_mode():
     env = local._utf8_env({"FOO": "bar"})
     assert env["PYTHONUTF8"] == "1"
-    assert env["PYTHONIOENCODING"] == "utf-8"
     assert env["FOO"] == "bar"  # base is preserved
+    # Deliberately NOT set — a bare PYTHONIOENCODING makes stdio strict, which
+    # would re-introduce a crash on exotic output (UTF-8 mode already covers it).
+    assert "PYTHONIOENCODING" not in env
 
 
 def test_utf8_env_respects_explicit_override():
-    # setdefault: an operator who deliberately set these keeps them.
-    env = local._utf8_env({"PYTHONUTF8": "0", "PYTHONIOENCODING": "latin-1"})
+    # setdefault: an operator who deliberately set UTF-8 mode off keeps it.
+    env = local._utf8_env({"PYTHONUTF8": "0"})
     assert env["PYTHONUTF8"] == "0"
-    assert env["PYTHONIOENCODING"] == "latin-1"
 
 
 def test_boot_script_must_be_read_as_utf8():

--- a/tests/test_scratchpad_utf8.py
+++ b/tests/test_scratchpad_utf8.py
@@ -1,0 +1,34 @@
+"""ENG-824 regression: the scratchpad must be UTF-8-safe regardless of the
+host locale code page (e.g. GBK/cp936 on Chinese Windows)."""
+
+from __future__ import annotations
+
+import pytest
+
+import anton.core.backends.local as local
+
+
+def test_utf8_env_forces_utf8_mode():
+    env = local._utf8_env({"FOO": "bar"})
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    assert env["FOO"] == "bar"  # base is preserved
+
+
+def test_utf8_env_respects_explicit_override():
+    # setdefault: an operator who deliberately set these keeps them.
+    env = local._utf8_env({"PYTHONUTF8": "0", "PYTHONIOENCODING": "latin-1"})
+    assert env["PYTHONUTF8"] == "0"
+    assert env["PYTHONIOENCODING"] == "latin-1"
+
+
+def test_boot_script_must_be_read_as_utf8():
+    # The boot script contains non-ASCII (…, —). Reading it with a non-UTF-8
+    # host-locale default (GBK on Chinese Windows) throws a UnicodeDecodeError
+    # before the scratchpad can start — the exact ENG-824 crash. Guard that (a)
+    # UTF-8 decodes cleanly and (b) the content genuinely needs UTF-8, so a
+    # locale-default read is unsafe and must not regress.
+    raw = local._BOOT_SCRIPT_PATH.read_bytes()
+    raw.decode("utf-8")  # the fix: explicit UTF-8 succeeds
+    with pytest.raises(UnicodeDecodeError):
+        raw.decode("gbk")  # a GBK-locale default read would crash

--- a/tests/test_scratchpad_utf8.py
+++ b/tests/test_scratchpad_utf8.py
@@ -51,3 +51,40 @@ def test_boot_script_is_read_as_utf8(monkeypatch):
     monkeypatch.setattr(local.Path, "read_text", spy)
     assert local._read_boot_script()  # exercises the real read path
     assert seen.get("encoding") == "utf-8"
+
+
+def test_parent_venv_pth_is_written_as_utf8(tmp_path, monkeypatch):
+    # Sibling of the boot-script read: the child reads .pth files as UTF-8 under
+    # UTF-8 mode, so the parent must *write* _parent_venv.pth as UTF-8 or a
+    # non-ASCII site-packages path (e.g. a CJK Windows user dir) corrupts.
+    # Pin the write encoding without spinning up a real venv.
+    import builtins
+    import site
+
+    # Force the "running inside a venv" branch deterministically.
+    monkeypatch.setattr(local.sys, "prefix", "/venv")
+    monkeypatch.setattr(local.sys, "base_prefix", "/usr")
+    monkeypatch.setattr(site, "getsitepackages", lambda: ["/parent/site-packages"])
+
+    child_site = tmp_path / "lib" / "python3.11" / "site-packages"
+    child_site.mkdir(parents=True)
+
+    # Bypass the heavy __init__ (no network/subprocess) — the method only reads
+    # self._venv_dir.
+    runtime = object.__new__(local.LocalScratchpadRuntime)
+    runtime._venv_dir = str(tmp_path)
+
+    seen = {}
+    real_open = builtins.open
+
+    def spy_open(file, *args, **kwargs):
+        if str(file).endswith("_parent_venv.pth"):
+            seen["encoding"] = kwargs.get("encoding")
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", spy_open)
+    runtime._setup_parent_site_packages()
+
+    assert seen.get("encoding") == "utf-8"  # assert before any later read
+    written = (child_site / "_parent_venv.pth").read_text(encoding="utf-8")
+    assert "/parent/site-packages" in written

--- a/tests/test_scratchpad_utf8.py
+++ b/tests/test_scratchpad_utf8.py
@@ -23,7 +23,7 @@ def test_utf8_env_respects_explicit_override():
     assert env["PYTHONUTF8"] == "0"
 
 
-def test_boot_script_must_be_read_as_utf8():
+def test_boot_script_content_requires_utf8():
     # The boot script contains non-ASCII (…, —). Reading it with a non-UTF-8
     # host-locale default (GBK on Chinese Windows) throws a UnicodeDecodeError
     # before the scratchpad can start — the exact ENG-824 crash. Guard that (a)
@@ -33,3 +33,21 @@ def test_boot_script_must_be_read_as_utf8():
     raw.decode("utf-8")  # the fix: explicit UTF-8 succeeds
     with pytest.raises(UnicodeDecodeError):
         raw.decode("gbk")  # a GBK-locale default read would crash
+
+
+def test_boot_script_is_read_as_utf8(monkeypatch):
+    # Pin the *read*, not just the file's bytes: if someone drops the explicit
+    # encoding="utf-8" (reverting to a host-locale default), this fails even on a
+    # UTF-8 CI box — where a bytes-only check would still pass. Spy on
+    # Path.read_text and assert the boot-script read passes encoding="utf-8".
+    seen = {}
+    real_read_text = local.Path.read_text
+
+    def spy(self, *args, **kwargs):
+        if self == local._BOOT_SCRIPT_PATH:
+            seen["encoding"] = kwargs.get("encoding")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(local.Path, "read_text", spy)
+    assert local._read_boot_script()  # exercises the real read path
+    assert seen.get("encoding") == "utf-8"


### PR DESCRIPTION
## What
On a host whose default code page isn't UTF-8 — **GBK/cp936 on Chinese Windows**, and likely other CJK locales — `LocalScratchpadRuntime` crashes **before any cell runs**, so the scratchpad (and thus most real tasks) is 100% unusable for those users.

## Root cause (confirmed)
`local.py` crossed the parent↔scratchpad byte boundary using the **host locale encoding** everywhere. First failure: `_BOOT_SCRIPT_PATH.read_text()` decodes the 32 KB boot script with the locale default; the script contains `…`/`—` (a `…` at byte ~6382), so on GBK it throws `'gbk' codec can't decode byte 0xa6`. Verified locally: the boot script's bytes decode fine as UTF-8 but **raise under GBK** — byte `0xa6` matches the reporter's error exactly.

## Fix (interpreter-level + explicit at every boundary)
- **Boot script** read/written as UTF-8 (`read_text(encoding="utf-8")` / `encode("utf-8")`).
- **Subprocess env** forces UTF-8 mode — `PYTHONUTF8=1` / `PYTHONIOENCODING=utf-8` via `_utf8_env` (`setdefault`, so an explicit operator override still wins) — so the child's file I/O + stdio are UTF-8 regardless of host locale, covering user data (Chinese DB rows/CSVs) too.
- **Cell payload + stdout/install output** encoded/decoded as UTF-8 (`errors="replace"` on display output so stray bytes never crash the reader).

## Why it can't break anything
All of this content is already UTF-8 on the wire (anton writes UTF-8). On macOS/Linux/English-Windows the default is already UTF-8 → behavior is identical. It **only** changes non-UTF-8-locale hosts — turning a hard crash into working. There's no working baseline to regress (it was a 100% crash there).

## Testing
- New `tests/test_scratchpad_utf8.py`: `_utf8_env` forces UTF-8 / respects an explicit override; the boot script must be read as UTF-8 (its bytes are **not** GBK-decodable — the regression guard).
- **96 existing scratchpad tests pass** (`test_scratchpad.py`, `test_scratchpad_observer_dispatch.py`).

## Origin
Prod **Cowork-desktop (Windows)** user tried to test a PostgreSQL connection 3× today; every attempt died on this GBK codec error (Langfuse `tool:report_failure` ×3). See ENG-824.

## Coordination
This is the **scratchpad** half. A companion `cowork` PR sets `PYTHONUTF8=1` on the cowork-server **sidecar launch**, covering the non-scratchpad anton reads (workspace `anton.md`/`.env`, memory store) at the process level. The two are independent (either can merge first); together they close the whole locale surface. Both reach users on the next desktop build (cowork-server bumps its anton dep).

## Security check
Encoding-only change; no new surface, no secrets touched.

Closes ENG-824 (scratchpad half).