### PR TITLE
ENG 648: A public-data-sources skill

### DIFF
--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -52,48 +52,13 @@ to pick the right source, then fetch and parse it in the scratchpad.
 - If the first source doesn't work, try alternatives. Don't give up after one \
 attempt — try 2-3 different approaches before telling the user it's unavailable.
 
-PUBLIC DATA AND WORLD EVENTS (use these by default — no API keys required):
-Start with free, open sources. Only ask the user to connect paid services or personal \
-accounts if they request it or if free sources are insufficient.
-
-News & current events (via RSS — use feedparser):
-- Google News RSS: `https://news.google.com/rss/search?q={{query}}&hl={{lang}}&gl={{country}}` \
-— any topic, any country. Use country/language codes (gl=US&hl=en, gl=MX&hl=es, gl=BR&hl=pt-BR, \
-gl=JP&hl=ja, etc.). This is your primary news source.
-- Reuters: `https://www.rss.reuters.com/news/` (world, business, tech sections)
-- AP News: `https://rsshub.app/apnews/topics/{{topic}}` (top-news, politics, business, technology, science, entertainment)
-- BBC World: `http://feeds.bbci.co.uk/news/rss.xml` (also /world, /business, /technology)
-- NPR: `https://feeds.npr.org/1001/rss.xml` (news), `1006/rss.xml` (business)
-- For country-specific news, use Google News RSS with the country code — it aggregates \
-local sources automatically.
-- Parse feeds with `feedparser`: title, link, published date, summary. \
-Store as a list of dicts for dashboard integration.
-
-Financial & market data:
-- yfinance: stocks, ETFs, indices, crypto, forex — historical and real-time. \
-Use tickers like ^GSPC (S&P 500), ^DJI (Dow), ^IXIC (Nasdaq), BTC-USD, etc.
-- FRED (Federal Reserve): `https://fred.stlouisfed.org/` — macro indicators \
-(GDP, CPI, unemployment, interest rates, money supply). Use fredapi package \
-with free API key, or fetch CSV directly: \
-`https://fred.stlouisfed.org/graph/fredgraph.csv?id={{series_id}}` (no key needed for CSV).
-- CoinGecko: `https://api.coingecko.com/api/v3/` — crypto prices, market cap, \
-volume, trending coins. Free, no key.
-
-Economic & global data:
-- World Bank: `https://api.worldbank.org/v2/country/{{code}}/indicator/{{indicator}}?format=json` \
-— GDP, population, poverty, education, health by country. Free, no key.
-- OECD: `https://sdmx.oecd.org/public/rest/data/` — economic indicators for OECD countries.
-- Open Exchange Rates: `https://open.er-api.com/v6/latest/{{base}}` — free forex rates.
-
-Social & sentiment:
-- Reddit JSON: `https://www.reddit.com/r/{{subreddit}}/.json` — add .json to any \
-Reddit URL for structured data. Good for sentiment on specific topics.
-- HackerNews: `https://hacker-news.firebaseio.com/v0/` — tech news, top/new/best stories.
-
-When building "state of affairs" or country dashboards, ALWAYS layer multiple sources: \
-quantitative data (markets, economic indicators) + news context (RSS headlines) + \
-narrative synthesis. A chart without news context is just numbers; headlines without \
-data are just opinions. Combine them.
+PUBLIC DATA AND WORLD EVENTS:
+Prefer free, open sources by default (Google News RSS, yfinance, FRED, CoinGecko, \
+World Bank, Reddit JSON, HackerNews) — only ask the user to connect paid services or \
+personal accounts if they request it or if free sources are insufficient. A curated \
+catalog of ready-to-use endpoints and URL patterns is available: call \
+`recall_skill("public-data-sources")` BEFORE fetching public news, market, or \
+world data.
 
 PROACTIVE FOLLOW-UP SUGGESTIONS:
 After completing analysis on public datasets, think about whether the user's own data \

