### PR TITLE
ENG-1084: memory & extraction subsystems silently did nothing on narrating models — shared truncation ladder for every forced-schema call

### DIFF
--- a/anton/commands/datasource/custom.py
+++ b/anton/commands/datasource/custom.py
@@ -9,6 +9,10 @@ from pydantic import BaseModel, Field
 
 from anton.connect_collector import extract_variables
 from anton.commands.datasource.helpers import show_credential_help
+from anton.core.llm.structured import (
+    generate_with_truncation_retry,
+    no_preamble_instruction,
+)
 from anton.core.datasources.datasource_registry import DatasourceEngine, DatasourceField
 from anton.utils.datasources import persist_custom_engine
 from anton.utils.prompt import prompt_or_cancel
@@ -252,11 +256,6 @@ async def handle_add_custom_datasource(
     )
 
     try:
-        from anton.core.llm.structured import (
-            generate_with_truncation_retry,
-            no_preamble_instruction,
-        )
-
         # 1024 sat inside the measured narration range (245–1,654+) — the
         # shared ladder gives narrating models room to reach the forced call
         # (ENG-1084).

--- a/anton/commands/datasource/custom.py
+++ b/anton/commands/datasource/custom.py
@@ -252,11 +252,21 @@ async def handle_add_custom_datasource(
     )
 
     try:
-        spec: _CustomDatasourceSpec = await session._llm.generate_object(
+        from anton.core.llm.structured import (
+            generate_with_truncation_retry,
+            no_preamble_instruction,
+        )
+
+        # 1024 sat inside the measured narration range (245–1,654+) — the
+        # shared ladder gives narrating models room to reach the forced call
+        # (ENG-1084).
+        spec: _CustomDatasourceSpec = await generate_with_truncation_retry(
+            session._llm.generate_object,
             _CustomDatasourceSpec,
-            system="You are a data source connection expert.",
+            system="You are a data source connection expert."
+            + no_preamble_instruction(_CustomDatasourceSpec),
             messages=[{"role": "user", "content": llm_prompt}],
-            max_tokens=1024,
+            subsystem="custom-datasource-spec",
         )
     except Exception:
         console.print(

--- a/anton/commands/share.py
+++ b/anton/commands/share.py
@@ -15,6 +15,11 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel, Field
 from rich.console import Console
 
+from anton.core.llm.structured import (
+    generate_with_truncation_retry,
+    no_preamble_instruction,
+)
+
 if TYPE_CHECKING:
     from anton.config.settings import AntonSettings
     from anton.core.llm.client import LLMClient
@@ -60,11 +65,6 @@ async def _generate_meta(
     session_id: str,
 ) -> tuple[str, str]:
     try:
-        from anton.core.llm.structured import (
-            generate_with_truncation_retry,
-            no_preamble_instruction,
-        )
-
         conversation_text = _format_history_for_llm(history)
         # 300 was tighter than the verifier's infamous 256 (ENG-1081), for a
         # call asked to produce a whole-session distillation — narrating

--- a/anton/commands/share.py
+++ b/anton/commands/share.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import getpass
 import json
+import logging
 import os
 import re
 import tempfile
@@ -59,24 +60,38 @@ async def _generate_meta(
     session_id: str,
 ) -> tuple[str, str]:
     try:
+        from anton.core.llm.structured import (
+            generate_with_truncation_retry,
+            no_preamble_instruction,
+        )
+
         conversation_text = _format_history_for_llm(history)
-        result = await llm_client.generate_object_code(
+        # 300 was tighter than the verifier's infamous 256 (ENG-1081), for a
+        # call asked to produce a whole-session distillation — narrating
+        # models could never finish it (ENG-1084).
+        result = await generate_with_truncation_retry(
+            llm_client.generate_object_code,
             _SessionMeta,
             system=(
                 "You are producing a portable context distillation of an analytical session. "
                 "For the summary: cover the goal, key discoveries, any corrections or dead ends, "
                 "and where the analysis currently stands. Every distinct finding should appear once. "
                 "No filler, no repetition, no omissions of meaningful conclusions."
+                + no_preamble_instruction(_SessionMeta)
             ),
             messages=[{
                 "role": "user",
                 "content": f"Distill this analytical session:\n\n{conversation_text}",
             }],
-            max_tokens=300,
+            subsystem="session-share-meta",
         )
 
         return result.title, result.summary
-    except Exception:
+    except Exception as exc:
+        logging.getLogger(__name__).warning(
+            "session-share-meta failed (%s) — using the fallback title",
+            type(exc).__name__,
+        )
         return f"session-{session_id}", ""
 
 

--- a/anton/commands/skills.py
+++ b/anton/commands/skills.py
@@ -27,6 +27,11 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.table import Table
 
+from anton.core.llm.structured import (
+    generate_with_truncation_retry,
+    no_preamble_instruction,
+)
+
 from anton.core.memory.skills import (
     Skill,
     SkillStats,
@@ -240,11 +245,6 @@ async def handle_skill_save(
     console.print("[anton.cyan](anton)[/] Drafting a skill from recent work…")
 
     try:
-        from anton.core.llm.structured import (
-            generate_with_truncation_retry,
-            no_preamble_instruction,
-        )
-
         # A skill draft is a real document, and narrating models spend
         # 245–1,654+ tokens on prose before the forced call — 1500 sat inside
         # that range (ENG-1084).

--- a/anton/commands/skills.py
+++ b/anton/commands/skills.py
@@ -240,11 +240,21 @@ async def handle_skill_save(
     console.print("[anton.cyan](anton)[/] Drafting a skill from recent work…")
 
     try:
-        draft: _SkillDraft = await session._llm.generate_object(
+        from anton.core.llm.structured import (
+            generate_with_truncation_retry,
+            no_preamble_instruction,
+        )
+
+        # A skill draft is a real document, and narrating models spend
+        # 245–1,654+ tokens on prose before the forced call — 1500 sat inside
+        # that range (ENG-1084).
+        draft: _SkillDraft = await generate_with_truncation_retry(
+            session._llm.generate_object,
             _SkillDraft,
-            system=_DRAFT_SYSTEM_PROMPT,
+            system=_DRAFT_SYSTEM_PROMPT + no_preamble_instruction(_SkillDraft),
             messages=[{"role": "user", "content": user_prompt}],
-            max_tokens=1500,
+            budgets=(2048, 8192),
+            subsystem="skill-draft",
         )
     except Exception as exc:
         console.print()

--- a/anton/connect_collector.py
+++ b/anton/connect_collector.py
@@ -18,10 +18,15 @@ This mirrors the LLM-returns-JSON pattern already used by
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 from pydantic import BaseModel, Field
 
+from anton.core.llm.structured import (
+    generate_with_truncation_retry,
+    no_preamble_instruction,
+)
 from anton.core.datasources.datasource_registry import (
     AuthMethod,
     DatasourceEngine,
@@ -32,6 +37,8 @@ if TYPE_CHECKING:
     from rich.console import Console
 
     from anton.core.session import ChatSession
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -247,13 +254,24 @@ async def extract_variables(
     )
 
     try:
-        extraction: _ExtractionResult = await session._llm.generate_object(
+        # 512 sat inside the measured narration range, so narrating models
+        # truncated before the forced call and the swallow below silently
+        # dropped the user's pasted credentials (ENG-1084).
+        extraction: _ExtractionResult = await generate_with_truncation_retry(
+            session._llm.generate_object,
             _ExtractionResult,
-            system=_SYSTEM_PROMPT,
+            system=_SYSTEM_PROMPT + no_preamble_instruction(_ExtractionResult),
             messages=[{"role": "user", "content": user_prompt}],
-            max_tokens=512,
+            log=logger,
+            subsystem="credential-extraction",
         )
-    except Exception:
+    except Exception as exc:
+        # Type name only — the exception message can quote the user's pasted
+        # text, which here is credentials.
+        logger.warning(
+            "credential-extraction failed (%s) — falling back to manual entry",
+            type(exc).__name__,
+        )
         return result
 
     # Filter and normalize variables — only keep keys that match the

--- a/anton/core/llm/structured.py
+++ b/anton/core/llm/structured.py
@@ -1,8 +1,10 @@
 """Shared schema-building / response-unwrapping for structured LLM output.
 
-Two pure helper functions that turn a Pydantic model (or `list[Model]`)
-into the inputs needed for a forced tool-call, and validate the LLM's
-response back into a typed Python instance.
+Pure helper functions that turn a Pydantic model (or `list[Model]`) into
+the inputs needed for a forced tool-call and validate the LLM's response
+back into a typed Python instance — plus the shared budget ladder
+(`generate_with_truncation_retry`) every forced-schema call site runs
+through so narrating models get room to reach the call (ENG-1084).
 
 Used by:
 
@@ -27,9 +29,103 @@ the subprocess already imports from `anton.core.*` at boot.
 
 from __future__ import annotations
 
-from typing import Any, NoReturn
+import logging
+from typing import Any, Awaitable, Callable, NoReturn
 
 from .provider import StructuredOutputError
+
+
+# Default output-budget ladder for forced-schema calls: first attempt, then
+# one retry used only when the first came back truncated. Sized by the same
+# measurement as the completion verifier's (ENG-1081): narrating models
+# (`mindshub_air`/kimi, `deepseek`) spend 245–1,654+ tokens on prose before
+# reaching the forced tool call — and the narration scales with the input, so
+# a consolidation pass over a whole scratchpad session was observed filling
+# 2,048 exactly (ENG-1084). Non-narrating models answer these calls in tens
+# of tokens and never pay for the headroom.
+DEFAULT_STRUCTURED_BUDGETS: tuple[int, ...] = (2048, 4096)
+
+
+def no_preamble_instruction(schema_class) -> str:
+    """System-prompt suffix that asks for the forced tool call first.
+
+    Shortens the preamble on narrating models but is NOT sufficient alone
+    (measured 0/3 at a 256 budget even with it — ENG-1081), so it pairs with
+    the budget ladder rather than replacing it. Tool name comes off the
+    schema class so it can't go stale.
+    """
+    name = getattr(schema_class, "__name__", str(schema_class))
+    return (
+        f"\n\nCall the {name} tool immediately as your first action. Do not "
+        "think out loud, restate the conversation, or explain your reasoning "
+        "before calling it — put any brief justification in the tool's fields."
+    )
+
+
+async def generate_with_truncation_retry(
+    generate: Callable[..., Awaitable[Any]],
+    schema_class,
+    *,
+    system: str,
+    messages: list[dict],
+    budgets: tuple[int, ...] = DEFAULT_STRUCTURED_BUDGETS,
+    log: logging.Logger | None = None,
+    subsystem: str = "structured-output",
+):
+    """Run a forced-schema call through the ENG-1081 budget ladder.
+
+    ``generate`` is a bound ``LLMClient.generate_object`` /
+    ``generate_object_code``. Each budget in ``budgets`` is tried in order;
+    a retry is bought ONLY for a truncated attempt
+    (``StructuredOutputError.truncated`` — the model narrated past the budget
+    before reaching the tool call). Any other failure — provider error,
+    schema mismatch, a model that declines the call outright — is re-raised
+    immediately: a bigger budget cannot fix it, so don't pay for one
+    (measured: fable returns an unusable ``{}`` call at 8 output tokens
+    regardless of budget, ENG-1095).
+
+    Exists because ENG-1084 found seven `generate_object*` call sites that
+    each hand-rolled a single tight budget with no retry — 512/600 sat
+    *inside* the measured narration range, so identity extraction, the
+    cerebellum diff pass and session consolidation silently returned nothing
+    for every narrating-model user. One ladder, shared, instead of an eighth
+    hand-rolled copy.
+
+    Logging stays content-safe: budgets, token counts and the truncation
+    verdict only — never the exception message, which can quote model output
+    derived from the user's conversation.
+    """
+    logger = log or logging.getLogger(__name__)
+    last_exc: StructuredOutputError | None = None
+    for attempt, budget in enumerate(budgets):
+        try:
+            return await generate(
+                schema_class, system=system, messages=messages, max_tokens=budget
+            )
+        except StructuredOutputError as exc:
+            retrying = exc.truncated and attempt + 1 < len(budgets)
+            logger.warning(
+                "%s: forced %s call failed (%s, budget=%d, output_tokens=%s) "
+                "retrying=%s",
+                subsystem,
+                getattr(schema_class, "__name__", schema_class),
+                "TRUNCATED" if exc.truncated else "NO_TOOL_CALL",
+                budget,
+                exc.output_tokens,
+                retrying,
+            )
+            if not retrying:
+                raise
+            last_exc = exc
+    # Only reachable with an empty `budgets`; treat as a caller bug but keep
+    # the contract (raise, never return None silently).
+    raise last_exc or StructuredOutputError(
+        "generate_with_truncation_retry called with no budgets",
+        truncated=False,
+        output_tokens=0,
+        max_tokens=0,
+        stop_reason=None,
+    )
 
 
 def looks_truncated(response, budget: int) -> bool:

--- a/anton/core/memory/cerebellum.py
+++ b/anton/core/memory/cerebellum.py
@@ -70,6 +70,10 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel, Field
 
 from anton.core.backends.base import Cell
+from anton.core.llm.structured import (
+    generate_with_truncation_retry,
+    no_preamble_instruction,
+)
 from anton.core.memory.base import Engram
 
 if TYPE_CHECKING:
@@ -280,7 +284,10 @@ class Cerebellum:
         try:
             lessons = await self._run_diff(cells)
         except Exception as exc:
-            _log.warning("cerebellum diff pass failed: %s", exc)
+            # Type name only: a ValidationError's message embeds the rejected
+            # model output, which is derived from the user's conversation and
+            # doesn't belong in app logs (ENG-1084).
+            _log.warning("cerebellum diff pass failed (%s)", type(exc).__name__)
             return []
 
         if not lessons:
@@ -289,7 +296,9 @@ class Cerebellum:
         try:
             await self._encode_lessons(lessons)
         except Exception as exc:
-            _log.warning("cerebellum failed to encode lessons: %s", exc)
+            _log.warning(
+                "cerebellum failed to encode lessons (%s)", type(exc).__name__
+            )
 
         return lessons
 
@@ -345,11 +354,16 @@ class Cerebellum:
         )
         prompt = _DIFF_USER_TEMPLATE.format(cells_block=cells_block)
 
-        result: _DiffPassResult = await self._llm.generate_object_code(
+        # 600 sat inside the measured narration range (245–1,654+ tokens of
+        # prose before the forced call on narrating models), so the diff pass
+        # truncated routinely and flush() logged it away (ENG-1084).
+        result: _DiffPassResult = await generate_with_truncation_retry(
+            self._llm.generate_object_code,
             _DiffPassResult,
-            system=_DIFF_SYSTEM_PROMPT,
+            system=_DIFF_SYSTEM_PROMPT + no_preamble_instruction(_DiffPassResult),
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=600,
+            log=_log,
+            subsystem="cerebellum-diff",
         )
 
         # Convert the validated Pydantic drafts to the public dataclass

--- a/anton/core/memory/consolidator.py
+++ b/anton/core/memory/consolidator.py
@@ -22,12 +22,19 @@ Like sleep, consolidation is:
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
 from anton.core.llm.prompts import CONSOLIDATION_PROMPT
+from anton.core.llm.structured import (
+    generate_with_truncation_retry,
+    no_preamble_instruction,
+)
 from anton.core.memory.base import Engram
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from anton.core.llm.client import LLMClient
@@ -165,13 +172,24 @@ class Consolidator:
         session_summary = "\n".join(summary_lines)
 
         try:
-            result: _ConsolidatedLessons = await llm_client.generate_object_code(
+            # Consolidation feeds in a whole scratchpad session, and narration
+            # scales with input — observed filling 2,048 exactly in prod on
+            # `mindshub_air` (ENG-1084). The ladder's 4,096 retry covers it.
+            result: _ConsolidatedLessons = await generate_with_truncation_retry(
+                llm_client.generate_object_code,
                 _ConsolidatedLessons,
-                system=CONSOLIDATION_PROMPT,
+                system=CONSOLIDATION_PROMPT
+                + no_preamble_instruction(_ConsolidatedLessons),
                 messages=[{"role": "user", "content": session_summary}],
-                max_tokens=2048,
+                log=logger,
+                subsystem="consolidation",
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "consolidation failed (%s) — no lessons extracted from this "
+                "session",
+                type(exc).__name__,
+            )
             return []
 
         engrams: list[Engram] = []

--- a/anton/core/memory/cortex.py
+++ b/anton/core/memory/cortex.py
@@ -19,11 +19,16 @@ like how the PFC coordinates retrieval from multiple brain memory systems.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
+from anton.core.llm.structured import (
+    generate_with_truncation_retry,
+    no_preamble_instruction,
+)
 from anton.core.memory.base import HippocampusProtocol
 from anton.core.memory.base import Engram
 from anton.core.memory.hippocampus import Hippocampus
@@ -31,6 +36,8 @@ from anton.core.memory.hippocampus import Hippocampus
 if TYPE_CHECKING:
     from anton.core.llm.client import LLMClient
     from anton.core.memory.episodes import EpisodicMemory
+
+logger = logging.getLogger(__name__)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -477,15 +484,29 @@ Do NOT add, modify, or summarize rules — return them verbatim.
             return
 
         try:
-            result: _CompactionResult = await self._llm.generate_object_code(
+            # Compaction echoes the kept entries back, so its output scales
+            # with the file — the ladder starts at the old fixed budget and
+            # buys one doubling on truncation (ENG-1084).
+            result: _CompactionResult = await generate_with_truncation_retry(
+                self._llm.generate_object_code,
                 _CompactionResult,
-                system=_COMPACTION_PROMPT,
+                system=_COMPACTION_PROMPT + no_preamble_instruction(_CompactionResult),
                 messages=[{"role": "user", "content": "\n".join(entries)}],
-                max_tokens=4096,
+                budgets=(4096, 8192),
+                log=logger,
+                subsystem="memory-compaction",
             )
             kept = result.kept or entries
-        except Exception:
-            return  # Don't corrupt memory on failure
+        except Exception as exc:
+            # Don't corrupt memory on failure — but never silently: an
+            # unlogged swallow made a dead memory subsystem indistinguishable
+            # from a working one (ENG-1084). Type name only; the message can
+            # quote conversation-derived content.
+            logger.warning(
+                "memory-compaction failed (%s) — keeping the file as-is",
+                type(exc).__name__,
+            )
+            return
 
         if not kept:
             return
@@ -527,16 +548,26 @@ Do NOT add, modify, or summarize rules — return them verbatim.
             return
 
         try:
-            result: _IdentityFacts = await self._llm.generate_object_code(
+            # 512 sat inside the measured narration range (245–1,654+), so
+            # narrating models truncated on essentially every pass and the
+            # silent except below hid it — confirmed live in prod on
+            # `mindshub_air` (ENG-1084).
+            result: _IdentityFacts = await generate_with_truncation_retry(
+                self._llm.generate_object_code,
                 _IdentityFacts,
-                system=_IDENTITY_EXTRACT_PROMPT,
+                system=_IDENTITY_EXTRACT_PROMPT + no_preamble_instruction(_IdentityFacts),
                 messages=[{"role": "user", "content": user_message}],
-                max_tokens=512,
+                log=logger,
+                subsystem="identity-extraction",
             )
             facts = result.facts
             if not facts:
                 return
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "identity-extraction failed (%s) — no facts stored this pass",
+                type(exc).__name__,
+            )
             return
 
         self.global_hc.rewrite_identity(facts)

--- a/tests/test_memory_truncation_retry.py
+++ b/tests/test_memory_truncation_retry.py
@@ -1,0 +1,294 @@
+"""Memory / extraction subsystems survive narrating-model truncation (ENG-1084).
+
+ENG-1081 fixed the completion verifier's token ceiling; the same defect lived
+at seven more `generate_object*` call sites — two of them with budgets *tighter*
+than the verifier's — and every failure was swallowed. Confirmed live in prod:
+identity extraction dying at its 512 cap and consolidation at its 2048 cap on
+`mindshub_air`, narrating right up to the budget and never reaching the forced
+tool call, with nothing logged.
+
+What must hold now (ticket Done-when):
+
+1. No forced-schema call site asks with a budget inside the measured narration
+   range (245–1,654+) without a truncation retry — all sites route through the
+   shared `generate_with_truncation_retry` ladder.
+2. Prose-at-the-cap through the REAL `LLMClient` is retried with a bigger
+   budget and the subsystem produces its result instead of silently degrading.
+3. A genuine (non-truncated) failure is not retried — a bigger budget can't
+   fix it (fable's `{}` verdicts, ENG-1095) — but it IS logged, content-safe.
+4. The no-preamble instruction reaches the provider's system prompt.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from anton.core.backends.base import Cell
+from anton.core.llm.client import LLMClient
+from anton.core.llm.provider import LLMResponse, StructuredOutputError, ToolCall, Usage
+from anton.core.llm.structured import (
+    DEFAULT_STRUCTURED_BUDGETS,
+    generate_with_truncation_retry,
+    no_preamble_instruction,
+)
+from anton.core.memory.cerebellum import Cerebellum
+from anton.core.memory.consolidator import Consolidator
+from anton.core.memory.cortex import Cortex
+
+
+SECRET = "the user's pasted p@ssw0rd hunter2"
+
+
+def _prose_at_cap(budget: int) -> LLMResponse:
+    """The prod signature: narration fills the whole budget, no tool call,
+    and the gateway labels it a normal stop (ENG-1082)."""
+    return LLMResponse(
+        content="The user is speaking in Turkish. Let me understand… " + SECRET,
+        tool_calls=[],
+        usage=Usage(input_tokens=100, output_tokens=budget),
+        stop_reason="stop",
+    )
+
+
+def _tool_response(name: str, payload: dict) -> LLMResponse:
+    return LLMResponse(
+        content="",
+        tool_calls=[ToolCall(id="tc_1", name=name, input=payload)],
+        usage=Usage(input_tokens=100, output_tokens=60),
+        stop_reason="tool_use",
+    )
+
+
+def _client_truncating_once(tool_name: str, payload: dict) -> tuple[LLMClient, AsyncMock]:
+    """Real LLMClient over a provider that narrates to the cap on the first
+    call, then answers properly on the (bigger-budget) retry."""
+    provider = MagicMock()
+
+    async def complete(**kwargs):
+        budget = kwargs.get("max_tokens")
+        if provider.complete.await_count == 1:
+            return _prose_at_cap(budget)
+        return _tool_response(tool_name, payload)
+
+    provider.complete = AsyncMock(side_effect=complete)
+    client = LLMClient(
+        planning_provider=provider,
+        planning_model="planner",
+        coding_provider=provider,
+        coding_model="coder",
+    )
+    return client, provider.complete
+
+
+# --------------------------------------------------------------------------
+# The shared ladder itself
+# --------------------------------------------------------------------------
+
+
+async def test_ladder_retries_truncation_with_a_bigger_budget():
+    client, complete = _client_truncating_once("_Probe", {"value": "ok"})
+    from pydantic import BaseModel
+
+    class _Probe(BaseModel):
+        value: str
+
+    result = await generate_with_truncation_retry(
+        client.generate_object_code, _Probe, system="s",
+        messages=[{"role": "user", "content": "m"}],
+    )
+
+    assert result.value == "ok"
+    budgets = [c.kwargs["max_tokens"] for c in complete.await_args_list]
+    assert budgets == list(DEFAULT_STRUCTURED_BUDGETS), (
+        "the retry must raise the budget, not re-issue the same call"
+    )
+
+
+async def test_ladder_does_not_retry_a_genuine_failure():
+    """fable's `{}` at 8 tokens (ENG-1095): well under budget, so truncation
+    is not the diagnosis and a bigger budget buys nothing."""
+    provider = MagicMock()
+    provider.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="", tool_calls=[], usage=Usage(input_tokens=10, output_tokens=8),
+            stop_reason="stop",
+        )
+    )
+    client = LLMClient(
+        planning_provider=provider, planning_model="p",
+        coding_provider=provider, coding_model="c",
+    )
+    from pydantic import BaseModel
+
+    class _Probe(BaseModel):
+        value: str
+
+    with pytest.raises(StructuredOutputError) as exc_info:
+        await generate_with_truncation_retry(
+            client.generate_object_code, _Probe, system="s",
+            messages=[{"role": "user", "content": "m"}],
+        )
+
+    assert exc_info.value.truncated is False
+    assert provider.complete.await_count == 1, "no retry for a non-truncated failure"
+
+
+async def test_ladder_raises_after_exhausting_every_budget():
+    provider = MagicMock()
+
+    async def always_prose(**kwargs):
+        return _prose_at_cap(kwargs.get("max_tokens"))
+
+    provider.complete = AsyncMock(side_effect=always_prose)
+    client = LLMClient(
+        planning_provider=provider, planning_model="p",
+        coding_provider=provider, coding_model="c",
+    )
+    from pydantic import BaseModel
+
+    class _Probe(BaseModel):
+        value: str
+
+    with pytest.raises(StructuredOutputError) as exc_info:
+        await generate_with_truncation_retry(
+            client.generate_object_code, _Probe, system="s",
+            messages=[{"role": "user", "content": "m"}],
+        )
+
+    assert exc_info.value.truncated is True
+    assert provider.complete.await_count == len(DEFAULT_STRUCTURED_BUDGETS)
+
+
+def test_no_preamble_names_the_tool():
+    from anton.core.memory.cortex import _IdentityFacts
+
+    text = no_preamble_instruction(_IdentityFacts)
+    assert "_IdentityFacts" in text
+    assert "immediately" in text
+
+
+# --------------------------------------------------------------------------
+# Per-subsystem: prose-at-the-cap is rescued, not silently swallowed
+# --------------------------------------------------------------------------
+
+
+def _cortex(client: LLMClient) -> Cortex:
+    global_hc = MagicMock()
+    project_hc = MagicMock()
+    return Cortex(global_hc, project_hc, mode="autopilot", llm_client=client)
+
+
+async def test_identity_extraction_survives_narration(caplog):
+    """The exact prod failure (observation 8e65e78151999148): identity
+    extraction narrating to the cap. The retry must rescue it and the facts
+    must actually be stored."""
+    client, complete = _client_truncating_once(
+        "_IdentityFacts", {"facts": ["User's name is Mynda"]}
+    )
+    cortex = _cortex(client)
+
+    await cortex.maybe_update_identity("hi, I'm Mynda and I work in Excel")
+
+    cortex.global_hc.rewrite_identity.assert_called_once_with(["User's name is Mynda"])
+    assert complete.await_count == 2
+    system_sent = complete.await_args_list[0].kwargs["system"]
+    assert "Call the _IdentityFacts tool immediately" in system_sent
+
+
+async def test_identity_extraction_failure_is_logged_not_silent(caplog):
+    provider = MagicMock()
+    provider.complete = AsyncMock(side_effect=RuntimeError(SECRET))
+    client = LLMClient(
+        planning_provider=provider, planning_model="p",
+        coding_provider=provider, coding_model="c",
+    )
+    cortex = _cortex(client)
+
+    with caplog.at_level(logging.WARNING):
+        await cortex.maybe_update_identity("hello")
+
+    cortex.global_hc.rewrite_identity.assert_not_called()
+    assert any("identity-extraction failed" in r.message for r in caplog.records), (
+        "a dead memory subsystem must be visible in logs (ENG-1084)"
+    )
+    assert SECRET not in caplog.text, "logs must never quote exception messages"
+
+
+async def test_cerebellum_diff_survives_narration():
+    client, complete = _client_truncating_once(
+        "_DiffPassResult",
+        {"lessons": [{"text": "progress() before long calls", "topic": "scratchpad"}]},
+    )
+    cortex_mock = MagicMock()
+    cortex_mock.encode = AsyncMock(return_value=[])
+    cere = Cerebellum(cortex=cortex_mock, llm=client)
+    cere._buffered.append(
+        Cell(code="print(1)", stdout="1", stderr="", error=None, description="test")
+    )
+
+    lessons = await cere.flush()
+
+    assert [lesson.text for lesson in lessons] == ["progress() before long calls"]
+    assert complete.await_count == 2
+
+
+async def test_cerebellum_failure_log_is_content_safe(caplog):
+    provider = MagicMock()
+    provider.complete = AsyncMock(side_effect=RuntimeError(SECRET))
+    client = LLMClient(
+        planning_provider=provider, planning_model="p",
+        coding_provider=provider, coding_model="c",
+    )
+    cere = Cerebellum(cortex=MagicMock(), llm=client)
+    cere._buffered.append(
+        Cell(code="x", stdout="", stderr="", error=None, description="t")
+    )
+
+    with caplog.at_level(logging.WARNING):
+        lessons = await cere.flush()
+
+    assert lessons == []
+    assert any("cerebellum diff pass failed" in r.message for r in caplog.records)
+    assert SECRET not in caplog.text
+
+
+async def test_consolidation_survives_narration():
+    """The other live prod failure (observation 38a951f93924473a):
+    consolidation filling its whole 2048 budget with analysis prose."""
+    client, complete = _client_truncating_once(
+        "_ConsolidatedLessons",
+        {"items": [{"text": "cache the API token", "kind": "lesson"}]},
+    )
+    cells = [Cell(code="print(1)", stdout="1", stderr="", error=None, description="t")]
+
+    engrams = await Consolidator().replay_and_extract(cells, client)
+
+    assert [e.text for e in engrams] == ["cache the API token"]
+    assert complete.await_count == 2
+
+
+async def test_credential_extraction_survives_narration():
+    from anton.connect_collector import extract_variables
+    from anton.core.datasources.datasource_registry import DatasourceField
+
+    client, complete = _client_truncating_once(
+        "_ExtractionResult",
+        {"variables": {"host": "db.example.com"}, "is_redirect": False},
+    )
+    session = MagicMock()
+    session._llm = client
+
+    result = await extract_variables(
+        "my host is db.example.com",
+        expected_fields=[DatasourceField(name="host", secret=False)],
+        current_engine="postgres",
+        current_engine_display="Postgres",
+        known_engine_slugs=["postgres", "mysql"],
+        session=session,
+    )
+
+    assert result.variables.get("host") == "db.example.com"
+    assert complete.await_count == 2


### PR DESCRIPTION
## What

[ENG-1084](https://linear.app/mindsdb/issue/ENG-1084): ENG-1081 fixed the completion verifier's token ceiling; the identical defect lived at **eight** more `generate_object*` call sites, and every failure was swallowed — five of them without a log line. The user-visible result: **memory silently stops working** (no identity facts, no lessons, no consolidation) for anyone on a narrating model, with nothing anywhere saying so.

Confirmed live in prod before building this (see ticket comment): identity extraction dying at exactly its 512 cap and consolidation at exactly its 2048 cap on `mindshub_air`, output pure narration, no tool call, silently swallowed.

## Changes

**Shared ladder** (`anton/core/llm/structured.py`):
- `generate_with_truncation_retry` — the ENG-1081 budget ladder (default 2048→4096), generalized. A retry is bought **only** for `StructuredOutputError.truncated`; a genuine failure (fable's `{}` verdicts at 8 tokens — ENG-1095) is re-raised immediately since a bigger budget can't fix it.
- `no_preamble_instruction(schema)` — the verifier's "call the tool first" suffix, tool name derived from the schema class.

**Eight call sites** route through it (old → new budgets):
| site | old | new |
|---|---|---|
| cortex identity extraction | 512 | 2048→4096 |
| connect_collector credential extraction | 512 | 2048→4096 |
| cerebellum diff pass | 600 | 2048→4096 |
| datasource custom spec | 1024 | 2048→4096 |
| skills draft | 1500 | 2048→8192 |
| consolidator lessons | 2048 | 2048→4096 |
| cortex compaction | 4096 | 4096→8192 |
| share.py session meta | **300** (ticket said "default 8192" — it was 300, tighter than the verifier's infamous 256) | 2048→4096 |

**Logging, content-safe:** every swallow now logs the exception **type name only** — never the message, because a `ValidationError` quotes the rejected model output, and at the credential site that's the user's pasted secrets. Also fixed the two pre-existing cerebellum logs that interpolated `%s exc`.

**Deliberately not touched:** `session.py` — the verifier already has this ladder (ENG-1081), and #276/#286 own that file; zero conflict surface among the three open PRs. Also out of scope, noted on the ticket: `cortex._filter_rules_by_relevance` (plain-text call, fails open — different failure semantics).

## Why fixed raises alone would not have worked

Narration scales with input — consolidation was observed filling 2,048 *exactly* (above ENG-1081's measured 1,654 worst case) because it feeds in a whole scratchpad session. The retry is the load-bearing part; per-site budgets are sized to the site's input.

## Tests

`tests/test_memory_truncation_retry.py` (10 tests; full suite 1,366 passed, the 2 pre-existing environmental `test_chat_scratchpad` failures excluded):
- **Per-subsystem prose-at-the-cap through the real `LLMClient`** (Done-when requirement): identity extraction, cerebellum flush, consolidation, credential extraction — each rescued by the retry and producing its result.
- Ladder semantics: retry raises the budget (never an unchanged re-issue), genuine failures not retried, exhaustion raises rather than returning None.
- **Content-safety asserted against a planted secret**: failure logs carry the type name and must not contain the exception message.
- No-preamble instruction verified in the system prompt the provider actually received.

## Security pass

The credential-extraction site was the sharpest edge: its exception messages can quote pasted secrets — logging is type-name-only there and everywhere else; the two pre-existing content-interpolating log lines were fixed. No new inputs cross a trust boundary; the no-preamble suffix is static text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## QA Instructions

**Where to test:** a build containing this change — desktop on the **git update channel**, or hosted after the snapshot bake. The affected population is narrating models, so QA runs on **`mindshub_air`** (the free/trial tier default — the real user path; sonnet users were never bitten).

1. **Identity extraction (the confirmed prod failure):** fresh session on `mindshub_air`, send: *"Hi, I'm Alex — I'm a data analyst at Acme and I prefer metric units."* Continue 2–3 more turns (extraction fires in the background). Then verify the facts landed: desktop — the identity section of Global memory (`~/.cowork` memory files) mentions Alex/Acme; or in Langfuse, the generation whose system prompt starts *"Extract identity facts"* now returns a **tool call** (before: 512 tokens of narration, no tool call, exactly at the cap).
2. **Lessons/consolidation:** run a scratchpad task that fails then succeeds (e.g. "read data.csv" when it doesn't exist, then "create it and retry"). After the turn, the consolidation generation in Langfuse (system prompt *"You are a memory consolidation system…"*) returns a tool call within ≤4096 tokens; a later session's context includes the extracted lesson.
3. **Credential extraction:** connect a datasource and paste all credentials as one blob (`host=… user=… password=…`). On `mindshub_air` this previously fell back to field-by-field prompting; now the blob parses in one shot.
4. **Failure visibility (not rescue):** switch to **`kimi`** (K3 — structured calls 400 until ENG-1095): memory features still degrade gracefully, but the backend log now shows `identity-extraction failed (…)` / `consolidation failed (…)` warnings naming the subsystem — exception type only, never message content (verify no user text appears in the log lines).
5. **Regression (sonnet/haiku):** memory features behave exactly as before — these models answer the forced calls in tens of tokens and never touch the retry.

**Langfuse re-measure recipe** (1 week post-deploy): count `mindshub_air` generations at exactly 2048/4096 output with no tool call and a subsystem prompt in the input — baseline was ~95/week at 2048; expect near-zero. Per the ENG-1084 ticket comment: verify candidates by payload, never by exact-cap token count alone (false positives are real).
