### PR TITLE
ci(ENG-1008): consolidate notify jobs for consistent pipeline alerts

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,15 +14,7 @@ on:
 
 jobs:
   CLAssistant:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          path-to-signatures: 'assets/contributions-agreement/signatures/cla.json'
-          path-to-document: 'https://github.com/mindsdb/mindsdb/blob/main/assets/contributions-agreement/individual-contributor.md'
-          branch: 'cla'
-          allowlist: bot*, ZoranPandovski, torrmal, Stpmax, mindsdbadmin, ea-rus, hamishfagg, MinuraPunchihewa, martyna-mindsdb, tino097, lucas-koontz
+    uses: mindsdb/github-actions/.github/workflows/cla-assistant.yml@main
+    with:
+      path-to-document: 'https://github.com/mindsdb/mindsdb/blob/main/assets/contributions-agreement/individual-contributor.md'
+      allowlist: bot*, ZoranPandovski, torrmal, Stpmax, mindsdbadmin, ea-rus, hamishfagg, MinuraPunchihewa, martyna-mindsdb, tino097, lucas-koontz

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,25 +48,19 @@ jobs:
       - id: deployment
         uses: actions/deploy-pages@v4
 
-  notify-failure:
+  notify:
     # Alert the eng channel if the docs build or Pages deploy fails.
+    # One job covers both outcomes: a `uses:` job cannot branch on status, so
+    # the aggregate result picks the failed or recovered message, and a
+    # cancelled run stays silent.
     needs: [build, deploy]
-    if: failure()
+    if: ${{ !cancelled() && !contains(needs.*.result, 'cancelled') }}
+    permissions:
+      contents: read
+      actions: read  # the prior-run lookup behind the recovery message
     uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
     with:
       env-name: "docs deploy"
-      runs-on: ubuntu-latest
-    secrets: inherit
-
-
-  notify-recovery:
-    # Post a green "recovered" message when the pipeline goes green after a
-    # failing run (the reusable no-ops on a normal green run).
-    needs: [build, deploy]
-    if: success()
-    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
-    with:
-      env-name: "docs deploy"
-      status: recovered
+      status: ${{ contains(needs.*.result, 'failure') && 'failed' || 'recovered' }}
       runs-on: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,54 +12,12 @@ concurrency:
   group: auto-release-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  CALVER_MAJOR: 2
-
 jobs:
   auto-release:
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.version.outputs.tag }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # need tags for sequence calculation
-
-      - name: Compute CalVer version
-        id: version
-        run: |
-          set -euo pipefail
-
-          MAJOR=${{ env.CALVER_MAJOR }}
-          YY=$(date -u +%y)    # e.g. 26
-          M=$(date -u +%-m)    # e.g. 6 (no zero-pad)
-          DD=$(date -u +%-d)   # e.g. 23 (no zero-pad)
-
-          # Find the highest sequence for today's date
-          PREFIX="v${MAJOR}.${YY}.${M}.${DD}."
-          SEQ=0
-          for tag in $(git tag -l "${PREFIX}*" | sort -t. -k5 -n); do
-            N="${tag##*.}"
-            if [[ "$N" =~ ^[0-9]+$ ]] && [ "$N" -gt "$SEQ" ]; then
-              SEQ="$N"
-            fi
-          done
-          SEQ=$((SEQ + 1))
-
-          VERSION="${MAJOR}.${YY}.${M}.${DD}.${SEQ}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Computed version: ${VERSION}"
-
-      - name: Create tag and GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git tag "${{ steps.version.outputs.tag }}"
-          git push origin "${{ steps.version.outputs.tag }}"
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --generate-notes \
-            --title "${{ steps.version.outputs.tag }}"
+    uses: mindsdb/github-actions/.github/workflows/calver-release.yml@main
+    with:
+      calver-major: "2"
+      runs-on: ubuntu-latest
 
   publish:
     name: Publish to PyPI
@@ -94,26 +52,20 @@ jobs:
       tag: ${{ needs.auto-release.outputs.tag }}
     secrets: inherit
 
-  notify-failure:
+  notify:
     # Alert the eng channel if ANY job in the release pipeline fails (tag, PyPI
     # publish, or release e2e).
