### PR TITLE
ENG-824 + ENG-981: hotfix — UTF-8 belt + compile() surrogate heal (→ main)

### DIFF
--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -22,6 +22,39 @@ from anton.core.settings import CoreSettings
 from anton.core.backends.utils import compute_timeouts
 
 _BOOT_SCRIPT_PATH = Path(__file__).parent / "scratchpad_boot.py"
+
+
+def _read_boot_script() -> str:
+    """Read the boot script as UTF-8 explicitly.
+
+    It contains non-ASCII (…, —), so a host-locale-default read (e.g. GBK on
+    Chinese Windows) crashes with a codec error before the scratchpad can start
+    (ENG-824). Kept as a helper so the explicit encoding is pinned by a test.
+    """
+    return _BOOT_SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+def _utf8_env(base: "os._Environ[str] | dict[str, str]") -> dict[str, str]:
+    """A copy of ``base`` with Python UTF-8 mode forced for the scratchpad
+    subprocess.
+
+    The parent may run under a non-UTF-8 host locale (e.g. GBK/cp936 on
+    Chinese Windows). Without this, the child interpreter inherits that code
+    page and every ``open()``/``print()``/stdio defaults to it — so reading the
+    boot script or emitting non-ASCII output crashes (ENG-824). ``setdefault``
+    so an explicit operator override still wins.
+
+    Only ``PYTHONUTF8`` is set: UTF-8 mode already makes open()/filesystem/stdio
+    UTF-8 with the lenient ``surrogateescape`` stdio handler. We deliberately do
+    NOT also set ``PYTHONIOENCODING`` — a bare value downgrades the stdio error
+    handler back to ``strict`` (verified), which would re-introduce a crash on
+    exotic output rather than round-tripping it.
+    """
+    env = dict(base)
+    env.setdefault("PYTHONUTF8", "1")
+    return env
+
+
 _MAX_OUTPUT = 10_000
 
 
@@ -199,7 +232,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 capture_output=True,
                 timeout=5,
             )
-            return result.returncode == 0 and "ok" in result.stdout.decode()
+            return result.returncode == 0 and "ok" in result.stdout.decode("utf-8", errors="replace")
         except Exception:
             return False
 
@@ -250,7 +283,12 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                     break
             if child_site and parent_site:
                 pth_path = os.path.join(child_site, "_parent_venv.pth")
-                with open(pth_path, "w") as f:
+                # UTF-8 explicitly: a plain open() encodes with the host locale
+                # (e.g. GBK on Chinese Windows), but the child reads .pth files
+                # as UTF-8 under UTF-8 mode — a mismatch corrupts non-ASCII
+                # site-packages paths (same class of bug as the boot script,
+                # ENG-824).
+                with open(pth_path, "w", encoding="utf-8") as f:
                     for sp in parent_site:
                         f.write(sp + "\n")
 
@@ -324,13 +362,15 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         """Write the boot script to a temp file and launch the subprocess."""
         self._ensure_venv()
 
-        boot_code = _BOOT_SCRIPT_PATH.read_text()
+        boot_code = _read_boot_script()
         fd, path = tempfile.mkstemp(suffix=".py", prefix="anton_scratchpad_")
-        os.write(fd, boot_code.encode())
+        os.write(fd, boot_code.encode("utf-8"))
         os.close(fd)
         self._boot_path = path
 
-        env = os.environ.copy()
+        # Force UTF-8 mode in the child so its I/O never depends on the host
+        # code page (ENG-824).
+        env = _utf8_env(os.environ)
         if self._coding_model:
             env["ANTON_SCRATCHPAD_MODEL"] = self._coding_model
         if self._coding_provider:
@@ -490,7 +530,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
             return
 
         payload = code + "\n" + CELL_DELIM + "\n"
-        self._proc.stdin.write(payload.encode())  # type: ignore[union-attr]
+        self._proc.stdin.write(payload.encode("utf-8"))  # type: ignore[union-attr]
         await self._proc.stdin.drain()  # type: ignore[union-attr]
 
         total_timeout, inactivity_timeout = compute_timeouts(estimated_seconds)
@@ -622,7 +662,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 }
                 return
 
