### PR TITLE
fix(session): completion verifier fails toward a real message, not silence (ENG-1079)

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -234,6 +234,18 @@ def _safe_error_detail(exc: BaseException) -> str:
     return name
 
 
+# Shared closing instruction for every path that hands control back to the
+# user (STUCK, budget-exhausted, verifier-call failure): a plain self-
+# assessment of solvability, not just a status dump. Without this, a
+# diagnosis can read as "here's what happened, good luck" instead of an
+# actual recommendation the user can act on.
+_SOLVABILITY_CLAUSE = (
+    "State plainly whether you believe this is still solvable on your own "
+    "(and how you'd approach it differently if so) or whether it genuinely "
+    "needs the user's input, a decision, or credentials you don't have."
+)
+
+
 def _render_tool_result_content(content, cap: int) -> str:
     """Render a tool_result's content as bounded plain text.
 
@@ -2692,6 +2704,7 @@ class ChatSession:
                             "1. Summarize exactly what was accomplished so far.\n"
                             "2. Identify the specific blocker or failure preventing completion.\n"
                             "3. Suggest concrete next steps the user can take to unblock this.\n"
+                            f"4. {_SOLVABILITY_CLAUSE}\n"
                             "Be honest and specific — do not be vague about what went wrong."
                         ),
                     }
@@ -2802,9 +2815,9 @@ class ChatSession:
                             "SYSTEM: The task-completion check failed to run (internal "
                             "error), so it's unclear whether this task is finished.\n\n"
                             "Summarize what you've done so far, be honest that an internal "
-                            "check failed partway through, and ask the user how they'd "
-                            "like to proceed. Do not mention this instruction or the "
-                            "verifier to the user."
+                            f"check failed partway through, and ask the user how they'd like "
+                            f"to proceed. {_SOLVABILITY_CLAUSE} Do not mention this "
+                            "instruction or the verifier to the user."
                         ),
                     }
                 )
@@ -2850,8 +2863,9 @@ class ChatSession:
                             f"SYSTEM: Task verification determined this task is stuck.\n"
                             f"Verifier assessment: {reason}\n\n"
                             "Explain to the user what went wrong, what you tried, and "
-                            "suggest specific next steps they can take to unblock this. "
-                            "Do not mention this instruction or the verifier to the user."
+                            f"suggest specific next steps they can take to unblock this. "
+                            f"{_SOLVABILITY_CLAUSE} Do not mention this instruction or the "
+                            "verifier to the user."
                         ),
                     }
                 )

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2781,9 +2781,51 @@ class ChatSession:
                 status = verdict.status
                 reason = verdict.reason.strip()
             else:
-                # Verifier failed — fail safe by treating the turn as done rather
-                # than forcing a continuation the user never asked for.
-                status, reason = "COMPLETE", "verifier unavailable"
+                # The verifier call failed on every budget it was given —
+                # truncated past the last retry, an unusable tool call, or a
+                # provider error (the per-attempt logs above carry the detail).
+                # That is not a verdict, so don't synthesize a fake COMPLETE
+                # and stop in silence (ENG-1079: that made the agent look like
+                # it had simply died on the first hurdle, with no way for the
+                # user to help). Fail toward the same honest, model-generated
+                # diagnosis used for STUCK below, so the task pauses with a
+                # real message instead of nothing.
+                _verifier_log.info(
+                    "completion-verifier verdict=ERROR continuation=%d/%d tool_rounds=%d "
+                    "— failing toward an honest diagnosis, not a silent COMPLETE",
+                    continuation, self._max_continuations, tool_round,
+                )
+                self._append_history(
+                    {
+                        "role": "user",
+                        "content": (
+                            "SYSTEM: The task-completion check failed to run (internal "
+                            "error), so it's unclear whether this task is finished.\n\n"
+                            "Summarize what you've done so far, be honest that an internal "
+                            "check failed partway through, and ask the user how they'd "
+                            "like to proceed. Do not mention this instruction or the "
+                            "verifier to the user."
+                        ),
+                    }
+                )
+                yield StreamTaskProgress(
+                    phase="analyzing", message="Checking in before continuing..."
+                )
+                diagnosis_response = None
+                async for event in self.plan_stream_with_recovery(system=system):
+                    yield event
+                    if isinstance(event, StreamComplete):
+                        diagnosis_response = event
+                # Persist the actual message the user just saw — not the stale
+                # pre-verification `reply` the post-loop fallback below would
+                # otherwise re-append, which would leave history (and thus the
+                # model's own memory of what it just told the user) out of sync
+                # with what was streamed.
+                if diagnosis_response is not None:
+                    self._append_history(
+                        {"role": "assistant", "content": diagnosis_response.response.content or ""}
+                    )
+                break
 
             _verifier_log.info(
                 # No `reason` — it's the model's free-text justification, derived

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2815,14 +2815,15 @@ class ChatSession:
                             "SYSTEM: The task-completion check failed to run (internal "
                             "error), so it's unclear whether this task is finished.\n\n"
                             "Summarize what you've done so far, be honest that an internal "
-                            f"check failed partway through, and ask the user how they'd like "
+                            "check failed partway through, and ask the user how they'd like "
                             f"to proceed. {_SOLVABILITY_CLAUSE} Do not mention this "
                             "instruction or the verifier to the user."
                         ),
                     }
                 )
                 yield StreamTaskProgress(
-                    phase="analyzing", message="Checking in before continuing..."
+                    phase="analyzing",
+                    message="Something went wrong — checking in with you...",
                 )
                 diagnosis_response = None
                 async for event in self.plan_stream_with_recovery(system=system):
@@ -2834,9 +2835,23 @@ class ChatSession:
                 # otherwise re-append, which would leave history (and thus the
                 # model's own memory of what it just told the user) out of sync
                 # with what was streamed.
-                if diagnosis_response is not None:
+                diagnosis_text = (
+                    (diagnosis_response.response.content or "").strip()
+                    if diagnosis_response is not None
+                    else ""
+                )
+                if diagnosis_text:
                     self._append_history(
-                        {"role": "assistant", "content": diagnosis_response.response.content or ""}
+                        {"role": "assistant", "content": diagnosis_text}
+                    )
+                else:
+                    # An empty diagnosis would silently recreate the exact
+                    # out-of-sync history this path exists to fix (the
+                    # post-loop fallback re-appends the stale reply). Make it
+                    # visible rather than circular.
+                    _verifier_log.warning(
+                        "verifier-failure diagnosis returned no content — "
+                        "history falls back to the pre-verification reply"
                     )
                 break
 
@@ -2863,7 +2878,7 @@ class ChatSession:
                             f"SYSTEM: Task verification determined this task is stuck.\n"
                             f"Verifier assessment: {reason}\n\n"
                             "Explain to the user what went wrong, what you tried, and "
-                            f"suggest specific next steps they can take to unblock this. "
+                            "suggest specific next steps they can take to unblock this. "
                             f"{_SOLVABILITY_CLAUSE} Do not mention this instruction or the "
                             "verifier to the user."
                         ),

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -1,0 +1,131 @@
+"""Completion-verifier fail-safe (ENG-1079).
+
+Before this fix, an exception from the verifier's ``generate_object_code``
+call (provider hiccup, malformed structured output, etc.) was silently
+treated as a COMPLETE verdict — the task loop just broke with no message,
+making the agent look like it had died on the first hurdle. It should
+instead behave like the STUCK path: append an honest SYSTEM note and let the
+model generate a real message summarizing progress and asking the user how
+to proceed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.conftest import make_mock_llm
+
+from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.llm.provider import (
+    LLMResponse,
+    StreamComplete,
+    StreamTaskProgress,
+    ToolCall,
+    Usage,
+)
+
+
+@pytest.fixture()
+def workspace():
+    # Keep scratchpad venvs inside the repo workspace (pytest runs sandboxed and
+    # can't write to the real home directory).
+    base = Path(__file__).resolve().parent / ".pytest-workspace"
+    base.mkdir(parents=True, exist_ok=True)
+    return MagicMock(base=base)
+
+
+def _text_response(text: str) -> LLMResponse:
+    return LLMResponse(
+        content=text,
+        tool_calls=[],
+        usage=Usage(input_tokens=10, output_tokens=20),
+        stop_reason="end_turn",
+    )
+
+
+def _scratchpad_response(text: str, action: str, name: str, code: str = "") -> LLMResponse:
+    tc_input: dict = {"action": action, "name": name}
+    if code:
+        tc_input["code"] = code
+    return LLMResponse(
+        content=text,
+        tool_calls=[ToolCall(id="tc_1", name="scratchpad", input=tc_input)],
+        usage=Usage(input_tokens=10, output_tokens=20),
+        stop_reason="tool_use",
+    )
+
+
+class _FakeAsyncIter:
+    def __init__(self, items):
+        self._items = items
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+async def test_verifier_exception_yields_real_message_not_silent_stop(workspace):
+    mock_llm = make_mock_llm()
+    mock_llm.generate_object_code = AsyncMock(side_effect=RuntimeError("provider hiccup"))
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Tool-call round.
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Running.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            # Final round of the tool loop — this text is what gets sent to
+            # (the now-failing) verifier.
+            return _FakeAsyncIter([
+                StreamComplete(response=_text_response("Done running the script."))
+            ])
+        # Third call is the honest-diagnosis re-prompt (plan_stream_with_recovery),
+        # only reached via the verifier-exception fail-safe.
+        return _FakeAsyncIter([
+            StreamComplete(
+                response=_text_response(
+                    "Here's what I've done so far — ran the script. An internal "
+                    "check failed, so let me know how you'd like to proceed."
+                )
+            )
+        ])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    try:
+        events = [e async for e in session.turn_stream("run my script")]
+
+        # Never silently stops: a progress event surfaces the check-in, and
+        # exactly one more model call happens (the honest diagnosis) — not a
+        # forced "Continue working" continuation, and not silence.
+        progress_msgs = [e.message for e in events if isinstance(e, StreamTaskProgress)]
+        assert "Checking in before continuing..." in progress_msgs
+        assert call_count == 3
+
+        history_texts = [
+            m["content"] for m in session.history
+            if m.get("role") == "user" and isinstance(m.get("content"), str)
+        ]
+        assert any("task-completion check failed to run" in t for t in history_texts)
+        assert not any("Continue working on the original request" in t for t in history_texts)
+
+        final_texts = [
+            m["content"] for m in session.history
+            if m.get("role") == "assistant" and isinstance(m.get("content"), str)
+        ]
+        assert any("how you'd like to proceed" in t for t in final_texts)
+    finally:
+        await session.close()

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -121,6 +121,10 @@ async def test_verifier_exception_yields_real_message_not_silent_stop(workspace)
         ]
         assert any("task-completion check failed to run" in t for t in history_texts)
         assert not any("Continue working on the original request" in t for t in history_texts)
