### PR TITLE
ENG-742: Count turns without tools-calls

### DIFF
--- a/anton/commands/session.py
+++ b/anton/commands/session.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from anton.config.settings import AntonSettings
 from anton.utils.prompt import prompt_or_cancel
 from anton.chat_session import rebuild_session
+from anton.memory.history_store import is_user_turn
 
 if TYPE_CHECKING:
     from anton.chat import ChatSession
@@ -121,7 +122,7 @@ async def restore_session(
         session_id=sid,
     )
     new_session._history = list(history)
-    new_session._turn_count = sum(1 for m in history if m.get("role") == "user")
+    new_session._turn_count = sum(1 for m in history if is_user_turn(m))
 
     console.print()
     console.print(

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -20,6 +20,7 @@ from anton.core.memory.base import Engram
 from anton.core.memory.cerebellum import Cerebellum
 from anton.core.memory.skills import SkillStore
 from anton.core.tools.recall_skill import RECALL_SKILL_TOOL
+from anton.memory.history_store import is_user_turn
 from anton.core.llm.prompts import (
     RESILIENCE_NUDGE,
     SCRATCHPAD_SIZE_NUDGE,
@@ -319,7 +320,7 @@ class ChatSession:
         )
         self._pending_memory_confirmations: list = []
         self._turn_count = (
-            sum(1 for m in self._history if m.get("role") == "user")
+            sum(1 for m in self._history if is_user_turn(m))
             if config.initial_history
             else 0
         )

--- a/anton/memory/history_store.py
+++ b/anton/memory/history_store.py
@@ -20,6 +20,24 @@ if TYPE_CHECKING:
     from anton.core.memory.episodes import EpisodicMemory
 
 
+def is_user_turn(message: dict) -> bool:
+    """True for a genuine user turn.
+
+    A user-role message whose content is only ``tool_result`` blocks is the
+    reply to a tool call, not a new turn. Counting it would inflate turn
+    totals once tool activity is replayed back into history.
+    """
+    if message.get("role") != "user":
+        return False
+    content = message.get("content")
+    if not isinstance(content, list):
+        return True  # string / multimodal input is always a real turn
+    return not any(
+        isinstance(block, dict) and block.get("type") == "tool_result"
+        for block in content
+    )
+
+
 class HistoryStore:
     """Persist and retrieve full chat history for session resume."""
 
@@ -159,8 +177,8 @@ class HistoryStore:
 
             session_id = path.stem.removesuffix("_history")
 
-            # Count user turns
-            turns = sum(1 for m in data if m.get("role") == "user")
+            # Count user turns (tool_result replies are not turns)
+            turns = sum(1 for m in data if is_user_turn(m))
             if turns == 0:
                 continue
 


### PR DESCRIPTION
Continue of https://github.com/mindsdb/cowork-server/pull/203

## Problem

`_turn_count` is seeded by counting `role == "user"` messages in history
(`session.py`, `commands/session.py`, `memory/history_store.py`). Once a host
replays tool activity into history, `tool_result` messages — which are also
`role == "user"` — get counted as turns. Every tool call inflates the count,
and the drift compounds as the session is rebuilt each turn.

Impact: the "every 5 turns" identity extraction misfires, telemetry/episodic
turn IDs are wrong, and resume/list show inflated turn totals.

## Fix

Add `is_user_turn(message)` in `history_store.py`: a `user`-role message whose
content is only `tool_result` blocks is a tool reply, not a turn. Replace all
three naive counts with it.

- One shared helper, no duplicated predicate.
- Backward compatible: histories without `tool_result` count unchanged.

Fixes https://linear.app/mindsdb/issue/ENG-742/cowork-tool-calls-are-not-stored-in-conversation-history