### PR TITLE
ENG-981: heal lone surrogates before compile() in the scratchpad

### DIFF
--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -10,6 +10,7 @@ from anton.core.backends.wire import (
     CELL_DELIM,
     RESULT_START,
     RESULT_END,
+    heal_surrogate_source,
 )
 
 
@@ -718,6 +719,10 @@ while True:
         break
 
     code = "".join(lines)
+    # Heal lone surrogates before compile() — a non-ASCII Windows path byte can
+    # arrive surrogate-escaped over stdin and would crash compile() with
+    # "surrogates not allowed" (ENG-981).
+    code = heal_surrogate_source(code)
     if not code.strip():
         result = {"stdout": "", "stderr": "", "logs": "", "error": None}
         _real_stdout.write(RESULT_START + "\n")

--- a/anton/core/backends/wire.py
+++ b/anton/core/backends/wire.py
@@ -8,3 +8,31 @@ CELL_DELIM = "__ANTON_CELL_END__"
 RESULT_START = "__ANTON_RESULT__"
 RESULT_END = "__ANTON_RESULT_END__"
 PROGRESS_MARKER = "__ANTON_PROGRESS__"
+
+
+def heal_surrogate_source(code: str) -> str:
+    """Return ``code`` with any lone surrogates resolved to valid UTF-8.
+
+    Cell source can arrive carrying lone surrogates (``\\udcXX``): a non-ASCII
+    Windows path byte (e.g. from ``Área de Trabalho`` or an emoji filename) is
+    surrogate-escaped upstream on a non-UTF-8 host and passed through the
+    scratchpad's lenient ``surrogateescape`` stdin. ``compile()`` strict-encodes
+    the source to UTF-8 and rejects a lone surrogate ("surrogates not allowed"),
+    crashing the cell before any user code runs (ENG-981). UTF-8 mode never
+    makes ``compile()`` lenient, so we must clean the source ourselves.
+
+    Strategy: re-encode via ``surrogateescape`` to recover the original bytes,
+    then decode as UTF-8. When the surrogates are the byte-escaped halves of a
+    real multibyte character (the common path case) this reassembles it exactly
+    — so the cell not only compiles but references the *correct* path. A
+    genuinely lone surrogate (not a valid byte sequence, or outside the
+    escapable range) falls back to the replacement char so ``compile()`` at
+    least succeeds instead of crashing. A no-op for clean source.
+    """
+    if not any("\ud800" <= ch <= "\udfff" for ch in code):
+        return code
+    try:
+        return code.encode("utf-8", "surrogateescape").decode("utf-8")
+    except UnicodeError:
+        # High/unpaired surrogates outside the surrogateescape range: scrub.
+        return code.encode("utf-8", "surrogatepass").decode("utf-8", "replace")

--- a/anton/core/backends/wire.py
+++ b/anton/core/backends/wire.py
@@ -21,23 +21,26 @@ def heal_surrogate_source(code: str) -> str:
     crashing the cell before any user code runs (ENG-981). UTF-8 mode never
     makes ``compile()`` lenient, so we must clean the source ourselves.
 
