### PR TITLE
ENG-648: cheap front-model thalamus gate (respond-or-delegate), off by default

### DIFF
--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -157,6 +157,29 @@ class LLMClient:
             max_tokens=max_tokens or self._max_tokens,
         )
 
+    async def gate(
+        self,
+        *,
+        system: str,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        tool_choice: dict | None = None,
+        max_tokens: int | None = None,
+    ) -> LLMResponse:
+        """One cheap gating call on the router role — see `anton.core.llm.thalamus`.
+
+        No ``native_web_tools``: the thalamus must never do work itself,
+        only answer from context or delegate.
+        """
+        return await self._router_provider.complete(
+            model=self._router_model,
+            system=system,
+            messages=messages,
+            tools=tools,
+            tool_choice=tool_choice,
+            max_tokens=max_tokens or self._max_tokens,
+        )
+
     async def _generate_object_with(
         self,
         schema_class,

--- a/anton/core/llm/thalamus.py
+++ b/anton/core/llm/thalamus.py
@@ -1,0 +1,332 @@
+"""Thalamus — the gate between an incoming turn and the cortex.
+
+Brain analogue
+==============
+
+The thalamus is the brain's central relay. Almost every sensory and
+motor signal passes through it on the way to the cortex — it is the
+first thing a signal hits, and it decides what happens next. Four of
+its properties are worth stealing:
+
+1. **It gates; it does not compute.** The thalamus relays signals and
+   modulates their gain. The heavy interpretation happens in the cortex.
+   A thalamus that started "thinking" would be both slow and a liability.
+
+2. **Its default posture is inhibitory.** The thalamic reticular
+   nucleus (TRN) is a shell of inhibitory neurons that suppresses relay
+   by default and selectively *dis*inhibits the one channel that earns
+   passage — Crick's "searchlight." Nothing gets through on a maybe.
+
+3. **It has two firing modes.** *Tonic* mode faithfully relays a simple,
+   attended signal. *Burst* mode is an alerting spike that says "cortex,
+   wake up, this one needs you." Every signal resolves to one or the
+   other.
+
+4. **The cortex talks back — a lot.** Corticothalamic fibers outnumber
+   the feed-forward ones roughly ten to one: the cortex constantly
+   biases what the thalamus lets through, based on context and
+   expectation. The gate is not context-free.
+
+Anton's analogue
+================
+
+Anton's thalamus is the cheap front-model that every text turn hits
+first (ENG-648). Mapping the four properties:
+
+1. *Gate, don't compute* — the gating call runs on a cost-effective
+   model with a minimal system prompt and **no tool schemas**. It may
+   answer, or it may hand off, but it never does real work (no
+   scratchpad, no data, no files). Keeping it thin is the whole point.
+
+2. *Default-inhibit* — the direct-answer path (the TRN "searchlight")
+   opens only for signals that are unambiguously trivial: derivable
+   from the conversation plus stable general knowledge, needing nothing
+   created, fetched, or computed. Every ambiguity — an empty response,
+   an answer that overran the output budget, an outright error — falls
+   through to the cortex. A wrong direct answer is far costlier than the
+   gating overhead, so "when in doubt, relay up" is the resting state.
+
+3. *Two modes* — the two decisions ARE tonic vs burst. ``ACTION_RESPOND``
+   is tonic relay: the thalamus itself passes a faithful, complete
+   answer for a simple signal. ``ACTION_DELEGATE`` is the burst: a
+   forced ``delegate`` tool call that alerts the planning model (the
+   cortex) and hands the turn up, optionally naming procedural skills to
+   preload so the cortex doesn't spend a round fetching them.
+
+4. *Corticothalamic feedback* — partial today, and the clearest place to
+   grow. The gate already receives one top-down signal: the list of
+   learned skills (a cortical/hippocampal product) shapes what it can
+   preload. The principled next step is to let recent cortical outcomes
+   bias the gate — e.g. if this project's turns almost always need
+   tools, lower the bar to delegate. That hook is called out at
+   ``gate_turn`` rather than built here.
+
+Because the thalamus is the first relay, a misfire starves everything
+downstream — so, like a lesioned thalamus that must not silently drop
+signals, ours fails *open*: any doubt or error relays the turn up to the
+cortex untouched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from anton.core.llm.provider import LLMResponse
+
+if TYPE_CHECKING:
+    from anton.core.llm.client import LLMClient
+
+
+# The two gate outcomes — tonic relay (answer here) vs burst (alert the
+# cortex / planning model). See the module docstring.
+ACTION_RESPOND = "respond"
+ACTION_DELEGATE = "delegate"
+
+# The thalamus sees a condensed, text-only view of history: full
+# transcripts (and the tool_use/tool_result blocks inside them) are what
+# the cortex needs, not what a gating call needs.
+_MAX_GATE_MESSAGES = 16
+_MAX_CHARS_PER_MESSAGE = 1_500
+
+
+DELEGATE_TOOL: dict = {
+    "name": "delegate",
+    "description": (
+        "Hand the current request to the full agent, which can execute "
+        "code, query data sources, search the web, read files, and build "
+        "artifacts. Call this immediately — with no preamble text — "
+        "whenever the request needs anything beyond a direct "
+        "conversational answer."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "reason": {
+                "type": "string",
+                "description": "One short sentence: why the full agent is needed.",
+            },
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Labels of known procedures (from the list in your "
+                    "system prompt) that clearly apply to this request, so "
+                    "they are preloaded for the full agent. Omit if none "
+                    "apply."
+                ),
+            },
+        },
+        "required": ["reason"],
+    },
+}
+
+
+_THALAMUS_SYSTEM_PROMPT = """\
+You are the fast front-line responder for Anton, an agent that analyzes data, \
+executes code, and builds things for the user. Decide, for the latest user \
+message, between exactly two actions:
+
+1. ANSWER DIRECTLY — reply yourself, only when ALL of these hold:
+   - No tools are needed: no code execution, no file or attachment access, no \
+data queries, no web search or fetching, no artifacts or dashboards.
+   - Nothing must be created, modified, computed, fetched, scheduled, or verified.
+   - You are not guessing: the answer is already in the conversation, or is \
+stable general knowledge.
+   Typical direct cases: greetings and small talk, answering questions about \
+results already shown in the conversation, explaining or rephrasing something \
+already said, asking the user a clarifying question when their request is too \
+vague to act on.
+
+2. DELEGATE — call the `delegate` tool immediately, with NO text before it, \
+when the request involves data analysis, files or attachments, running or \
+writing code, building or updating anything, web lookups or information that \
+could be stale, connecting to services, or memory/skill management — or \
+whenever you are unsure. When in doubt, delegate: a wrong or stale direct \
+answer is far worse than the small cost of delegating.
+{skills_section}
+Direct answers must be short, helpful, and in the user's language. Never \
+mention this routing step, the `delegate` tool, or "the full agent" — from \
+the user's point of view there is only one assistant."""
+
+
+_SKILLS_SECTION_HEADER = """
+When you delegate, include in `skills` any of these known procedures that \
+clearly apply (their labels exactly as written), so they are preloaded:
+"""
+
+
+def build_thalamus_system_prompt(
+    skill_summaries: list[dict] | None = None,
+) -> str:
+    """Render the thalamus's minimal system prompt.
+
+    ``skill_summaries`` is the ``SkillStore.list_summaries()`` shape:
+    dicts with ``label`` and ``description`` keys. Listed one per line so
+    the thalamus can name preloads at delegation time. This list is the
+    one corticothalamic signal the gate currently receives — top-down
+    context (learned procedures) biasing what it can relay upward.
+    """
+    skills_section = ""
+    lines: list[str] = []
+    for s in skill_summaries or []:
+        label = (s.get("label") or "").strip()
+        if not label:
+            continue
+        when = (s.get("description") or "").strip()
+        lines.append(f"- `{label}` — {when}" if when else f"- `{label}`")
+    if lines:
+        skills_section = _SKILLS_SECTION_HEADER + "\n".join(lines) + "\n"
+    return _THALAMUS_SYSTEM_PROMPT.format(skills_section=skills_section)
+
+
+def condense_history(
+    history: list[dict],
+    *,
+    max_messages: int = _MAX_GATE_MESSAGES,
+    max_chars: int = _MAX_CHARS_PER_MESSAGE,
+) -> list[dict]:
+    """Build the thalamus's text-only view of the conversation.
+
+    Tool blocks collapse to one-line markers (the gate only needs to
+    know work happened, not its payload), long messages are middle-
+    truncated, and consecutive same-role messages merge so the result
+    keeps the role alternation providers require. Only the most recent
+    ``max_messages`` survive, and a leading assistant message left over
+    from the cut is dropped so the list starts with a user message.
+    """
+    condensed: list[dict] = []
+    for msg in history:
+        role = msg.get("role")
+        if role not in ("user", "assistant"):
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            parts: list[str] = []
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "text":
+                    parts.append(str(block.get("text", "")))
+                elif btype == "tool_use":
+                    parts.append(f"[ran tool: {block.get('name', '?')}]")
+                elif btype == "tool_result":
+                    parts.append("[tool output omitted]")
+                elif btype == "image":
+                    parts.append("[image]")
+            text = "\n".join(p for p in parts if p)
+        else:
+            continue
+        text = text.strip()
+        if not text:
+            continue
+        if len(text) > max_chars:
+            half = max_chars // 2
+            text = f"{text[:half]}\n[… truncated …]\n{text[-half:]}"
+        if condensed and condensed[-1]["role"] == role:
+            condensed[-1]["content"] += "\n" + text
+        else:
+            condensed.append({"role": role, "content": text})
+
+    condensed = condensed[-max_messages:]
+    while condensed and condensed[0]["role"] != "user":
+        condensed.pop(0)
+    return condensed
+
+
+@dataclass
+class ThalamicDecision:
+    """Outcome of the gating call.
+
+    ``action`` is ACTION_RESPOND (tonic relay — ``text`` carries the
+    direct answer) or ACTION_DELEGATE (burst — ``skills`` carries
+    preload labels validated later). ``response`` is the raw gating
+    LLMResponse, kept so callers can surface its usage in stream events.
+    """
+
+    action: str
+    text: str = ""
+    skills: list[str] = field(default_factory=list)
+    reason: str = ""
+    response: LLMResponse | None = None
+
+
+async def gate_turn(
+    llm: "LLMClient",
+    *,
+    history: list[dict],
+    skill_summaries: list[dict] | None = None,
+    max_tokens: int = 1024,
+) -> ThalamicDecision:
+    """Run the gating call and interpret its outcome.
+
+    Every non-answer shape resolves to DELEGATE (default-inhibit): a
+    `delegate` tool call (the explicit burst), an empty response, or a
+    direct answer cut off by ``max_tokens`` — an answer that long is
+    evidence the turn wasn't trivial, and a truncated reply must never
+    reach the user.
+
+    Corticothalamic-feedback hook: today the only top-down signal is
+    ``skill_summaries``. A future version can accept recent cortical
+    outcomes (delegation rate per project, last-turn tool usage) here and
+    bias the gate — lowering the bar to delegate where the cortex keeps
+    getting woken anyway. Deliberately not built yet; see the module
+    docstring.
+    """
+    messages = condense_history(history)
+    if not messages:
+        return ThalamicDecision(action=ACTION_DELEGATE, reason="no routable history")
+
+    response = await llm.gate(
+        system=build_thalamus_system_prompt(skill_summaries),
+        messages=messages,
+        tools=[DELEGATE_TOOL],
+        max_tokens=max_tokens,
+    )
+
+    for tc in response.tool_calls:
+        if tc.name != "delegate":
+            continue
+        tc_input = tc.input if isinstance(tc.input, dict) else {}
+        skills = [
+            s.strip()
+            for s in (tc_input.get("skills") or [])
+            if isinstance(s, str) and s.strip()
+        ]
+        return ThalamicDecision(
+            action=ACTION_DELEGATE,
+            skills=skills,
+            reason=str(tc_input.get("reason", "")),
+            response=response,
+        )
+
+    if response.stop_reason in ("max_tokens", "length"):
+        return ThalamicDecision(
+            action=ACTION_DELEGATE,
+            reason="direct answer exceeded the gating output budget",
+            response=response,
+        )
+
+    text = (response.content or "").strip()
+    if not text:
+        return ThalamicDecision(
+            action=ACTION_DELEGATE,
+            reason="thalamus produced no answer",
+            response=response,
+        )
+
+    return ThalamicDecision(action=ACTION_RESPOND, text=text, response=response)
+
+
+__all__ = [
+    "ACTION_DELEGATE",
+    "ACTION_RESPOND",
+    "DELEGATE_TOOL",
+    "ThalamicDecision",
+    "build_thalamus_system_prompt",
+    "condense_history",
+    "gate_turn",
+]

--- a/anton/core/llm/thalamus.py
+++ b/anton/core/llm/thalamus.py
@@ -180,6 +180,22 @@ def build_thalamus_system_prompt(
     return _THALAMUS_SYSTEM_PROMPT.format(skills_section=skills_section)
 
 
+_TRUNCATION_MARKER = "\n[… truncated …]\n"
+
+
+def _truncate_middle(text: str, max_chars: int) -> str:
+    """Middle-truncate ``text`` to at most ``max_chars``, keeping head and tail.
+
+    The result (including the marker) never exceeds ``max_chars`` — the
+    marker length is subtracted from the head/tail budget — so callers can
+    rely on a hard per-entry cap.
+    """
+    if len(text) <= max_chars:
+        return text
+    half = max(0, (max_chars - len(_TRUNCATION_MARKER)) // 2)
+    return f"{text[:half]}{_TRUNCATION_MARKER}{text[-half:]}"
+
+
 def condense_history(
     history: list[dict],
     *,
@@ -188,12 +204,15 @@ def condense_history(
 ) -> list[dict]:
     """Build the thalamus's text-only view of the conversation.
 
-    Tool blocks collapse to one-line markers (the gate only needs to
-    know work happened, not its payload), long messages are middle-
-    truncated, and consecutive same-role messages merge so the result
-    keeps the role alternation providers require. Only the most recent
-    ``max_messages`` survive, and a leading assistant message left over
-    from the cut is dropped so the list starts with a user message.
+    Tool blocks collapse to one-line markers (the gate only needs to know
+    work happened, not its payload), and consecutive same-role messages
+    merge so the result keeps the role alternation providers require. Only
+    the most recent ``max_messages`` survive, and a leading assistant
+    message left over from the cut is dropped so the list starts with a
+    user message. Each surviving entry is then middle-truncated to
+    ``max_chars`` — applied AFTER the merge so a merged block can't exceed
+    the cap. The whole view is therefore bounded by
+    ``max_messages * max_chars``.
     """
     condensed: list[dict] = []
     for msg in history:
@@ -223,9 +242,6 @@ def condense_history(
         text = text.strip()
         if not text:
             continue
-        if len(text) > max_chars:
-            half = max_chars // 2
-            text = f"{text[:half]}\n[… truncated …]\n{text[-half:]}"
         if condensed and condensed[-1]["role"] == role:
             condensed[-1]["content"] += "\n" + text
         else:
@@ -234,6 +250,10 @@ def condense_history(
     condensed = condensed[-max_messages:]
     while condensed and condensed[0]["role"] != "user":
         condensed.pop(0)
+    # Truncate AFTER merge: each surviving (possibly merged) entry is capped
+    # here, so the per-entry cap holds no matter how many messages merged.
+    for msg in condensed:
+        msg["content"] = _truncate_middle(msg["content"], max_chars)
     return condensed
 
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1561,7 +1561,7 @@ class ChatSession:
         except Exception:
             summaries = []
         try:
-            return await gate_turn(
+            decision = await gate_turn(
                 self._llm,
                 history=self._history,
                 skill_summaries=summaries,
@@ -1573,6 +1573,18 @@ class ChatSession:
                 exc,
             )
             return None
+        # The gate hits every text turn, so its usage must be visible in
+        # telemetry regardless of outcome — StreamComplete only surfaces it
+        # on the direct-answer path, leaving all delegated turns unaccounted.
+        usage = getattr(decision.response, "usage", None)
+        if usage is not None:
+            logger.info(
+                "Router gate: action=%s in_tokens=%s out_tokens=%s",
+                decision.action,
+                getattr(usage, "input_tokens", "?"),
+                getattr(usage, "output_tokens", "?"),
+            )
+        return decision
 
     def _inject_recalled_skills(self, labels: list[str]) -> None:
         """Preload thalamus-named skills as a synthetic recall_skill exchange.
@@ -1591,7 +1603,10 @@ class ChatSession:
         store = self._skill_store
         if store is None:
             return
-        from anton.core.tools.recall_skill import _format_skill_response
+        from anton.core.tools.recall_skill import (
+            _already_in_history,
+            _format_skill_response,
+        )
 
         self._thalamus_recall_counter += 1
         tool_uses: list[dict] = []
@@ -1609,6 +1624,11 @@ class ChatSession:
             except Exception:
                 skill = None
             if skill is None:
+                continue
+            # Skip skills whose full body is already in context — mirrors
+            # handle_recall_skill's stub path so a preload can't duplicate a
+            # procedure the planning model already has (wasted tokens).
+            if _already_in_history(self, skill.label):
                 continue
             content = _format_skill_response(skill)
             try:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator, Callable
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime
 import json
+import logging
 import re
 from typing import TYPE_CHECKING, List, Literal
 import os
@@ -27,6 +28,7 @@ from anton.core.llm.prompts import (
 )
 from anton.core.llm.provider import (
     ContextOverflowError,
+    LLMResponse,
     ModelUnavailableError,
     StreamComplete,
     StreamContextCompacted,
@@ -36,6 +38,11 @@ from anton.core.llm.provider import (
     StreamToolResult,
     TokenLimitExceeded,
     ToolCall,
+)
+from anton.core.llm.thalamus import (
+    ACTION_RESPOND,
+    ThalamicDecision,
+    gate_turn,
 )
 from anton.core.llm.tracing import (
     TraceContext,
@@ -76,6 +83,8 @@ from anton.core.settings import CoreSettings
 # Sentinel prefixing a compacted-history summary so later compactions can
 # recognize and update it in place rather than summarize a summary.
 _COMPACTED_MARKER = "[COMPACTED CONTEXT — REFERENCE ONLY]"
+
+logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
@@ -282,6 +291,10 @@ class ChatSessionConfig:
     # None → fall back to today.
     started_at: datetime | None = None
     selection_elicitor: SelectionElicitor | None = None
+    # Cheap front-model routing (ENG-648). None (default) defers to the
+    # settings' `router_enabled` (ANTON_ROUTER_ENABLED); hosts pass an
+    # explicit bool to override per session.
+    router_enabled: bool | None = None
 
 
 class ChatSession:
@@ -302,6 +315,20 @@ class ChatSession:
         self._resilience_nudge_at = s.resilience_nudge_at
         self._token_status_cache_ttl = s.token_status_cache_ttl
         self._llm = config.llm_client
+        # Router (ENG-648): explicit host override wins; otherwise the
+        # settings flag (ANTON_ROUTER_ENABLED). getattr-guarded because
+        # tests pass bare CoreSettings-shaped objects.
+        self._router_enabled = (
+            config.router_enabled
+            if config.router_enabled is not None
+            else bool(getattr(s, "router_enabled", False))
+        )
+        self._router_max_tokens = int(getattr(s, "router_max_tokens", 1024))
+        # Monotonic counter for thalamus-preloaded tool_use ids. Deliberately
+        # separate from `_turn_count`, which only increments in turn_stream()
+        # — using it here would emit the same id on every call made through
+        # the non-streaming turn() API.
+        self._thalamus_recall_counter = 0
         self._self_awareness = config.self_awareness
         self._cortex = config.cortex
         self._episodic = config.episodic
@@ -935,11 +962,13 @@ class ChatSession:
         self._tracked_backends.clear()
 
     async def _summarize_history(self) -> None:
-        """Compress old conversation turns into a summary using the coding model.
+        """Compress old conversation turns into a summary.
 
         Splits history into old (first 60%) and recent (last 40%), keeping at
-        least 4 recent turns.  The old portion is summarized by the fast coding
-        model and replaced with a single user message.
+        least 4 recent turns. The old portion is summarized by the routing/
+        summarization model (the router role, which falls back to the coding
+        model when no distinct one is configured) and replaced with a single
+        user message.
         """
         if len(self._history) < 6:
             return  # Too short to summarize
@@ -1516,6 +1545,96 @@ class ChatSession:
             # Cerebellum learning is best-effort, so just drop the buffer.
             cb.reset()
 
+    async def _gate_turn(self) -> ThalamicDecision | None:
+        """Run the cheap routing call for the turn just appended to history.
+
+        Returns None — meaning "proceed to the planning model as if no
+        thalamus existed" — on any thalamus failure. Routing must never be
+        able to break a turn; it can only save one.
+        """
+        try:
+            summaries = (
+                self._skill_store.list_summaries()
+                if self._skill_store is not None
+                else []
+            )
+        except Exception:
+            summaries = []
+        try:
+            return await gate_turn(
+                self._llm,
+                history=self._history,
+                skill_summaries=summaries,
+                max_tokens=self._router_max_tokens,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Router call failed (%s) — falling through to the planning model.",
+                exc,
+            )
+            return None
+
+    def _inject_recalled_skills(self, labels: list[str]) -> None:
+        """Preload thalamus-named skills as a synthetic recall_skill exchange.
+
+        Appends an assistant `tool_use` + user `tool_result` pair to
+        history, byte-identical in payload to what the planning model
+        would have gotten by calling `recall_skill` itself — but without
+        spending a full-context planning round on the fetch. Labels must
+        match exactly (no fuzzy fallback: a wrong preload is worse than
+        none), unknown labels are dropped silently, and at most 3 skills
+        load per turn. Built-ins and user skills resolve through the same
+        SkillStore that `recall_skill` uses.
+        """
+        if not labels:
+            return
+        store = self._skill_store
+        if store is None:
+            return
+        from anton.core.tools.recall_skill import _format_skill_response
+
+        self._thalamus_recall_counter += 1
+        tool_uses: list[dict] = []
+        results: list[dict] = []
+        seen: set[str] = set()
+        for label in labels:
+            label = (label or "").strip()
+            if not label or label in seen:
+                continue
+            seen.add(label)
+            if len(tool_uses) >= 3:
+                break
+            try:
+                skill = store.load(label)
+            except Exception:
+                skill = None
+            if skill is None:
+                continue
+            content = _format_skill_response(skill)
+            try:
+                store.increment_recommended(skill.label, stage=1)
+            except Exception:
+                pass
+            tu_id = f"thalamus_recall_{self._thalamus_recall_counter}_{len(tool_uses)}"
+            tool_uses.append(
+                {
+                    "type": "tool_use",
+                    "id": tu_id,
+                    "name": "recall_skill",
+                    "input": {"label": skill.label},
+                }
+            )
+            results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tu_id,
+                    "content": content,
+                }
+            )
+        if tool_uses:
+            self._append_history({"role": "assistant", "content": tool_uses})
+            self._append_history({"role": "user", "content": results})
+
     async def turn(self, user_input: str | list[dict]) -> str:
         user_input = _scrub_user_input(user_input)
         self._append_history({"role": "user", "content": user_input})
@@ -1525,6 +1644,26 @@ class ChatSession:
             if isinstance(user_input, str)
             else next((b["text"] for b in user_input if b.get("type") == "text"), "")
         )
+
+        # Cheap front-model routing (ENG-648). Text-only turns first hit
+        # the thalamus model, which either answers trivial/from-context
+        # requests directly (skipping the full prompt + tools + planning
+        # model entirely) or delegates, optionally preloading skills.
+        # Image turns skip the thalamus — attachments imply real work.
+        if self._router_enabled and isinstance(user_input, str):
+            decision = await self._gate_turn()
+            if decision is not None and decision.action == ACTION_RESPOND:
+                self._append_history(
+                    {"role": "assistant", "content": decision.text}
+                )
+                if self._cortex is not None and self._cortex.mode != "off":
+                    self._cortex.maybe_vacuum()
+                self._schedule_cerebellum_flush()
+                self._schedule_acc_flush()
+                return decision.text
+            if decision is not None and decision.skills:
+                self._inject_recalled_skills(decision.skills)
+
         tools = self._build_tools()
         system = await self._build_system_prompt(user_msg_str)
         self._compacted_this_turn = False
@@ -1722,7 +1861,34 @@ class ChatSession:
         )
 
         try:
-            while True:
+            # Cheap front-model routing (ENG-648). Text-only turns first
+            # hit the thalamus model, which either answers trivial/from-
+            # context requests directly (skipping the full prompt + tool
+            # schemas + planning model entirely) or delegates, optionally
+            # preloading skills into history so the planning model doesn't
+            # spend a round on recall_skill. Image turns skip the thalamus —
+            # attachments imply real work. The thalamus buffers rather than
+            # streams: direct answers are short by construction
+            # (router_max_tokens), and a delegate decision must never leak
+            # preamble text to the user.
+            routed_direct = False
+            if self._router_enabled and isinstance(user_input, str):
+                decision = await self._gate_turn()
+                if decision is not None and decision.action == ACTION_RESPOND:
+                    self._append_history(
+                        {"role": "assistant", "content": decision.text}
+                    )
+                    assistant_text_parts.append(decision.text)
+                    yield StreamTextDelta(text=decision.text)
+                    yield StreamComplete(
+                        response=decision.response
+                        or LLMResponse(content=decision.text)
+                    )
+                    routed_direct = True
+                elif decision is not None and decision.skills:
+                    self._inject_recalled_skills(decision.skills)
+
+            while not routed_direct:
                 try:
                     async for event in self._stream_and_handle_tools(user_msg_str):
                         if isinstance(event, StreamTextDelta):

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1561,7 +1561,7 @@ class ChatSession:
         except Exception:
             summaries = []
         try:
-            decision = await gate_turn(
+            return await gate_turn(
                 self._llm,
                 history=self._history,
                 skill_summaries=summaries,
@@ -1573,18 +1573,6 @@ class ChatSession:
                 exc,
             )
             return None
-        # The gate hits every text turn, so its usage must be visible in
-        # telemetry regardless of outcome — StreamComplete only surfaces it
-        # on the direct-answer path, leaving all delegated turns unaccounted.
-        usage = getattr(decision.response, "usage", None)
-        if usage is not None:
-            logger.info(
-                "Router gate: action=%s in_tokens=%s out_tokens=%s",
-                decision.action,
-                getattr(usage, "input_tokens", "?"),
-                getattr(usage, "output_tokens", "?"),
-            )
-        return decision
 
     def _inject_recalled_skills(self, labels: list[str]) -> None:
         """Preload thalamus-named skills as a synthetic recall_skill exchange.
@@ -1905,8 +1893,15 @@ class ChatSession:
                         or LLMResponse(content=decision.text)
                     )
                     routed_direct = True
-                elif decision is not None and decision.skills:
-                    self._inject_recalled_skills(decision.skills)
+                elif decision is not None:
+                    # Delegating: surface the gate call's usage as its own
+                    # StreamComplete so token accounting counts it, exactly
+                    # like a planning round (the loop below emits more). The
+                    # gate hits every turn, so dropping it would under-report.
+                    if decision.response is not None:
+                        yield StreamComplete(response=decision.response)
+                    if decision.skills:
+                        self._inject_recalled_skills(decision.skills)
 
             while not routed_direct:
                 try:

--- a/anton/core/settings.py
+++ b/anton/core/settings.py
@@ -5,6 +5,18 @@ from pydantic_settings import BaseSettings
 class CoreSettings(BaseSettings):
     model_config = {"env_prefix": "ANTON_", "extra": "ignore"}
 
+    # Router — cheap front-model gating (ENG-648). When enabled, every text
+    # turn first hits the router model, which either answers trivial/from-
+    # context requests directly or delegates to the planning model (optionally
+    # preloading skills). The mechanism is the "thalamus" (see
+    # anton/core/llm/thalamus.py); the user-facing knobs stay "router". Off by
+    # default until evaluated; flip with ANTON_ROUTER_ENABLED=true.
+    router_enabled: bool = False
+    # Output budget for the gating call. Deliberately small: a direct
+    # answer that doesn't fit here is evidence the turn wasn't trivial,
+    # and the router treats truncation as "delegate".
+    router_max_tokens: int = 1024
+
     # Session orchestration tuning
     max_tool_rounds: int = 25
     max_continuations: int = 3

--- a/tests/test_thalamus.py
+++ b/tests/test_thalamus.py
@@ -245,21 +245,36 @@ class TestSessionThalamus:
     async def test_preload_ids_unique_across_non_streaming_turns(self):
         # turn() (unlike turn_stream()) never increments _turn_count, so an
         # id derived from it would repeat on every call — regression guard
-        # for that.
+        # for that. Two *different* skills across the two turns, since the
+        # same skill would be deduped on the second preload.
+        skills = {
+            "csv-summary": SimpleNamespace(
+                label="csv-summary", name="CSV Summary",
+                description="", declarative_md="1. load the CSV",
+            ),
+            "json-summary": SimpleNamespace(
+                label="json-summary", name="JSON Summary",
+                description="", declarative_md="1. load the JSON",
+            ),
+        }
+        store = MagicMock()
+        store.load.side_effect = lambda label: skills.get(label)
+
         llm = make_mock_llm()
         llm.gate = AsyncMock(
-            return_value=_response(
-                tool_calls=[_delegate_call(skills=["csv-summary"])]
-            )
+            side_effect=[
+                _response(tool_calls=[_delegate_call(skills=["csv-summary"])]),
+                _response(tool_calls=[_delegate_call(skills=["json-summary"])]),
+            ]
         )
         llm.plan = AsyncMock(return_value=_response("ok"))
         session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
-        session._skill_store = _mock_skill_store()
+        session._skill_store = store
 
         await session.turn("summarize data.csv")
         first_id = session.history[1]["content"][0]["id"]
 
-        await session.turn("summarize data.csv again")
+        await session.turn("now summarize data.json")
         second_id = session.history[5]["content"][0]["id"]
 
         assert first_id != second_id
@@ -278,6 +293,20 @@ class TestSessionThalamus:
         assert any(
             isinstance(e, StreamTextDelta) and e.text == "Working on it." for e in events
         )
+
+    async def test_preload_skips_skill_already_in_history(self):
+        # A skill whose full body is already in context must not be
+        # re-injected — mirrors handle_recall_skill's stub path, so a
+        # later delegate naming the same skill can't duplicate the
+        # procedure (wasted tokens).
+        llm = make_mock_llm()
+        session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
+        session._skill_store = _mock_skill_store()
+
+        session._inject_recalled_skills(["csv-summary"])
+        assert len(session.history) == 2  # tool_use + tool_result appended
+        session._inject_recalled_skills(["csv-summary"])
+        assert len(session.history) == 2  # second preload is a no-op
 
     async def test_thalamus_failure_falls_back_to_planning(self):
         llm = make_mock_llm()

--- a/tests/test_thalamus.py
+++ b/tests/test_thalamus.py
@@ -1,0 +1,341 @@
+"""Tests for the cheap front-model thalamus (ENG-648).
+
+Covers the three layers: history condensation, decision parsing in
+`gate_turn`, and the ChatSession integration (direct answer, delegation
+with skill preload, fail-open fallback, and the off-by-default flag).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.llm.provider import (
+    LLMResponse,
+    StreamComplete,
+    StreamTextDelta,
+    ToolCall,
+    Usage,
+)
+from anton.core.llm.thalamus import (
+    ACTION_DELEGATE,
+    ACTION_RESPOND,
+    condense_history,
+    gate_turn,
+)
+from tests.conftest import make_mock_llm
+
+
+def _response(
+    content: str = "",
+    tool_calls: list[ToolCall] | None = None,
+    stop_reason: str | None = "end_turn",
+) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        tool_calls=tool_calls or [],
+        usage=Usage(input_tokens=10, output_tokens=20),
+        stop_reason=stop_reason,
+    )
+
+
+def _delegate_call(reason: str = "needs tools", skills: list[str] | None = None) -> ToolCall:
+    tc_input: dict = {"reason": reason}
+    if skills is not None:
+        tc_input["skills"] = skills
+    return ToolCall(id="tc_1", name="delegate", input=tc_input)
+
+
+class TestCondenseHistory:
+    def test_tool_blocks_collapse_to_markers(self):
+        history = [
+            {"role": "user", "content": "crunch the numbers"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "On it."},
+                    {"type": "tool_use", "id": "t1", "name": "scratchpad", "input": {}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "x" * 9000}
+                ],
+            },
+            {"role": "assistant", "content": "Done — the mean is 4.2."},
+            {"role": "user", "content": "what was the mean again?"},
+        ]
+        condensed = condense_history(history)
+        assert condensed[0] == {"role": "user", "content": "crunch the numbers"}
+        assert "[ran tool: scratchpad]" in condensed[1]["content"]
+        assert "[tool output omitted]" in condensed[2]["content"]
+        assert "x" * 100 not in condensed[2]["content"]  # payload not leaked
+        assert condensed[-1]["content"] == "what was the mean again?"
+
+    def test_merges_consecutive_same_role_and_truncates(self):
+        history = [
+            {"role": "user", "content": "a"},
+            {"role": "user", "content": "b" * 5000},
+            {"role": "assistant", "content": "ok"},
+        ]
+        condensed = condense_history(history, max_chars=200)
+        assert len(condensed) == 2
+        assert condensed[0]["role"] == "user"
+        assert condensed[0]["content"].startswith("a\n")
+        assert "[… truncated …]" in condensed[0]["content"]
+
+    def test_window_keeps_recent_and_starts_with_user(self):
+        history = []
+        for i in range(20):
+            history.append({"role": "user", "content": f"u{i}"})
+            history.append({"role": "assistant", "content": f"a{i}"})
+        condensed = condense_history(history, max_messages=5)
+        # 5 kept, but the leading assistant left by the cut is dropped
+        assert len(condensed) == 4
+        assert condensed[0]["role"] == "user"
+        assert condensed[-1]["content"] == "a19"
+
+    def test_empty_and_nontext_history(self):
+        assert condense_history([]) == []
+        assert condense_history([{"role": "system", "content": "x"}]) == []
+
+
+class TestGateTurn:
+    async def test_direct_answer(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(return_value=_response("Four."))
+        decision = await gate_turn(llm, history=[{"role": "user", "content": "2+2?"}])
+        assert decision.action == ACTION_RESPOND
+        assert decision.text == "Four."
+
+    async def test_delegate_tool_call_with_skills(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(
+            return_value=_response(
+                tool_calls=[_delegate_call(skills=["csv-summary", "  ", 42, "other"])]
+            )
+        )
+        decision = await gate_turn(llm, history=[{"role": "user", "content": "analyze data.csv"}])
+        assert decision.action == ACTION_DELEGATE
+        assert decision.skills == ["csv-summary", "other"]
+        assert decision.reason == "needs tools"
+
+    async def test_truncated_answer_delegates(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(
+            return_value=_response("a very long answer that got cut", stop_reason="max_tokens")
+        )
+        decision = await gate_turn(llm, history=[{"role": "user", "content": "explain X"}])
+        assert decision.action == ACTION_DELEGATE
+
+    async def test_empty_answer_delegates(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(return_value=_response(""))
+        decision = await gate_turn(llm, history=[{"role": "user", "content": "hm"}])
+        assert decision.action == ACTION_DELEGATE
+
+    async def test_unroutable_history_delegates_without_llm_call(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock()
+        decision = await gate_turn(llm, history=[{"role": "system", "content": "x"}])
+        assert decision.action == ACTION_DELEGATE
+        llm.gate.assert_not_called()
+
+    async def test_skill_summaries_listed_in_prompt(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(return_value=_response("hi"))
+        await gate_turn(
+            llm,
+            history=[{"role": "user", "content": "hi"}],
+            skill_summaries=[{"label": "csv-summary", "description": "Summarize CSVs"}],
+        )
+        system = llm.gate.call_args.kwargs["system"]
+        assert "`csv-summary` — Summarize CSVs" in system
+
+
+def _mock_skill_store():
+    skill = SimpleNamespace(
+        label="csv-summary",
+        name="CSV Summary",
+        description="Summarize CSVs",
+        declarative_md="1. load the CSV\n2. describe it",
+    )
+    store = MagicMock()
+    store.list_summaries.return_value = [
+        {"label": "csv-summary", "description": "Summarize CSVs"}
+    ]
+    store.load.side_effect = lambda label: skill if label == "csv-summary" else None
+    return store
+
+
+class TestSessionThalamus:
+    async def test_thalamus_off_by_default(self):
+        llm = make_mock_llm()
+        llm.plan = AsyncMock(return_value=_response("Hey!"))
+        llm.gate = AsyncMock()
+        session = ChatSession(ChatSessionConfig(llm_client=llm))
+        reply = await session.turn("hi")
+        assert reply == "Hey!"
+        llm.gate.assert_not_called()
+
+    async def test_direct_answer_skips_planning(self):
+        llm = make_mock_llm()
+        llm.plan = AsyncMock()
+        llm.gate = AsyncMock(return_value=_response("Four."))
+        session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
+        reply = await session.turn("what is 2+2?")
+        assert reply == "Four."
+        llm.plan.assert_not_called()
+        assert session.history == [
+            {"role": "user", "content": "what is 2+2?"},
+            {"role": "assistant", "content": "Four."},
+        ]
+
+    async def test_direct_answer_streaming(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(return_value=_response("Four."))
+
+        async def _plan_stream(**kwargs):
+            raise AssertionError("planning model must not be called")
+            yield  # pragma: no cover
+
+        llm.plan_stream = _plan_stream
+        session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
+        events = [e async for e in session.turn_stream("what is 2+2?")]
+        deltas = [e for e in events if isinstance(e, StreamTextDelta)]
+        completes = [e for e in events if isinstance(e, StreamComplete)]
+        assert [d.text for d in deltas] == ["Four."]
+        assert len(completes) == 1
+        assert session.history[-1] == {"role": "assistant", "content": "Four."}
+
+    async def test_delegate_preloads_skills_then_plans(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(
+            return_value=_response(
+                tool_calls=[_delegate_call(skills=["csv-summary", "nonexistent"])]
+            )
+        )
+        llm.plan = AsyncMock(return_value=_response("Here's the summary."))
+        session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
+        session._skill_store = _mock_skill_store()
+
+        reply = await session.turn("summarize data.csv")
+
+        assert reply == "Here's the summary."
+        llm.plan.assert_called_once()
+        # history: user → assistant(recall tool_use) → user(tool_result) → assistant
+        assert len(session.history) == 4
+        tool_use = session.history[1]["content"][0]
+        assert tool_use["name"] == "recall_skill"
+        assert tool_use["input"] == {"label": "csv-summary"}
+        tool_result = session.history[2]["content"][0]
+        assert tool_result["tool_use_id"] == tool_use["id"]
+        assert "1. load the CSV" in tool_result["content"]
+        # only the existing skill was preloaded, and its counter bumped
+        assert len(session.history[1]["content"]) == 1
+        session._skill_store.increment_recommended.assert_called_once_with(
+            "csv-summary", stage=1
+        )
+        # planning saw the preloaded exchange
+        planned_messages = llm.plan.call_args.kwargs["messages"]
+        assert planned_messages[1]["content"][0]["name"] == "recall_skill"
+
+    async def test_preload_ids_unique_across_non_streaming_turns(self):
+        # turn() (unlike turn_stream()) never increments _turn_count, so an
+        # id derived from it would repeat on every call — regression guard
+        # for that.
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(
+            return_value=_response(
+                tool_calls=[_delegate_call(skills=["csv-summary"])]
+            )
+        )
+        llm.plan = AsyncMock(return_value=_response("ok"))
+        session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
+        session._skill_store = _mock_skill_store()
+
+        await session.turn("summarize data.csv")
+        first_id = session.history[1]["content"][0]["id"]
+
+        await session.turn("summarize data.csv again")
+        second_id = session.history[5]["content"][0]["id"]
+
+        assert first_id != second_id
+
+    async def test_delegate_streaming_reaches_planning(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(return_value=_response(tool_calls=[_delegate_call()]))
+
+        async def _plan_stream(**kwargs):
+            yield StreamTextDelta(text="Working on it.")
+            yield StreamComplete(response=_response("Working on it."))
+
+        llm.plan_stream = _plan_stream
+        session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
+        events = [e async for e in session.turn_stream("analyze data.csv")]
+        assert any(
+            isinstance(e, StreamTextDelta) and e.text == "Working on it." for e in events
+        )
+
+    async def test_thalamus_failure_falls_back_to_planning(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(side_effect=RuntimeError("thalamus down"))
+        llm.plan = AsyncMock(return_value=_response("Handled anyway."))
+        session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
+        reply = await session.turn("hi")
+        assert reply == "Handled anyway."
+        llm.plan.assert_called_once()
+
+    async def test_image_turns_skip_thalamus(self):
+        llm = make_mock_llm()
+        llm.gate = AsyncMock()
+        llm.plan = AsyncMock(return_value=_response("Nice chart."))
+        session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
+        reply = await session.turn(
+            [
+                {"type": "text", "text": "what's in this image?"},
+                {"type": "image", "source": {"type": "base64", "data": "…"}},
+            ]
+        )
+        assert reply == "Nice chart."
+        llm.gate.assert_not_called()
+
+
+class TestLLMClientGate:
+    async def test_gate_defaults_to_coding_role(self):
+        from anton.core.llm.client import LLMClient
+
+        planning = AsyncMock()
+        coding = AsyncMock()
+        coding.complete = AsyncMock(return_value=_response("ok"))
+        client = LLMClient(
+            planning_provider=planning,
+            planning_model="big-model",
+            coding_provider=coding,
+            coding_model="small-model",
+        )
+        assert client.router_model == "small-model"
+        await client.gate(system="s", messages=[{"role": "user", "content": "x"}])
+        assert coding.complete.call_args.kwargs["model"] == "small-model"
+        planning.complete.assert_not_called()
+
+    async def test_gate_uses_explicit_router_role(self):
+        from anton.core.llm.client import LLMClient
+
+        planning = AsyncMock()
+        coding = AsyncMock()
+        router = AsyncMock()
+        router.complete = AsyncMock(return_value=_response("ok"))
+        client = LLMClient(
+            planning_provider=planning,
+            planning_model="big-model",
+            coding_provider=coding,
+            coding_model="small-model",
+            router_provider=router,
+            router_model="tiny-model",
+        )
+        await client.gate(system="s", messages=[{"role": "user", "content": "x"}])
+        assert router.complete.call_args.kwargs["model"] == "tiny-model"
+        coding.complete.assert_not_called()

--- a/tests/test_thalamus.py
+++ b/tests/test_thalamus.py
@@ -101,6 +101,18 @@ class TestCondenseHistory:
         assert condense_history([]) == []
         assert condense_history([{"role": "system", "content": "x"}]) == []
 
+    def test_merged_block_respects_max_chars_cap(self):
+        # Point 3: truncation runs AFTER merge, so a block merged from several
+        # near-cap same-role messages still honours the per-entry cap (before
+        # the fix each piece was capped but the merged sum blew past it).
+        history = [{"role": "user", "content": "x" * 1000} for _ in range(5)]
+        max_chars = 200
+        condensed = condense_history(history, max_chars=max_chars)
+        assert len(condensed) == 1  # all merged into one user block
+        assert len(condensed[0]["content"]) <= max_chars
+        # and the whole view is bounded by max_messages * max_chars
+        assert all(len(m["content"]) <= max_chars for m in condensed)
+
 
 class TestGateTurn:
     async def test_direct_answer(self):

--- a/tests/test_thalamus.py
+++ b/tests/test_thalamus.py
@@ -308,6 +308,26 @@ class TestSessionThalamus:
         session._inject_recalled_skills(["csv-summary"])
         assert len(session.history) == 2  # second preload is a no-op
 
+    async def test_gate_usage_counted_on_delegate_streaming(self):
+        # The gate hits every text turn; on delegate its usage must reach the
+        # consumer as its own StreamComplete (like a planning round), or token
+        # counters that sum StreamComplete usage under-report every gate call.
+        llm = make_mock_llm()
+        llm.gate = AsyncMock(return_value=_response(tool_calls=[_delegate_call()]))
+
+        async def _plan_stream(**kwargs):
+            yield StreamTextDelta(text="Working on it.")
+            yield StreamComplete(response=_response("Working on it."))
+
+        llm.plan_stream = _plan_stream
+        session = ChatSession(ChatSessionConfig(llm_client=llm, router_enabled=True))
+        events = [e async for e in session.turn_stream("analyze data.csv")]
+        completes = [e for e in events if isinstance(e, StreamComplete)]
+        # two calls billed: the gate, then the planning round
+        assert len(completes) == 2
+        total_in = sum(e.response.usage.input_tokens for e in completes)
+        assert total_in == 20  # 10 (gate) + 10 (planning)
+
     async def test_thalamus_failure_falls_back_to_planning(self):
         llm = make_mock_llm()
         llm.gate = AsyncMock(side_effect=RuntimeError("thalamus down"))


### PR DESCRIPTION

Moved from https://github.com/mindsdb/anton/pull/239

Adds the **thalamus** — a cheap front-model that every text turn hits first
when `ANTON_ROUTER_ENABLED=true`. It either answers trivial/from-context turns
directly (skipping the full prompt + tool schemas + planning model) or delegates
to the planning model, optionally preloading skills so the cortex doesn't spend
a round on `recall_skill`. **Off by default** until eval'd.

## What
- `anton/core/llm/thalamus.py` — the gate: `condense_history` (text-only view),
  `gate_turn` (decision parsing), `DELEGATE_TOOL`, `ThalamicDecision`. Fails
  *open*: any doubt/error/truncation/empty answer → delegate.
- `LLMClient.gate()` — one cheap gating call on the router role (no
  `native_web_tools`).
- `CoreSettings`: `router_enabled` (default False), `router_max_tokens` (1024).
- `ChatSession`: `_gate_turn` + `_inject_recalled_skills`, wired into both
  `turn()` and `turn_stream()`. Image turns skip the gate. Preloaded skills
  resolve through the same `SkillStore` `recall_skill` uses (built-ins included
  via #244's mechanism) — payload byte-identical to a real recall.

## Naming
Mechanism = **thalamus** (brain-inspired, matches anton's architecture);
config surface stays **`router_*`** (consistent with cowork-server / PR C).