### PR TITLE
ENG-716: add WAITING verdict to the completion verifier

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1823,11 +1823,17 @@ class ChatSession:
         # task isn't actually done yet.
         continuation = 0
         _max_rounds_hit = False
+        import logging as _logging
+        _verifier_log = _logging.getLogger(__name__)
 
         while True:  # Completion verification loop
             tool_round = 0
             error_streak: dict[str, int] = {}
             resilience_nudged: set[str] = set()
+            # Compact per-tool outcome log for this iteration, so the completion
+            # verifier can cross-check the assistant's claims against what tools
+            # actually did without receiving the full transcript (ENG-716).
+            tool_outcomes: list[str] = []
 
             while llm_response.tool_calls:
                 tool_round += 1
@@ -2090,6 +2096,7 @@ class ChatSession:
                             severity=1,
                             round_idx=tool_round,
                         )
+                        tool_outcomes.append(f"{tc.name}=ok")
                         tool_results.append(
                             {
                                 "type": "tool_result",
@@ -2132,6 +2139,7 @@ class ChatSession:
                         severity=5 if _failed else 1,
                         round_idx=tool_round,
                     )
+                    tool_outcomes.append(f"{tc.name}={'error' if _failed else 'ok'}")
                     tool_results.append(
                         {
                             "type": "tool_result",
@@ -2263,6 +2271,7 @@ class ChatSession:
             # needs for the verdict, keeps the call cheap, and — being plain text
             # — avoids any tool_use/tool_result pairing constraints (ENG-716).
             request_text = (user_message or "").strip() or "(see the assistant's message)"
+            tools_summary = ", ".join(tool_outcomes) if tool_outcomes else "none"
             verify_messages = [
                 {"role": "user", "content": f"USER'S REQUEST:\n{request_text}"},
                 {
@@ -2272,8 +2281,11 @@ class ChatSession:
                 {
                     "role": "user",
                     "content": (
-                        "Based on the assistant's latest message above, which status "
-                        "applies to the user's request?"
+                        f"TOOLS RUN THIS TURN (name=outcome): {tools_summary}\n\n"
+                        "Based on the assistant's latest message and the tool outcomes "
+                        "above, which status applies to the user's request? If a tool the "
+                        "task depended on returned an error but the assistant implied "
+                        "success, that is INCOMPLETE or STUCK — not COMPLETE."
                     ),
                 },
             ]
@@ -2297,8 +2309,7 @@ class ChatSession:
                 # than forcing a continuation the user never asked for.
                 status, reason = "COMPLETE", "verifier unavailable"
 
-            import logging as _logging
-            _logging.getLogger(__name__).info(
+            _verifier_log.info(
                 "completion-verifier verdict=%s continuation=%d/%d tool_rounds=%d reason=%s",
                 status, continuation, self._max_continuations, tool_round, reason,
             )

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -145,47 +145,83 @@ class _VerifierVerdict(BaseModel):
     reason: str = Field(description="One brief sentence explaining the verdict.")
 
 
+def _render_tool_result_content(content, cap: int) -> str:
+    """Render a tool_result's content as bounded plain text.
+
+    Never serializes raw payloads: a multimodal result (e.g. read_image) can
+    carry megabytes of base64, so we keep only text blocks and mark images with
+    a placeholder rather than ``json.dumps``-ing the whole thing (ENG-716).
+    """
+    if isinstance(content, str):
+        return content[:cap] or "(empty result)"
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text":
+                parts.append((block.get("text") or "").strip())
+            elif block.get("type") in ("image", "image_url"):
+                parts.append("[image]")
+        return (" ".join(p for p in parts if p)[:cap]) or "[non-text result]"
+    return str(content)[:cap]
+
+
 def _render_verify_transcript(
     history: list[dict],
     *,
-    max_messages: int = 16,
+    max_convo: int = 10,
+    max_tool: int = 12,
     tool_cap: int = 400,
     text_cap: int = 2000,
 ) -> str:
     """Render a compact, text-only view of the recent conversation for the
     completion verifier.
 
-    Gives the verifier enough to judge reliably — prior turns (so referential
-    follow-ups keep their task context) and truncated tool-result *content* (so
-    a claimed-successful tool can be cross-checked, not just its ok/error flag)
-    — without shipping the full raw transcript or tripping the provider's
-    tool_use/tool_result pairing constraints (ENG-716). Internal ``SYSTEM:``
-    injections are omitted; they are directives, not conversation.
+    Budgets the conversational thread and the tool activity *separately* so a
+    voluminous tool loop can't crowd out the user/assistant turns the verifier
+    needs to resolve referential requests ("do the same for the other file"):
+    the most recent ``max_convo`` user/assistant text turns plus the most recent
+    ``max_tool`` tool events, merged back into chronological order. Speaker is
+    taken from the message role (list-based *user* content — images/files — is
+    labelled USER, not ASSISTANT); multimodal blocks are rendered block-by-block
+    (text kept, images as a placeholder, never raw base64); internal ``SYSTEM:``
+    injections are dropped before budgeting so they don't consume slots. Keeps
+    the call cheap and free of tool_use/tool_result pairing constraints
+    (ENG-716).
     """
-    lines: list[str] = []
-    for msg in history[-max_messages:]:
+    convo: list[tuple[int, str]] = []   # (orig_index, line) — user/assistant text
+    tools: list[tuple[int, str]] = []   # (orig_index, line) — tool activity
+
+    for i, msg in enumerate(history):
         role = msg.get("role")
         content = msg.get("content")
+        speaker = "USER" if role == "user" else "ASSISTANT"
         if isinstance(content, str):
             text = content.strip()
             if not text or (role == "user" and text.startswith("SYSTEM:")):
                 continue
-            speaker = "USER" if role == "user" else "ASSISTANT"
-            lines.append(f"{speaker}: {text[:text_cap]}")
+            convo.append((i, f"{speaker}: {text[:text_cap]}"))
         elif isinstance(content, list):
             for block in content:
                 if not isinstance(block, dict):
                     continue
                 btype = block.get("type")
-                if btype == "text" and (block.get("text") or "").strip():
-                    lines.append(f"ASSISTANT: {block['text'][:text_cap]}")
+                if btype == "text":
+                    text = (block.get("text") or "").strip()
+                    if text:
+                        convo.append((i, f"{speaker}: {text[:text_cap]}"))
+                elif btype in ("image", "image_url"):
+                    convo.append((i, f"{speaker}: [image]"))
                 elif btype == "tool_use":
-                    lines.append(f"ASSISTANT called tool: {block.get('name')}")
+                    tools.append((i, f"ASSISTANT called tool: {block.get('name')}"))
                 elif btype == "tool_result":
-                    c = block.get("content")
-                    text = c if isinstance(c, str) else json.dumps(c)
-                    lines.append(f"TOOL RESULT: {text[:tool_cap]}")
-    return "\n".join(lines) or "(no conversation)"
+                    rendered = _render_tool_result_content(block.get("content"), tool_cap)
+                    tools.append((i, f"TOOL RESULT: {rendered}"))
+
+    kept = convo[-max_convo:] + tools[-max_tool:]
+    kept.sort(key=lambda entry: entry[0])
+    return "\n".join(line for _, line in kept) or "(no conversation)"
 
 
 @dataclass

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2309,13 +2309,18 @@ class ChatSession:
             # and free of tool_use/tool_result pairing constraints (ENG-716). The
             # assistant's latest reply is already in history (appended above).
             transcript = _render_verify_transcript(self._history)
+            # Always state the current request explicitly: a long tool-heavy turn
+            # can push the turn's opening user message out of the transcript window,
+            # and the request is the anchor for the whole judgment (ENG-716).
+            request = (user_message or "").strip()
+            request_header = f"USER'S CURRENT REQUEST: {request}\n\n" if request else ""
             verify_messages = [
                 {
                     "role": "user",
                     "content": (
                         "Assess the conversation below (tool results are truncated) and "
                         "decide the status of the USER's most recent request.\n\n"
-                        f"{transcript}\n\n"
+                        f"{request_header}{transcript}\n\n"
                         "Which status applies? A tool the task depended on that returned "
                         "an error — or returned no usable data while the assistant implied "
                         "success — means INCOMPLETE or STUCK, not COMPLETE."

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -6,8 +6,10 @@ from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime
 import json
 import re
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Literal
 import os
+
+from pydantic import BaseModel, Field
 
 from anton.core.backends.base import Cell, ScratchpadRuntimeFactory
 from anton.core.backends.local import local_scratchpad_runtime_factory
@@ -120,6 +122,29 @@ def _scrub_user_input(user_input: str | list[dict]) -> str | list[dict]:
     ]
 
 
+class _VerifierVerdict(BaseModel):
+    """Structured verdict from the completion verifier (runs on the cheap
+    coding model). The field descriptions below double as the verifier's
+    instructions — see LLMClient.generate_object_code (ENG-716)."""
+
+    status: Literal["COMPLETE", "WAITING", "INCOMPLETE", "STUCK"] = Field(
+        description=(
+            "Classify the assistant's latest message against the user's request:\n"
+            "- COMPLETE: the requested task is done. A finished task followed by an "
+            "optional 'want me to…?' offer is still COMPLETE.\n"
+            "- WAITING: the assistant's latest message asks the user a question it "
+            "genuinely needs answered to proceed with the requested task, or is a "
+            "reasoned refusal. This is a valid stopping point — do NOT treat it as "
+            "unfinished; the correct action is to wait for the user's reply.\n"
+            "- INCOMPLETE: the assistant stopped partway through the requested task "
+            "WITHOUT asking the user anything, and could keep going on its own.\n"
+            "- STUCK: a hard blocker prevents completion (missing credentials, an "
+            "unavailable service, or a permission the assistant does not have)."
+        )
+    )
+    reason: str = Field(description="One brief sentence explaining the verdict.")
+
+
 @dataclass
 class ChatSessionConfig:
     """All construction parameters for a ChatSession.
@@ -183,6 +208,7 @@ class ChatSession:
         self._settings = config.settings
         self._max_tool_rounds = s.max_tool_rounds
         self._max_continuations = s.max_continuations
+        self._verify_min_tool_rounds = s.verify_min_tool_rounds
         self._context_pressure_threshold = s.context_pressure_threshold
         self._max_consecutive_errors = s.max_consecutive_errors
         self._resilience_nudge_at = s.resilience_nudge_at
@@ -2197,9 +2223,10 @@ class ChatSession:
                     )
 
             # --- Completion verification ---
-            # Only verify when tools were actually used (not for simple Q&A)
-            # and we haven't hit the max-rounds hard stop.
-            if tool_round == 0 or _max_rounds_hit:
+            # Skip when too few tool rounds were used (pure Q&A always skips at
+            # tool_round==0; raising verify_min_tool_rounds also skips trivial
+            # single-round turns) or when we hit the max-rounds hard stop.
+            if tool_round < self._verify_min_tool_rounds or _max_rounds_hit:
                 break
 
             # Append the assistant's final text so the verifier can see it
@@ -2230,47 +2257,60 @@ class ChatSession:
                 # Consolidation still runs after diagnosis
                 break
 
-            # Ask the LLM to self-assess completion.
-            # Use a copy of history with a trailing user message so models
-            # that don't support assistant-prefill won't reject the request.
-            # Factory is re-invoked on each recovery attempt so the verifier
-            # sees the latest post-compaction history.
-            def build_verify_messages() -> list[dict]:
-                return list(self._history) + [
-                    {
-                        "role": "user",
-                        "content": (
-                            "SYSTEM: Evaluate whether the task the user originally requested "
-                            "has been fully completed based on the conversation above."
-                        ),
-                    }
-                ]
+            # Ask the cheap coding model to self-assess completion, using a
+            # compact text-only view (the user's request + the assistant's latest
+            # message) rather than the full transcript. That is all the verifier
+            # needs for the verdict, keeps the call cheap, and — being plain text
+            # — avoids any tool_use/tool_result pairing constraints (ENG-716).
+            request_text = (user_message or "").strip() or "(see the assistant's message)"
+            verify_messages = [
+                {"role": "user", "content": f"USER'S REQUEST:\n{request_text}"},
+                {
+                    "role": "assistant",
+                    "content": reply.strip() or "(the assistant produced no final text)",
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Based on the assistant's latest message above, which status "
+                        "applies to the user's request?"
+                    ),
+                },
+            ]
             verifier_system = (
-                "You are a task-completion verifier. Given the conversation, determine "
-                "whether the user's original request has been fully completed.\n\n"
-                "Respond with EXACTLY one of these lines, followed by a brief reason:\n"
-                "STATUS: COMPLETE — <reason>\n"
-                "STATUS: INCOMPLETE — <reason>\n"
-                "STATUS: STUCK — <reason>\n\n"
-                "COMPLETE = the task is done or the response fully answers the question.\n"
-                "INCOMPLETE = more work can be done to finish the task.\n"
-                "STUCK = a blocker prevents completion (missing info, permissions, etc).\n\n"
-                "Be strict: if the user asked for X and only part of X was delivered, "
-                "that is INCOMPLETE, not COMPLETE. But if the user asked a question "
-                "and the assistant answered it, that is COMPLETE even without tool use."
+                "You are a task-completion verifier. Decide whether the user's "
+                "request is complete, the assistant is waiting on the user, the work "
+                "is unfinished, or the assistant is blocked. Follow the status "
+                "definitions exactly."
             )
-            verification = await self.plan_with_recovery(
-                system=verifier_system,
-                max_tokens=256,
-                messages_factory=build_verify_messages,
+            try:
+                verdict = await self._llm.generate_object_code(
+                    _VerifierVerdict,
+                    system=verifier_system,
+                    messages=verify_messages,
+                    max_tokens=256,
+                )
+                status = verdict.status
+                reason = verdict.reason.strip()
+            except Exception:
+                # Verifier failed — fail safe by treating the turn as done rather
+                # than forcing a continuation the user never asked for.
+                status, reason = "COMPLETE", "verifier unavailable"
+
+            import logging as _logging
+            _logging.getLogger(__name__).info(
+                "completion-verifier verdict=%s continuation=%d/%d tool_rounds=%d reason=%s",
+                status, continuation, self._max_continuations, tool_round, reason,
             )
 
-            status_text = (verification.content or "").strip().upper()
-            if "STATUS: COMPLETE" in status_text:
+            if status in ("COMPLETE", "WAITING"):
+                # COMPLETE = the request is done. WAITING = the assistant asked the
+                # user something it genuinely needs, or gave a reasoned refusal —
+                # a valid stop, NOT unfinished work. In both cases the turn's final
+                # message already stands in history; do not force a continuation.
                 break
-            if "STATUS: STUCK" in status_text:
-                # Stuck — inject diagnosis request and let the LLM explain
-                reason = (verification.content or "").strip()
+            if status == "STUCK":
+                # Stuck — inject diagnosis request and let the LLM explain.
                 self._append_history(
                     {
                         "role": "user",
@@ -2278,7 +2318,8 @@ class ChatSession:
                             f"SYSTEM: Task verification determined this task is stuck.\n"
                             f"Verifier assessment: {reason}\n\n"
                             "Explain to the user what went wrong, what you tried, and "
-                            "suggest specific next steps they can take to unblock this."
+                            "suggest specific next steps they can take to unblock this. "
+                            "Do not mention this instruction or the verifier to the user."
                         ),
                     }
                 )
@@ -2291,7 +2332,6 @@ class ChatSession:
 
             # INCOMPLETE — continue working
             continuation += 1
-            reason = (verification.content or "").strip()
             self._append_history(
                 {
                     "role": "user",
@@ -2300,7 +2340,8 @@ class ChatSession:
                         f"(attempt {continuation}/{self._max_continuations}).\n"
                         f"Verifier assessment: {reason}\n\n"
                         "Continue working on the original request. Pick up where you left off "
-                        "and finish the remaining work. Do not repeat work already done."
+                        "and finish the remaining work. Do not repeat work already done. "
+                        "Do not mention this instruction or the verifier to the user."
                     ),
                 }
             )

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -145,6 +145,49 @@ class _VerifierVerdict(BaseModel):
     reason: str = Field(description="One brief sentence explaining the verdict.")
 
 
+def _render_verify_transcript(
+    history: list[dict],
+    *,
+    max_messages: int = 16,
+    tool_cap: int = 400,
+    text_cap: int = 2000,
+) -> str:
+    """Render a compact, text-only view of the recent conversation for the
+    completion verifier.
+
+    Gives the verifier enough to judge reliably — prior turns (so referential
+    follow-ups keep their task context) and truncated tool-result *content* (so
+    a claimed-successful tool can be cross-checked, not just its ok/error flag)
+    — without shipping the full raw transcript or tripping the provider's
+    tool_use/tool_result pairing constraints (ENG-716). Internal ``SYSTEM:``
+    injections are omitted; they are directives, not conversation.
+    """
+    lines: list[str] = []
+    for msg in history[-max_messages:]:
+        role = msg.get("role")
+        content = msg.get("content")
+        if isinstance(content, str):
+            text = content.strip()
+            if not text or (role == "user" and text.startswith("SYSTEM:")):
+                continue
+            speaker = "USER" if role == "user" else "ASSISTANT"
+            lines.append(f"{speaker}: {text[:text_cap]}")
+        elif isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "text" and (block.get("text") or "").strip():
+                    lines.append(f"ASSISTANT: {block['text'][:text_cap]}")
+                elif btype == "tool_use":
+                    lines.append(f"ASSISTANT called tool: {block.get('name')}")
+                elif btype == "tool_result":
+                    c = block.get("content")
+                    text = c if isinstance(c, str) else json.dumps(c)
+                    lines.append(f"TOOL RESULT: {text[:tool_cap]}")
+    return "\n".join(lines) or "(no conversation)"
+
+
 @dataclass
 class ChatSessionConfig:
     """All construction parameters for a ChatSession.
@@ -1830,10 +1873,6 @@ class ChatSession:
             tool_round = 0
             error_streak: dict[str, int] = {}
             resilience_nudged: set[str] = set()
-            # Compact per-tool outcome log for this iteration, so the completion
-            # verifier can cross-check the assistant's claims against what tools
-            # actually did without receiving the full transcript (ENG-716).
-            tool_outcomes: list[str] = []
 
             while llm_response.tool_calls:
                 tool_round += 1
@@ -2096,7 +2135,6 @@ class ChatSession:
                             severity=1,
                             round_idx=tool_round,
                         )
-                        tool_outcomes.append(f"{tc.name}=ok")
                         tool_results.append(
                             {
                                 "type": "tool_result",
@@ -2139,7 +2177,6 @@ class ChatSession:
                         severity=5 if _failed else 1,
                         round_idx=tool_round,
                     )
-                    tool_outcomes.append(f"{tc.name}={'error' if _failed else 'ok'}")
                     tool_results.append(
                         {
                             "type": "tool_result",
@@ -2265,27 +2302,23 @@ class ChatSession:
                 # Consolidation still runs after diagnosis
                 break
 
-            # Ask the cheap coding model to self-assess completion, using a
-            # compact text-only view (the user's request + the assistant's latest
-            # message) rather than the full transcript. That is all the verifier
-            # needs for the verdict, keeps the call cheap, and — being plain text
-            # — avoids any tool_use/tool_result pairing constraints (ENG-716).
-            request_text = (user_message or "").strip() or "(see the assistant's message)"
-            tools_summary = ", ".join(tool_outcomes) if tool_outcomes else "none"
+            # Ask the cheap coding model to self-assess completion over a compact,
+            # text-rendered view of the recent conversation: enough context for
+            # referential follow-ups plus truncated tool-result evidence to
+            # cross-check success claims, but far smaller than the raw transcript
+            # and free of tool_use/tool_result pairing constraints (ENG-716). The
+            # assistant's latest reply is already in history (appended above).
+            transcript = _render_verify_transcript(self._history)
             verify_messages = [
-                {"role": "user", "content": f"USER'S REQUEST:\n{request_text}"},
-                {
-                    "role": "assistant",
-                    "content": reply.strip() or "(the assistant produced no final text)",
-                },
                 {
                     "role": "user",
                     "content": (
-                        f"TOOLS RUN THIS TURN (name=outcome): {tools_summary}\n\n"
-                        "Based on the assistant's latest message and the tool outcomes "
-                        "above, which status applies to the user's request? If a tool the "
-                        "task depended on returned an error but the assistant implied "
-                        "success, that is INCOMPLETE or STUCK — not COMPLETE."
+                        "Assess the conversation below (tool results are truncated) and "
+                        "decide the status of the USER's most recent request.\n\n"
+                        f"{transcript}\n\n"
+                        "Which status applies? A tool the task depended on that returned "
+                        "an error — or returned no usable data while the assistant implied "
+                        "success — means INCOMPLETE or STUCK, not COMPLETE."
                     ),
                 },
             ]

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -203,14 +203,23 @@ def _render_verify_transcript(
                 continue
             convo.append((i, f"{speaker}: {text[:text_cap]}"))
         elif isinstance(content, list):
+            # Assistant text emitted alongside a tool call is preamble/narration
+            # ("Processing step 4"), not a conversational turn — route it to the
+            # tool budget so a long tool loop can't evict real requests/replies
+            # from the conversation budget.
+            preamble = role == "assistant" and any(
+                isinstance(b, dict) and b.get("type") == "tool_use" for b in content
+            )
             for block in content:
                 if not isinstance(block, dict):
                     continue
                 btype = block.get("type")
                 if btype == "text":
                     text = (block.get("text") or "").strip()
-                    if text:
-                        convo.append((i, f"{speaker}: {text[:text_cap]}"))
+                    if not text:
+                        continue
+                    bucket = tools if preamble else convo
+                    bucket.append((i, f"{speaker}: {text[:text_cap]}"))
                 elif btype in ("image", "image_url"):
                     convo.append((i, f"{speaker}: [image]"))
                 elif btype == "tool_use":

--- a/anton/core/settings.py
+++ b/anton/core/settings.py
@@ -8,6 +8,11 @@ class CoreSettings(BaseSettings):
     # Session orchestration tuning
     max_tool_rounds: int = 25
     max_continuations: int = 3
+    # Skip the completion verifier when a turn used fewer than this many tool
+    # rounds. Default 1 preserves today's behavior (only pure Q&A, tool_round==0,
+    # is skipped). Raise to 2 to also skip trivial single-tool-round turns once
+    # verdict logs confirm they're rarely INCOMPLETE (ENG-716).
+    verify_min_tool_rounds: int = 1
     context_pressure_threshold: float = 0.7
     max_consecutive_errors: int = 5
     resilience_nudge_at: int = 2

--- a/tests/e2e/scenarios/test_loop_safety.py
+++ b/tests/e2e/scenarios/test_loop_safety.py
@@ -50,6 +50,33 @@ def test_continuation_limit_respected(cfg, stub, tmp_path):
     ), f"Budget-exhausted message not found. Request count: {stub.request_count}"
 
 
+@pytest.mark.stub_only
+def test_waiting_verdict_stops_without_continuation(cfg, stub, tmp_path):
+    # ENG-716: a tool-using turn that ends by asking the user a question must
+    # STOP when the verifier returns WAITING — not inject "Continue working"
+    # and answer its own question. Also asserts the tool-outcome cross-check
+    # actually reaches the verifier.
+    stub.queue_tool_call("scratchpad", {"action": "exec", "name": "c", "code": "print(1)"})
+    stub.queue_text("Which format would you like — PDF or HTML? WAITING_ON_USER")
+    stub.queue_verification_waiting("assistant asked the user a question it needs answered")
+    result = run_anton(["--folder", str(tmp_path)], ["make me a report", "exit"],
+                       env=base_env(stub), timeout=cfg.timeout(30))
+
+    assert_exit_ok(result)
+    assert_not_output(result, "Traceback (most recent call last)")
+    assert_output(result, "WAITING_ON_USER")
+    # WAITING is a valid stop: no continuation injection may be sent.
+    assert not any(
+        "Continue working on the original request" in json.dumps(r.get("messages", []))
+        for r in stub.requests
+    ), "WAITING verdict must not trigger a continuation injection"
+    # The verifier must receive the compact per-tool outcome log (cross-check).
+    assert any(
+        "TOOLS RUN THIS TURN" in json.dumps(r.get("messages", []))
+        for r in stub.requests
+    ), "verifier did not receive the tool-outcome summary"
+
+
 def test_session_exits_within_timeout(cfg, stub, tmp_path):
     stub.queue_text("Quick reply. QUICK_EXIT")
     stub.queue_verification_ok()

--- a/tests/e2e/scenarios/test_loop_safety.py
+++ b/tests/e2e/scenarios/test_loop_safety.py
@@ -76,6 +76,12 @@ def test_waiting_verdict_stops_without_continuation(cfg, stub, tmp_path):
         "TOOL RESULT:" in json.dumps(r.get("messages", []))
         for r in stub.requests
     ), "verifier did not receive tool-result evidence"
+    # ...and the current request is always stated, even if a long turn evicts it
+    # from the transcript window.
+    assert any(
+        "USER'S CURRENT REQUEST" in json.dumps(r.get("messages", []))
+        for r in stub.requests
+    ), "verifier did not receive the current request header"
 
 
 def test_session_exits_within_timeout(cfg, stub, tmp_path):

--- a/tests/e2e/scenarios/test_loop_safety.py
+++ b/tests/e2e/scenarios/test_loop_safety.py
@@ -70,11 +70,12 @@ def test_waiting_verdict_stops_without_continuation(cfg, stub, tmp_path):
         "Continue working on the original request" in json.dumps(r.get("messages", []))
         for r in stub.requests
     ), "WAITING verdict must not trigger a continuation injection"
-    # The verifier must receive the compact per-tool outcome log (cross-check).
+    # The verifier must receive truncated tool-result evidence (not just a flag),
+    # so it can cross-check claimed success against what the tool actually did.
     assert any(
-        "TOOLS RUN THIS TURN" in json.dumps(r.get("messages", []))
+        "TOOL RESULT:" in json.dumps(r.get("messages", []))
         for r in stub.requests
-    ), "verifier did not receive the tool-outcome summary"
+    ), "verifier did not receive tool-result evidence"
 
 
 def test_session_exits_within_timeout(cfg, stub, tmp_path):

--- a/tests/e2e/stub_server.py
+++ b/tests/e2e/stub_server.py
@@ -67,24 +67,35 @@ class StubServer:
         }]))
         return self
 
-    def queue_verification_ok(self) -> "StubServer":
-        """Queue a non-streaming 'STATUS: COMPLETE' verification response."""
-        self._queue.put(
-            _Response(content="STATUS: COMPLETE — task is done.", force_streaming=False)
-        )
+    def _queue_verdict(self, status: str, reason: str) -> "StubServer":
+        """Queue a non-streaming structured verifier verdict.
+
+        The completion verifier now runs via ``generate_object_code`` with a
+        forced tool_choice on the ``_VerifierVerdict`` schema, so the stub must
+        answer with a tool call (status + reason), not free text (ENG-716).
+        """
+        self._queue.put(_Response(
+            tool_calls=[{
+                "id": f"call_{uuid.uuid4().hex[:8]}",
+                "name": "_VerifierVerdict",
+                "arguments": {"status": status, "reason": reason},
+            }],
+            force_streaming=False,
+        ))
         return self
+
+    def queue_verification_ok(self) -> "StubServer":
+        """Queue a COMPLETE verifier verdict."""
+        return self._queue_verdict("COMPLETE", "task is done.")
 
     def queue_verification_incomplete(self, reason: str = "still more to do") -> "StubServer":
-        self._queue.put(
-            _Response(content=f"STATUS: INCOMPLETE — {reason}", force_streaming=False)
-        )
-        return self
+        return self._queue_verdict("INCOMPLETE", reason)
+
+    def queue_verification_waiting(self, reason: str = "waiting on the user") -> "StubServer":
+        return self._queue_verdict("WAITING", reason)
 
     def queue_verification_stuck(self, reason: str = "blocked") -> "StubServer":
-        self._queue.put(
-            _Response(content=f"STATUS: STUCK — {reason}", force_streaming=False)
-        )
-        return self
+        return self._queue_verdict("STUCK", reason)
 
     def queue_summary(self, text: str = "Summary of earlier turns.") -> "StubServer":
         """Queue a response for _summarize_history's coding model call."""
@@ -212,6 +223,16 @@ def _send_sse(handler: BaseHTTPRequestHandler, resp: _Response) -> None:
 
 
 def _send_json(handler: BaseHTTPRequestHandler, resp: _Response) -> None:
+    message: dict = {"role": "assistant", "content": resp.content or None}
+    finish_reason = "stop"
+    if resp.tool_calls:
+        tc = resp.tool_calls[0]
+        message["tool_calls"] = [{
+            "id": tc["id"],
+            "type": "function",
+            "function": {"name": tc["name"], "arguments": json.dumps(tc["arguments"])},
+        }]
+        finish_reason = "tool_calls"
     data = {
         "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
         "object": "chat.completion",
@@ -219,8 +240,8 @@ def _send_json(handler: BaseHTTPRequestHandler, resp: _Response) -> None:
         "model": "gpt-test",
         "choices": [{
             "index": 0,
-            "message": {"role": "assistant", "content": resp.content},
-            "finish_reason": "stop",
+            "message": message,
+            "finish_reason": finish_reason,
         }],
         "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
     }

--- a/tests/test_chat_scratchpad.py
+++ b/tests/test_chat_scratchpad.py
@@ -7,7 +7,7 @@ from tests.conftest import make_mock_llm
 import pytest
 
 from anton.core.backends.base import Cell
-from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.session import ChatSession, ChatSessionConfig, _VerifierVerdict
 from anton.core.tools.tool_defs import SCRATCHPAD_TOOL
 from anton.commands.session import handle_resume
 from anton.core.llm.provider import LLMResponse, StreamComplete, StreamToolResult, ToolCall, Usage
@@ -251,7 +251,9 @@ class TestScratchpadDumpStreaming:
         """dump action yields a StreamToolResult for display, but sends a short
         summary back to the LLM to avoid it parroting the full notebook."""
         mock_llm = make_mock_llm()
-        mock_llm.plan = AsyncMock(return_value=_text_response("STATUS: COMPLETE — task done"))
+        mock_llm.generate_object_code = AsyncMock(
+            return_value=_VerifierVerdict(status="COMPLETE", reason="task done")
+        )
 
         call_count = 0
 
@@ -306,7 +308,9 @@ class TestScratchpadStreaming:
         final_response = _text_response("Got 99.")
 
         mock_llm = make_mock_llm()
-        mock_llm.plan = AsyncMock(return_value=_text_response("STATUS: COMPLETE — task done"))
+        mock_llm.generate_object_code = AsyncMock(
+            return_value=_VerifierVerdict(status="COMPLETE", reason="task done")
+        )
 
         call_count = 0
 

--- a/tests/test_verify_transcript.py
+++ b/tests/test_verify_transcript.py
@@ -1,0 +1,67 @@
+"""Unit tests for the completion-verifier's compact transcript view (ENG-716).
+
+Guards the two review findings on PR #255: the verifier view must retain
+referential task context from prior turns AND carry truncated tool-result
+evidence (not just an ok/error flag), while omitting internal SYSTEM
+injections.
+"""
+
+from __future__ import annotations
+
+from anton.core.session import _render_verify_transcript
+
+
+def test_keeps_prior_turn_context_for_referential_followups():
+    history = [
+        {"role": "user", "content": "clean up report_q1.csv"},
+        {"role": "assistant", "content": "Done — deduped 12 rows."},
+        {"role": "user", "content": "now do the same for the other file"},
+        {"role": "assistant", "content": "Which file did you mean?"},
+    ]
+    out = _render_verify_transcript(history)
+    # The current request is referential ("the same", "the other file"); the
+    # prior turn must remain so the verifier can resolve it.
+    assert "clean up report_q1.csv" in out
+    assert "now do the same for the other file" in out
+
+
+def test_includes_truncated_tool_result_evidence():
+    history = [
+        {"role": "user", "content": "how many open PRs?"},
+        {"role": "assistant", "content": [{"type": "tool_use", "name": "scratchpad"}]},
+        {"role": "user", "content": [{"type": "tool_result", "content": "[error]\nHTTP 403 Forbidden"}]},
+        {"role": "assistant", "content": "There are 42 open PRs."},
+    ]
+    out = _render_verify_transcript(history)
+    # The tool actually errored while the assistant claimed a number — the
+    # verifier must see the error content to catch the mismatch.
+    assert "TOOL RESULT: [error]" in out
+    assert "HTTP 403 Forbidden" in out
+    assert "There are 42 open PRs." in out
+
+
+def test_omits_internal_system_injections():
+    history = [
+        {"role": "user", "content": "build the dashboard"},
+        {"role": "user", "content": "SYSTEM: Task verification determined this task is not yet complete. Continue working."},
+        {"role": "assistant", "content": "Working on it."},
+    ]
+    out = _render_verify_transcript(history)
+    assert "SYSTEM:" not in out
+    assert "Continue working" not in out
+    assert "build the dashboard" in out
+
+
+def test_truncates_large_tool_output():
+    big = "x" * 5000
+    history = [
+        {"role": "user", "content": "run it"},
+        {"role": "user", "content": [{"type": "tool_result", "content": big}]},
+    ]
+    out = _render_verify_transcript(history, tool_cap=400)
+    # Tool output is capped so the verify call stays cheap.
+    assert out.count("x") <= 400
+
+
+def test_empty_history_is_safe():
+    assert _render_verify_transcript([]) == "(no conversation)"

--- a/tests/test_verify_transcript.py
+++ b/tests/test_verify_transcript.py
@@ -75,15 +75,20 @@ def test_long_tool_turn_keeps_request_and_antecedent():
         {"role": "assistant", "content": "Done — deduped 12 rows in report_q1.csv."},
         {"role": "user", "content": "now do the same for the other file"},
     ]
-    for i in range(10):  # 10 tool rounds = 20 tool messages
-        history.append({"role": "assistant", "content": [{"type": "tool_use", "name": "scratchpad"}]})
+    for i in range(10):  # 10 tool rounds, each with preamble text + a tool call
+        history.append({"role": "assistant", "content": [
+            {"type": "text", "text": f"Processing step {i}"},
+            {"type": "tool_use", "name": "scratchpad"},
+        ]})
         history.append({"role": "user", "content": [{"type": "tool_result", "content": f"row {i} cleaned"}]})
     history.append({"role": "assistant", "content": "All cleaned."})
 
     out = _render_verify_transcript(history)
-    # Both the referential request and its antecedent survive the tool volume.
+    # Both the referential request and its antecedent survive the tool volume —
+    # preamble text ("Processing step N") must not consume the conversation budget.
     assert "now do the same for the other file" in out
     assert "clean up report_q1.csv" in out
+    assert "Done — deduped 12 rows in report_q1.csv." in out  # antecedent's answer
     # And tool evidence is still present.
     assert "TOOL RESULT:" in out
 

--- a/tests/test_verify_transcript.py
+++ b/tests/test_verify_transcript.py
@@ -65,3 +65,65 @@ def test_truncates_large_tool_output():
 
 def test_empty_history_is_safe():
     assert _render_verify_transcript([]) == "(no conversation)"
+
+
+def test_long_tool_turn_keeps_request_and_antecedent():
+    # A prior turn establishes context; the current turn is referential and runs
+    # >8 tool rounds. Tool activity must NOT evict the conversational thread.
+    history = [
+        {"role": "user", "content": "clean up report_q1.csv"},
+        {"role": "assistant", "content": "Done — deduped 12 rows in report_q1.csv."},
+        {"role": "user", "content": "now do the same for the other file"},
+    ]
+    for i in range(10):  # 10 tool rounds = 20 tool messages
+        history.append({"role": "assistant", "content": [{"type": "tool_use", "name": "scratchpad"}]})
+        history.append({"role": "user", "content": [{"type": "tool_result", "content": f"row {i} cleaned"}]})
+    history.append({"role": "assistant", "content": "All cleaned."})
+
+    out = _render_verify_transcript(history)
+    # Both the referential request and its antecedent survive the tool volume.
+    assert "now do the same for the other file" in out
+    assert "clean up report_q1.csv" in out
+    # And tool evidence is still present.
+    assert "TOOL RESULT:" in out
+
+
+def test_multimodal_user_text_labeled_user_not_assistant():
+    history = [
+        {"role": "user", "content": [
+            {"type": "text", "text": "describe this image and save a report"},
+            {"type": "image", "source": {"type": "base64", "data": "A" * 500}},
+        ]},
+        {"role": "assistant", "content": "Here's the description."},
+    ]
+    out = _render_verify_transcript(history)
+    assert "USER: describe this image and save a report" in out
+    assert "ASSISTANT: describe this image" not in out
+    assert "USER: [image]" in out
+    assert "A" * 100 not in out  # no base64 leaked
+
+
+def test_multimodal_tool_result_keeps_summary_drops_base64():
+    history = [
+        {"role": "user", "content": "read the chart"},
+        {"role": "user", "content": [{"type": "tool_result", "content": [
+            {"type": "image", "source": {"type": "base64", "data": "Z" * 5000}},
+            {"type": "text", "text": "Chart saved: 12 monthly bars"},
+        ]}]},
+    ]
+    out = _render_verify_transcript(history)
+    assert "Chart saved: 12 monthly bars" in out
+    assert "[image]" in out
+    assert "Z" * 100 not in out  # base64 payload never serialized into the view
+
+
+def test_system_injections_do_not_consume_budget():
+    # SYSTEM injections are dropped before budgeting, so real turns aren't evicted
+    # by internal noise.
+    history = []
+    for i in range(8):
+        history.append({"role": "user", "content": f"SYSTEM: internal note {i}"})
+    history.append({"role": "user", "content": "the actual request"})
+    out = _render_verify_transcript(history, max_convo=3)
+    assert "the actual request" in out
+    assert "internal note" not in out


### PR DESCRIPTION
## What & why

The completion-verifier loop (`anton/core/session.py`) classified **every tool-using turn that ended by asking the user a question** as `INCOMPLETE` and force-continued it — so the agent answered its own questions (or fabricated) instead of waiting. Root cause: the verdict vocabulary had no "waiting for the user" state, so the verifier overrode the agent's correct instinct to stop and ask.

## Evidence (three converging confirmations)

1. **The original ticket screenshot, traced to its prod Langfuse session (Jul 10):** verifier `INCOMPLETE` on the question-ending turn → forced continuation → the exact screenshot text (*"The verifier note is noted … I'll make sensible default assumptions and draft the skill now"*). A later verdict in the same session read verbatim: **"The assistant is *waiting for user feedback* … has not been completed."** — the verifier naming the missing state itself.
2. **Reproduced on a fresh, memory-empty staging instance** (verified clean via Langfuse) — so it's structural, not a memory artifact.
3. **Cost, confirmed in prod:** the verifier fired a full-conversation call on the expensive planning model on every tool-using turn.

## What changed

- **`WAITING` verdict** — a turn ending in a genuine question to the user (or a reasoned refusal) is a valid stop, not unfinished work.
- **Cheap model + structured output** — the verdict now runs via `generate_object_code` (coding model) with a typed `_VerifierVerdict` over a compact **request + reply + per-tool-outcome** view, instead of a full-transcript call on the planning model parsed from free-text `STATUS:` lines. Cheaper and structurally reliable; the tool-outcome log preserves the verifier's ability to catch "claimed done but a tool errored."
- **`verify_min_tool_rounds`** (default `1` = current behavior) to later skip trivial single-tool-round turns once verdict logs confirm they're rarely `INCOMPLETE`.
- **Leak fix** — internal `SYSTEM:` continuation/diagnosis injections now carry a non-disclosure clause so they aren't echoed to the user (*"the verifier note is noted"*).
- **Verdict logging** for measurability.

## Why it's low-risk

Genuine multi-step work completes inside the **inner** tool loop, where the verifier returns `COMPLETE` once with no continuation (verified). The outer continuation loop — the only thing `WAITING` touches — fires only *after* a text-only response, so legitimate completion barely uses it. On a verifier error we fail-safe to `COMPLETE` (failing to `INCOMPLETE` would risk re-introducing the over-continuation this fixes).

## Testing

- Full suite: **1194 passed**, 17 skipped; only pre-existing scratchpad-exec env failures remain (identical on clean `staging`).
- **New** `test_waiting_verdict_stops_without_continuation` guards the fix (WAITING stops, no continuation injection, tool-outcome log reaches the verifier).
- Broader testing caught and fixed a regression: the E2E stub spoke the old free-text verifier protocol; updated it to emit structured `_VerifierVerdict` tool calls (see commit `dbdcdf4`).

## Self-review trail

Ran an adversarial self-review; findings + resolutions are posted as a comment below (2 fixed, 1 kept-intentional, 1 low/noted). The `AttributeError`-on-init risk was checked and cleared (`AntonSettings` inherits `CoreSettings`, so the new setting flows to the cowork path).

## Security

Reviewed the diff: the reduced view sends **less** data to the LLM than before; the verdict is a constrained enum (no injected control flow); the log line carries only status/counters/reason (no credentials or reply content). No new endpoints, auth, or deserialization.

## Merge order (not stacked)

anton merges **first**; a follow-up cowork-server `anton-agent` bump ships it to the desktop path. Stated here so the two don't get stacked.

Closes ENG-716.