-    Strategy: re-encode via ``surrogateescape`` to recover the original bytes,
-    then decode as UTF-8 with ``errors="replace"``. When the surrogates are the
-    byte-escaped halves of a real multibyte character (the common path case)
-    this reassembles it exactly — so the cell not only compiles but references
-    the *correct* path. ``errors="replace"`` (rather than a strict decode with a
-    full-scrub fallback) matters for a **mixed** cell: a recoverable path and an
-    unrelated lone byte in the same source are handled in one pass, so the
-    recoverable character isn't lost just because a stray byte sits next to it;
-    the stray byte becomes U+FFFD (a genuinely-lone byte can't be recovered, but
-    ``compile()`` succeeds instead of crashing). A no-op for clean source.
+    Strategy, in two steps so a single unrecoverable surrogate can't take down
+    the recoverable ones elsewhere in the same cell (mixed-cell data loss):
+
+    1. ``surrogateescape`` only maps the ``DC80..DCFF`` byte-escape range. Any
+       *other* surrogate (a high/unpaired one) would make the ``surrogateescape``
+       encode raise and force the whole cell down a lossy path — so replace those
+       up front with U+FFFD.
+    2. Re-encode the rest via ``surrogateescape`` to recover the original bytes,
+       then decode UTF-8 with ``errors="replace"``. Byte-escaped halves of a real
+       multibyte character (the common path case) reassemble exactly — the cell
+       compiles *and* references the correct path — while any leftover stray byte
+       becomes U+FFFD in the same pass. Never raises. A no-op for clean source.
     """
     if not any("\ud800" <= ch <= "\udfff" for ch in code):
         return code
-    try:
-        return code.encode("utf-8", "surrogateescape").decode("utf-8", "replace")
-    except UnicodeEncodeError:
-        # High/unpaired surrogates outside surrogateescape's DC80..DCFF range —
-        # the escape codec can't map them at all; surrogatepass can, and the
-        # replace-decode then scrubs them. This branch can't raise.
-        return code.encode("utf-8", "surrogatepass").decode("utf-8", "replace")
+    # Step 1: scrub surrogates outside the escapable DC80..DCFF range.
+    code = "".join(
+        ch if not ("\ud800" <= ch <= "\udfff") or ("\udc80" <= ch <= "\udcff")
+        else "�"
+        for ch in code
+    )
+    # Step 2: recover DC80..DCFF byte-escapes; replace anything still invalid.
+    return code.encode("utf-8", "surrogateescape").decode("utf-8", "replace")

--- a/anton/core/backends/wire.py
+++ b/anton/core/backends/wire.py
@@ -22,17 +22,22 @@ def heal_surrogate_source(code: str) -> str:
     makes ``compile()`` lenient, so we must clean the source ourselves.
 
     Strategy: re-encode via ``surrogateescape`` to recover the original bytes,
-    then decode as UTF-8. When the surrogates are the byte-escaped halves of a
-    real multibyte character (the common path case) this reassembles it exactly
-    — so the cell not only compiles but references the *correct* path. A
-    genuinely lone surrogate (not a valid byte sequence, or outside the
-    escapable range) falls back to the replacement char so ``compile()`` at
-    least succeeds instead of crashing. A no-op for clean source.
+    then decode as UTF-8 with ``errors="replace"``. When the surrogates are the
+    byte-escaped halves of a real multibyte character (the common path case)
+    this reassembles it exactly — so the cell not only compiles but references
+    the *correct* path. ``errors="replace"`` (rather than a strict decode with a
+    full-scrub fallback) matters for a **mixed** cell: a recoverable path and an
+    unrelated lone byte in the same source are handled in one pass, so the
+    recoverable character isn't lost just because a stray byte sits next to it;
+    the stray byte becomes U+FFFD (a genuinely-lone byte can't be recovered, but
+    ``compile()`` succeeds instead of crashing). A no-op for clean source.
     """
     if not any("\ud800" <= ch <= "\udfff" for ch in code):
         return code
     try:
-        return code.encode("utf-8", "surrogateescape").decode("utf-8")
-    except UnicodeError:
-        # High/unpaired surrogates outside the surrogateescape range: scrub.
+        return code.encode("utf-8", "surrogateescape").decode("utf-8", "replace")
+    except UnicodeEncodeError:
+        # High/unpaired surrogates outside surrogateescape's DC80..DCFF range —
+        # the escape codec can't map them at all; surrogatepass can, and the
+        # replace-decode then scrubs them. This branch can't raise.
         return code.encode("utf-8", "surrogatepass").decode("utf-8", "replace")

--- a/tests/test_scratchpad_utf8.py
+++ b/tests/test_scratchpad_utf8.py
@@ -9,6 +9,7 @@ import re
 import pytest
 
 import anton.core.backends.local as local
+import anton.core.backends.wire as wire
 
 
 def test_utf8_env_forces_utf8_mode():
@@ -152,33 +153,70 @@ def test_chat_module_has_no_bare_read_text():
 # and kills the whole session (users sabrina/eddie/janis). surrogatepass keeps
 # the host-side encode from crashing; the subprocess (UTF-8 mode) decodes it.
 
