### PR TITLE
fix(cli): flush per-round preambles separately instead of concatenating

### DIFF
--- a/anton/chat_ui.py
+++ b/anton/chat_ui.py
@@ -202,11 +202,7 @@ class StreamDisplay:
         self._live: Live | None = None
         self._toolbar = toolbar
         self._activities: list[_ToolActivity] = []
-        self._buffer = ""  # answer text accumulated during streaming
-        self._in_tool_phase = False
-        self._last_was_tool = False
-        self._initial_text = ""
-        self._initial_printed = False
+        self._pending = ""  # assistant text accumulated during streaming
         self._active = False
         # 3-line footer state
         self._line1_fun: str = ""  # Line 1: Esc to cancel — fun message
@@ -280,11 +276,7 @@ class StreamDisplay:
         self._line3_peek = ""
         self._set_status(self._line1_fun)
         self._activities = []
-        self._buffer = ""
-        self._initial_text = ""
-        self._initial_printed = False
-        self._in_tool_phase = False
-        self._last_was_tool = False
+        self._pending = ""
         self._cancel_msg = ""
         self._active = True
         self._start_spinner()
@@ -292,15 +284,9 @@ class StreamDisplay:
     def append_text(self, delta: str) -> None:
         if not self._active:
             return
-        if self._in_tool_phase:
-            self._buffer += delta
-            self._last_was_tool = False
-            self._line3_peek = self._extract_peek(self._buffer)
-            self._update_spinner()
-        else:
-            self._initial_text += delta
-            self._line3_peek = self._extract_peek(self._initial_text)
-            self._update_spinner()
+        self._pending += delta
+        self._line3_peek = self._extract_peek(self._pending)
+        self._update_spinner()
 
     def show_tool_result(self, content: str) -> None:
         """Print a tool result permanently (immediately scrollable)."""
@@ -308,7 +294,6 @@ class StreamDisplay:
             return
         self._stop_spinner()
         self._console.print(Markdown(content))
-        self._last_was_tool = True
         self._start_spinner()
 
     def show_tool_execution(self, task: str) -> None:
@@ -316,13 +301,25 @@ class StreamDisplay:
         self.on_tool_use_start(f"_compat_{id(task)}", task)
 
     def on_tool_use_start(self, tool_id: str, name: str) -> None:
-        """Track a new tool use."""
+        """Track a new tool use.
+
+        Any text accumulated since the last flush is the current round's
+        preamble (inner-speech). Print it dimmed now and clear the
+        accumulator, so it is visually separated from other rounds'
+        preambles and from the final answer.
+        """
         import time as _time
 
         if not self._active:
             return
-        self._in_tool_phase = True
-        self._last_was_tool = True
+        preamble = self._pending.rstrip()
+        if preamble:
+            self._stop_spinner()
+            self._console.print(Text(preamble, style="anton.muted"))
+            self._start_spinner()
+        self._pending = ""
+        self._line3_peek = ""
+        self._update_spinner()  # refresh footer even when preamble was empty
         activity = _ToolActivity(
             tool_id=tool_id, name=name, start_time=_time.monotonic()
         )
@@ -467,23 +464,12 @@ class StreamDisplay:
                 act.done_line_printed = True
                 self._print_done_line(act, act.work_elapsed)
 
-        # Print initial text as muted "inner speech" (if not already printed)
-        if self._initial_text and not self._initial_printed:
-            if self._activities:
-                self._console.print(
-                    Text(self._initial_text.rstrip(), style="anton.muted")
-                )
-
-        # Print answer
-        if self._activities:
-            if self._buffer:
-                self._console.print(Text("anton> ", style="anton.prompt"), end="")
-                self._console.print(Markdown(self._buffer))
-        else:
-            all_text = self._initial_text + self._buffer
-            if all_text:
-                self._console.print(Text("anton> ", style="anton.prompt"), end="")
-                self._console.print(Markdown(all_text))
+        # Whatever remains in _pending is the text after the last tool — the
+        # true final answer. All preambles were already flushed dimmed at
+        # each tool start, so there is nothing to disambiguate here.
+        if self._pending:
+            self._console.print(Text("anton> ", style="anton.prompt"), end="")
+            self._console.print(Markdown(self._pending))
 
         self._active = False
         self._console.print()

--- a/tests/test_chat_ui.py
+++ b/tests/test_chat_ui.py
@@ -20,7 +20,7 @@ class TestStreamDisplay:
         MockLive.return_value.start.assert_called_once()
 
     @patch("anton.chat_ui.Live")
-    def test_append_text_updates_buffer(self, MockLive):
+    def test_append_text_accumulates_in_pending(self, MockLive):
         display, console = self._make_display()
         display.start()
         live = MockLive.return_value
@@ -28,8 +28,8 @@ class TestStreamDisplay:
         display.append_text("Hello ")
         display.append_text("world!")
 