--- a/anton/core/memory/builtin_skills/public-data-sources/SKILL.md
+++ b/anton/core/memory/builtin_skills/public-data-sources/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: public-data-sources
+description: 'Recall BEFORE fetching public news, market, economic, or world data
+  from the scratchpad. Catalog of free, open, no-API-key data endpoints and URL
+  patterns — news RSS (Google News, Reuters, AP, BBC, NPR), financial/market
+  (yfinance, FRED, CoinGecko), economic/global (World Bank, OECD, exchange rates),
+  and social/sentiment (Reddit, HackerNews) — plus how to layer them for "state of
+  affairs" and country dashboards. When in doubt about where to get free live data,
+  recall it.'
+metadata:
+  display_name: Public data & world-event sources
+  provenance: builtin
+---
+PUBLIC DATA AND WORLD EVENTS (use these by default — no API keys required):
+Start with free, open sources. Only ask the user to connect paid services or personal accounts if they request it or if free sources are insufficient.
+
+News & current events (via RSS — use feedparser):
+- Google News RSS: `https://news.google.com/rss/search?q={query}&hl={lang}&gl={country}` — any topic, any country. Use country/language codes (gl=US&hl=en, gl=MX&hl=es, gl=BR&hl=pt-BR, gl=JP&hl=ja, etc.). This is your primary news source.
+- Reuters: `https://www.rss.reuters.com/news/` (world, business, tech sections)
+- AP News: `https://rsshub.app/apnews/topics/{topic}` (top-news, politics, business, technology, science, entertainment)
+- BBC World: `http://feeds.bbci.co.uk/news/rss.xml` (also /world, /business, /technology)
+- NPR: `https://feeds.npr.org/1001/rss.xml` (news), `1006/rss.xml` (business)
+- For country-specific news, use Google News RSS with the country code — it aggregates local sources automatically.
+- Parse feeds with `feedparser`: title, link, published date, summary. Store as a list of dicts for dashboard integration.
+
+Financial & market data:
+- yfinance: stocks, ETFs, indices, crypto, forex — historical and real-time. Use tickers like ^GSPC (S&P 500), ^DJI (Dow), ^IXIC (Nasdaq), BTC-USD, etc.
+- FRED (Federal Reserve): `https://fred.stlouisfed.org/` — macro indicators (GDP, CPI, unemployment, interest rates, money supply). Use fredapi package with free API key, or fetch CSV directly: `https://fred.stlouisfed.org/graph/fredgraph.csv?id={series_id}` (no key needed for CSV).
+- CoinGecko: `https://api.coingecko.com/api/v3/` — crypto prices, market cap, volume, trending coins. Free, no key.
+
+Economic & global data:
+- World Bank: `https://api.worldbank.org/v2/country/{code}/indicator/{indicator}?format=json` — GDP, population, poverty, education, health by country. Free, no key.
+- OECD: `https://sdmx.oecd.org/public/rest/data/` — economic indicators for OECD countries.
+- Open Exchange Rates: `https://open.er-api.com/v6/latest/{base}` — free forex rates.
+
+Social & sentiment:
+- Reddit JSON: `https://www.reddit.com/r/{subreddit}/.json` — add .json to any Reddit URL for structured data. Good for sentiment on specific topics.
+- HackerNews: `https://hacker-news.firebaseio.com/v0/` — tech news, top/new/best stories.
+
+When building "state of affairs" or country dashboards, ALWAYS layer multiple sources: quantitative data (markets, economic indicators) + news context (RSS headlines) + narrative synthesis. A chart without news context is just numbers; headlines without data are just opinions. Combine them.

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -10,7 +10,7 @@ from anton.core.memory.skills import Skill, SkillStore
 REAL_BUILTIN_ROOT = (
     Path(skills_mod.__file__).parent / "builtin_skills"
 )
-SHIPPED_LABELS = {"build-fullstack-backend", "build-html-dashboard"}
+SHIPPED_LABELS = {"build-fullstack-backend", "build-html-dashboard", "public-data-sources"}
 
 
 @pytest.fixture()
@@ -37,6 +37,14 @@ class TestShippedSkills:
         assert dashboard is not None
         assert dashboard.provenance == "builtin"
         assert len(dashboard.declarative_md) > 5_000
+
+        data_sources = store.load("public-data-sources")
+        assert data_sources is not None
+        assert data_sources.provenance == "builtin"
+        # spot-check endpoints + single-brace URL params (SKILL.md bodies are
+        # not str.format()'d, unlike the CHAT_SYSTEM_PROMPT they moved out of)
+        assert "feedparser" in data_sources.declarative_md
+        assert "api.worldbank.org/v2/country/{code}/indicator/{indicator}" in data_sources.declarative_md
 
     def test_descriptions_fit_prompt_budget(self, store):
         for summary in store.list_summaries():
@@ -98,12 +106,14 @@ class TestHintLabelDrift:
     def test_prompt_hints_reference_shipped_skills(self, store):
         from anton.core.llm.prompts import (
             BACKEND_GENERATION_PROMPT,
+            CHAT_SYSTEM_PROMPT,
             VISUALIZATIONS_HTML_OUTPUT_FORMAT_PROMPT,
             VISUALIZATIONS_MARKDOWN_OUTPUT_FORMAT_PROMPT,
         )
 
         referenced = self._referenced_labels(
             BACKEND_GENERATION_PROMPT,
+            CHAT_SYSTEM_PROMPT,
             VISUALIZATIONS_HTML_OUTPUT_FORMAT_PROMPT,
             VISUALIZATIONS_MARKDOWN_OUTPUT_FORMAT_PROMPT,
         )
@@ -120,6 +130,27 @@ class TestHintLabelDrift:
         assert referenced
         for label in referenced:
             assert store.load(label) is not None, f"hinted skill missing: {label}"
+
+
+class TestDataCatalogMovedToSkill:
+    """The public-data endpoint catalog must live in the recalled skill only,
+    not inline in the always-on CHAT_SYSTEM_PROMPT (that duplication is the
+    token cost this move removes)."""
+
+    CATALOG_MARKERS = ("api.worldbank.org", "hacker-news.firebaseio.com", "feedparser")
+
+    def test_catalog_not_inline_in_base_prompt(self):
+        from anton.core.llm.prompts import CHAT_SYSTEM_PROMPT
+
+        for marker in self.CATALOG_MARKERS:
+            assert marker not in CHAT_SYSTEM_PROMPT, f"catalog leaked into base prompt: {marker}"
+        assert 'recall_skill("public-data-sources")' in CHAT_SYSTEM_PROMPT
+
+    def test_catalog_lives_in_skill(self, store):
+        skill = store.load("public-data-sources")
+        assert skill is not None and skill.provenance == "builtin"
+        for marker in self.CATALOG_MARKERS:
+            assert marker in skill.declarative_md, f"catalog marker missing from skill: {marker}"
 
 
 class TestBrokenShadowFallback:


### PR DESCRIPTION
Moved from https://github.com/mindsdb/anton/pull/239

Moved prompts related to public-data-sources to  buildin skill (to reduce main prompt size and token usage)