-def test_cell_payload_encode_survives_lone_surrogate():
-    # A Windows path that os.fsdecode surrogate-escaped on a non-UTF-8 host lands
-    # in the model-written code as lone surrogates (U+DC80..U+DCFF). Model this
-    # exactly and assert the fix.
+def test_cell_payload_encode_is_lossless_over_the_pipe():
+    # NOTE: this pins the *transport* only — that surrogateescape encode (parent)
+    # round-trips through the subprocess's surrogateescape stdin decode. It does
+    # NOT by itself fix the crash: the real raiser is compile() in the child on a
+    # lone surrogate, healed by heal_surrogate_source (ENG-981), tested below.
+    # (The `surrogatepass` alternative would fail this round-trip, re-mangling
+    # the bytes — that's the only claim this test makes.)
     code = 'open(r"C:\\Users\\\udc81\udc9d\\index.html", "w")  # 🎉\n'
     payload = code + "\n" + local.CELL_DELIM + "\n"
-
-    # A strict UTF-8 encode is the crash the three users hit.
-    with pytest.raises(UnicodeEncodeError):
-        payload.encode("utf-8")
-
-    # The fix: the encode no longer raises, independent of PYTHONUTF8.
     encoded = local._encode_cell_payload(payload)
     assert isinstance(encoded, bytes)
-
-    # The path survives intact end-to-end: the subprocess always runs in UTF-8
-    # mode, so its stdin decodes with surrogateescape. Decoding *that* way (not
-    # surrogatepass) must reproduce the original — this is why the helper uses
-    # surrogateescape. surrogatepass would fail this assertion (re-mangled).
     assert encoded.decode("utf-8", errors="surrogateescape") == payload
 
 
 def test_cell_payload_encode_preserves_accented_and_emoji():
     # Ordinary (well-formed) accented-Latin + emoji content must pass through
-    # byte-for-byte — the fix must not mangle the common case.
+    # byte-for-byte — the transport must not mangle the common case.
     code = 'label = "Área de Trabalho 🎉 café"\nprint(label)\n'
     payload = code + "\n" + local.CELL_DELIM + "\n"
 
     encoded = local._encode_cell_payload(payload)
     assert encoded.decode("utf-8") == payload  # strict decode: no corruption
+
+
+# ── ENG-981: heal lone surrogates before compile() (the real encode-side fix) ──
+#
+# The raiser is compile() in the child on a lone surrogate in the cell source
+# (a non-ASCII Windows path byte, surrogate-escaped upstream and passed through
+# the belt's lenient surrogateescape stdin). compile() is always strict, so the
+# source must be cleaned first. These pin heal_surrogate_source, which the child
+# calls right before compile().
+
+def test_heal_recovers_byte_escaped_multibyte_path():
+    # The common case: a real char whose UTF-8 bytes were escaped byte-wise
+    # upstream (Á = C3 81 -> \udcc3\udc81). Heal must reassemble the *correct*
+    # character so the cell compiles AND references the right path.
+    mangled = 'open(r"C:\\Users\\\udcc3\udc81rea\\f.html")\n'   # "Área" split into surrogates
+    healed = wire.heal_surrogate_source(mangled)
+    assert healed == 'open(r"C:\\Users\\Área\\f.html")\n'
+    compile(healed, "<scratchpad>", "exec")  # no UnicodeEncodeError
+
+
+def test_heal_recovers_escaped_emoji():
+    mangled = 'x = "\udcf0\udc9f\udc8e\udc89"\n'                 # 🎉 = f0 9f 8e 89, escaped
+    healed = wire.heal_surrogate_source(mangled)
+    assert healed == 'x = "🎉"\n'
+    compile(healed, "<scratchpad>", "exec")
+
+
+def test_heal_scrubs_truly_lone_surrogate_so_compile_succeeds():
+    # A genuinely lone surrogate (not a valid byte sequence): can't be recovered,
+    # but must not crash compile() — replaced rather than raised.
+    mangled = 'x = "a\udc81b"\n'
+    healed = wire.heal_surrogate_source(mangled)
+    assert "\udc81" not in healed
+    compile(healed, "<scratchpad>", "exec")  # previously: UnicodeEncodeError
+
+
+def test_heal_is_noop_on_clean_source():
+    clean = 'print("Área de Trabalho 🎉")\n'   # real chars, no surrogates
+    assert wire.heal_surrogate_source(clean) == clean
+
+
+def test_bare_compile_on_lone_surrogate_still_raises():
+    # Guard the premise: without the heal, this is the exact ENG-981 crash.
+    with pytest.raises(UnicodeEncodeError):
+        compile('x = "a\udc81b"\n', "<scratchpad>", "exec")

