### PR TITLE
fix(prompts): reference created artifact in final message

### DIFF
--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -301,6 +301,13 @@ WORKFLOW:
 again — that creates a duplicate.
 3. If you discover the entry-point filename only later (or change it), call \
 `update_artifact(slug, primary=...)` so the renderer opens the right file.
+4. AFTER FINISHING — reference the artifact in your final message. Once the \
+artifact's files are written, tell the user what was created and point to it by \
+`name` and `slug`, and include the primary file's path \
+(`<artifact_path>/<primary>`) so it is clickable/openable in a plain CLI. NEVER \
+end with only a description of the content and no pointer to the result. (For \
+fullstack apps, prefer the `url` returned by `launch_backend` as the primary \
+pointer — see the BACKEND & FULLSTACK section.)
 """
 
 


### PR DESCRIPTION
# Description

## Problem

After generating a non-fullstack artifact (`html-app`, `document`, `image`, `dataset`), Anton ends the turn with something like "Done! Artifact created…" but never points the user to the result. In a plain CLI/transcript this looks unfinished — there is nothing to click and no hint where to view the output.

This is a gap in instructions, not a model bug:

- `ARTIFACTS_PROMPT` (`anton/core/llm/prompts.py`) described registering and writing the artifact only. Nothing told the model to reference the artifact in its final response.
- The only place that mandated giving the user a pointer (a URL) was the BACKEND & FULLSTACK section, which relies on `launch_backend` returning a `url`. That exists only for `fullstack-stateless-app` / `fullstack-stateful-app`.
- Non-fullstack types have no `backend.py`, no `launch_backend`, and therefore no URL — the model had nothing to insert.

The data the model needs is already present: `create_artifact` returns `id / slug / name / type / primary / path`. The model simply was not instructed to surface any of it at the end.

Note: the problem is only visible in a plain CLI/transcript. In the cowork GUI the artifact panel is rendered by `slug`/`path`, so an explicit link is not required there.

## Change

Prompt-only, mode-agnostic fix. Added a final step to the `WORKFLOW` block of `ARTIFACTS_PROMPT` instructing the model to reference the finished artifact by `name`, `slug`, and primary-file `path` in its final message, and to never end with only a content description. Fullstack apps are directed to prefer the `launch_backend` URL as the primary pointer, leaving the existing FULLSTACK PREVIEW/PUBLISH behavior authoritative for those types.

No tool-code changes and no CLI-vs-GUI detection: a mode-agnostic pointer is harmless in the GUI (the panel renders by `slug`/`path`) and useful in the CLI.

## Out of scope

- Adding a link/pointer field to `handle_create_artifact` (ticket Option 2) — unnecessary; the model already receives `slug`/`path` in the tool result.
- CLI-vs-GUI client detection or any `runtime_context` client flag.
- Any change to the BACKEND & FULLSTACK section.

## Testing

Prompt-string change; model behavior cannot be asserted by unit tests, and no existing test snapshots `ARTIFACTS_PROMPT`. Verified that the prompt module and `prompt_builder` still import cleanly and the new step renders without broken line joins. Manual verification: run "create the simplest html artifact that displays the current time" in the CLI and confirm the final message points to the artifact (name/slug + primary path) rather than just describing its content.

Close ENG-900