-            line = raw.decode().rstrip("\r\n")
+            line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
 
             if line.startswith(PROGRESS_MARKER):
                 current_inactivity = max(
@@ -676,6 +716,9 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            # Same UTF-8 mode as the scratchpad process, so pip/uv output on a
+            # non-UTF-8 host locale doesn't come back as mojibake (ENG-824).
+            env=_utf8_env(os.environ),
         )
         try:
             stdout, _ = await asyncio.wait_for(
@@ -685,7 +728,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
             proc.kill()
             await proc.wait()
             return f"Install timed out after {_install_timeout}s."
-        output = stdout.decode()
+        output = stdout.decode("utf-8", errors="replace")
         if proc.returncode != 0:
             return f"Install failed (exit {proc.returncode}):\n{output}"
         for p in needed:

--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -10,6 +10,7 @@ from anton.core.backends.wire import (
     CELL_DELIM,
     RESULT_START,
     RESULT_END,
+    heal_surrogate_source,
 )
 
 
@@ -735,6 +736,10 @@ while True:
         break
 
     code = "".join(lines)
+    # Heal lone surrogates before compile() — a non-ASCII Windows path byte can
+    # arrive surrogate-escaped over stdin and would crash compile() with
+    # "surrogates not allowed" (ENG-981).
+    code = heal_surrogate_source(code)
     if not code.strip():
         result = {"stdout": "", "stderr": "", "logs": "", "error": None}
         _real_stdout.write(RESULT_START + "\n")

--- a/anton/core/backends/wire.py
+++ b/anton/core/backends/wire.py
@@ -8,3 +8,39 @@ CELL_DELIM = "__ANTON_CELL_END__"
 RESULT_START = "__ANTON_RESULT__"
 RESULT_END = "__ANTON_RESULT_END__"
 PROGRESS_MARKER = "__ANTON_PROGRESS__"
+
+
+def heal_surrogate_source(code: str) -> str:
+    """Return ``code`` with any lone surrogates resolved to valid UTF-8.
+
+    Cell source can arrive carrying lone surrogates (``\\udcXX``): a non-ASCII
+    Windows path byte (e.g. from ``Área de Trabalho`` or an emoji filename) is
+    surrogate-escaped upstream on a non-UTF-8 host and passed through the
+    scratchpad's lenient ``surrogateescape`` stdin. ``compile()`` strict-encodes
+    the source to UTF-8 and rejects a lone surrogate ("surrogates not allowed"),
+    crashing the cell before any user code runs (ENG-981). UTF-8 mode never
+    makes ``compile()`` lenient, so we must clean the source ourselves.
+
+    Strategy, in two steps so a single unrecoverable surrogate can't take down
+    the recoverable ones elsewhere in the same cell (mixed-cell data loss):
+
+    1. ``surrogateescape`` only maps the ``DC80..DCFF`` byte-escape range. Any
+       *other* surrogate (a high/unpaired one) would make the ``surrogateescape``
+       encode raise and force the whole cell down a lossy path — so replace those
+       up front with U+FFFD.
+    2. Re-encode the rest via ``surrogateescape`` to recover the original bytes,
+       then decode UTF-8 with ``errors="replace"``. Byte-escaped halves of a real
+       multibyte character (the common path case) reassemble exactly — the cell
+       compiles *and* references the correct path — while any leftover stray byte
+       becomes U+FFFD in the same pass. Never raises. A no-op for clean source.
+    """
+    if not any("\ud800" <= ch <= "\udfff" for ch in code):
+        return code
+    # Step 1: scrub surrogates outside the escapable DC80..DCFF range.
+    code = "".join(
+        ch if not ("\ud800" <= ch <= "\udfff") or ("\udc80" <= ch <= "\udcff")
+        else "�"
+        for ch in code
+    )
+    # Step 2: recover DC80..DCFF byte-escapes; replace anything still invalid.
+    return code.encode("utf-8", "surrogateescape").decode("utf-8", "replace")

--- a/tests/test_scratchpad_utf8.py
+++ b/tests/test_scratchpad_utf8.py
@@ -1,0 +1,90 @@
+"""ENG-824 regression: the scratchpad must be UTF-8-safe regardless of the
+host locale code page (e.g. GBK/cp936 on Chinese Windows)."""
+
+from __future__ import annotations
+
+import pytest
+
+import anton.core.backends.local as local
+
+
+def test_utf8_env_forces_utf8_mode():
+    env = local._utf8_env({"FOO": "bar"})
+    assert env["PYTHONUTF8"] == "1"
+    assert env["FOO"] == "bar"  # base is preserved
+    # Deliberately NOT set — a bare PYTHONIOENCODING makes stdio strict, which
+    # would re-introduce a crash on exotic output (UTF-8 mode already covers it).
+    assert "PYTHONIOENCODING" not in env
+
+
+def test_utf8_env_respects_explicit_override():
+    # setdefault: an operator who deliberately set UTF-8 mode off keeps it.
+    env = local._utf8_env({"PYTHONUTF8": "0"})
+    assert env["PYTHONUTF8"] == "0"
+
+
+def test_boot_script_content_requires_utf8():
+    # The boot script contains non-ASCII (…, —). Reading it with a non-UTF-8
+    # host-locale default (GBK on Chinese Windows) throws a UnicodeDecodeError
+    # before the scratchpad can start — the exact ENG-824 crash. Guard that (a)
+    # UTF-8 decodes cleanly and (b) the content genuinely needs UTF-8, so a
+    # locale-default read is unsafe and must not regress.
+    raw = local._BOOT_SCRIPT_PATH.read_bytes()
+    raw.decode("utf-8")  # the fix: explicit UTF-8 succeeds
+    with pytest.raises(UnicodeDecodeError):
+        raw.decode("gbk")  # a GBK-locale default read would crash
+
+
+def test_boot_script_is_read_as_utf8(monkeypatch):
+    # Pin the *read*, not just the file's bytes: if someone drops the explicit
+    # encoding="utf-8" (reverting to a host-locale default), this fails even on a
+    # UTF-8 CI box — where a bytes-only check would still pass. Spy on
+    # Path.read_text and assert the boot-script read passes encoding="utf-8".
+    seen = {}
+    real_read_text = local.Path.read_text
+
+    def spy(self, *args, **kwargs):
+        if self == local._BOOT_SCRIPT_PATH:
+            seen["encoding"] = kwargs.get("encoding")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(local.Path, "read_text", spy)
+    assert local._read_boot_script()  # exercises the real read path
+    assert seen.get("encoding") == "utf-8"
+
+
+def test_parent_venv_pth_is_written_as_utf8(tmp_path, monkeypatch):
+    # Sibling of the boot-script read: the child reads .pth files as UTF-8 under
+    # UTF-8 mode, so the parent must *write* _parent_venv.pth as UTF-8 or a
+    # non-ASCII site-packages path (e.g. a CJK Windows user dir) corrupts.
+    # Pin the write encoding without spinning up a real venv.
+    import builtins
+    import site
+
+    # Force the "running inside a venv" branch deterministically.
+    monkeypatch.setattr(local.sys, "prefix", "/venv")
+    monkeypatch.setattr(local.sys, "base_prefix", "/usr")
+    monkeypatch.setattr(site, "getsitepackages", lambda: ["/parent/site-packages"])
+
+    child_site = tmp_path / "lib" / "python3.11" / "site-packages"
+    child_site.mkdir(parents=True)
+
+    # Bypass the heavy __init__ (no network/subprocess) — the method only reads
+    # self._venv_dir.
+    runtime = object.__new__(local.LocalScratchpadRuntime)
+    runtime._venv_dir = str(tmp_path)
+
+    seen = {}
+    real_open = builtins.open
+
+    def spy_open(file, *args, **kwargs):
+        if str(file).endswith("_parent_venv.pth"):
+            seen["encoding"] = kwargs.get("encoding")
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", spy_open)
+    runtime._setup_parent_site_packages()
+
+    assert seen.get("encoding") == "utf-8"  # assert before any later read
+    written = (child_site / "_parent_venv.pth").read_text(encoding="utf-8")
+    assert "/parent/site-packages" in written

--- a/tests/test_scratchpad_utf8.py
+++ b/tests/test_scratchpad_utf8.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import pytest
 
 import anton.core.backends.local as local
+import anton.core.backends.wire as wire
 
 
 def test_utf8_env_forces_utf8_mode():
@@ -88,3 +89,59 @@ def test_parent_venv_pth_is_written_as_utf8(tmp_path, monkeypatch):
     assert seen.get("encoding") == "utf-8"  # assert before any later read
     written = (child_site / "_parent_venv.pth").read_text(encoding="utf-8")
     assert "/parent/site-packages" in written
+
+
+# ── ENG-981: heal lone surrogates before compile() (folded into the belt hotfix)
+#
+# The scratchpad child crashes at compile() on a lone surrogate in the cell
+# source — a non-ASCII Windows path byte (Área de Trabalho, an emoji) surrogate-
+# escaped upstream and passed through the belt's lenient surrogateescape stdin.
+# compile() is always strict, so heal_surrogate_source() cleans the source first.
+
+def test_heal_recovers_byte_escaped_multibyte_path():
+    mangled = 'open(r"C:\\Users\\\udcc3\udc81rea\\f.html")\n'   # "Área" split into surrogates
+    healed = wire.heal_surrogate_source(mangled)
+    assert healed == 'open(r"C:\\Users\\Área\\f.html")\n'
+    compile(healed, "<scratchpad>", "exec")
+
+
+def test_heal_recovers_escaped_emoji():
+    mangled = 'x = "\udcf0\udc9f\udc8e\udc89"\n'                 # 🎉 = f0 9f 8e 89, escaped
+    healed = wire.heal_surrogate_source(mangled)
+    assert healed == 'x = "🎉"\n'
+    compile(healed, "<scratchpad>", "exec")
+
+
+def test_heal_preserves_recoverable_char_in_mixed_cell():
+    mixed = 'p = r"C:\\\udcc3\udc81rea"  # noqa\nq = "\udc81"\n'
+    healed = wire.heal_surrogate_source(mixed)
+    assert "Área" in healed
+    assert not any("\ud800" <= ch <= "\udfff" for ch in healed)
+    compile(healed, "<scratchpad>", "exec")
+
+
+def test_heal_preserves_recoverable_char_beside_unmappable_surrogate():
+    # A recoverable byte-escaped "Á" and a high/unpaired surrogate (\ud800,
+    # outside DC80..DCFF) in the same cell: the unmappable one is scrubbed WITHOUT
+    # dragging "Á" into a full-cell scrub.
+    mixed = 'p = r"C:\\\udcc3\udc81rea"\nq = "\ud800"\n'
+    healed = wire.heal_surrogate_source(mixed)
+    assert "Área" in healed
+    assert not any("\ud800" <= ch <= "\udfff" for ch in healed)
+    compile(healed, "<scratchpad>", "exec")
+
+
+def test_heal_scrubs_truly_lone_surrogate_so_compile_succeeds():
+    healed = wire.heal_surrogate_source('x = "a\udc81b"\n')
+    assert "\udc81" not in healed
+    compile(healed, "<scratchpad>", "exec")
+
+
+def test_heal_is_noop_on_clean_source():
+    clean = 'print("Área de Trabalho 🎉")\n'
+    assert wire.heal_surrogate_source(clean) == clean
+
+
+def test_bare_compile_on_lone_surrogate_still_raises():
+    with pytest.raises(UnicodeEncodeError):
+        compile('x = "a\udc81b"\n', "<scratchpad>", "exec")


### PR DESCRIPTION
## Hotfix to prod (`main`) — the complete anton UTF-8 crash fix
Carries **both** halves so `main` isn't left half-fixed:

**1. ENG-824 belt** — cherry-pick of #253 (`86b5d13`, merged to `staging`). `_utf8_env()` sets `PYTHONUTF8=1` on the scratchpad subprocess + explicit UTF-8 boot-script/`.pth` reads → a non-UTF-8 Windows locale (GBK/cp936) no longer crashes on the **decode** side.

**2. ENG-981 heal** — the **encode/compile()** side, a **live prod crash** (sabrina/eddie/**tim** on desktop). A non-ASCII Windows path byte (`Área de Trabalho`, an emoji) arrives surrogate-escaped over the belt's lenient stdin and crashes `compile()` with `surrogates not allowed`. `heal_surrogate_source()` cleans the cell source right before `compile()`.

### Why folded (not a separate cherry-pick)
ENG-981's staging PR (#268, **approved** by @pnewsam) also edits the ENG-940 (#263) transport tests, and **#263 is intentionally not on `main`** (chat.py divergence). A straight cherry-pick would drag that entanglement onto prod. So the **curated** ENG-981 fix is folded here: `wire.py` heal (identical to the merged staging version) + the `scratchpad_boot.py` call + the heal **unit** tests only.

### Verified
- `tests/test_scratchpad_utf8.py` 12/12 green on this branch; `heal_surrogate_source` fuzzed clean over 200k mixed inputs (total, no residual surrogate, idempotent).
- Clean cherry-pick/compose onto `main` (belt + heal sites are stable across `main`/`staging`).

### Security
No new surface — env-var pin + encoding normalization of already-received source; no new input, no trust-boundary change.

### Ships with / order
Land together with **cowork#459** (sidecar belt) — the belt spans both process layers.

### ⚠️ Deploy
Merging to `main` is the git step only; sabrina/eddie/tim are **desktop** users, so a **desktop app build from the release ref** must ship for them to get it.

Do not merge without human review — protected branch. Related: ENG-824, ENG-981, ENG-940 (#263, staging-only).