### PR TITLE
feat(llm): capture Claude/OpenAI reasoning as a real subtype:reasoning channel (ENG-1109)

### DIFF
--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -16,6 +16,7 @@ from .provider import (
     ProviderConnectionInfo,
     StreamComplete,
     StreamEvent,
+    StreamReasoningDelta,
     StreamTextDelta,
     StreamToolUseDelta,
     StreamToolUseEnd,
@@ -262,6 +263,11 @@ class AnthropicProvider(LLMProvider):
                                 "json_parts": [],
                             }
                             yield StreamToolUseStart(id=block.id, name=block.name)
+                        elif block.type in ("thinking", "redacted_thinking"):
+                            # Adaptive thinking (triggered by output_config.effort,
+                            # set above when self._reasoning_effort is configured)
+                            # — the model's own reasoning, not the final answer.
+                            blocks[idx] = {"type": "thinking"}
                         else:
                             blocks[idx] = {"type": "text"}
 
@@ -278,6 +284,10 @@ class AnthropicProvider(LLMProvider):
                                 yield StreamToolUseDelta(
                                     id=info["id"], json_delta=delta.partial_json
                                 )
+                        elif delta.type == "thinking_delta":
+                            yield StreamReasoningDelta(text=delta.thinking)
+                        # signature_delta carries only a verification signature
+                        # for the thinking block, no user-facing text — ignored.
 
                     elif event.type == "content_block_stop":
                         idx = event.index

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -20,6 +20,7 @@ from .provider import (
     ProviderConnectionInfo,
     StreamComplete,
     StreamEvent,
+    StreamReasoningDelta,
     StreamTextDelta,
     StreamToolUseDelta,
     StreamToolUseEnd,
@@ -953,6 +954,17 @@ class OpenAIProvider(LLMProvider):
                     content_text += delta.content
                     yield StreamTextDelta(text=delta.content)
 
+                # Reasoning content — chat.completions has no first-party
+                # reasoning-summary field (that's Responses-API-only), but
+                # `reasoning_content` is the de facto convention several
+                # OpenAI-compatible reasoning gateways use (DeepSeek, vLLM's
+                # reasoning parser, and possibly the mdb.ai passthrough for
+                # non-Anthropic reasoning models). Read defensively via
+                # getattr since the SDK's Delta model doesn't declare it.
+                reasoning_delta = getattr(delta, "reasoning_content", None)
+                if reasoning_delta:
+                    yield StreamReasoningDelta(text=reasoning_delta)
+
                 # Tool call deltas
                 if delta.tool_calls:
                     for tc_delta in delta.tool_calls:
@@ -1112,7 +1124,14 @@ class OpenAIProvider(LLMProvider):
         if system:
             kwargs["instructions"] = system
         if self._reasoning_effort:
-            kwargs["reasoning"] = {"effort": self._reasoning_effort}
+            # "summary": "auto" asks the Responses API to also stream a
+            # natural-language summary of the reasoning itself (as
+            # response.reasoning_summary_text.delta events) — without it,
+            # reasoning happens server-side but is never surfaced to us at
+            # all. Safe to always pair with effort: only sent when effort
+            # is already set, which is itself gated to reasoning-capable
+            # models by the caller (see AntonSettings.planning_reasoning_effort).
+            kwargs["reasoning"] = {"effort": self._reasoning_effort, "summary": "auto"}
 
         merged_tools: list[dict] = []
         if tools:
@@ -1213,6 +1232,14 @@ class OpenAIProvider(LLMProvider):
                     if delta:
                         content_text += delta
                         yield StreamTextDelta(text=delta)
+
+                # The model's own reasoning summary — not the final answer.
+                # Only arrives when `reasoning.summary` was requested (see
+                # _build_responses_kwargs, gated on self._reasoning_effort).
+                elif etype == "response.reasoning_summary_text.delta":
+                    delta = getattr(event, "delta", "")
+                    if delta:
+                        yield StreamReasoningDelta(text=delta)
 
                 # New output item (could be a function_call, server-tool call,
                 # or message). We only need to react when a function_call

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -105,6 +105,21 @@ class StreamContextCompacted:
     message: str
 
 
+@dataclass
+class StreamReasoningDelta:
+    """A chunk of the model's own extended-thinking/reasoning text.
+
+    NOT part of the final answer — Anthropic's `thinking_delta` content
+    blocks (surfaced via `output_config.effort`'s adaptive thinking) and
+    OpenAI's `response.reasoning_summary_text.delta` Responses-API events
+    both map to this. Kept distinct from `StreamTextDelta` so the harness
+    layer can route it to a separate "current thought" channel instead of
+    the persisted answer body.
+    """
+
+    text: str
+
+
 StreamEvent = (
     StreamTextDelta
     | StreamToolUseStart
@@ -114,6 +129,7 @@ StreamEvent = (
     | StreamTaskProgress
     | StreamToolResult
     | StreamContextCompacted
+    | StreamReasoningDelta
 )
 
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -144,15 +144,24 @@ class _VerifierVerdict(BaseModel):
 
     status: Literal["COMPLETE", "WAITING", "INCOMPLETE", "STUCK"] = Field(
         description=(
-            "Classify the assistant's latest message against the user's request:\n"
-            "- COMPLETE: the requested task is done. A finished task followed by an "
-            "optional 'want me to…?' offer is still COMPLETE.\n"
+            "Classify the assistant's latest message against the user's request. "
+            "Judge the FINAL delivered outcome, not every intermediate step taken "
+            "to reach it:\n"
+            "- COMPLETE: the requested task is done and the assistant delivered a "
+            "usable answer. A tool that errored or returned nothing but that the "
+            "assistant RECOVERED from — it got the needed data another way, or the "
+            "failed step wasn't essential to the answer — is still COMPLETE; do NOT "
+            "mark a turn incomplete just because an earlier tool call failed. A "
+            "finished task followed by an optional 'want me to…?' offer is still "
+            "COMPLETE.\n"
             "- WAITING: the assistant's latest message asks the user a question it "
             "genuinely needs answered to proceed with the requested task, or is a "
             "reasoned refusal. This is a valid stopping point — do NOT treat it as "
             "unfinished; the correct action is to wait for the user's reply.\n"
             "- INCOMPLETE: the assistant stopped partway through the requested task "
-            "WITHOUT asking the user anything, and could keep going on its own.\n"
+            "WITHOUT asking the user anything, and could keep going on its own — "
+            "including when it implied success but the data its answer actually "
+            "depends on errored or came back empty and was never recovered.\n"
             "- STUCK: a hard blocker prevents completion (missing credentials, an "
             "unavailable service, or a permission the assistant does not have)."
         )
@@ -185,6 +194,25 @@ _VERIFIER_NO_PREAMBLE = (
     "action. Do not think out loud, restate the conversation, or explain your "
     "reasoning before calling it — put your one-sentence justification in the "
     "tool's `reason` field."
+)
+
+# Judgment rubric appended to the per-turn verify message. Keys the "errored
+# tool → not COMPLETE" logic off the FINAL answer's dependency on the failed
+# data, not the mere presence of an errored tool result in the transcript —
+# without this, a turn where the model tried a tool, it failed, and the model
+# recovered another way and answered correctly was judged INCOMPLETE and forced
+# into a redundant continuation that re-streamed the whole answer (ENG-1134).
+# The hallucinated-success safeguard is preserved: implying success while the
+# data the answer relies on errored/came back empty is still INCOMPLETE.
+_VERIFIER_JUDGMENT_RUBRIC = (
+    "Which status applies? Judge the FINAL outcome, not every intermediate step. "
+    "An errored or empty tool result only makes the task INCOMPLETE or STUCK when "
+    "the assistant's final answer depends on data that never arrived and was not "
+    "recovered another way. A tool that failed but the assistant worked around — "
+    "getting what it needed elsewhere, or the failed step being inessential — and "
+    "then answered from is COMPLETE. Conversely, an assistant that implied success "
+    "while the data its answer relies on errored or came back empty is INCOMPLETE, "
+    "not COMPLETE."
 )
 
 
@@ -2726,9 +2754,7 @@ class ChatSession:
                         "Assess the conversation below (tool results are truncated) and "
                         "decide the status of the USER's most recent request.\n\n"
                         f"{request_header}{transcript}\n\n"
-                        "Which status applies? A tool the task depended on that returned "
-                        "an error — or returned no usable data while the assistant implied "
-                        "success — means INCOMPLETE or STUCK, not COMPLETE."
+                        + _VERIFIER_JUDGMENT_RUBRIC
                     ),
                 },
             ]

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -36,6 +36,7 @@ from anton.core.llm.provider import (
     StreamComplete,
     StreamContextCompacted,
     StreamEvent,
+    StreamReasoningDelta,
     StreamTaskProgress,
     StreamTextDelta,
     StreamToolResult,
@@ -2605,9 +2606,12 @@ class ChatSession:
                 async for event in self.plan_stream_with_recovery(
                     system=system, tools=tools
                 ):
-                    # Capture reasoning elapsed on first text or tool event
+                    # Capture reasoning elapsed on first text, reasoning, or
+                    # tool event — a StreamReasoningDelta means the model has
+                    # already started reasoning, same signal as the first
+                    # text token.
                     if _reasoning_t0 and isinstance(
-                        event, (StreamTextDelta, StreamComplete)
+                        event, (StreamTextDelta, StreamReasoningDelta, StreamComplete)
                     ):
                         _reasoning_elapsed = _time.monotonic() - _reasoning_t0
                         _reasoning_t0 = 0  # only fire once

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -670,3 +671,134 @@ class TestOpenAICompatibleFlavorResolution:
             )
             client = LLMClient.from_settings(settings)
             assert client._planning_provider._flavor == OpenAIProvider.FLAVOR_OPENAI
