### PR TITLE
Feat/eng 648 enable router model

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1927,7 +1927,7 @@ class ChatSession:
             routed_direct = False
             if self._router_enabled and isinstance(user_input, str):
                 decision = await self._gate_turn()
-                1/0
+
                 if decision is not None and decision.action == ACTION_RESPOND:
                     self._append_history(
                         {"role": "assistant", "content": decision.text}

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1927,6 +1927,7 @@ class ChatSession:
             routed_direct = False
             if self._router_enabled and isinstance(user_input, str):
                 decision = await self._gate_turn()
+                1/0
                 if decision is not None and decision.action == ACTION_RESPOND:
                     self._append_history(
                         {"role": "assistant", "content": decision.text}

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1927,7 +1927,6 @@ class ChatSession:
             routed_direct = False
             if self._router_enabled and isinstance(user_input, str):
                 decision = await self._gate_turn()
-
                 if decision is not None and decision.action == ACTION_RESPOND:
                     self._append_history(
                         {"role": "assistant", "content": decision.text}

--- a/anton/core/settings.py
+++ b/anton/core/settings.py
@@ -9,9 +9,9 @@ class CoreSettings(BaseSettings):
     # turn first hits the router model, which either answers trivial/from-
     # context requests directly or delegates to the planning model (optionally
     # preloading skills). The mechanism is the "thalamus" (see
-    # anton/core/llm/thalamus.py); the user-facing knobs stay "router". Off by
-    # default until evaluated; flip with ANTON_ROUTER_ENABLED=true.
-    router_enabled: bool = False
+    # anton/core/llm/thalamus.py); the user-facing knobs stay "router". On by
+    # default; disable with ANTON_ROUTER_ENABLED=false.
+    router_enabled: bool = True
     # Output budget for the gating call. Deliberately small: a direct
     # answer that doesn't fit here is evidence the turn wasn't trivial,
     # and the router treats truncation as "delegate".

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,19 @@ def make_mock_llm() -> AsyncMock:
     # Default test posture: no native web tools — fallback tools also off
     # unless a specific test configures otherwise via ChatSessionConfig.
     mock.planning_provider.native_web_tools = MagicMock(return_value=set())
+    # Router is on by default (ANTON_ROUTER_ENABLED). Give the gate a
+    # delegate-by-default response so tests that only exercise the planning
+    # model don't have to configure it — the turn falls straight through to
+    # `plan`/`plan_stream`, exactly as before the router existed. Tests that
+    # assert routing behavior override `mock.gate` explicitly.
+    mock.gate = AsyncMock(
+        return_value=LLMResponse(
+            content="",
+            tool_calls=[],
+            usage=Usage(input_tokens=0, output_tokens=0),
+            stop_reason="end_turn",
+        )
+    )
     return mock
 
 

--- a/tests/e2e/stub_server.py
+++ b/tests/e2e/stub_server.py
@@ -177,6 +177,16 @@ class StubServer:
                 except Exception:
                     body = {}
 
+                # Router gate (ENG-648): the thalamus call carries exactly one
+                # tool, `delegate`. Answer it with a canned delegate so the turn
+                # falls through to the planning model, and neither log it nor
+                # consume the scenario queue — keeping the router transparent to
+                # scenarios written before it existed. Routing itself is covered
+                # by the unit tests.
+                if _is_gate_request(body):
+                    _send_gate_delegate(self, body)
+                    return
+
                 with stub._lock:
                     stub._log.append(body)
 
@@ -198,6 +208,26 @@ class StubServer:
                 pass  # suppress server access logs
 
         return Handler
+
+
+def _is_gate_request(body: dict) -> bool:
+    """True for the router's thalamus call — its only tool is `delegate`."""
+    tools = body.get("tools") or []
+    names = {(t.get("function") or {}).get("name") for t in tools if isinstance(t, dict)}
+    return names == {"delegate"}
+
+
+def _send_gate_delegate(handler: BaseHTTPRequestHandler, body: dict) -> None:
+    """Answer a gate request with a delegate tool call (hand off to planning)."""
+    resp = _Response(tool_calls=[{
+        "id": f"call_{uuid.uuid4().hex[:8]}",
+        "name": "delegate",
+        "arguments": {"reason": "stub: always delegate"},
+    }])
+    if bool(body.get("stream", False)):
+        _send_sse(handler, resp)
+    else:
+        _send_json(handler, resp)
 
 
 def _send_sse(handler: BaseHTTPRequestHandler, resp: _Response) -> None:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -93,13 +93,15 @@ class TestChatSessionStreaming:
         async for event in session.turn_stream("hi"):
             events.append(event)
 
-        # Should have 2 text deltas + 1 complete
+        # 2 text deltas from planning. Completes: the router gate emits its
+        # own (delegate) StreamComplete for token accounting, then planning
+        # emits the final one — the last carries the answer.
         text_deltas = [e for e in events if isinstance(e, StreamTextDelta)]
         completes = [e for e in events if isinstance(e, StreamComplete)]
         assert len(text_deltas) == 2
         assert text_deltas[0].text == "Hello "
         assert text_deltas[1].text == "world!"
-        assert len(completes) == 1
+        assert completes[-1].response.content == "Hello world!"
 
         # History: user + assistant
         assert len(session.history) == 2

--- a/tests/test_thalamus.py
+++ b/tests/test_thalamus.py
@@ -183,11 +183,26 @@ def _mock_skill_store():
 
 
 class TestSessionThalamus:
-    async def test_thalamus_off_by_default(self):
+    async def test_thalamus_on_by_default(self):
+        # Router is on by default (ANTON_ROUTER_ENABLED); no explicit
+        # router_enabled needed. The gate runs and, delegating, hands the
+        # turn to the planning model.
+        llm = make_mock_llm()
+        llm.plan = AsyncMock(return_value=_response("Hey!"))
+        llm.gate = AsyncMock(return_value=_response("", tool_calls=[_delegate_call()]))
+        session = ChatSession(ChatSessionConfig(llm_client=llm))
+        reply = await session.turn("hi")
+        assert reply == "Hey!"
+        llm.gate.assert_called_once()
+        llm.plan.assert_called_once()
+
+    async def test_router_disabled_skips_gate(self):
         llm = make_mock_llm()
         llm.plan = AsyncMock(return_value=_response("Hey!"))
         llm.gate = AsyncMock()
-        session = ChatSession(ChatSessionConfig(llm_client=llm))
+        session = ChatSession(
+            ChatSessionConfig(llm_client=llm, router_enabled=False)
+        )
         reply = await session.turn("hi")
         assert reply == "Hey!"
         llm.gate.assert_not_called()


### PR DESCRIPTION
Changes:
- Enable thalamus gate mode
- Fix failing tests with the router enabled by default