### PR TITLE
Surface provider 401s as typed ProviderAuthError with provider-aware invalid-key copy

### DIFF
--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -10,6 +10,7 @@ from .provider import (
     ContextOverflowError,
     LLMProvider,
     LLMResponse,
+    ProviderAuthError,
     ProviderConnectionInfo,
     StreamComplete,
     StreamEvent,
@@ -120,7 +121,7 @@ class AnthropicProvider(LLMProvider):
         except anthropic.APIStatusError as exc:
             if exc.status_code == 401:
                 msg = "Invalid API key — check your ANTHROPIC_API_KEY environment variable."
-                raise ConnectionError(msg) from exc
+                raise ProviderAuthError(msg) from exc
             elif (
                 exc.status_code == 429
                 and isinstance(exc.body, dict)
@@ -267,7 +268,7 @@ class AnthropicProvider(LLMProvider):
         except anthropic.APIStatusError as exc:
             if exc.status_code == 401:
                 msg = "Invalid API key — check your ANTHROPIC_API_KEY environment variable."
-                raise ConnectionError(msg) from exc
+                raise ProviderAuthError(msg) from exc
             elif (
                 exc.status_code == 429
                 and isinstance(exc.body, dict)

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -43,9 +43,6 @@ def _raise_for_status_error(
         lets the caller supply provider-aware wording (MindsHub vs. a
         generic OpenAI-compatible endpoint vs. direct OpenAI); None keeps
         the direct-OpenAI copy so external callers stay source-compatible.
-        Whatever the hint, the message must contain "Invalid API key" —
-        cowork-server's provider_auth detection matches the lowercase
-        substring "invalid api key".
       - 403 with a structured gateway code (``model_access_denied`` /
         ``model_disabled``) → ModelUnavailableError carrying the code +
         model, with actionable copy. Detection is code-exact on purpose:
@@ -633,6 +630,9 @@ class OpenAIProvider(LLMProvider):
         # chat.completions path and as ``reasoning={"effort": ...}`` on the
         # Responses API path. None = the model's default.
         self._reasoning_effort = reasoning_effort
+        is_minds_endpoint = bool(base_url) and (
+            "mindshub.ai" in base_url or "mdb.ai" in base_url
+        )
         # Whether to attach langfuse-style headers (Langfuse-Session-Id,
         # Langfuse-Tags, Langfuse-Metadata) to outbound requests. Default-on
         # only for the MindsHub-backed deployment, which is the curated
@@ -644,22 +644,15 @@ class OpenAIProvider(LLMProvider):
         # Power-user opt-in: set `ANTON_LANGFUSE_HEADERS=1` to force-emit
         # the headers regardless of base URL — useful when the user has
         # pointed `base_url` at their own langfuse-instrumented proxy.
-        self._emit_trace_headers = bool(base_url) and (
-            "mindshub.ai" in base_url or "mdb.ai" in base_url
-        )
+        self._emit_trace_headers = is_minds_endpoint
         if os.environ.get("ANTON_LANGFUSE_HEADERS", "").strip().lower() in {
             "1", "true", "yes", "on",
         }:
             self._emit_trace_headers = True
 
-        # Provider-aware 401 copy for `_raise_for_status_error`. This class
-        # serves three very different backends behind the same client, and
-        # "check your OpenAI API key" is actively misleading when the key
-        # that failed belongs to MindsHub or a self-hosted endpoint. Every
-        # variant must keep the "Invalid API key" phrase — cowork-server's
-        # provider_auth detection matches the lowercase substring
-        # "invalid api key".
-        if base_url and ("mindshub.ai" in base_url or "mdb.ai" in base_url):
+        # Provider-aware 401 copy; "check your OpenAI API key" is misleading
+        # for MindsHub/self-hosted keys. Copy contract: see ProviderAuthError.
+        if is_minds_endpoint:
             self._auth_hint = "Invalid API key — check your MindsHub API key in Settings."
         elif base_url:
             self._auth_hint = (

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -14,6 +14,7 @@ from .provider import (
     LLMProvider,
     LLMResponse,
     ModelUnavailableError,
+    ProviderAuthError,
     ProviderConnectionInfo,
     StreamComplete,
     StreamEvent,
@@ -28,7 +29,9 @@ from .provider import (
 )
 
 
-def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoReturn:
+def _raise_for_status_error(
+    exc: "openai.APIStatusError", model: str, auth_hint: str | None = None
+) -> NoReturn:
     """Map a provider HTTP error onto anton's typed/curated exceptions.
 
     The single mapper shared by all four call paths (chat/stream ×
@@ -36,8 +39,13 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     previous four copy-pasted blocks had already diverged in wording.
 
     Mapping policy:
-      - 401 → ConnectionError with the invalid-key copy (cowork-server's
-        provider_auth detection keys on this exact phrase).
+      - 401 → ProviderAuthError with the invalid-key copy. ``auth_hint``
+        lets the caller supply provider-aware wording (MindsHub vs. a
+        generic OpenAI-compatible endpoint vs. direct OpenAI); None keeps
+        the direct-OpenAI copy so external callers stay source-compatible.
+        Whatever the hint, the message must contain "Invalid API key" —
+        cowork-server's provider_auth detection matches the lowercase
+        substring "invalid api key".
       - 403 with a structured gateway code (``model_access_denied`` /
         ``model_disabled``) → ModelUnavailableError carrying the code +
         model, with actionable copy. Detection is code-exact on purpose:
@@ -71,8 +79,8 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     messages as MindsHub quota would put an upsell CTA on BYOK errors.
     """
     if exc.status_code == 401:
-        raise ConnectionError(
-            "Invalid API key — check your OpenAI API key configuration."
+        raise ProviderAuthError(
+            auth_hint or "Invalid API key — check your OpenAI API key configuration."
         ) from exc
 
     body = exc.body if isinstance(exc.body, dict) else {}
@@ -644,6 +652,23 @@ class OpenAIProvider(LLMProvider):
         }:
             self._emit_trace_headers = True
 
+        # Provider-aware 401 copy for `_raise_for_status_error`. This class
+        # serves three very different backends behind the same client, and
+        # "check your OpenAI API key" is actively misleading when the key
+        # that failed belongs to MindsHub or a self-hosted endpoint. Every
+        # variant must keep the "Invalid API key" phrase — cowork-server's
+        # provider_auth detection matches the lowercase substring
+        # "invalid api key".
+        if base_url and ("mindshub.ai" in base_url or "mdb.ai" in base_url):
+            self._auth_hint = "Invalid API key — check your MindsHub API key in Settings."
+        elif base_url:
+            self._auth_hint = (
+                "Invalid API key — check the API key configured for your "
+                "OpenAI-compatible endpoint."
+            )
+        else:
+            self._auth_hint = "Invalid API key — check your OpenAI API key configuration."
+
         import httpx
 
         if api_version and _is_azure_endpoint(base_url):
@@ -793,7 +818,7 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            _raise_for_status_error(exc, model)
+            _raise_for_status_error(exc, model, auth_hint=self._auth_hint)
         except openai.APIConnectionError as exc:
             raise ConnectionError(
                 "Could not reach the LLM server — check your connection or try again in a moment."
@@ -947,7 +972,7 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            _raise_for_status_error(exc, model)
+            _raise_for_status_error(exc, model, auth_hint=self._auth_hint)
         except openai.APIConnectionError as exc:
             raise ConnectionError(
                 "Could not reach the LLM server — check your connection or try again in a moment."
@@ -1050,7 +1075,7 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            _raise_for_status_error(exc, model)
+            _raise_for_status_error(exc, model, auth_hint=self._auth_hint)
         except openai.APIConnectionError as exc:
             raise ConnectionError(
                 "Could not reach the LLM server — check your connection or try again in a moment."
@@ -1164,7 +1189,7 @@ class OpenAIProvider(LLMProvider):
                 raise ContextOverflowError(str(exc)) from exc
             raise
         except openai.APIStatusError as exc:
-            _raise_for_status_error(exc, model)
+            _raise_for_status_error(exc, model, auth_hint=self._auth_hint)
         except openai.APIConnectionError as exc:
             raise ConnectionError(
                 "Could not reach the LLM server — check your connection or try again in a moment."

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -312,6 +312,18 @@ class TokenLimitExceeded(Exception):
     """Raised when the LLM returns 429 due to billing/token limits."""
 
 
+class ProviderAuthError(ConnectionError):
+    """Raised on a provider HTTP 401 — the credential is invalid, revoked,
+    or missing.
+
+    Subclasses ConnectionError so legacy call sites that only know the
+    ConnectionError mapping keep working unchanged. The message MUST always
+    contain the phrase "Invalid API key": cowork-server's
+    ``turn_errors.is_auth_error`` matches the lowercase substring
+    "invalid api key" to map the failure onto its reconnect/update-key card.
+    """
+
+
 class ModelUnavailableError(ConnectionError):
     """Raised when the gateway rejects the requested model with a structured 403.
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -26,6 +26,7 @@ from anton.core.llm.prompts import (
 from anton.core.llm.provider import (
     ContextOverflowError,
     ModelUnavailableError,
+    ProviderAuthError,
     StreamComplete,
     StreamContextCompacted,
     StreamEvent,
@@ -1616,12 +1617,18 @@ class ChatSession:
                         yield event
                     break  # completed successfully
                 except Exception as _agent_exc:
-                    # Token/billing limits and model-gate 403s are
-                    # deterministic — the auto-retry below would just re-send
-                    # the same doomed request (and burn its budget) before
-                    # failing anyway. Don't retry; let the chat loop / server
-                    # map them to their cards.
-                    if isinstance(_agent_exc, (TokenLimitExceeded, ModelUnavailableError)):
+                    # Token/billing limits, model-gate 403s, and provider
+                    # 401s are deterministic — the auto-retry below would
+                    # just re-send the same doomed request (burning latency
+                    # and budget) before hitting the same failure. Don't
+                    # retry; let the chat loop / server map them to their
+                    # cards (token_limit / model-unavailable /
+                    # reconnect-or-update-key), which only fire when the
+                    # exception propagates.
+                    if isinstance(
+                        _agent_exc,
+                        (TokenLimitExceeded, ModelUnavailableError, ProviderAuthError),
+                    ):
                         raise
                     _retry_count += 1
                     # Anthropic's API rejects any history where the
@@ -1676,13 +1683,14 @@ class ChatSession:
                                 if isinstance(event, StreamTextDelta):
                                     assistant_text_parts.append(event.text)
                                 yield event
-                        except (TokenLimitExceeded, ModelUnavailableError):
+                        except (TokenLimitExceeded, ModelUnavailableError, ProviderAuthError):
                             # Curated provider failures must FAIL the turn, not
                             # get wrapped into assistant prose: the server maps
                             # them to actionable error cards (token_limit /
-                            # model-unavailable), which can only fire when the
-                            # exception propagates. Wrapping them as text is
-                            # how "Server returned 403" ended up mid-chat with
+                            # model-unavailable / reconnect-or-update-key),
+                            # which can only fire when the exception
+                            # propagates. Wrapping them as text is how
+                            # "Server returned 403" ended up mid-chat with
                             # "please rephrase your request" advice.
                             raise
                         except Exception as e:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -268,3 +268,67 @@ class TestHardTruncateHistory:
         assert tail_head["content"] == [
             {"type": "text", "text": "plus my follow-up question"},
         ]
+
+
+class TestProviderAuthErrorPropagation:
+    """Provider 401s must FAIL a streaming turn — typed, unretried, never
+    wrapped into assistant prose. cowork-server's `turn_errors.is_auth_error`
+    (lowercase substring match on "invalid api key" → reconnect/update-key
+    card) can only fire when the exception propagates out of turn_stream."""
+
+    async def test_turn_stream_reraises_provider_auth_error_without_retry(self):
+        from anton.core.llm.provider import ProviderAuthError
+
+        call_count = 0
+
+        async def _plan_stream(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ProviderAuthError(
+                "Invalid API key — check your MindsHub API key in Settings."
+            )
+            yield  # pragma: no cover — makes this an async generator
+
+        session = ChatSession(ChatSessionConfig(llm_client=make_mock_llm()))
+        session._llm.plan_stream = _plan_stream
+
+        events = []
+        with pytest.raises(ProviderAuthError) as err:
+            async for event in session.turn_stream("hi"):
+                events.append(event)
+
+        # A 401 is deterministic — the auto-retry loop must not re-send the
+        # same doomed request before failing.
+        assert call_count == 1
+        assert "invalid api key" in str(err.value).lower()
+
+        # And the failure must never be softened into assistant prose.
+        prose = "".join(
+            e.text for e in events if isinstance(e, StreamTextDelta)
+        )
+        assert "An unexpected error occurred" not in prose
+
+    async def test_plain_connection_error_still_retries_and_falls_back(self):
+        """The generic transient ConnectionError keeps the legacy behavior:
+        auto-retried, then wrapped in the fallback text — proving the
+        no-retry escape is scoped to the typed subclass, not all
+        ConnectionErrors."""
+        call_count = 0
+
+        async def _plan_stream(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ConnectionError(
+                "Server returned 503 — the LLM endpoint may be temporarily unavailable."
+            )
+            yield  # pragma: no cover
+
+        session = ChatSession(ChatSessionConfig(llm_client=make_mock_llm()))
+        session._llm.plan_stream = _plan_stream
+
+        events = [e async for e in session.turn_stream("hi")]
+
+        # 1 initial + 2 auto-retries + 1 summarize attempt = 4 calls
+        assert call_count == 4
+        prose = "".join(e.text for e in events if isinstance(e, StreamTextDelta))
+        assert "An unexpected error occurred" in prose

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -3,8 +3,9 @@
 One mapper (`openai._raise_for_status_error`) serves all four call paths
 (chat/stream × completions/responses). These tests pin the mapping policy:
 
-- 401 → ConnectionError with the exact invalid-key copy (cowork-server's
-  provider_auth detection string-matches it).
+- 401 → ProviderAuthError whose copy always contains "Invalid API key"
+  (cowork-server's provider_auth detection matches the lowercase substring
+  "invalid api key"), with provider-aware wording via `auth_hint`.
 - 429 + quota detail → TokenLimitExceeded (and it outranks any 403 logic).
 - 403 + structured gateway code → ModelUnavailableError carrying code+model,
   with actionable copy per code.
@@ -25,8 +26,12 @@ import httpx
 import openai
 import pytest
 
-from anton.core.llm.openai import _raise_for_status_error
-from anton.core.llm.provider import ModelUnavailableError, TokenLimitExceeded
+from anton.core.llm.openai import OpenAIProvider, _raise_for_status_error
+from anton.core.llm.provider import (
+    ModelUnavailableError,
+    ProviderAuthError,
+    TokenLimitExceeded,
+)
 
 
 def _sdk_error(status_code, json_body=None, text_body=None):
@@ -80,21 +85,85 @@ def test_sdk_unwraps_error_envelope():
 
 # ── 401 ───────────────────────────────────────────────────────────────
 
-def test_401_maps_to_invalid_key_connection_error():
+def test_401_maps_to_provider_auth_error():
     exc = _sdk_error(401, json_body={"error": {"message": "bad key"}})
-    with pytest.raises(ConnectionError) as err:
+    with pytest.raises(ProviderAuthError) as err:
         _raise_for_status_error(exc, "sonnet")
-    # cowork-server's provider_auth detection keys on this exact phrase.
+    # cowork-server's provider_auth detection matches the lowercase
+    # substring "invalid api key".
     assert "Invalid API key" in str(err.value)
     assert not isinstance(err.value, ModelUnavailableError)
+
+
+def test_401_is_still_a_connection_error():
+    # Legacy call sites only know ConnectionError — the typed error must
+    # keep flowing through them unchanged.
+    exc = _sdk_error(401, json_body={"error": {"message": "bad key"}})
+    with pytest.raises(ConnectionError):
+        _raise_for_status_error(exc, "sonnet")
 
 
 def test_401_html_body_maps_to_invalid_key():
     # nginx auth walls return HTML — the 401 branch must not need a body.
     exc = _sdk_error(401, text_body="<html>401 Authorization Required</html>")
-    with pytest.raises(ConnectionError) as err:
+    with pytest.raises(ProviderAuthError) as err:
         _raise_for_status_error(exc, "sonnet")
     assert "Invalid API key" in str(err.value)
+
+
+def test_401_default_copy_is_openai():
+    # No auth_hint → the direct-OpenAI copy, so external callers of the
+    # mapper stay source-compatible.
+    exc = _sdk_error(401, json_body={})
+    with pytest.raises(ProviderAuthError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert str(err.value) == "Invalid API key — check your OpenAI API key configuration."
+
+
+def test_401_auth_hint_overrides_copy():
+    exc = _sdk_error(401, json_body={})
+    with pytest.raises(ProviderAuthError) as err:
+        _raise_for_status_error(
+            exc, "sonnet",
+            auth_hint="Invalid API key — check your MindsHub API key in Settings.",
+        )
+    assert str(err.value) == "Invalid API key — check your MindsHub API key in Settings."
+
+
+# ── provider-aware auth hint computed from base_url ───────────────────
+
+@pytest.mark.parametrize("base_url", [
+    "https://llm.mindshub.ai/v1",
+    "https://llm.mdb.ai",
+])
+def test_auth_hint_mindshub(base_url):
+    provider = OpenAIProvider(api_key="k", base_url=base_url)
+    assert provider._auth_hint == "Invalid API key — check your MindsHub API key in Settings."
+
+
+def test_auth_hint_generic_compatible_endpoint():
+    provider = OpenAIProvider(api_key="k", base_url="https://my-vllm.internal/v1")
+    assert provider._auth_hint == (
+        "Invalid API key — check the API key configured for your "
+        "OpenAI-compatible endpoint."
+    )
+
+
+def test_auth_hint_direct_openai():
+    provider = OpenAIProvider(api_key="k")
+    assert provider._auth_hint == "Invalid API key — check your OpenAI API key configuration."
+
+
+@pytest.mark.parametrize("base_url", [
+    None,
+    "https://llm.mindshub.ai/v1",
+    "https://my-vllm.internal/v1",
+])
+def test_every_auth_hint_contains_the_detection_substring(base_url):
+    # The contract with cowork-server's `turn_errors.is_auth_error`: every
+    # 401 message must contain the lowercase substring "invalid api key".
+    provider = OpenAIProvider(api_key="k", base_url=base_url)
+    assert "invalid api key" in provider._auth_hint.lower()
 
 
 # ── 429 (quota) ───────────────────────────────────────────────────────

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -93,14 +93,9 @@ def test_401_maps_to_provider_auth_error():
     # substring "invalid api key".
     assert "Invalid API key" in str(err.value)
     assert not isinstance(err.value, ModelUnavailableError)
-
-
-def test_401_is_still_a_connection_error():
     # Legacy call sites only know ConnectionError — the typed error must
     # keep flowing through them unchanged.
-    exc = _sdk_error(401, json_body={"error": {"message": "bad key"}})
-    with pytest.raises(ConnectionError):
-        _raise_for_status_error(exc, "sonnet")
+    assert isinstance(err.value, ConnectionError)
 
 
 def test_401_html_body_maps_to_invalid_key():
@@ -132,37 +127,20 @@ def test_401_auth_hint_overrides_copy():
 
 # ── provider-aware auth hint computed from base_url ───────────────────
 
-@pytest.mark.parametrize("base_url", [
-    "https://llm.mindshub.ai/v1",
-    "https://llm.mdb.ai",
+@pytest.mark.parametrize("base_url,expected", [
+    (None, "Invalid API key — check your OpenAI API key configuration."),
+    ("https://llm.mindshub.ai/v1", "Invalid API key — check your MindsHub API key in Settings."),
+    ("https://llm.mdb.ai", "Invalid API key — check your MindsHub API key in Settings."),
+    (
+        "https://my-vllm.internal/v1",
+        "Invalid API key — check the API key configured for your OpenAI-compatible endpoint.",
+    ),
 ])
-def test_auth_hint_mindshub(base_url):
+def test_auth_hint_per_base_url(base_url, expected):
     provider = OpenAIProvider(api_key="k", base_url=base_url)
-    assert provider._auth_hint == "Invalid API key — check your MindsHub API key in Settings."
-
-
-def test_auth_hint_generic_compatible_endpoint():
-    provider = OpenAIProvider(api_key="k", base_url="https://my-vllm.internal/v1")
-    assert provider._auth_hint == (
-        "Invalid API key — check the API key configured for your "
-        "OpenAI-compatible endpoint."
-    )
-
-
-def test_auth_hint_direct_openai():
-    provider = OpenAIProvider(api_key="k")
-    assert provider._auth_hint == "Invalid API key — check your OpenAI API key configuration."
-
-
-@pytest.mark.parametrize("base_url", [
-    None,
-    "https://llm.mindshub.ai/v1",
-    "https://my-vllm.internal/v1",
-])
-def test_every_auth_hint_contains_the_detection_substring(base_url):
+    assert provider._auth_hint == expected
     # The contract with cowork-server's `turn_errors.is_auth_error`: every
     # 401 message must contain the lowercase substring "invalid api key".
-    provider = OpenAIProvider(api_key="k", base_url=base_url)
     assert "invalid api key" in provider._auth_hint.lower()
 
 


### PR DESCRIPTION
## What

Provider HTTP 401s (invalid/missing API key) are now surfaced as a typed `ProviderAuthError` instead of being swallowed into assistant prose, and the 401 message is provider-aware instead of always blaming OpenAI.

## Why

User-reported (2026-07-17): with a missing/invalid MindsHub key, a chat turn rendered this as ordinary assistant text:

> "An unexpected error occurred: Invalid API key — check your OpenAI API key configuration.. Please try again or rephrase your request."

Two defects:

1. **Swallowed auth errors.** The `turn_stream` retry loop in `anton/core/session.py` re-raises `TokenLimitExceeded` / `ModelUnavailableError` so the server can map them to actionable error cards, but a provider-auth `ConnectionError` was auto-retried twice (pointless — a 401 is deterministic) and then wrapped into the generic "An unexpected error occurred: … Please try again or rephrase" fallback prose. cowork-server's `turn_errors.is_auth_error` (which maps auth failures to a reconnect/update-key card) could therefore never fire for streaming turns.
2. **Misleading copy.** `_raise_for_status_error` in `anton/core/llm/openai.py` hardcoded "check your OpenAI API key configuration" even when `OpenAIProvider` was serving MindsHub (`api.mindshub.ai` / `mdb.ai`) or another OpenAI-compatible endpoint.

## How

- New `ProviderAuthError(ConnectionError)` in `anton/core/llm/provider.py`, beside `TokenLimitExceeded` / `ModelUnavailableError`. Subclasses `ConnectionError` so legacy call sites keep working. Its docstring pins the copy contract: every message must contain "Invalid API key" (cowork-server matches the lowercase substring `"invalid api key"`).
- Raised at every provider 401 site:
  - `anthropic.py` (both complete/stream): message unchanged — `Invalid API key — check your ANTHROPIC_API_KEY environment variable.`
  - `openai.py` `_raise_for_status_error`: new optional `auth_hint` parameter (default `None` → existing OpenAI copy, so external callers stay source-compatible). `OpenAIProvider.__init__` computes the hint once from `base_url` and all four call paths (chat/stream × completions/responses) pass it:
    - `mindshub.ai` / `mdb.ai` → `Invalid API key — check your MindsHub API key in Settings.`
    - other non-empty base URL → `Invalid API key — check the API key configured for your OpenAI-compatible endpoint.`
    - no base URL (direct OpenAI) → `Invalid API key — check your OpenAI API key configuration.` (unchanged)
- `session.py`: `ProviderAuthError` added to both curated escape points — the no-retry isinstance check and the exhausted-retries re-raise clause. A 401 now propagates immediately (no retries, no fallback prose), letting the server map it to the reconnect/update-key card.

Deliberately **not** widened to plain `ConnectionError`: the generic "temporarily unavailable" mapping also raises bare `ConnectionError` for transient failures, which must keep auto-retrying. A regression test pins this.

## Testing

- `uv run --extra dev pytest tests/ -q` — **1208 passed, 13 skipped** (full suite green; baseline 1200).
- New/updated tests:
  - `tests/test_status_error_mapper.py`: 401 → `ProviderAuthError` (and still a `ConnectionError`), HTML-body 401, hint override vs. default copy, and a parametrized `test_auth_hint_per_base_url` covering None / `mindshub.ai` / `mdb.ai` / generic base URLs — each case also asserts the `"invalid api key"` substring contract.
  - `tests/test_chat.py`: streaming turn re-raises `ProviderAuthError` after exactly 1 LLM call with no fallback prose; a plain transient `ConnectionError` still retries (4 calls) and falls back — proving the escape is scoped to the typed subclass.
- Cross-checked read-only against cowork-server `cowork/handlers/turn_errors.py::is_auth_error`: all four message variants contain the matched substring.
- Live repro context: the original failure was reproduced in the Cowork desktop app (MindsHub provider, invalid key) and the pipeline was verified working end-to-end with a valid key — the only broken part was this error surfacing.

## Notes for reviewers

- Small, standalone, no behavior change for non-401 paths. Targets `staging`; please review and merge manually (not part of the Browser Control M1 PR stack).
- The `auth_hint` parameter default keeps `_raise_for_status_error` source-compatible for any external caller.