+
+
+async def _fake_async_iter(items):
+    for item in items:
+        yield item
+
+
+class TestResponsesAPIReasoningSummary:
+    """ENG-1109: the Responses API only streams a reasoning summary when
+    explicitly asked for it via `reasoning.summary` — check the request
+    kwargs carry it, and that the resulting delta event maps correctly."""
+
+    def test_build_responses_kwargs_requests_summary_when_effort_set(self):
+        with patch("anton.core.llm.openai.openai"):
+            provider = OpenAIProvider(
+                api_key="k", flavor=OpenAIProvider.FLAVOR_OPENAI, reasoning_effort="high",
+            )
+            kwargs = provider._build_responses_kwargs(
+                model="gpt-5", system="s", messages=[{"role": "user", "content": "hi"}],
+                tools=None, tool_choice=None, max_tokens=100, native_web_tools=None,
+            )
+            assert kwargs["reasoning"] == {"effort": "high", "summary": "auto"}
+
+    def test_build_responses_kwargs_omits_reasoning_when_effort_unset(self):
+        with patch("anton.core.llm.openai.openai"):
+            provider = OpenAIProvider(api_key="k", flavor=OpenAIProvider.FLAVOR_OPENAI)
+            kwargs = provider._build_responses_kwargs(
+                model="gpt-5", system="s", messages=[{"role": "user", "content": "hi"}],
+                tools=None, tool_choice=None, max_tokens=100, native_web_tools=None,
+            )
+            assert "reasoning" not in kwargs
+
+    async def test_stream_maps_reasoning_summary_delta_not_output_text(self):
+        from anton.core.llm.provider import StreamReasoningDelta, StreamTextDelta
+
+        events = [
+            SimpleNamespace(type="response.reasoning_summary_text.delta", delta="Checking the docs first."),
+            SimpleNamespace(type="response.output_text.delta", delta="The real answer."),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(usage=None, status="completed")),
+        ]
+        with patch("anton.core.llm.openai.openai") as mock_openai:
+            mock_client = AsyncMock()
+            mock_openai.AsyncOpenAI.return_value = mock_client
+            mock_client.responses.create = AsyncMock(return_value=_fake_async_iter(events))
+
+            provider = OpenAIProvider(
+                api_key="k", flavor=OpenAIProvider.FLAVOR_OPENAI, reasoning_effort="high",
+            )
+            yielded = [
+                e async for e in provider.stream(
+                    model="gpt-5", system="s", messages=[{"role": "user", "content": "hi"}],
+                )
+            ]
+
+        assert [e for e in yielded if isinstance(e, StreamReasoningDelta)] == [
+            StreamReasoningDelta(text="Checking the docs first.")
+        ]
+        assert [e for e in yielded if isinstance(e, StreamTextDelta)] == [
+            StreamTextDelta(text="The real answer.")
+        ]
+
+
+class TestChatCompletionsReasoningContent:
+    """ENG-1109: mdb.ai passthrough / openai-compatible reasoning gateways —
+    `delta.reasoning_content` is read best-effort, never crashes when the
+    SDK's Delta model doesn't declare the field."""
+
+    async def test_stream_reads_reasoning_content_delta(self):
+        from anton.core.llm.provider import StreamReasoningDelta, StreamTextDelta
+
+        reasoning_chunk = MagicMock()
+        reasoning_chunk.usage = None
+        reasoning_chunk.choices = [MagicMock(delta=MagicMock(content=None, tool_calls=None), finish_reason=None)]
+        reasoning_chunk.choices[0].delta.reasoning_content = "Thinking about the best approach."
+
+        text_chunk = MagicMock()
+        text_chunk.usage = None
+        text_chunk.choices = [MagicMock(delta=MagicMock(content="Final answer.", tool_calls=None), finish_reason="stop")]
+        text_chunk.choices[0].delta.reasoning_content = None
+
+        with patch("anton.core.llm.openai.openai") as mock_openai:
+            mock_client = AsyncMock()
+            mock_openai.AsyncOpenAI.return_value = mock_client
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=_fake_async_iter([reasoning_chunk, text_chunk])
+            )
+
+            provider = OpenAIProvider(
+                api_key="k", flavor=OpenAIProvider.FLAVOR_MINDS_PASSTHROUGH, reasoning_effort="high",
+            )
+            yielded = [
+                e async for e in provider.stream(
+                    model="claude-sonnet-4-6", system="s", messages=[{"role": "user", "content": "hi"}],
+                )
+            ]
+
+        assert [e for e in yielded if isinstance(e, StreamReasoningDelta)] == [
+            StreamReasoningDelta(text="Thinking about the best approach.")
+        ]
+        assert [e for e in yielded if isinstance(e, StreamTextDelta)] == [
+            StreamTextDelta(text="Final answer.")
+        ]
+
+    async def test_stream_tolerates_missing_reasoning_content_field(self):
+        # A Delta object that doesn't declare `reasoning_content` at all
+        # (e.g. a real openai.types.chat.ChoiceDelta from a non-reasoning
+        # model) must not raise — getattr's default covers this, but a
+        # plain SimpleNamespace (no attr at all, unlike MagicMock which
+        # auto-vivifies) is the real test that we're not assuming the
+        # field always exists.
+        chunk = SimpleNamespace(
+            usage=None,
+            choices=[SimpleNamespace(
+                delta=SimpleNamespace(content="hi", tool_calls=None),
+                finish_reason="stop",
+            )],
+        )
+        with patch("anton.core.llm.openai.openai") as mock_openai:
+            mock_client = AsyncMock()
+            mock_openai.AsyncOpenAI.return_value = mock_client
+            mock_client.chat.completions.create = AsyncMock(return_value=_fake_async_iter([chunk]))
+
+            provider = OpenAIProvider(api_key="k", flavor=OpenAIProvider.FLAVOR_MINDS_PASSTHROUGH)
+            yielded = [
+                e async for e in provider.stream(
+                    model="claude-sonnet-4-6", system="s", messages=[{"role": "user", "content": "hi"}],
+                )
+            ]
+        from anton.core.llm.provider import StreamReasoningDelta, StreamTextDelta
+        assert [e for e in yielded if isinstance(e, StreamReasoningDelta)] == []
+        assert [e for e in yielded if isinstance(e, StreamTextDelta)] == [StreamTextDelta(text="hi")]

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -188,6 +188,114 @@ class TestAnthropicProvider:
             mock_anthropic.AsyncAnthropic.assert_called_once_with()
 
 