-        # Before any tool use, text goes to _initial_text
-        assert display._initial_text == "Hello world!"
+        # All streamed text accumulates in the single _pending buffer
+        assert display._pending == "Hello world!"
         assert live.update.call_count == 2
 
     @patch("anton.chat_ui.Live")
@@ -115,22 +115,50 @@ class TestActivityTracking:
 
     @patch("anton.chat_ui.Live")
     def test_finish_prints_activity_summary(self, MockLive):
+        from rich.markdown import Markdown as RichMarkdown
+        from rich.text import Text as RichText
+
         display, console = self._make_display()
         display.start()
 
-        # Initial text before tools
+        # Preamble before the tool — must flush dimmed AT on_tool_use_start
         display.append_text("Let me check...")
-
         display.on_tool_use_start("tool_1", "scratchpad")
+
+        muted_before_finish = [
+            c.args[0].plain
+            for c in console.print.call_args_list
+            if c.args
+            and isinstance(c.args[0], RichText)
+            and c.args[0].style == "anton.muted"
+        ]
+        assert muted_before_finish == ["Let me check..."]
+
         display.on_tool_use_delta("tool_1", '{"action": "exec", "name": "pad"}')
         display.on_tool_use_end("tool_1")
 
-        # Answer text after tools
+        # Answer text after the tool
         display.append_text("Here's what I found...")
-        display.finish()
 
-        # finish should print: muted initial, activity tree, anton> + answer markdown, trailing newline
-        assert console.print.call_count >= 4
+        calls_before_finish = len(console.print.call_args_list)
+        display.finish()
+        finish_calls = console.print.call_args_list[calls_before_finish:]
+
+        # finish() prints NO muted inner-speech (it was flushed earlier) …
+        assert not [
+            c
+            for c in finish_calls
+            if c.args
+            and isinstance(c.args[0], RichText)
+            and c.args[0].style == "anton.muted"
+        ]
+        # … and prints the final answer as a single Markdown block.
+        markdowns = [
+            c.args[0].markup
+            for c in finish_calls
+            if c.args and isinstance(c.args[0], RichMarkdown)
+        ]
+        assert markdowns == ["Here's what I found..."]
 
     @patch("anton.chat_ui.Live")
     def test_no_activities_no_tree(self, MockLive):
@@ -203,24 +231,130 @@ class TestActivityTracking:
         assert result == "exec"
 
     @patch("anton.chat_ui.Live")
-    def test_text_routes_to_initial_before_tools(self, MockLive):
-        display, _ = self._make_display()
-        display.start()
+    def test_preamble_flushed_dimmed_at_tool_start(self, MockLive):
+        from rich.text import Text as RichText
 
-        display.append_text("Let me check...")
-        assert display._initial_text == "Let me check..."
-        assert display._buffer == ""
-        assert not display._in_tool_phase
-
-    @patch("anton.chat_ui.Live")
-    def test_text_routes_to_buffer_after_tools(self, MockLive):
-        display, _ = self._make_display()
+        display, console = self._make_display()
         display.start()
 
         display.append_text("Initial text")
         display.on_tool_use_start("tool_1", "scratchpad")
-        display.append_text("Answer text")
 
