### PR TITLE
ENG-847: Fix scratchpad web_search() on the minds-cloud gateway

### DIFF
--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -104,28 +104,11 @@ if _scratchpad_model:
                 _llm_provider_kwargs["vision_format"] = "anthropic"
             # Resolve the OpenAI "flavor" so the injected web_search() helper can
             # route through whatever native web tooling the endpoint exposes.
-            # Mirrors LLMClient._resolve_openai_compatible_flavor: direct OpenAI
-            # BYOK uses the Responses API (web_search); an openai-compatible base
-            # URL pointing at Minds/mdb.ai uses the chat.completions passthrough;
-            # any other openai-compatible endpoint is generic (no native search).
-            if _scratchpad_provider_name == "openai":
-                _llm_provider_kwargs["flavor"] = _ProviderClass.FLAVOR_OPENAI
-            else:
-                _minds_url_norm = (
-                    os.environ.get("ANTON_MINDS_URL", "").rstrip("/").lower()
-                )
-                _base_norm = (_llm_base_url or "").rstrip("/").lower()
-                if _minds_url_norm and _base_norm in (
-                    _minds_url_norm,
-                    f"{_minds_url_norm}/api/v1",
-                ):
-                    _llm_provider_kwargs["flavor"] = (
-                        _ProviderClass.FLAVOR_MINDS_PASSTHROUGH
-                    )
-                else:
-                    _llm_provider_kwargs["flavor"] = (
-                        _ProviderClass.FLAVOR_OPENAI_COMPATIBLE_GENERIC
-                    )
+            # Detect Minds/mdb.ai by HOST, not provider name (always "openai" for
+            # an OpenAIProvider even on the minds gateway) — see resolve_web_flavor.
+            _llm_provider_kwargs["flavor"] = _ProviderClass.resolve_web_flavor(
+                _scratchpad_provider_name, _llm_base_url
+            )
             _llm_provider = _ProviderClass(**_llm_provider_kwargs)
         else:
             _llm_provider = _ProviderClass()  # Anthropic doesn't need ssl_verify

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -687,6 +687,22 @@ class OpenAIProvider(LLMProvider):
         return set()
 
     @staticmethod
+    def resolve_web_flavor(provider_name: str, base_url: str) -> str:
+        """Flavor for the scratchpad's web_search(), from provider name + base URL.
+
+        ``name`` is always "openai" for an OpenAIProvider even when the base URL is
+        the minds gateway, so a minds/mdb.ai HOST must win over the name: minds
+        serves web_search over the chat.completions passthrough, not the Responses
+        API. Direct OpenAI uses Responses; anything else is generic (no native web).
+        """
+        host = (base_url or "").lower()
+        if any(h in host for h in ("mdb.ai", "mindshub.ai")):
+            return OpenAIProvider.FLAVOR_MINDS_PASSTHROUGH
+        if provider_name == "openai":
+            return OpenAIProvider.FLAVOR_OPENAI
+        return OpenAIProvider.FLAVOR_OPENAI_COMPATIBLE_GENERIC
+
+    @staticmethod
     def _sanitize_langfuse_tag(tag: str) -> str:
         """Clean a caller-supplied langfuse tag so it survives the wire intact.
 

--- a/tests/test_scratchpad_flavor.py
+++ b/tests/test_scratchpad_flavor.py
@@ -1,0 +1,52 @@
+"""Flavor resolution for the scratchpad's injected web_search() helper.
+
+Regression guard for the minds gateway case: OpenAIProvider.name is always
+"openai" even when the base URL is the minds gateway, so keying the flavor off
+the provider name alone picked the Responses-API flavor and dispatched
+web_search to a Responses endpoint the minds gateway does not implement — it
+silently returned empty. The host must win over the name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from anton.core.llm.openai import OpenAIProvider
+
+resolve = OpenAIProvider.resolve_web_flavor
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.mindshub.ai/v1",
+        "https://api.staging.mindshub.ai/v1",
+        "https://mdb.ai/api/v1",
+        "HTTPS://API.MINDSHUB.AI/v1",  # case-insensitive
+    ],
+)
+def test_minds_host_uses_passthrough_even_with_openai_name(base_url):
+    # provider name is "openai" (the class default) yet the host is minds ->
+    # must be the chat.completions passthrough, NOT the Responses API.
+    assert resolve("openai", base_url) == OpenAIProvider.FLAVOR_MINDS_PASSTHROUGH
+
+
+def test_direct_openai_uses_responses_api():
+    assert resolve("openai", "https://api.openai.com/v1") == OpenAIProvider.FLAVOR_OPENAI
+    assert resolve("openai", "") == OpenAIProvider.FLAVOR_OPENAI
+    assert resolve("openai", None) == OpenAIProvider.FLAVOR_OPENAI
+
+
+def test_other_compatible_endpoint_is_generic():
+    assert (
+        resolve("openai-compatible", "https://my-proxy.internal/v1")
+        == OpenAIProvider.FLAVOR_OPENAI_COMPATIBLE_GENERIC
+    )
+
+
+def test_openai_compatible_minds_base_still_passthrough():
+    # An "openai-compatible" provider pointed at minds keeps passthrough too.
+    assert (
+        resolve("openai-compatible", "https://api.mindshub.ai/v1")
+        == OpenAIProvider.FLAVOR_MINDS_PASSTHROUGH
+    )


### PR DESCRIPTION
## Problem
Scratchpad `web_search()` returns an empty string under the minds-cloud provider (the
standard config), so the agent silently loses web access and falls back to scraping.
Affects real cowork/anton usage, not just evals.

Cause: the scratchpad picks its web "flavor" by provider name, but `OpenAIProvider.name`
is always `"openai"` even on the minds gateway — so it chose the OpenAI Responses API and
dispatched web_search to an endpoint the minds gateway doesn't implement (minds serves it
over the chat.completions passthrough) → empty. The gateway itself is fine (a direct
chat.completions call with `tools=[{"type":"web_search"}]` returns real results).

## Fix
Resolve the flavor by HOST, not provider name: minds/mdb.ai base URL → passthrough.
Extracted as `OpenAIProvider.resolve_web_flavor()`, called from `scratchpad_boot.py`.
All prior cases unchanged; only the broken `openai`-name + minds-base case now works.

## Repro
cowork-server on `minds_cloud`, then in the scratchpad:
`print(repr(web_search("current US CPI year-over-year rate")))`
Before: `''`. After: a non-empty answer with sources.

## Tests
`tests/test_scratchpad_flavor.py` (new, 7 cases); `test_scratchpad.py` + `test_web_tools.py`
still green (107 passed).

Fixes https://linear.app/mindsdb/issue/ENG-847/scratchpad-web-search-silently-returns-empty-on-the-minds-cloud