### PR TITLE
fix(llm): unwrap array-shaped provider errors; 404 → model-unavailable (ENG-1145)

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -23,6 +23,7 @@ from anton.clipboard import (
 from anton.core.session import ChatSession, ChatSessionConfig
 from anton.core.llm.prompt_builder import SystemPromptContext
 from anton.core.llm.provider import (
+    EndpointConfigurationError,
     ModelUnavailableError,
     TokenLimitExceeded,
     StreamComplete,
@@ -1970,13 +1971,15 @@ async def _chat_loop(
                     "  (anton) Switch LLM provider, update API key, or retry?",
                     choices=["setup", "retry", "s", "r"],
                     choices_display="setup/retry",
-                    # A ModelUnavailableError is a deterministic plan/kill-switch
-                    # gate — retrying re-sends the same doomed request — so steer
-                    # the default to "setup" (switch model / provider). Other
-                    # ConnectionErrors (transient) keep retry as the default.
+                    # ModelUnavailableError (plan/kill-switch gate) and
+                    # EndpointConfigurationError (wrong base URL / route) are both
+                    # deterministic for the identical request — retrying re-sends a
+                    # doomed call — so steer the default to "setup" (switch model /
+                    # provider / fix endpoint). Other ConnectionErrors (transient)
+                    # keep retry as the default.
                     default=(
                         "setup"
-                        if isinstance(exc, ModelUnavailableError)
+                        if isinstance(exc, (ModelUnavailableError, EndpointConfigurationError))
                         else ("retry" if isinstance(exc, ConnectionError) else "setup")
                     ),
                 )

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -14,6 +14,7 @@ from anton.utils.datasources import scrub_credentials
 from .provider import safe_parse_tool_input
 from .provider import (
     ContextOverflowError,
+    EndpointConfigurationError,
     LLMProvider,
     LLMResponse,
     ModelUnavailableError,
@@ -155,18 +156,30 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
                 or "does not exist" in msg_l
             )
         )
-        detail = f" {provider_msg.strip()}" if isinstance(provider_msg, str) and provider_msg.strip() else ""
+        # Provider message as a leading-space fragment with a normalized
+        # terminator, so the appended copy reads cleanly whether or not the
+        # provider punctuated its own message (Gemini's ends in a period; a raw
+        # proxy/FastAPI detail may not). Named `suffix`, not `detail`: the `detail`
+        # bound above is the FastAPI 429 detail, and reusing the name would leak
+        # this 404-local value into any branch added after this block.
+        clean = provider_msg.strip() if isinstance(provider_msg, str) else ""
+        if clean and clean[-1] not in ".!?":
+            clean += "."
+        suffix = f" {clean}" if clean else ""
         if model_specific:
+            reason = f":{suffix}" if suffix else "."
             raise ModelUnavailableError(
-                f"The model '{model}' isn't available:{detail} Switch models in Settings.",
+                f"The model '{model}' isn't available{reason} Switch models in Settings.",
                 code="model_not_found", model=model,
             ) from exc
-        # Not model-specific → almost always a misrouted/misconfigured endpoint.
-        # Permanent for this request (retrying won't help), but the remedy is the
-        # endpoint config, not the model — so don't send the user to switch models.
-        raise ConnectionError(
+        # Not model-specific → almost always a misrouted/misconfigured endpoint
+        # (bad base URL, missing /v1, proxy route). Permanent for this request,
+        # but the remedy is the endpoint config, not the model — a distinct type
+        # so the CLI defaults it to `setup` (fix provider/endpoint), not `retry`,
+        # and never to "switch models" (ENG-1145 review).
+        raise EndpointConfigurationError(
             f"The model endpoint returned 404 — check the endpoint URL and model "
-            f"configuration.{detail}"
+            f"configuration.{suffix}"
         ) from exc
 
     # Retryable provider/infra failures — overload/api_error (incl. the mid-stream

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -131,25 +131,43 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
             )
         raise ModelUnavailableError(msg, code=code, model=model) from exc
 
-    # A 404 from an OpenAI-compatible endpoint means the model id isn't served
-    # here — retired, not enabled for this key, or never existed — which is
-    # permanent for this request, NOT the transient outage the generic branch
-    # below implies ("try again in a moment"). Surface the provider's own copy
-    # so the user switches models instead of retrying; Google's is e.g.
-    # "models/gemini-2.5-flash is no longer available to new users." (ENG-1145)
+    # A 404 needs care: this mapper is shared by direct OpenAI, Gemini, MindsHub,
+    # Azure, and arbitrary OpenAI-compatible endpoints, so a bare 404 does NOT by
+    # itself mean the model is missing — a wrong base URL, a missing ``/v1``, a
+    # reverse-proxy route, or an unsupported API path all 404 too, and there
+    # "switch models" is the wrong remedy. Only treat it as model-not-found when
+    # the structured body actually points at the model: OpenAI's
+    # ``code="model_not_found"``, or a model-oriented message (Gemini's
+    # ``status="NOT_FOUND"`` with "models/<id> is not found / no longer
+    # available"). Everything else is surfaced as an endpoint/configuration
+    # failure carrying the provider's own words. (ENG-1145 review)
     if exc.status_code == 404:
         provider_msg = envelope.get("message") or body.get("message")
-        if isinstance(provider_msg, str) and provider_msg.strip():
-            msg = (
-                f"The model '{model}' isn't available: {provider_msg.strip()} "
-                "Switch models in Settings."
+        msg_l = provider_msg.lower() if isinstance(provider_msg, str) else ""
+        status_str = str(body.get("status") or envelope.get("status") or "").upper()
+        model_specific = code == "model_not_found" or (
+            "model" in msg_l
+            and (
+                status_str == "NOT_FOUND"
+                or "not found" in msg_l
+                or "not available" in msg_l
+                or "no longer available" in msg_l
+                or "does not exist" in msg_l
             )
-        else:
-            msg = (
-                f"The model '{model}' isn't available at this endpoint. "
-                "Switch to a supported model in Settings."
-            )
-        raise ModelUnavailableError(msg, code="model_not_found", model=model) from exc
+        )
+        detail = f" {provider_msg.strip()}" if isinstance(provider_msg, str) and provider_msg.strip() else ""
+        if model_specific:
+            raise ModelUnavailableError(
+                f"The model '{model}' isn't available:{detail} Switch models in Settings.",
+                code="model_not_found", model=model,
+            ) from exc
+        # Not model-specific → almost always a misrouted/misconfigured endpoint.
+        # Permanent for this request (retrying won't help), but the remedy is the
+        # endpoint config, not the model — so don't send the user to switch models.
+        raise ConnectionError(
+            f"The model endpoint returned 404 — check the endpoint URL and model "
+            f"configuration.{detail}"
+        ) from exc
 
     # Retryable provider/infra failures — overload/api_error (incl. the mid-stream
     # HTTP-200 case), 5xx, or a plain 429 — get backed off and retried by the

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -83,7 +83,16 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
             "Invalid API key — check your OpenAI API key configuration."
         ) from exc
 
-    body = exc.body if isinstance(exc.body, dict) else {}
+    # Google's Gemini OpenAI-compat endpoint wraps chat errors in a single-
+    # element ARRAY (``[{"error": {...}}]``) while OpenAI and others use a bare
+    # object; the SDK stores whatever it parsed. Unwrap the list here or every
+    # structured check below (auth / quota / model) silently misses on Gemini
+    # and the error falls through to the generic "temporarily unavailable"
+    # message — the exact reason ENG-1145 surfaced as an opaque 404.
+    raw_body = exc.body
+    if isinstance(raw_body, list) and raw_body and isinstance(raw_body[0], dict):
+        raw_body = raw_body[0]
+    body = raw_body if isinstance(raw_body, dict) else {}
     envelope = body.get("error") if isinstance(body.get("error"), dict) else {}
     detail = body.get("detail") or envelope.get("detail")
     # str-only: FastAPI validation errors put a LIST in detail — rendering
@@ -121,6 +130,26 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
                 "upgrading your plan may enable it."
             )
         raise ModelUnavailableError(msg, code=code, model=model) from exc