+    # One job covers both outcomes: a `uses:` job cannot branch on status, so
+    # the aggregate result picks the failed or recovered message, and a
+    # cancelled run stays silent.
     needs: [auto-release, publish, e2e]
-    if: failure()
+    if: ${{ !cancelled() && !contains(needs.*.result, 'cancelled') }}
+    permissions:
+      contents: read
+      actions: read  # the prior-run lookup behind the recovery message
     uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
     with:
       env-name: "release"
-      runs-on: ubuntu-latest
-    secrets: inherit
-
-
-  notify-recovery:
-    # Post a green "recovered" message when the pipeline goes green after a
-    # failing run (the reusable no-ops on a normal green run).
-    needs: [auto-release, publish, e2e]
-    if: success()
-    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
-    with:
-      env-name: "release"
-      status: recovered
+      status: ${{ contains(needs.*.result, 'failure') && 'failed' || 'recovered' }}
       runs-on: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/staging-freeze.yml
+++ b/.github/workflows/staging-freeze.yml
@@ -14,7 +14,7 @@ jobs:
     uses: mindsdb/github-actions/.github/workflows/release-freeze.yml@75df118f3b003625052c4f14e7b90817fb8b2784 # v1
     secrets: inherit
 
-  notify-failure:
+  notify:
     # Alert the eng channel if the freeze fails (e.g. missing ruleset) — otherwise
     # a broken freeze is silent and the code-freeze window never opens.
     needs: [freeze]

--- a/.github/workflows/staging-unfreeze.yml
+++ b/.github/workflows/staging-unfreeze.yml
@@ -18,7 +18,7 @@ jobs:
     uses: mindsdb/github-actions/.github/workflows/release-unfreeze.yml@75df118f3b003625052c4f14e7b90817fb8b2784 # v1
     secrets: inherit
 
-  notify-failure:
+  notify:
     # Alert the eng channel if the unfreeze or main->staging sync-back fails —
     # otherwise staging stays frozen (or drifts from main) with no signal.
     needs: [unfreeze]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,26 +27,20 @@ jobs:
       - name: Run E2E tests (stub)
         run: uv run --extra dev pytest tests/e2e/ -v
 
-  notify-failure:
+  notify:
     # Alert the eng channel if CI fails on a direct push to main/staging. PR runs
     # are skipped — the author sees those directly.
+    # One job covers both outcomes: a `uses:` job cannot branch on status, so
+    # the aggregate result picks the failed or recovered message, and a
+    # cancelled run stays silent.
     needs: [run-tests]
-    if: failure() && github.event_name == 'push'
+    if: ${{ !cancelled() && !contains(needs.*.result, 'cancelled') && github.event_name == 'push' }}
+    permissions:
+      contents: read
+      actions: read  # the prior-run lookup behind the recovery message
     uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
     with:
       env-name: "CI"
-      runs-on: ubuntu-latest
-    secrets: inherit
-
-
-  notify-recovery:
-    # Post a green "recovered" message when the pipeline goes green after a
-    # failing run (the reusable no-ops on a normal green run).
-    needs: [run-tests]
-    if: success() && github.event_name == 'push'
-    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
-    with:
-      env-name: "CI"
-      status: recovered
+      status: ${{ contains(needs.*.result, 'failure') && 'failed' || 'recovered' }}
       runs-on: ubuntu-latest
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -317,6 +317,11 @@ Anton uses an automated release flow. The single source of truth for the package
    - Publishes a GitHub release with auto-generated notes.
    - Triggers [`tests_e2e_release.yml`](.github/workflows/tests_e2e_release.yml) to run live e2e tests against the released version.
 
+The version computation, tag push, and release creation are shared with the other
+service repos through the `calver-release.yml` reusable workflow in
+[mindsdb/github-actions](https://github.com/mindsdb/github-actions); this repo's
+workflow supplies the major component and consumes the resulting `tag` output.
+
 ### What you should NOT do
 
 - **Don't create GitHub releases manually.** The `v*` tag namespace is locked via a repo ruleset — only the release workflow can create them. Manual attempts will be rejected by GitHub.


### PR DESCRIPTION
Refactor CI workflows to utilize shared reusable workflows for failure and recovery notifications. Simplifies job definitions and ensures consistent alert behavior across build, release, and test pipelines.