-        assert display._initial_text == "Initial text"
-        assert display._buffer == "Answer text"
-        assert display._in_tool_phase
+        # Preamble printed dimmed at the tool boundary, accumulator cleared
+        muted = [
+            c.args[0].plain
+            for c in console.print.call_args_list
+            if c.args
+            and isinstance(c.args[0], RichText)
+            and c.args[0].style == "anton.muted"
+        ]
+        assert muted == ["Initial text"]
+        assert display._pending == ""
+
+        # Subsequent text accumulates fresh
+        display.append_text("Answer text")
+        assert display._pending == "Answer text"
+
+    @patch("anton.chat_ui.Live")
+    def test_multiround_preambles_flushed_separately(self, MockLive):
+        from rich.markdown import Markdown as RichMarkdown
+        from rich.text import Text as RichText
+
+        display, console = self._make_display()
+        display.start()
+
+        # Round 1: preamble → tool
+        display.append_text("Now launching the backend:")
+        display.on_tool_use_start("t1", "scratchpad")
+        display.on_tool_use_delta("t1", '{"action": "exec", "name": "p"}')
+        display.on_tool_use_end("t1")
+
+        # Round 2: preamble → tool
+        display.append_text("Launched! Checking the API:")
+        display.on_tool_use_start("t2", "scratchpad")
+        display.on_tool_use_delta("t2", '{"action": "exec", "name": "p"}')
+        display.on_tool_use_end("t2")
+
+        # Trailing text after the last tool = the real final answer
+        display.append_text("Everything works.")
+        display.finish()
+
+        muted = [
+            c.args[0].plain
+            for c in console.print.call_args_list
+            if c.args
+            and isinstance(c.args[0], RichText)
+            and c.args[0].style == "anton.muted"
+        ]
+        # Both preambles printed live, in order, each on its own line
+        assert muted == [
+            "Now launching the backend:",
+            "Launched! Checking the API:",
+        ]
+
+        markdowns = [
+            c.args[0].markup
+            for c in console.print.call_args_list
+            if c.args and isinstance(c.args[0], RichMarkdown)
+        ]
+        # Final answer is a single block — NOT concatenated with the preambles
+        assert markdowns == ["Everything works."]
+
+    @patch("anton.chat_ui.Live")
+    def test_consecutive_tools_no_text_no_flush(self, MockLive):
+        from rich.text import Text as RichText
+
+        display, console = self._make_display()
+        display.start()
+
+        display.on_tool_use_start("t1", "scratchpad")
+        display.on_tool_use_end("t1")
+        display.on_tool_use_start("t2", "scratchpad")
+        display.on_tool_use_end("t2")
+
+        muted = [
+            c
+            for c in console.print.call_args_list
+            if c.args
+            and isinstance(c.args[0], RichText)
+            and getattr(c.args[0], "style", None) == "anton.muted"
+        ]
+        assert muted == []
+
+    @patch("anton.chat_ui.Live")
+    def test_turn_ending_with_tool_prints_no_answer(self, MockLive):
+        from rich.markdown import Markdown as RichMarkdown
+
+        display, console = self._make_display()
+        display.start()
+
+        display.append_text("Preamble")
+        display.on_tool_use_start("t1", "scratchpad")
+        display.on_tool_use_end("t1")
+        display.finish()
+
+        markdowns = [
+            c
+            for c in console.print.call_args_list
+            if c.args and isinstance(c.args[0], RichMarkdown)
+        ]
+        # No trailing text → no anton> answer block
+        assert markdowns == []
+
+    @patch("anton.chat_ui.Live")
+    def test_no_tools_single_markdown_answer(self, MockLive):
+        from rich.markdown import Markdown as RichMarkdown
+
+        display, console = self._make_display()
+        display.start()
+
+        display.append_text("Hello ")
+        display.append_text("world!")
+        display.finish()
+
+        markdowns = [
+            c.args[0].markup
+            for c in console.print.call_args_list
+            if c.args and isinstance(c.args[0], RichMarkdown)
+        ]
+        assert markdowns == ["Hello world!"]


### PR DESCRIPTION
## Problem

In a multi-round turn (`text → tool → text → tool → text`), the CLI printed the text preambles of every round and the final answer concatenated back-to-back, with no separators. The user saw something like:

> Now launching the backend:anton_state is not a public package — using SQLite directly, without it.Launched! Quickly checking the API:Everything works. Open the app in your browser: ...

This is purely a rendering bug in `StreamDisplay` (`anton/chat_ui.py`) — in the message history these are separate, correct assistant messages.

## Root cause

`StreamDisplay` assumed a single-round shape: "a bit of inner-speech → tools → one final answer". It kept two accumulators — `_initial_text` (text before the first tool) and `_buffer` (everything after) — and printed `_buffer` exactly once, as a single Markdown block, in `finish()`.

In a real multi-round turn every preamble except the first fell into `_buffer`, which was never reset between rounds and had no separator inserted between messages. So all intermediate preambles piled up together with the true final answer and were rendered glued together and misclassified as part of the answer.

## Fix

Switch to a single-accumulator model with a flush at each tool boundary:

- Replace `_initial_text` + `_buffer` with one `_pending` accumulator.
- In `on_tool_use_start`, if `_pending` holds text, it is the current round's preamble — print it immediately as dimmed inner-speech (`anton.muted`) and clear `_pending`. This is the natural flush point and gives each preamble its own line, in the correct chronological position.
- `finish()` now prints only whatever remains in `_pending` — the text after the last tool, i.e. the real final answer — with the `anton>` prompt as Markdown. The "no tools at all" case collapses into the same code path.
- Remove the now-dead fields `_in_tool_phase`, `_initial_printed`, and `_last_was_tool`.

Resulting output order for a multi-round turn:
```
<preamble 1, dimmed> ← flushed at tool 1 start
✔ <tool 1 line>
<preamble 2, dimmed> ← flushed at tool 2 start
✔ <tool 2 line>
anton> <final answer, markdown> ← finish()
```
Concatenation is now impossible because round boundaries coincide with flush points.
## Tests
`tests/test_chat_ui.py`:
- Updated the tests that referenced the removed fields to assert against `_pending`.
- Reworked `test_finish_prints_activity_summary` to verify the preamble is flushed dimmed at tool start (not in `finish()`).
- Added coverage for: multi-round preambles flushed separately and a single Markdown answer block; consecutive tools with no text between them (no spurious flush); a turn that ends with a tool (no `anton>` answer block); and the no-tools regression (single Markdown answer).
`pytest tests/test_chat_ui.py` — 22 passed. `ruff check` — clean.
Fixes [ENG-901](https://linear.app/mindsdb/issue/ENG-901/cli-concatenates-intermediate-round-preambles-into-a-single-block).