+        # The model must be asked for a solvability self-assessment, not just
+        # a status dump — otherwise "let me know how to proceed" is a vague
+        # ask instead of an actual recommendation (ENG-1079 follow-up).
+        assert any("whether you believe this is still solvable on your own" in t for t in history_texts)
 
         final_texts = [
             m["content"] for m in session.history

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -133,3 +133,64 @@ async def test_verifier_exception_yields_real_message_not_silent_stop(workspace)
         assert any("how you'd like to proceed" in t for t in final_texts)
     finally:
         await session.close()
+
+
+async def test_truncation_exhausting_every_budget_also_gets_the_diagnosis(workspace):
+    """The ENG-1081 ladder can run dry: a verdict truncated at 2048 AND at the
+    4096 retry (narrating model, huge session) used to fall into the same
+    silent fake-COMPLETE this file exists to remove. Exhausted budgets are not
+    a verdict either — the honest-diagnosis path must fire for them too.
+    """
+    from anton.core.llm.provider import StructuredOutputError
+    from anton.core.session import _VERIFIER_TOKEN_BUDGETS
+
+    budgets_seen: list[int] = []
+
+    async def always_truncated(_schema, *, system, messages, max_tokens):
+        budgets_seen.append(max_tokens)
+        raise StructuredOutputError(
+            "no tool call", truncated=True, output_tokens=max_tokens,
+            max_tokens=max_tokens, stop_reason="stop",
+        )
+
+    mock_llm = make_mock_llm()
+    mock_llm.generate_object_code = AsyncMock(side_effect=always_truncated)
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Running.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            return _FakeAsyncIter([
+                StreamComplete(response=_text_response("Done running the script."))
+            ])
+        return _FakeAsyncIter([
+            StreamComplete(
+                response=_text_response(
+                    "I ran the script; an internal check failed — how would "
+                    "you like to proceed?"
+                )
+            )
+        ])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    try:
+        events = [e async for e in session.turn_stream("run my script")]
+
+        assert budgets_seen == list(_VERIFIER_TOKEN_BUDGETS), (
+            "the ladder must exhaust every budget before giving up"
+        )
+        progress_msgs = [e.message for e in events if isinstance(e, StreamTaskProgress)]
+        assert "Checking in before continuing..." in progress_msgs, (
+            "exhausted budgets must fail toward the diagnosis, not a silent COMPLETE"
+        )
+        assert call_count == 3
+    finally:
+        await session.close()

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -32,7 +32,7 @@ from anton.core.llm.provider import (
 def workspace():
     # Keep scratchpad venvs inside the repo workspace (pytest runs sandboxed and
     # can't write to the real home directory).
-    base = Path(__file__).resolve().parent / ".pytest-workspace"
+    base = Path(__file__).resolve().parents[1] / ".pytest-workspace"
     base.mkdir(parents=True, exist_ok=True)
     return MagicMock(base=base)
 
@@ -112,7 +112,7 @@ async def test_verifier_exception_yields_real_message_not_silent_stop(workspace)
         # exactly one more model call happens (the honest diagnosis) — not a
         # forced "Continue working" continuation, and not silence.
         progress_msgs = [e.message for e in events if isinstance(e, StreamTaskProgress)]
-        assert "Checking in before continuing..." in progress_msgs
+        assert "Something went wrong — checking in with you..." in progress_msgs
         assert call_count == 3
 
         history_texts = [
@@ -188,9 +188,56 @@ async def test_truncation_exhausting_every_budget_also_gets_the_diagnosis(worksp
             "the ladder must exhaust every budget before giving up"
         )
         progress_msgs = [e.message for e in events if isinstance(e, StreamTaskProgress)]
-        assert "Checking in before continuing..." in progress_msgs, (
+        assert "Something went wrong — checking in with you..." in progress_msgs, (
             "exhausted budgets must fail toward the diagnosis, not a silent COMPLETE"
         )
         assert call_count == 3
+    finally:
+        await session.close()
+
+
+async def test_empty_diagnosis_is_logged_not_circular(workspace, caplog):
+    """Review follow-up: an empty diagnosis must not silently recreate the
+    out-of-sync history this path fixes — it logs, and the post-loop fallback
+    keeps history consistent (stale-but-true beats empty)."""
+    import logging
+
+    mock_llm = make_mock_llm()
+    mock_llm.generate_object_code = AsyncMock(side_effect=RuntimeError("hiccup"))
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Running.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            return _FakeAsyncIter([
+                StreamComplete(response=_text_response("Done running the script."))
+            ])
+        # Diagnosis comes back empty (refusal / provider hiccup).
+        return _FakeAsyncIter([StreamComplete(response=_text_response(""))])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    try:
+        with caplog.at_level(logging.WARNING):
+            async for _ in session.turn_stream("run my script"):
+                pass
+
+        assert any(
+            "diagnosis returned no content" in r.message for r in caplog.records
+        ), "an empty diagnosis must be visible in logs, not silent"
+        # History must not gain an empty assistant entry; the post-loop
+        # fallback re-appends the (real) pre-verification reply instead.
+        assert all(
+            m.get("content") not in ("",)
+            for m in session.history
+            if m.get("role") == "assistant"
+        )
     finally:
         await session.close()


### PR DESCRIPTION
## Summary
- The completion-verifier's `generate_object_code` call can throw (provider hiccup, malformed structured output, etc.). Before this fix, that exception was silently mapped to a fake `COMPLETE` verdict, so the task loop just broke with no message at all — the agent looked like it had died on the first hurdle it hit, even in a fresh session (ENG-1079).
- On a verifier-call exception, this now routes through the same honest-diagnosis pattern already used for `STUCK`: append a `SYSTEM` note admitting the check itself failed, and let the model generate a real message — summarize progress, be honest about the internal failure, and ask the user how they'd like to proceed. Functionally a WAITING-style stop, but with a real, model-generated message instead of silence.
- Also persists that generated message to history directly, rather than relying on the shared post-loop fallback (which re-appends the stale pre-verification `reply` and would otherwise leave history out of sync with what the user actually saw).
- **Follow-up**: none of the three "hand control back to the user" paths (STUCK, budget-exhausted, and the new verifier-failure path) asked the model for a solvability self-assessment — just "what I tried" + "next steps," which can read as "here's what happened, good luck" instead of an actual recommendation. Added a shared `_SOLVABILITY_CLAUSE` ("is this still solvable on your own with a different approach, or does it genuinely need the user's input/decision/credentials") wired into all three.

## Context
Traced from a regression report that Anton seems to get stuck/"die" on the first hurdle even after restarting from scratch. Root-caused to the ENG-716 verifier rework (`db10fdcf`/`92f47b14`/etc.), which moved the verdict to a `generate_object_code` call on the cheap coding model over a compact transcript — a less forgiving code path than before, sitting behind a silent fail-safe that had never existed pre-ENG-716.

## Test plan
- [x] `tests/test_verifier_failsafe.py` — verifier exception yields a real streamed message (not silence), makes exactly one honest-diagnosis LLM call, does NOT inject a "Continue working" continuation, persists the real message to history, and asks for the solvability self-assessment.
- [x] `uv run pytest tests/ -k "session or verifier or loop_safety" --ignore=tests/e2e` — 89 passed, 2 skipped.
- [x] `uv run pytest tests/e2e/scenarios/test_loop_safety.py` — passes in an isolated worktree; occasional single-test timeouts under load are pre-existing environmental flakiness (real subprocess CLI spawn, confirmed to pass in isolation both before and after this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## QA Instructions

**Where to test:** a build that actually contains this change — desktop on the **git update channel** (lands minutes after merge), or hosted after the manual snapshot bake + SAM redeploy. PyPI-channel desktop builds will NOT receive an anton-only change (ENG-1094).

**Precondition for every scenario:** the turn must use at least one tool round (a scratchpad task, not pure Q&A) — the completion verifier is skipped otherwise.

1. **Happy-path regression (sonnet):** give a small multi-step task ("fetch example.com and save a summary to a file"). It should complete normally — no check-in message, no behavior change.
2. **The fix, via the real user path:** in the model picker select **`kimi`** (Kimi K3 — its verdict call 400s deterministically until ENG-1095 lands, which makes it a natural live trigger, no test rigging needed). Give the same multi-step task.
   - **Before this PR:** the agent does the work, then the turn just ends — no final message (silent fake-COMPLETE).
   - **After:** the progress line briefly shows *"Something went wrong — checking in with you..."*, then the agent posts a real message that (a) summarizes what it did, (b) is honest that an internal check failed, (c) states whether it thinks the task is still solvable, and (d) asks how to proceed. It must NOT mention "the verifier".
3. **History integrity:** reply "continue" after the check-in — the agent's next answer must be consistent with the check-in message it just showed (the diagnosis is persisted, not lost).
4. **Logs:** backend log shows `completion-verifier verdict=ERROR … failing toward an honest diagnosis, not a silent COMPLETE`, and per-attempt lines with exception type only (no conversation content).
5. **STUCK-path regression:** a genuinely blocked task (e.g. ask it to read a file that doesn't exist and insist) still produces the stuck diagnosis as before, now ending with a solvability self-assessment.