+class _FakeAnthropicStream:
+    """Minimal async-context-manager + async-iterator stand-in for the
+    object `client.messages.stream(**kwargs)` returns (NOT awaited itself
+    — used via `async with ... as stream: async for event in stream:`)."""
+
+    def __init__(self, events):
+        self._events = events
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for event in self._events:
+            yield event
+
+
+class TestAnthropicProviderReasoningStream:
+    """ENG-1109: extended-thinking content blocks (triggered server-side by
+    `output_config.effort`, already sent whenever reasoning_effort is set)
+    must surface as StreamReasoningDelta, not get misclassified as text or
+    silently dropped."""
+
+    async def test_thinking_delta_becomes_stream_reasoning_delta(self):
+        from anton.core.llm.provider import StreamReasoningDelta, StreamTextDelta
+
+        events = [
+            SimpleNamespace(
+                type="message_start",
+                message=SimpleNamespace(usage=SimpleNamespace(input_tokens=5, output_tokens=0)),
+            ),
+            SimpleNamespace(
+                type="content_block_start", index=0,
+                content_block=SimpleNamespace(type="thinking"),
+            ),
+            SimpleNamespace(
+                type="content_block_delta", index=0,
+                delta=SimpleNamespace(type="thinking_delta", thinking="Let me check that first."),
+            ),
+            SimpleNamespace(
+                type="content_block_delta", index=0,
+                delta=SimpleNamespace(type="signature_delta", signature="sig-abc"),
+            ),
+            SimpleNamespace(type="content_block_stop", index=0),
+            SimpleNamespace(
+                type="content_block_start", index=1,
+                content_block=SimpleNamespace(type="text"),
+            ),
+            SimpleNamespace(
+                type="content_block_delta", index=1,
+                delta=SimpleNamespace(type="text_delta", text="The real answer."),
+            ),
+            SimpleNamespace(type="content_block_stop", index=1),
+            SimpleNamespace(
+                type="message_delta",
+                delta=SimpleNamespace(stop_reason="end_turn"),
+                usage=SimpleNamespace(output_tokens=12),
+            ),
+        ]
+
+        with patch("anton.core.llm.anthropic.anthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.stream = MagicMock(return_value=_FakeAnthropicStream(events))
+            mock_anthropic.AsyncAnthropic.return_value = mock_client
+
+            provider = AnthropicProvider(api_key="test-key", reasoning_effort="medium")
+            yielded = [
+                e async for e in provider.stream(
+                    model="claude-sonnet-4-6",
+                    system="be helpful",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            ]
+
+        reasoning_events = [e for e in yielded if isinstance(e, StreamReasoningDelta)]
+        text_events = [e for e in yielded if isinstance(e, StreamTextDelta)]
+        assert reasoning_events == [StreamReasoningDelta(text="Let me check that first.")]
+        assert text_events == [StreamTextDelta(text="The real answer.")]
+
+    async def test_stream_passes_effort_via_extra_body(self):
+        with patch("anton.core.llm.anthropic.anthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.stream = MagicMock(
+                return_value=_FakeAnthropicStream([
+                    SimpleNamespace(
+                        type="message_delta",
+                        delta=SimpleNamespace(stop_reason="end_turn"),
+                        usage=SimpleNamespace(output_tokens=0),
+                    ),
+                ])
+            )
+            mock_anthropic.AsyncAnthropic.return_value = mock_client
+
+            provider = AnthropicProvider(api_key="k", reasoning_effort="high")
+            async for _ in provider.stream(
+                model="claude-sonnet-4-6", system="s", messages=[{"role": "user", "content": "hi"}],
+            ):
+                pass
+
+            call_kwargs = mock_client.messages.stream.call_args[1]
+            assert call_kwargs["extra_body"] == {"output_config": {"effort": "high"}}
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Native server-side web tools (web_search / web_fetch)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_verifier_truncation.py
+++ b/tests/test_verifier_truncation.py
@@ -34,6 +34,7 @@ from anton.core.llm.provider import (
     Usage,
 )
 from anton.core.session import (
+    _VERIFIER_JUDGMENT_RUBRIC,
     _VERIFIER_TOKEN_BUDGETS,
     ChatSession,
     ChatSessionConfig,
@@ -492,6 +493,46 @@ async def test_verifier_prompt_forbids_preamble(workspace):
 
     assert "immediately as your first action" in seen["system"]
     assert "Do not think out loud" in seen["system"]
+
+
+async def test_verifier_prompt_judges_final_outcome_not_intermediate_errors(workspace):
+    """ENG-1134: the recovery-aware rubric reaches the verifier, and the old
+    blanket 'any errored tool → not COMPLETE' rule is gone. That rule made the
+    verifier flag a turn INCOMPLETE whenever an earlier tool call errored — even
+    when the model recovered and answered — forcing a redundant continuation that
+    re-streamed the whole answer 2-3x."""
+    seen: dict = {}
+
+    async def fake_verdict(_schema, *, system, messages, max_tokens):
+        seen["prompt"] = str(messages[-1].get("content", ""))
+        return _VerifierVerdict(status="COMPLETE", reason="done")
+
+    mock_llm = make_mock_llm()
+    mock_llm.generate_object_code = AsyncMock(side_effect=fake_verdict)
+
+    session = _session_that_uses_a_tool(mock_llm, workspace)
+    try:
+        async for _ in session.turn_stream("compare two stocks"):
+            pass
+    finally:
+        await session.close()
+
+    prompt = seen["prompt"]
+    # The recovery-aware rubric reaches the verifier verbatim…
+    assert _VERIFIER_JUDGMENT_RUBRIC in prompt
+    assert "recovered another way" in prompt
+    # …and the old over-eager phrasing is gone.
+    assert "means INCOMPLETE or STUCK, not COMPLETE" not in prompt
+
+
+def test_verdict_schema_treats_recovered_errors_as_complete():
+    """The COMPLETE definition itself carries the recovery principle — the schema
+    field description doubles as the verifier's instructions (ENG-716/1134)."""
+    desc = _VerifierVerdict.model_fields["status"].description
+    assert "Judge the FINAL delivered outcome" in desc
+    assert "RECOVERED" in desc
+    # The hallucinated-success safeguard is preserved.
+    assert "implied success" in desc
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Also fixes [ENG-1134](https://linear.app/mindsdb/issue/ENG-1134/completion-verifier-forces-unnecessary-continuations-same-answer-re) — commit `8e28138b`, `fix(verifier): judge final outcome, not intermediate tool errors`. Two tickets landed in this PR; adding the reference so the verifier change is discoverable from ENG-1134 and so a future revert of this PR is known to touch both.

---

## Summary
Anton has no way to distinguish the model's own reasoning/narration ("let me verify that first...", "confirmed — this changed, let me re-check...") from the final answer — both travel through `StreamTextDelta`, the only text-carrying event that exists. That means narration gets permanently baked into the persisted answer instead of showing as a live, disappearing "current thought." The frontend already supports this correctly (built for cowork's ENG-1108) via a `thought.progress` + `subtype: reasoning|thinking` event — the Hermes harness already emits it; Anton just never did.

Confirmed via direct code reading, not assumption:
- `StreamTextDelta` is the only text event in `provider.py`'s `StreamEvent` union.
- Anthropic's extended-thinking content blocks were never parsed (misclassified as plain text, or `thinking_delta`/`signature_delta` silently dropped).
- OpenAI's Responses-API reasoning-summary events were never requested (`reasoning.summary` was missing from the request kwargs) and never handled in the streaming loop.
- The MindsHub-managed gateway path (mdb.ai/mindshub.ai) proxies even **Claude** calls over an OpenAI **chat.completions**-shaped envelope (`FLAVOR_MINDS_PASSTHROUGH`), not the Responses API — so a correct fix needs 3 code paths, not just "enable Claude thinking."

### Changes

- **`provider.py`**: new `StreamReasoningDelta` event, added to `StreamEvent`.
- **`anthropic.py`**: `output_config.effort` (verified real — Claude 4.6/4.7's adaptive-thinking parameter, already sent whenever `reasoning_effort` is configured for a compatible model) already triggers server-side thinking; the gap was purely on the parsing side. Added `content_block_start` handling for `thinking`/`redacted_thinking` block types, and `content_block_delta` handling for `thinking_delta` → `StreamReasoningDelta`. `signature_delta` is intentionally a no-op (cryptographic verification signature, not user-facing text). No new request parameter — reuses the existing, safely-gated `reasoning_effort` config.
- **`openai.py` (Responses API / `FLAVOR_OPENAI`)**: added `"summary": "auto"` alongside the existing `effort` in the `reasoning` kwarg (only sent when `reasoning_effort` is already configured, same gating as today), plus a new `response.reasoning_summary_text.delta` branch.
- **`openai.py` (chat.completions / `FLAVOR_MINDS_PASSTHROUGH` + `FLAVOR_OPENAI_COMPATIBLE_GENERIC`)**: reads `delta.reasoning_content` defensively via `getattr` — the de facto convention several OpenAI-compatible reasoning gateways (DeepSeek, vLLM's reasoning parser) use. **This one is best-effort** — flagging clearly for review since I couldn't verify the actual mdb.ai gateway's wire format from this repo alone.
- **`session.py`**: the synthetic "Thinking..." timer (`reasoning_start`/`reasoning_done`) now also closes on the first `StreamReasoningDelta`, matching its existing behavior for text/complete.

Companion PR in cowork-server (maps `StreamReasoningDelta` → the wire `subtype: reasoning` event, matching hermes_harness's existing shape exactly): mindsdb/cowork-server#241 (opening next).

No frontend changes needed — cowork's ENG-1108 already built the client-side handling for this exact `subtype: reasoning|thinking` shape.

Linear: https://linear.app/mindsdb/issue/ENG-1109/anton-capture-claudeopenai-reasoning-as-a-real-subtypereasoning

## Test plan
- [x] New tests: `TestAnthropicProviderReasoningStream` (thinking_delta → StreamReasoningDelta, signature_delta ignored, effort passed via extra_body), `TestResponsesAPIReasoningSummary` (kwargs gating, reasoning_summary_text.delta mapping), `TestChatCompletionsReasoningContent` (reasoning_content read + graceful absence)
- [x] Full suite: 1377 passed, 17 skipped — 2 pre-existing failures in `test_chat_scratchpad.py` (subprocess sandbox execution issue), confirmed identical on unmodified `staging` via `git stash`, unrelated to this change
- [x] `ast.parse` sanity check on all 4 edited modules; `ruff check` clean (one pre-existing, unrelated `E741` elsewhere in `session.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)