+
+    # A 404 from an OpenAI-compatible endpoint means the model id isn't served
+    # here — retired, not enabled for this key, or never existed — which is
+    # permanent for this request, NOT the transient outage the generic branch
+    # below implies ("try again in a moment"). Surface the provider's own copy
+    # so the user switches models instead of retrying; Google's is e.g.
+    # "models/gemini-2.5-flash is no longer available to new users." (ENG-1145)
+    if exc.status_code == 404:
+        provider_msg = envelope.get("message") or body.get("message")
+        if isinstance(provider_msg, str) and provider_msg.strip():
+            msg = (
+                f"The model '{model}' isn't available: {provider_msg.strip()} "
+                "Switch models in Settings."
+            )
+        else:
+            msg = (
+                f"The model '{model}' isn't available at this endpoint. "
+                "Switch to a supported model in Settings."
+            )
+        raise ModelUnavailableError(msg, code="model_not_found", model=model) from exc
 
     # Retryable provider/infra failures — overload/api_error (incl. the mid-stream
     # HTTP-200 case), 5xx, or a plain 429 — get backed off and retried by the

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -492,6 +492,20 @@ class ModelUnavailableError(ConnectionError):
         self.model = model
 
 
+class EndpointConfigurationError(ConnectionError):
+    """Raised when a request fails in a way that points at the endpoint
+    configuration — a wrong base URL, a missing ``/v1``, a reverse-proxy route,
+    or an unsupported API path — rather than at the model or a transient outage.
+
+    Permanent for the identical request (a retry re-sends it to the same broken
+    route), and the remedy is the provider *setup* flow (fix the base URL /
+    route), NOT switching models and NOT waiting. Subclasses ConnectionError so
+    legacy call sites that only know the ConnectionError mapping keep working;
+    the interactive CLI reads the type to default such a failure to ``setup``
+    rather than ``retry`` (ENG-1145 review).
+    """
+
+
 @dataclass
 class ProviderConnectionInfo:
     """Serializable provider connection details.

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -27,6 +27,7 @@ import pytest
 
 from anton.core.llm.openai import _raise_for_status_error
 from anton.core.llm.provider import (
+    EndpointConfigurationError,
     ModelUnavailableError,
     TokenLimitExceeded,
     TransientProviderError,
@@ -348,8 +349,11 @@ def test_404_bad_endpoint_is_config_error_not_model_unavailable():
     # also 404s, with a body that says nothing about the model — that must NOT
     # become "switch models". FastAPI-style {"detail": "Not Found"}.
     exc = _sdk_error(404, json_body={"detail": "Not Found"})
-    with pytest.raises(ConnectionError) as err:
+    with pytest.raises(EndpointConfigurationError) as err:
         _raise_for_status_error(exc, "sonnet")
+    # A distinct type (still a ConnectionError) so the CLI defaults it to `setup`,
+    # not `retry` — retry re-sends the same misrouted request (ENG-1145 review).
+    assert isinstance(err.value, ConnectionError)
     assert not isinstance(err.value, ModelUnavailableError)
     assert "endpoint" in str(err.value).lower()
     assert "Switch models" not in str(err.value)
@@ -358,7 +362,22 @@ def test_404_bad_endpoint_is_config_error_not_model_unavailable():
 def test_404_html_body_is_config_error():
     # An nginx/proxy 404 returns HTML (SDK stores it as a string body, not dict).
     exc = _sdk_error(404, text_body="<html>404 Not Found</html>")
-    with pytest.raises(ConnectionError) as err:
+    with pytest.raises(EndpointConfigurationError) as err:
         _raise_for_status_error(exc, "sonnet")
     assert not isinstance(err.value, ModelUnavailableError)
     assert "endpoint" in str(err.value).lower()
+
+
+def test_404_model_message_without_terminator_is_normalized():
+    # A model-oriented 404 whose provider message has NO trailing punctuation
+    # must not run into the appended sentence ("...available Switch models").
+    # The mapper normalizes the terminator rather than trusting the provider's
+    # punctuation (ENG-1145 review).
+    exc = _sdk_error(404, json_body={"error": {
+        "message": "models/foo is no longer available",  # no period
+        "status": "NOT_FOUND",
+    }})
+    with pytest.raises(ModelUnavailableError) as err:
+        _raise_for_status_error(exc, "foo")
+    assert "available. Switch models" in str(err.value)
+    assert "available Switch" not in str(err.value)

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -292,3 +292,39 @@ def test_500_is_transient_fail_fast():
         _raise_for_status_error(exc, "sonnet")
     assert err.value.session_backoff is False
     assert "returned 500" in str(err.value)
+
+
+# ── 404 model-not-found (ENG-1145) ────────────────────────────────────
+
+
+def test_404_object_body_maps_to_model_unavailable():
+    # A 404 is "model isn't served here", NOT a transient outage — it must be a
+    # ModelUnavailableError (permanent, no retry copy), surfacing the provider's
+    # message so the user switches models rather than waiting.
+    exc = _sdk_error(404, json_body={"error": {
+        "message": "models/foo is not found for API version v1beta.",
+    }})
+    with pytest.raises(ModelUnavailableError) as err:
+        _raise_for_status_error(exc, "foo")
+    assert err.value.code == "model_not_found"
+    assert "is not found" in str(err.value)
+    assert "temporarily unavailable" not in str(err.value)
+    assert not isinstance(err.value, TransientProviderError)
+
+
+def test_404_gemini_array_body_unwrapped_and_surfaced():
+    # Gemini's OpenAI-compat CHAT errors arrive as a single-element ARRAY, which
+    # the SDK stores verbatim (exc.body is a list, not a dict). The mapper must
+    # unwrap it, or the model-not-found reason is lost to the generic message —
+    # the exact ENG-1145 symptom ("Server returned 404 ... temporarily
+    # unavailable" instead of Google's real copy).
+    exc = _sdk_error(404, json_body=[{"error": {
+        "message": "This model models/gemini-2.5-flash is no longer available to new users.",
+        "code": 404,
+        "status": "NOT_FOUND",
+    }}])
+    assert isinstance(exc.body, list)  # pin the SDK behavior this fix relies on
+    with pytest.raises(ModelUnavailableError) as err:
+        _raise_for_status_error(exc, "gemini-2.5-flash")
+    assert "no longer available to new users" in str(err.value)
+    assert "Switch models in Settings" in str(err.value)

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -328,3 +328,37 @@ def test_404_gemini_array_body_unwrapped_and_surfaced():
         _raise_for_status_error(exc, "gemini-2.5-flash")
     assert "no longer available to new users" in str(err.value)
     assert "Switch models in Settings" in str(err.value)
+
+
+def test_404_openai_model_not_found_code_maps_to_model_unavailable():
+    # OpenAI's unknown-model 404 carries code=model_not_found (SDK-unwrapped to
+    # the top level) — model-specific, so "switch models" is the right remedy.
+    exc = _sdk_error(404, json_body={"error": {
+        "message": "The model `gpt-x` does not exist or you do not have access to it.",
+        "type": "invalid_request_error",
+        "code": "model_not_found",
+    }})
+    with pytest.raises(ModelUnavailableError) as err:
+        _raise_for_status_error(exc, "gpt-x")
+    assert err.value.code == "model_not_found"
+
+
+def test_404_bad_endpoint_is_config_error_not_model_unavailable():
+    # A misrouted/misconfigured endpoint (bad base URL, missing /v1, proxy path)
+    # also 404s, with a body that says nothing about the model — that must NOT
+    # become "switch models". FastAPI-style {"detail": "Not Found"}.
+    exc = _sdk_error(404, json_body={"detail": "Not Found"})
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert not isinstance(err.value, ModelUnavailableError)
+    assert "endpoint" in str(err.value).lower()
+    assert "Switch models" not in str(err.value)
+
+
+def test_404_html_body_is_config_error():
+    # An nginx/proxy 404 returns HTML (SDK stores it as a string body, not dict).
+    exc = _sdk_error(404, text_body="<html>404 Not Found</html>")
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert not isinstance(err.value, ModelUnavailableError)
+    assert "endpoint" in str(err.value).lower()


### PR DESCRIPTION
## Problem

A Gemini chat turn on a dead model surfaced as *"Server returned 404 — the LLM endpoint may be temporarily unavailable. Try again in a moment"* ([ENG-1145](https://linear.app/mindsdb/issue/ENG-1145)) — misleading on two counts: the failure is permanent (the model isn't served), not a transient outage, and the provider's real message was thrown away.

Root cause: Google's Gemini OpenAI-compat endpoint wraps chat errors in a single-element **array** (`[{"error":{…}}]`) while OpenAI uses a bare object. The SDK stores whatever it parsed, so `exc.body` is a `list` — and every structured branch in `_raise_for_status_error` (auth / quota / model) reads it as a dict, misses, and falls through to the generic message. (Pinned by a new test: `assert isinstance(exc.body, list)`.)

## Changes

- Unwrap a single-element list at the top of `_raise_for_status_error`, so all downstream checks see the error object regardless of provider body shape.
- Map a **404** to `ModelUnavailableError` (permanent — "switch models in Settings") instead of the transient "try again" `ConnectionError`, surfacing the provider's own message (e.g. Google's "no longer available to new users").

## Test plan

- `tests/test_status_error_mapper.py` (+2, real SDK via `httpx.MockTransport`): object-body 404 → `ModelUnavailableError` (not transient, no "temporarily unavailable"); Gemini array-body 404 unwrapped and message surfaced.
- `uv run pytest -k "openai or status or provider or llm or transient"` → 240 passed, 4 skipped.

## Related / rollout

Part of a 3-repo fix (cowork-server defaults + live overlay, cowork onboarding errors). This change reaches the desktop app only once anton is repinned in cowork-server — folds into the anton staging promotion tracked in ENG-1159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
