### PR TITLE
ENG-838: cap RESILIENCE_NUDGE with an honesty floor

### DIFF
--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -403,10 +403,12 @@ Do NOT extract trivial observations. Only encode genuinely reusable knowledge.
 """
 
 RESILIENCE_NUDGE = (
-    "\n\nSYSTEM: This tool has failed twice in a row. Before retrying the same approach or "
-    "asking the user for help, try a creative workaround — different headers/user-agent, "
-    "a public API, archive.org, an alternate library, or a completely different data source. "
-    "Only involve the user if the problem truly requires something only they can provide."
+    "\n\nSYSTEM: This tool has failed twice in a row. Before retrying the same approach, "
+    "try one or two more genuine workarounds — different headers/user-agent, a public API, "
+    "archive.org, an alternate library, or a different data source. If those also fail, "
+    "STOP and tell the user exactly what failed and what you need — do NOT fabricate a "
+    "result, claim success, or silently give up. Once real options are exhausted, asking "
+    "the user is the correct move."
 )
 
 # Scratchpad failures need different advice than the generic (scrape/fetch)


### PR DESCRIPTION
## What
Rewrites the transient `RESILIENCE_NUDGE` (`anton/core/llm/prompts.py`, injected after 2 same-tool failures) to keep its "try a workaround first" value but add an explicit honesty floor, and drops the risky closing line *"Only involve the user if the problem truly requires something only they can provide."*

## Why
- **Redundant:** the always-on `PROBLEM-SOLVING RESILIENCE` block in `CHAT_SYSTEM_PROMPT` already covers the same workaround guidance with *safer* user-involvement wording.
- **Riskiest wording in the fabrication path:** that closing line is the ENG-296 "smoking gun" — it biases away from involving the user at the moment a tool fails. No observed harm today (the `STUCK` verdict + `act_first` honesty rules win — see the ENG-296 close-out), so this is **defense-in-depth** to lower the probabilistic tail risk.

Kept (not deleted) for its just-in-time salience.

## Diff
Before: *"…Before retrying the same approach or asking the user for help, try a creative workaround… **Only involve the user if the problem truly requires something only they can provide.**"*
After: *"…Before retrying the same approach, try one or two genuine workarounds… **If those also fail, STOP and tell the user exactly what failed and what you need — do NOT fabricate a result, claim success, or silently give up.** Once real options are exhausted, asking the user is the correct move."*

## Safety / scope (verified)
- Opening marker **"This tool has failed twice in a row."** retained — two e2e tests (`test_loop_safety`, `test_circuit_breaker_evasion`) detect the nudge by it.
- `test_resilience_nudge.py` checks identity against the constant (rewrite-safe).
- **No change** to firing logic (`resilience_nudge_at`), the circuit-breaker escalation, or the scratchpad `SIZE`/`TIMEOUT` nudges.
- Full suite: 1204 passed (only pre-existing scratchpad-exec env failures).

## Remaining (Done-when)
- [ ] **Eval:** add a blocked-task case to the ENG-381 harness to measure fabrication rate before/after (prove resilience isn't weakened). Not in this PR — prompt change is text-only and test-covered; flagging so it isn't lost.
- [ ] Delivery: cowork pins anton `main`, so reaching the desktop path also needs the anton `staging→main` promotion + a cowork-server `uv.lock` bump.

Closes ENG-838.