### PR TITLE
ENG-1042: revive main-loop truncation recovery — silent turns at the output-token cap

### DIFF
--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -100,6 +100,17 @@ class LLMClient:
         return self._planning_provider
 
     @property
+    def max_tokens(self) -> int:
+        """Default output-token budget for calls that don't pass their own.
+
+        Exposed so the session's truncation recovery can compare a
+        response's ``output_tokens`` against the budget the call actually
+        ran with (ENG-1042) — the gateway's ``finish_reason`` can't be
+        trusted at the cap (ENG-1082).
+        """
+        return self._max_tokens
+
+    @property
     def coding_provider(self) -> LLMProvider:
         """The LLM provider used for coding/skill execution."""
         return self._coding_provider

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -44,6 +44,7 @@ from anton.core.llm.provider import (
     ToolCall,
     TransientProviderError,
 )
+from anton.core.llm.structured import looks_truncated
 from anton.core.llm.thalamus import (
     ACTION_RESPOND,
     ThalamicDecision,
@@ -88,6 +89,36 @@ from anton.core.settings import CoreSettings
 # Sentinel prefixing a compacted-history summary so later compactions can
 # recognize and update it in place rather than summarize a summary.
 _COMPACTED_MARKER = "[COMPACTED CONTEXT — REFERENCE ONLY]"
+
+# Truncation-recovery nudges (ENG-1042). Two variants of the same failure —
+# the response burned its whole output budget without producing a tool call:
+#
+# - Partial text arrived → the answer was cut mid-flight; ask the model to
+#   pick up where it stopped (the pre-existing recovery message).
+# - Nothing visible arrived → the whole budget went to internal reasoning
+#   (reasoning models share one max_tokens between thinking and answer);
+#   "continue where you left off" is meaningless when nothing was emitted,
+#   so ask for the answer up front instead.
+_TRUNCATED_CONTINUE_NUDGE = (
+    "SYSTEM: Your response was truncated because it exceeded the output token limit. "
+    "Continue exactly where you left off. If you were about to call a tool, "
+    "call it now. If the code you were writing was too long, split it into smaller parts."
+)
+_TRUNCATED_SILENT_NUDGE = (
+    "SYSTEM: Your previous response spent its entire output-token budget before "
+    "producing any visible text or tool call — the user saw nothing. Respond again, "
+    "and lead with the answer or the tool call immediately; keep deliberation brief. "
+    "If the output you are building is large, produce it in smaller parts."
+)
+# Shown to the user when the retry ALSO burns its (doubled) budget with
+# nothing visible. The one outcome this ticket forbids is the turn ending
+# silently.
+_TRUNCATION_FAILURE_NOTICE = (
+    "I ran out of output-token budget twice in a row before completing a "
+    "response, so I could not finish this step. Try splitting the request "
+    "into smaller steps; if this keeps happening, lowering the reasoning "
+    "effort in Settings also helps."
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2200,6 +2231,105 @@ class ChatSession:
         self._schedule_cerebellum_flush()
         self._schedule_acc_flush()
 
+    def _turn_max_tokens(self) -> int:
+        """Output-token budget the turn's planning calls actually run with.
+
+        `looks_truncated` compares output tokens against the budget the
+        call was given; the main loop never overrides ``max_tokens``, so
+        that is the client default. Falls back to LLMClient's own default
+        when the client doesn't expose one (mocks, exotic hosts).
+        """
+        budget = getattr(self._llm, "max_tokens", None)
+        return budget if isinstance(budget, int) and budget > 0 else 8192
+
+    async def _recover_truncated_stream(
+        self,
+        llm_response: LLMResponse,
+        *,
+        system: str,
+        tools: list[dict] | None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Retry a response that burned its output budget without finishing.
+
+        ``llm_response`` hit ``max_tokens`` before producing a tool call —
+        detected by token count (`looks_truncated`), NOT ``stop_reason``:
+        the MindsHub gateway reports a normal stop at the cap (ENG-1082),
+        which is what kept this recovery dead for every hosted user
+        (ENG-1042).
+
+        The retry always CHANGES the call — an identical re-issue dies
+        identically (measured: three unchanged retries 14 minutes apart,
+        all silent):
+
+        - the output budget is doubled for this one call, and
+        - a corrective nudge is injected into history — "continue where
+          you left off" when partial text arrived, "answer now, deliberate
+          less" when the whole budget went to internal reasoning.
+
+        If the retry also comes back truncated with nothing visible, a
+        failure notice is shown to the user (and recorded in history) —
+        the turn must never end silently. The retry's ``StreamComplete``
+        is withheld until after that decision so the notice text lands
+        inside the message, then re-yielded for the caller to capture.
+        """
+        budget = self._turn_max_tokens()
+        silent = not (llm_response.content or "").strip()
+        # Empty-content appends are no-ops inside _append_history, so the
+        # silent variant only records the nudge.
+        self._append_history(
+            {"role": "assistant", "content": llm_response.content or ""}
+        )
+        self._append_history(
+            {
+                "role": "user",
+                "content": (
+                    _TRUNCATED_SILENT_NUDGE if silent else _TRUNCATED_CONTINUE_NUDGE
+                ),
+            }
+        )
+        retry_budget = budget * 2
+        logger.warning(
+            "Response truncated at the output budget with no tool call "
+            "(output_tokens=%s, budget=%s, stop_reason=%s, silent=%s) — "
+            "retrying once with max_tokens=%s",
+            llm_response.usage.output_tokens,
+            budget,
+            llm_response.stop_reason,
+            silent,
+            retry_budget,
+        )
+
+        retry: StreamComplete | None = None
+        async for event in self.plan_stream_with_recovery(
+            system=system, tools=tools, max_tokens=retry_budget
+        ):
+            if isinstance(event, StreamComplete):
+                retry = event
+                continue  # withheld — re-yielded below, after the failure check
+            yield event
+
+        if retry is None:
+            return
+
+        retried = retry.response
+        if (
+            not retried.tool_calls
+            and not (retried.content or "").strip()
+            and looks_truncated(retried, retry_budget)
+        ):
+            logger.error(
+                "Truncation retry also burned its whole budget with no "
+                "visible output (output_tokens=%s, retry_budget=%s) — "
+                "surfacing failure to the user",
+                retried.usage.output_tokens,
+                retry_budget,
+            )
+            self._append_history(
+                {"role": "assistant", "content": _TRUNCATION_FAILURE_NOTICE}
+            )
+            yield StreamTextDelta(text=_TRUNCATION_FAILURE_NOTICE)
+        yield retry
+
     async def _stream_and_handle_tools(
         self, user_message: str = ""
     ) -> AsyncIterator[StreamEvent]:
@@ -2221,26 +2351,16 @@ class ChatSession:
         llm_response = response.response
 
         # Detect max_tokens truncation — the LLM was cut off mid-response.
-        # Inject a continuation prompt so it can finish what it was doing.
-        if (
-            llm_response.stop_reason in ("max_tokens", "length")
-            and not llm_response.tool_calls
+        # By token count, not stop_reason: the gateway reports a normal stop
+        # at the cap (ENG-1082), which made a stop_reason gate dead code for
+        # every MindsHub-routed user (ENG-1042).
+        if not llm_response.tool_calls and looks_truncated(
+            llm_response, self._turn_max_tokens()
         ):
-            self._append_history(
-                {"role": "assistant", "content": llm_response.content or ""}
-            )
-            self._append_history(
-                {
-                    "role": "user",
-                    "content": (
-                        "SYSTEM: Your response was truncated because it exceeded the output token limit. "
-                        "Continue exactly where you left off. If you were about to call a tool, "
-                        "call it now. If the code you were writing was too long, split it into smaller parts."
-                    ),
-                }
-            )
             response = None
-            async for event in self.plan_stream_with_recovery(system=system, tools=tools):
+            async for event in self._recover_truncated_stream(
+                llm_response, system=system, tools=tools
+            ):
                 yield event
                 if isinstance(event, StreamComplete):
                     response = event
@@ -2624,27 +2744,14 @@ class ChatSession:
                     return
                 llm_response = response.response
 
-                # Detect max_tokens truncation inside tool loop
-                if (
-                    llm_response.stop_reason in ("max_tokens", "length")
-                    and not llm_response.tool_calls
+                # Detect max_tokens truncation inside tool loop — same
+                # token-count evidence as the pre-loop gate (ENG-1042).
+                if not llm_response.tool_calls and looks_truncated(
+                    llm_response, self._turn_max_tokens()
                 ):
-                    self._append_history(
-                        {"role": "assistant", "content": llm_response.content or ""}
-                    )
-                    self._append_history(
-                        {
-                            "role": "user",
-                            "content": (
-                                "SYSTEM: Your response was truncated because it exceeded the output token limit. "
-                                "Continue exactly where you left off. If you were about to call a tool, "
-                                "call it now. If the code you were writing was too long, split it into smaller parts."
-                            ),
-                        }
-                    )
                     response = None
-                    async for event in self.plan_stream_with_recovery(
-                        system=system, tools=tools
+                    async for event in self._recover_truncated_stream(
+                        llm_response, system=system, tools=tools
                     ):
                         yield event
                         if isinstance(event, StreamComplete):

--- a/anton/core/settings.py
+++ b/anton/core/settings.py
@@ -17,6 +17,15 @@ class CoreSettings(BaseSettings):
     # and the router treats truncation as "delegate".
     router_max_tokens: int = 1024
 
+    # Output-token budget per planning/coding LLM call. Was a hardcoded
+    # fallback in LLMClient.from_settings (always 8192, because this field
+    # didn't exist — ENG-1042 Fix 4); now configurable via ANTON_MAX_TOKENS
+    # or a host overlay (cowork-server). Reasoning models spend internal
+    # thinking from this same budget, so raising it is the blunt mitigation
+    # for answers that die at the cap; the session's truncation recovery
+    # retries one-off at double this value.
+    max_tokens: int = 8192
+
     # Session orchestration tuning
     max_tool_rounds: int = 25
     max_continuations: int = 3

--- a/tests/test_session_truncation_recovery.py
+++ b/tests/test_session_truncation_recovery.py
@@ -1,0 +1,360 @@
+"""Main-loop output-budget truncation recovery (ENG-1042).
+
+A completion can burn its entire ``max_tokens`` on internal reasoning (or
+narration) and return nothing — no text, no tool call, no error. The session
+has had a recovery for this since early on, but it gated on
+``stop_reason in ("max_tokens", "length")`` and the MindsHub gateway reports
+``finish_reason: "stop"`` at the cap (ENG-1082), so the recovery was dead code
+for every hosted user: 38 fully-silent generations across 12 users in one week.
+
+What must hold now:
+
+1. The gate fires on token-count evidence (`looks_truncated`), so the
+   gateway's dishonest ``"stop"`` no longer disables it.
+2. The retry is never an unchanged re-issue — the three prod failures in the
+   ticket ARE an unchanged retry loop dying identically. The retry must raise
+   the output budget and inject a corrective nudge.
+3. The nudge matches the variant: "continue where you left off" is meaningless
+   when nothing visible was produced.
+4. If the retry also dies silently, the user sees an explicit failure notice —
+   a turn must never end silently.
+5. Completions that finish inside the budget are untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.conftest import make_mock_llm
+
+from anton.core.llm.provider import (
+    LLMResponse,
+    StreamComplete,
+    StreamTextDelta,
+    ToolCall,
+    Usage,
+)
+from anton.core.session import (
+    _TRUNCATED_CONTINUE_NUDGE,
+    _TRUNCATED_SILENT_NUDGE,
+    _TRUNCATION_FAILURE_NOTICE,
+    ChatSession,
+    ChatSessionConfig,
+    _VerifierVerdict,
+)
+
+BUDGET = 8192
+
+
+@pytest.fixture()
+def workspace():
+    # Keep scratchpad venvs inside the repo workspace (pytest runs sandboxed
+    # and can't write to the real home directory).
+    base = Path(__file__).resolve().parents[1] / ".pytest-workspace"
+    base.mkdir(parents=True, exist_ok=True)
+    return MagicMock(base=base)
+
+
+def _response(
+    content: str = "",
+    output_tokens: int = 20,
+    stop_reason: str | None = "end_turn",
+    tool_calls: list[ToolCall] | None = None,
+) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        tool_calls=tool_calls or [],
+        usage=Usage(input_tokens=10, output_tokens=output_tokens),
+        stop_reason=stop_reason,
+    )
+
+
+def _silent_at_cap(output_tokens: int = BUDGET) -> LLMResponse:
+    """The prod signature: whole budget spent, nothing visible, and the
+    gateway calls it a normal stop (ENG-1082)."""
+    return _response(content="", output_tokens=output_tokens, stop_reason="stop")
+
+
+class _FakeAsyncIter:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+class _ScriptedPlanStream:
+    """`plan_stream` fake that plays back one response per call and records
+    every call's kwargs, so tests can assert what the retry actually sent."""
+
+    def __init__(self, responses: list[LLMResponse]):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        # Snapshot messages — the session mutates the same history list
+        # between calls, so a live reference would alias every entry.
+        recorded = dict(kwargs)
+        recorded["messages"] = [dict(m) for m in kwargs.get("messages", [])]
+        self.calls.append(recorded)
+        return _FakeAsyncIter([StreamComplete(response=self._responses.pop(0))])
+
+
+def _make_session(responses: list[LLMResponse], workspace) -> tuple[ChatSession, _ScriptedPlanStream]:
+    mock_llm = make_mock_llm()
+    mock_llm.max_tokens = BUDGET
+    script = _ScriptedPlanStream(responses)
+    mock_llm.plan_stream = script
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    return session, script
+
+
+async def _run_turn(session: ChatSession, prompt: str = "build the forecast workbook"):
+    events = []
+    try:
+        async for event in session.turn_stream(prompt):
+            events.append(event)
+    finally:
+        await session.close()
+    return events
+
+
+# --------------------------------------------------------------------------
+# 1. The gate fires on the gateway dialect (the dead-code revival).
+# --------------------------------------------------------------------------
+
+
+async def test_silent_burn_with_finish_reason_stop_is_recovered(workspace):
+    """output_tokens == budget with stop_reason "stop" — exactly what the
+    gateway reports (ENG-1082) and exactly what the old stop_reason gate
+    could never see. One retry must happen and its answer must reach the
+    user."""
+    session, script = _make_session(
+        [_silent_at_cap(), _response("Here is the forecast plan.", output_tokens=40)],
+        workspace,
+    )
+
+    events = await _run_turn(session)
+
+    assert len(script.calls) == 2, "the truncated call must be retried once"
+    final = [e for e in events if isinstance(e, StreamComplete)]
+    assert final and final[-1].response.content == "Here is the forecast plan."
+
+
+async def test_honest_length_stop_reason_still_fires(workspace):
+    """Providers that report truncation honestly (OpenAI "length") keep
+    working even below the cap — `looks_truncated` honours both signals."""
+    session, script = _make_session(
+        [
+            _response(content="", output_tokens=100, stop_reason="length"),
+            _response("Recovered.", output_tokens=10),
+        ],
+        workspace,
+    )
+
+    await _run_turn(session)
+
+    assert len(script.calls) == 2
+
+
+# --------------------------------------------------------------------------
+# 2. The retry is never an unchanged re-issue (ticket Done-when).
+# --------------------------------------------------------------------------
+
+
+async def test_retry_is_not_an_unchanged_reissue(workspace):
+    """The three prod failures in ENG-1042 are an unchanged retry loop dying
+    identically 14 minutes apart. The retry must differ from the failed call
+    in BOTH the budget and the messages."""
+    session, script = _make_session(
+        [_silent_at_cap(), _response("Done.", output_tokens=10)],
+        workspace,
+    )
+
+    await _run_turn(session)
+
+    first, retry = script.calls
+    assert retry.get("max_tokens") == BUDGET * 2, (
+        "the retry must raise the output budget, not re-issue the same call"
+    )
+    assert retry["messages"] != first["messages"], (
+        "the retry must inject a corrective nudge into the conversation"
+    )
+
+
+async def test_retry_budget_scales_with_the_client_budget(workspace):
+    """The doubled budget is relative to the budget the call actually ran
+    with (the configurable client default — ENG-1042 Fix 4), not a magic
+    constant."""
+    mock_llm = make_mock_llm()
+    mock_llm.max_tokens = 1000
+    script = _ScriptedPlanStream(
+        [
+            _response(content="", output_tokens=1000, stop_reason="stop"),
+            _response("ok", output_tokens=5),
+        ]
+    )
+    mock_llm.plan_stream = script
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    await _run_turn(session)
+
+    assert script.calls[1].get("max_tokens") == 2000
+
+
+# --------------------------------------------------------------------------
+# 3. The nudge matches the variant.
+# --------------------------------------------------------------------------
+
+
+def _user_texts(messages: list[dict]) -> list[str]:
+    return [str(m.get("content")) for m in messages if m.get("role") == "user"]
+
+
+async def test_silent_burn_gets_the_answer_now_nudge(workspace):
+    """Nothing visible was produced — 'continue where you left off' is
+    meaningless. The model must be told to answer immediately instead."""
+    session, script = _make_session(
+        [_silent_at_cap(), _response("Done.", output_tokens=10)],
+        workspace,
+    )
+
+    await _run_turn(session)
+
+    retry_user_texts = "\n".join(_user_texts(script.calls[1]["messages"]))
+    assert _TRUNCATED_SILENT_NUDGE in retry_user_texts
+    assert _TRUNCATED_CONTINUE_NUDGE not in retry_user_texts
+
+
+async def test_partial_text_gets_the_continue_nudge_and_keeps_the_partial(workspace):
+    """Truncated-text variant: the partial answer must be preserved in
+    history (so the continuation actually continues it) and the nudge is the
+    'continue where you left off' one."""
+    partial = "## Forecast method per account\n1. Revenue: run-rate…"
+    session, script = _make_session(
+        [
+            _response(content=partial, output_tokens=BUDGET, stop_reason="stop"),
+            _response("…2. COGS: seasonal average. Workbook built.", output_tokens=30),
+        ],
+        workspace,
+    )
+
+    await _run_turn(session)
+
+    retry_messages = script.calls[1]["messages"]
+    retry_user_texts = "\n".join(_user_texts(retry_messages))
+    assert _TRUNCATED_CONTINUE_NUDGE in retry_user_texts
+    assert _TRUNCATED_SILENT_NUDGE not in retry_user_texts
+    assert any(
+        m.get("role") == "assistant" and partial in str(m.get("content"))
+        for m in retry_messages
+    ), "the truncated partial answer must be in history for the continuation"
+
+
+# --------------------------------------------------------------------------
+# 4. A double failure is surfaced, never silent.
+# --------------------------------------------------------------------------
+
+
+async def test_double_silent_burn_surfaces_a_visible_failure(workspace):
+    """The retry also burns its (doubled) budget with nothing visible. The
+    user must see an explicit notice — the one outcome ENG-1042 forbids is
+    the turn ending silently."""
+    session, script = _make_session(
+        [_silent_at_cap(), _silent_at_cap(output_tokens=BUDGET * 2)],
+        workspace,
+    )
+
+    events = await _run_turn(session)
+
+    assert len(script.calls) == 2, "one retry, then stop — no unchanged loop"
+    notice_deltas = [
+        e for e in events
+        if isinstance(e, StreamTextDelta) and _TRUNCATION_FAILURE_NOTICE in e.text
+    ]
+    assert notice_deltas, "the user must be told the turn died"
+    # The notice must precede the final StreamComplete so it lands inside
+    # the message rather than after the renderer closes it.
+    notice_idx = events.index(notice_deltas[0])
+    complete_idx = max(
+        i for i, e in enumerate(events) if isinstance(e, StreamComplete)
+    )
+    assert notice_idx < complete_idx
+
+
+async def test_double_failure_is_recorded_in_history(workspace):
+    """The failure notice must also land in history so the next turn's model
+    knows the previous turn died rather than silently vanished."""
+    session, script = _make_session(
+        [_silent_at_cap(), _silent_at_cap(output_tokens=BUDGET * 2)],
+        workspace,
+    )
+
+    await _run_turn(session)
+
+    assert any(
+        m.get("role") == "assistant"
+        and _TRUNCATION_FAILURE_NOTICE in str(m.get("content"))
+        for m in session._history
+    )
+
+
+# --------------------------------------------------------------------------
+# 5. Healthy completions are untouched.
+# --------------------------------------------------------------------------
+
+
+async def test_completion_inside_the_budget_is_not_retried(workspace):
+    session, script = _make_session(
+        [_response("All done.", output_tokens=500)], workspace
+    )
+
+    await _run_turn(session)
+
+    assert len(script.calls) == 1
+
+
+async def test_at_cap_with_a_tool_call_is_not_intercepted(workspace):
+    """A response that hit the cap but still delivered a usable tool call
+    proceeds into the tool loop — the recovery only owns the no-tool-call
+    case. (Damaged tool-call JSON is the structured-output path's job,
+    ENG-1081.)"""
+    tool_call = ToolCall(
+        id="tc_1",
+        name="scratchpad",
+        input={"action": "exec", "name": "main", "code": "print(1)"},
+    )
+    session, script = _make_session(
+        [
+            _response(
+                content="",
+                output_tokens=BUDGET,
+                stop_reason="stop",
+                tool_calls=[tool_call],
+            ),
+            _response("Tool output looks right — done.", output_tokens=30),
+        ],
+        workspace,
+    )
+    # The tool round trips the completion verifier — give it a clean verdict
+    # so it doesn't spend the scripted responses on continuations.
+    session._llm.generate_object_code = AsyncMock(
+        return_value=_VerifierVerdict(status="COMPLETE", reason="done")
+    )
+
+    await _run_turn(session)
+
+    # Call 2 is the post-tool follow-up, not a truncation retry: no raised
+    # budget, no nudge.
+    assert script.calls[1].get("max_tokens") is None
+    assert _TRUNCATED_SILENT_NUDGE not in "\n".join(
+        _user_texts(script.calls[1]["messages"])
+    )

--- a/tests/test_session_truncation_recovery.py
+++ b/tests/test_session_truncation_recovery.py
@@ -303,7 +303,7 @@ async def test_double_failure_is_recorded_in_history(workspace):
     assert any(
         m.get("role") == "assistant"
         and _TRUNCATION_FAILURE_NOTICE in str(m.get("content"))
-        for m in session._history
+        for m in session.history
     )
 
 


### PR DESCRIPTION
## What

A completion can burn its entire `max_tokens` on internal reasoning (or narration) and return **nothing** — no text, no tool call, no error. Measured in the 07-22→07-29 Langfuse sweep: **38 fully-silent generations across 12 users**, 22 from one named customer (Mynda Treacy) whose "it simply does nothing" report this explains.

Linear: [ENG-1042](https://linear.app/mindsdb/issue/ENG-1042)

## Root cause chain

anton already had a recovery for exactly this (`session.py`, two gates), but it gated on `stop_reason in ("max_tokens", "length")` — and the MindsHub gateway reports `finish_reason: "stop"` at the cap (ENG-1082, gateway fix in review as mindshub_inference#367). The recovery was **dead code for every hosted user**.

## Changes

1. **Both main-loop gates now use `looks_truncated()`** (ENG-1081's shared classifier): `output_tokens >= budget` is the evidence; an honest `stop_reason` still counts, a dishonest one no longer disables the net. Works today, with or without the gateway fix.
2. **The retry always CHANGES the call** (ticket Done-when: the three prod failures *are* an unchanged retry loop dying identically 14 min apart):
   - output budget doubled for that one retry (`plan_stream_with_recovery(max_tokens=…)`), and
   - a variant-aware nudge: *continue where you left off* when partial text arrived; *answer now, deliberate less* when the whole budget went to reasoning and nothing was emitted (the old "continue" nudge is meaningless there).
3. **Double failure is surfaced, never silent**: if the retry also burns its doubled budget with nothing visible, the user sees an explicit notice (yielded before the withheld `StreamComplete` so it lands inside the message) and it's recorded in history for the next turn.
4. **`CoreSettings.max_tokens`** (default 8192, `ANTON_MAX_TOKENS`) — ticket Fix 4: `LLMClient.from_settings` already read `getattr(settings, "max_tokens", 8192)` but the field never existed, so the fallback always won. Hosts (cowork-server overlay — follow-up) can now raise the budget.

The truncated-**text** variant (partial deliverable presented as complete) is covered by the same gate: the partial answer is preserved in history and the continue-nudge retry finishes it.

## Tests

`tests/test_session_truncation_recovery.py` (10 tests, all passing; full suite 1,345 passed — the 2 `test_chat_scratchpad` failures are pre-existing on clean `origin/staging`, real-subprocess sandbox issue):

- gate fires on the gateway dialect (`stop_reason "stop"` + `output_tokens == budget`) — the dead-code revival itself
- **retry differs from the failed call in both budget and messages** (explicit ticket Done-when requirement)
- silent vs partial nudge variants; partial text preserved in history
- double silent burn yields a visible failure notice, ordered before the final `StreamComplete`, and lands in history
- healthy completions and at-cap-with-tool-call responses are untouched

## Security pass

Reviewed the changed surface: no new inputs cross a trust boundary (nudges/notice are static strings; model content was already appended to history on this path), no credentials/secrets in the new log lines (token counts and stop_reason only), no new endpoints or deserialization. Nothing flagged.

## Out of scope / follow-ups

- Gateway `finish_reason` fix: ENG-1082 (mindshub_inference#367, in review) — independent, complementary.
- Reserved thinking headroom at the gateway (ticket Fix 1): recorded on the ticket — the effort API (`output_config: {effort}`) has no separate thinking-budget knob, so headroom is implemented reactively here (doubled retry budget) instead.
- cowork-server `UserSettings`/overlay for `max_tokens` so hosted deployments can set it per-user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## QA Instructions

**Where to test:** a build containing this change (desktop git channel after the weekly release; or the sandbox driver on the branch), pointed at a gateway **that has ENG-1082/#367** — staging today, prod after next week's promotion. ⚠️ **Against a pre-#367 gateway this fix is inert on streamed calls** (the gateway sends no streaming usage — ENG-1158 — and mislabels truncation as "stop"), so QA against prod before the gateway promotes will falsely fail.

1. **Deterministic recovery check (validated on staging 2026-07-30):** run anton with `ANTON_MAX_TOKENS=400`, model `sonnet` via MindsHub, prompt "write a 1200-word explanation of X, no tools". Expect the log `Response truncated at the output budget … retrying once with max_tokens=800`, a continuation in the streamed text, and no silent cut-off. (BYO direct Anthropic key also works — real providers report streaming usage, so the token clause fires without #367.)
2. **Silent-variant nudge:** same setup at `ANTON_MAX_TOKENS=200` on a reasoning-heavy question — if a response burns the budget with nothing visible, the retry log shows `silent=True` and the answer still arrives (or the explicit double-burn notice does).
3. **Double-burn notice:** if both attempts die at the cap, the user-visible message "I ran out of output-token budget twice in a row…" must appear — never a silent end.
4. **Healthy-path regression:** normal tasks at the default 8192 behave identically to before (no retries in logs, no nudges in history).
5. **Config knob (Fix 4):** `ANTON_MAX_TOKENS=16384` is honored (visible in the retry log arithmetic: retries at 32768).
6. **Post-prod re-measure (7 days):** baseline to beat — 38 fully-silent generations / 12 users / week; sonnet-5 40–80k band 1.92% (ENG-1042 sweep protocol; verify candidates by payload, not exact-cap counts alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
