### PR TITLE
fix for eng-845

### DIFF
--- a/anton/core/datasources/data_vault.py
+++ b/anton/core/datasources/data_vault.py
@@ -235,7 +235,7 @@ class LocalDataVault:
         tmp = path.with_suffix(".tmp")
         tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
         tmp.chmod(0o600)
-        tmp.rename(path)
+        tmp.replace(path)
         return path
 
     def load(self, engine: str, name: str) -> dict[str, str] | None:


### PR DESCRIPTION
Linear ticket: https://linear.app/mindsdb/issue/ENG-845/reinstall-fails-due-to-existing-google-drive-data-vault-file-conflict

Another Linear ticket fix here: https://linear.app/mindsdb/issue/ENG-902/datavaultsave-crashes-on-windows-with-fileexistserror-winerror-183