### PR TITLE
ci(ENG-1008): merge-to-main + staging panic and recovery alerts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,3 +47,26 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+
+  notify-failure:
+    # Alert the eng channel if the docs build or Pages deploy fails.
+    needs: [build, deploy]
+    if: failure()
+    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
+    with:
+      env-name: "docs deploy"
+      runs-on: ubuntu-latest
+    secrets: inherit
+
+
+  notify-recovery:
+    # Post a green "recovered" message when the pipeline goes green after a
+    # failing run (the reusable no-ops on a normal green run).
+    needs: [build, deploy]
+    if: success()
+    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
+    with:
+      env-name: "docs deploy"
+      status: recovered
+      runs-on: ubuntu-latest
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,3 +93,27 @@ jobs:
     with:
       tag: ${{ needs.auto-release.outputs.tag }}
     secrets: inherit
+
+  notify-failure:
+    # Alert the eng channel if ANY job in the release pipeline fails (tag, PyPI
+    # publish, or release e2e).
+    needs: [auto-release, publish, e2e]
+    if: failure()
+    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
+    with:
+      env-name: "release"
+      runs-on: ubuntu-latest
+    secrets: inherit
+
+
+  notify-recovery:
+    # Post a green "recovered" message when the pipeline goes green after a
+    # failing run (the reusable no-ops on a normal green run).
+    needs: [auto-release, publish, e2e]
+    if: success()
+    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
+    with:
+      env-name: "release"
+      status: recovered
+      runs-on: ubuntu-latest
+    secrets: inherit

--- a/.github/workflows/staging-freeze.yml
+++ b/.github/workflows/staging-freeze.yml
@@ -13,3 +13,14 @@ jobs:
   freeze:
     uses: mindsdb/github-actions/.github/workflows/release-freeze.yml@75df118f3b003625052c4f14e7b90817fb8b2784 # v1
     secrets: inherit
+
+  notify-failure:
+    # Alert the eng channel if the freeze fails (e.g. missing ruleset) — otherwise
+    # a broken freeze is silent and the code-freeze window never opens.
+    needs: [freeze]
+    if: failure()
+    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
+    with:
+      env-name: "staging freeze"
+      runs-on: ubuntu-latest
+    secrets: inherit

--- a/.github/workflows/staging-unfreeze.yml
+++ b/.github/workflows/staging-unfreeze.yml
@@ -17,3 +17,14 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     uses: mindsdb/github-actions/.github/workflows/release-unfreeze.yml@75df118f3b003625052c4f14e7b90817fb8b2784 # v1
     secrets: inherit
+
+  notify-failure:
+    # Alert the eng channel if the unfreeze or main->staging sync-back fails —
+    # otherwise staging stays frozen (or drifts from main) with no signal.
+    needs: [unfreeze]
+    if: failure()
+    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
+    with:
+      env-name: "staging unfreeze"
+      runs-on: ubuntu-latest
+    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,3 +26,27 @@ jobs:
 
       - name: Run E2E tests (stub)
         run: uv run --extra dev pytest tests/e2e/ -v
+
+  notify-failure:
+    # Alert the eng channel if CI fails on a direct push to main/staging. PR runs
+    # are skipped — the author sees those directly.
+    needs: [run-tests]
+    if: failure() && github.event_name == 'push'
+    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
+    with:
+      env-name: "CI"
+      runs-on: ubuntu-latest
+    secrets: inherit
+
+
+  notify-recovery:
+    # Post a green "recovered" message when the pipeline goes green after a
+    # failing run (the reusable no-ops on a normal green run).
+    needs: [run-tests]
+    if: success() && github.event_name == 'push'
+    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
+    with:
+      env-name: "CI"
+      status: recovered
+      runs-on: ubuntu-latest
+    secrets: inherit


### PR DESCRIPTION
Integrates panic and recovery alerts for CI workflows to notify the engineering team of failures and subsequent recoveries:

- Adds failure and recovery notification steps to auto-release, prod, staging, freeze, and unfreeze workflows
- Transitions integration tests to runtime provisioning of test tenants, eliminating the need for long-lived API keys and pre-seeded accounts

Addresses:
- https://linear.app/mindsdb/issue/ENG-1008
- https://linear.app/mindsdb/issue/ENG-1051