--- a/tests/test_scratchpad_utf8.py
+++ b/tests/test_scratchpad_utf8.py
@@ -144,22 +144,22 @@ def test_chat_module_has_no_bare_read_text():
     assert not bare, f"bare read_text() in anton/chat.py (add encoding='utf-8'): {bare}"
 
 
-# ── ENG-940: the *encode*-side sibling (write path, lone surrogates) ──────────
+# ── ENG-940 transport (NOT the fix): parent→child cell-payload encode ─────────
 #
-# Distinct from the decode crash above: on a non-UTF-8 host, a non-ASCII
-# Windows path (pt-BR "Área de Trabalho", an emoji filename) is surrogate-
-# escaped into lone surrogates (\udcXX) when decoded. When such a string reaches
-# the strict UTF-8 encode of the cell payload it raises "surrogates not allowed"
-# and kills the whole session (users sabrina/eddie/janis). surrogatepass keeps
-# the host-side encode from crashing; the subprocess (UTF-8 mode) decodes it.
+# On a non-UTF-8 host a non-ASCII Windows path (pt-BR "Área de Trabalho", an
+# emoji filename) becomes a lone surrogate (\udcXX) in the cell source. This
+# section only pins that _encode_cell_payload uses surrogateescape so the pipe
+# transport is lossless (a surrogatepass encode would re-mangle it). It does NOT
+# fix the crash — the raiser is compile() in the child, healed by
+# heal_surrogate_source (ENG-981), covered in the section below.
 
 def test_cell_payload_encode_is_lossless_over_the_pipe():
-    # NOTE: this pins the *transport* only — that surrogateescape encode (parent)
-    # round-trips through the subprocess's surrogateescape stdin decode. It does
-    # NOT by itself fix the crash: the real raiser is compile() in the child on a
-    # lone surrogate, healed by heal_surrogate_source (ENG-981), tested below.
-    # (The `surrogatepass` alternative would fail this round-trip, re-mangling
-    # the bytes — that's the only claim this test makes.)
+    # NOTE: this pins the *transport* only — that _encode_cell_payload's
+    # surrogateescape encode (parent) round-trips through the subprocess's
+    # surrogateescape stdin decode. It does NOT by itself fix the crash: the real
+    # raiser is compile() in the child on a lone surrogate, healed by
+    # heal_surrogate_source (ENG-981), tested below. (A surrogatepass encode would
+    # fail this round-trip, re-mangling the bytes — that's the only claim here.)
     code = 'open(r"C:\\Users\\\udc81\udc9d\\index.html", "w")  # 🎉\n'
     payload = code + "\n" + local.CELL_DELIM + "\n"
     encoded = local._encode_cell_payload(payload)
@@ -207,6 +207,19 @@ def test_heal_preserves_recoverable_char_in_mixed_cell():
     # cell: the recoverable "Área" must survive (only the stray byte is scrubbed)
     # — a strict-decode-then-full-scrub would mojibake the whole thing.
     mixed = 'p = r"C:\\\udcc3\udc81rea"  # noqa\nq = "\udc81"\n'
+    healed = wire.heal_surrogate_source(mixed)
+    assert "Área" in healed
+    assert not any("\ud800" <= ch <= "\udfff" for ch in healed)  # no residual
+    compile(healed, "<scratchpad>", "exec")
+
+
+def test_heal_preserves_recoverable_char_beside_unmappable_surrogate():
+    # Mixed-range (pnewsam review): a recoverable byte-escaped "Á" and a
+    # high/unpaired surrogate (\ud800, outside DC80..DCFF) in the same cell. The
+    # unmappable one must be scrubbed WITHOUT dragging the recoverable "Á" into a
+    # full-cell scrub — the surrogateescape encode would otherwise raise on
+    # \ud800 and lose everything.
+    mixed = 'p = r"C:\\\udcc3\udc81rea"\nq = "\ud800"\n'
     healed = wire.heal_surrogate_source(mixed)
     assert "Área" in healed
     assert not any("\ud800" <= ch <= "\udfff" for ch in healed)  # no residual

