### PR TITLE
fail fast on OpenAI insufficient_quota 429

### DIFF
--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -72,10 +72,10 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     Known limits, on purpose: a wire body carrying BOTH a top-level
     ``detail`` and an ``error`` envelope loses the detail inside the SDK
     (the unwrap discards siblings of ``error``) — unrecoverable from
-    ``exc.body``, and no real dialect emits that shape. And a 429 whose
-    envelope carries only ``message`` (OpenAI's own quota dialect, e.g.
-    ``insufficient_quota``) stays generic: classifying arbitrary provider
-    messages as MindsHub quota would put an upsell CTA on BYOK errors.
+    ``exc.body``, and no real dialect emits that shape. OpenAI's own quota
+    dialect (429 + ``insufficient_quota`` code) maps to TokenLimitExceeded
+    with BYOK copy (OpenAI billing link, no MindsHub CTA) — detection is
+    code-exact so arbitrary provider messages never get quota treatment.
     """
     if exc.status_code == 401:
         raise ConnectionError(
@@ -93,6 +93,17 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
         raise TokenLimitExceeded(msg) from exc
 
     code = body.get("code") or envelope.get("code")
+    etype = body.get("type") or envelope.get("type")
+    # OpenAI's own quota dialect (BYOK): permanent for the identical request, so
+    # retrying it as a rate limit just burns the session's backoff budget and
+    # surfaces a misleading "provider overloaded". No MindsHub CTA — the remedy
+    # is the user's OpenAI billing, not an upgrade.
+    if exc.status_code == 429 and "insufficient_quota" in (code, etype):
+        raise TokenLimitExceeded(
+            "Server returned 429 — your OpenAI quota is exhausted. Check your plan "
+            "and billing at https://platform.openai.com."
+        ) from exc
+
     if exc.status_code == 403 and code in ("model_access_denied", "model_disabled"):
         if code == "model_access_denied":
             msg = (

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -442,8 +442,12 @@ def classify_transient(
             provider=provider, code=f"http_{status_code}", session_backoff=False, model=model,
         )
     if status_code == 429 and not b.get("detail"):
-        # Plain rate-limit ("slow down"), NOT an out-of-quota 429 (that carries a
-        # `detail` and is mapped to TokenLimitExceeded upstream of this call).
+        # Plain rate-limit ("slow down"), NOT an out-of-quota 429. Quota 429s are
+        # mapped upstream (gateway dialect carries a `detail`, OpenAI's carries
+        # ``insufficient_quota``); the guard here is defense for direct callers —
+        # a billing failure is permanent and must never enter the retry loop.
+        if etype == "insufficient_quota":
+            return None
         return TransientProviderError(
             f"{provider or 'The model provider'} is rate-limiting requests.",
             provider=provider, code="rate_limited", session_backoff=False, model=model,

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -30,6 +30,7 @@ from anton.core.llm.provider import (
     ModelUnavailableError,
     TokenLimitExceeded,
     TransientProviderError,
+    classify_transient,
 )
 
 
@@ -116,8 +117,6 @@ def test_429_fastapi_detail_maps_to_token_limit():
 def test_429_enveloped_detail_also_maps_to_token_limit():
     # If the gateway ever moves its 429 into the OpenAI envelope while keeping
     # the `detail` field, the SDK unwraps it to top level — still classified.
-    # (An envelope carrying only `message` — OpenAI's own quota dialect —
-    # deliberately stays generic; see the mapper docstring's known limits.)
     # Classified before the transient path (429+detail → quota), so ENG-673's
     # bare-429-is-transient change leaves this untouched.
     exc = _sdk_error(429, json_body={"error": {"detail": "Monthly limit exceeded for tokens: 5/5"}})
@@ -135,6 +134,40 @@ def test_bare_429_is_transient_fail_fast():
         _raise_for_status_error(exc, "sonnet")
     assert err.value.session_backoff is False
     assert "rate-limiting" in str(err.value).lower()
+
+
+def _openai_quota_429():
+    """OpenAI's own quota dialect, byte-shaped like the live body captured
+    from a zero-quota project key on 2026-07-28."""
+    return _sdk_error(429, json_body={"error": {
+        "message": (
+            "You exceeded your current quota, please check your plan and "
+            "billing details. For more information on this error, read the "
+            "docs: https://platform.openai.com/docs/guides/error-codes/api-errors."
+        ),
+        "type": "insufficient_quota",
+        "param": None,
+        "code": "insufficient_quota",
+    }})
+
+
+def test_429_insufficient_quota_maps_to_token_limit():
+    # BYOK OpenAI quota exhaustion is permanent for the identical request —
+    # it must fail fast as a billing error, never enter the retry loop and
+    # surface a misleading "provider overloaded" after the backoff budget.
+    with pytest.raises(TokenLimitExceeded) as err:
+        _raise_for_status_error(_openai_quota_429(), "gpt-4o")
+    assert "platform.openai.com" in str(err.value)
+    # BYOK error: the remedy is the user's OpenAI billing, not a MindsHub plan.
+    assert "console.mindshub.ai" not in str(err.value)
+
+
+def test_429_insufficient_quota_never_transient():
+    # Defense for direct classify_transient callers (mid-stream paths): the
+    # quota 429 has no `detail`, so without the code-exact guard it would
+    # classify as a retryable plain rate-limit.
+    exc = _openai_quota_429()
+    assert classify_transient(429, exc.body, provider="openai", model="gpt-4o") is None
 
 
 def test_429_list_detail_stays_generic():


### PR DESCRIPTION
OpenAI signals out-of-quota with a 429 + `insufficient_quota` code, without the `detail` field our quota check looks for. It fell through to the transient  classifier, got retried for the full backoff budget, and surfaced ~60s later as
a misleading "provider overloaded" error.

Fixes https://linear.app/mindsdb/issue/ENG-1138/429-error-from-openai-is-retried