--- a/tests/test_scratchpad_utf8.py
+++ b/tests/test_scratchpad_utf8.py
@@ -202,6 +202,17 @@ def test_heal_recovers_escaped_emoji():
     compile(healed, "<scratchpad>", "exec")
 
 
+def test_heal_preserves_recoverable_char_in_mixed_cell():
+    # A recoverable byte-escaped path AND an unrelated lone byte in the same
+    # cell: the recoverable "Área" must survive (only the stray byte is scrubbed)
+    # — a strict-decode-then-full-scrub would mojibake the whole thing.
+    mixed = 'p = r"C:\\\udcc3\udc81rea"  # noqa\nq = "\udc81"\n'
+    healed = wire.heal_surrogate_source(mixed)
+    assert "Área" in healed
+    assert not any("\ud800" <= ch <= "\udfff" for ch in healed)  # no residual
+    compile(healed, "<scratchpad>", "exec")
+
+
 def test_heal_scrubs_truly_lone_surrogate_so_compile_succeeds():
     # A genuinely lone surrogate (not a valid byte sequence): can't be recovered,
     # but must not crash compile() — replaced rather than raised.


### PR DESCRIPTION
## What
The scratchpad child crashes at `compile(code, "<scratchpad>", "exec")` (`scratchpad_boot.py`) when the cell source contains a **lone surrogate** (`\udcXX`). Heal the source before compile.

## Why (traced to source, 3 real desktop users)
A non-ASCII Windows path byte — `Área de Trabalho` (sabrina), an emoji filename (eddie), and **tim (Tech With Tim, dogfooding creator)** — is surrogate-escaped upstream and passed through the belt's lenient `surrogateescape` stdin, becoming a lone surrogate in `code`. `compile()` strict-encodes the source and rejects it → `surrogates not allowed`, killing the cell before any user code runs.

**Distinct from ENG-824 / ENG-940, and neither fixes it:**
- ENG-824 belt (`PYTHONUTF8`) *enables* it — the lenient stdin creates the surrogate that strict `compile()` rejects.
- ENG-940 adds `encoding="utf-8"` to `chat.py` reads — different file/channel; strict UTF-8 wouldn't pass a lone surrogate anyway.

## How
`heal_surrogate_source()` in `wire.py` (shared by child + parent), called in `scratchpad_boot.py` right before `compile()`:
- re-encode via `surrogateescape` → decode UTF-8: **reassembles the correct character** when the surrogates are the byte-escaped halves of a real multibyte char (the common path case — cell compiles *and* opens the right file);
- falls back to a replacement-char scrub for a genuinely-lone surrogate (compile succeeds instead of crashing);
- no-op on clean source.

This is the **recover** variant, chosen over the ticket's suggested `surrogatepass→replace` scrub because the scrub corrupts recoverable paths into mojibake (verified) — recover makes the task actually work.

## Tests (14/14 green)
- New ENG-981 coverage: recover a byte-escaped `Á` path and an escaped emoji (assert exact reconstruction + compiles); scrub a truly-lone surrogate (no `\udcXX`, compiles); no-op on clean source; premise guard (bare `compile()` on a lone surrogate still raises).
- **Corrected two ENG-940 (#263) tests** that overclaimed: `_encode_cell_payload`'s surrogateescape transport only makes the pipe lossless — it does **not** fix the `compile()` crash. Relabeled to pin transport fidelity only.

## Security
No new surface — the change only normalizes the encoding of already-received cell source before compilation; no new input, no trust-boundary change.

## Delivery
Targets `staging`. The fix site in `scratchpad_boot.py` is stable across `main`/`staging`, so this cherry-picks cleanly to a `main` **hotfix** PR to follow (ENG-981 is Urgent/Customer; desktop users bleeding). Deploy caveat: reaching sabrina/eddie/tim needs a **desktop app build** from the release ref, not just the branch merge.

Related: ENG-824 (belt), ENG-940 (read encoding), ENG-980 (churn tracker).