### PR TITLE
ci: publish Anton staging release candidates (ENG-1159)

### DIFF
--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,0 +1,83 @@
+name: Staging pre-release and publish to PyPI
+
+# RC stream: validate every push to staging, cut a PEP 440 pre-release tag,
+# and publish the immutable package consumed by cowork-server staging.
+#
+# PyPI Trusted Publishing binds authorization to this top-level workflow
+# filename. Register `publish-staging.yml` for the `anton-agent` project with
+# GitHub environment `pypi`; no API token or other long-lived credential is
+# required.
+#
+# run-tree-ok: PyPI Trusted Publishing binds to this top-level workflow file.
+
+on:
+  push:
+    branches: [staging]
+  workflow_dispatch:
+
+concurrency:
+  group: staging-prerelease-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate package source
+    if: github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv python install 3.12
+      - name: Run unit and stub e2e tests
+        run: uv run --extra dev pytest tests/ -v
+
+  release:
+    needs: validate
+    if: github.ref == 'refs/heads/staging'
+    permissions:
+      contents: write  # tag push + release creation
+    uses: mindsdb/github-actions/.github/workflows/calver-release.yml@main
+    with:
+      calver-major: "2"
+      prerelease: true
+      runs-on: ubuntu-latest
+
+  publish:
+    name: Publish immutable pre-release to PyPI
+    needs: release
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write  # required for trusted publisher (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+          fetch-depth: 0  # hatch-vcs needs tags to derive version
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  notify:
+    needs: [validate, release, publish]
+    if: ${{ github.ref == 'refs/heads/staging' && !cancelled() && !contains(needs.*.result, 'cancelled') }}
+    permissions:
+      contents: read
+      actions: read
+    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
+    with:
+      env-name: "staging prerelease"
+      status: ${{ contains(needs.*.result, 'failure') && 'failed' || 'recovered' }}
+      runs-on: ubuntu-latest
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,54 @@
-name: Auto-release on push to main
+name: Publish stable and staging releases
 
-permissions:
-  contents: write
+# One immutable package stream per release-train branch:
+#   main    -> stable PyPI releases
+#   staging -> PyPI rc pre-releases
+#
+# Both streams intentionally publish from this workflow file so the existing
+# PyPI Trusted Publisher identity (`release.yml`, environment `pypi`) covers
+# both without adding another long-lived credential or publisher.
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   workflow_dispatch:
 
 concurrency:
-  group: auto-release-${{ github.ref }}
+  group: anton-release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  validate:
+    name: Validate package source
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv python install 3.12
+      - name: Run unit and stub e2e tests
+        run: uv run --extra dev pytest tests/ -v
+
   auto-release:
+    needs: validate
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
+    permissions:
+      contents: write  # tag push + release creation
     uses: mindsdb/github-actions/.github/workflows/calver-release.yml@main
     with:
       calver-major: "2"
+      prerelease: ${{ github.ref == 'refs/heads/staging' }}
       runs-on: ubuntu-latest
 
   publish:
-    name: Publish to PyPI
+    name: Publish immutable package to PyPI
     needs: auto-release
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write  # required for trusted publisher (OIDC)
     steps:
       - uses: actions/checkout@v4
@@ -47,6 +71,13 @@ jobs:
 
   e2e:
     needs: auto-release
+    # Keep the existing live release test on the stable stream. Running it for
+    # every staging commit would consume external API capacity; staging already
+    # passed the full unit + stub-e2e suite in `validate` before its rc was
+    # created.
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
     uses: ./.github/workflows/tests_e2e_release.yml
     with:
       tag: ${{ needs.auto-release.outputs.tag }}
@@ -58,14 +89,14 @@ jobs:
     # One job covers both outcomes: a `uses:` job cannot branch on status, so
     # the aggregate result picks the failed or recovered message, and a
     # cancelled run stays silent.
-    needs: [auto-release, publish, e2e]
+    needs: [validate, auto-release, publish, e2e]
     if: ${{ !cancelled() && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read
       actions: read  # the prior-run lookup behind the recovery message
     uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
     with:
-      env-name: "release"
+      env-name: ${{ github.ref == 'refs/heads/staging' && 'staging prerelease' || 'release' }}
       status: ${{ contains(needs.*.result, 'failure') && 'failed' || 'recovered' }}
       runs-on: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,25 @@
-name: Publish stable and staging releases
+name: Auto-release and publish to PyPI
 
-# One immutable package stream per release-train branch:
-#   main    -> stable PyPI releases
-#   staging -> PyPI rc pre-releases
+# Stable release stream: validate every push to main, cut a CalVer tag and
+# GitHub release, publish the immutable package to PyPI, then run live release
+# e2e. Staging pre-releases live in publish-staging.yml so the Actions history,
+# permissions, notifications, and publishing identities stay environment-shaped.
 #
-# Both streams intentionally publish from this workflow file so the existing
-# PyPI Trusted Publisher identity (`release.yml`, environment `pypi`) covers
-# both without adding another long-lived credential or publisher.
+# run-tree-ok: PyPI Trusted Publishing binds to this top-level workflow file.
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: anton-release-${{ github.ref }}
+  group: auto-release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   validate:
     name: Validate package source
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,13 +32,12 @@ jobs:
 
   auto-release:
     needs: validate
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write  # tag push + release creation
     uses: mindsdb/github-actions/.github/workflows/calver-release.yml@main
     with:
       calver-major: "2"
-      prerelease: ${{ github.ref == 'refs/heads/staging' }}
       runs-on: ubuntu-latest
 
   publish:
@@ -71,11 +69,6 @@ jobs:
 
   e2e:
     needs: auto-release
-    # Keep the existing live release test on the stable stream. Running it for
-    # every staging commit would consume external API capacity; staging already
-    # passed the full unit + stub-e2e suite in `validate` before its rc was
-    # created.
-    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
     uses: ./.github/workflows/tests_e2e_release.yml
@@ -90,13 +83,13 @@ jobs:
     # the aggregate result picks the failed or recovered message, and a
     # cancelled run stays silent.
     needs: [validate, auto-release, publish, e2e]
-    if: ${{ !cancelled() && !contains(needs.*.result, 'cancelled') }}
+    if: ${{ github.ref == 'refs/heads/main' && !cancelled() && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read
       actions: read  # the prior-run lookup behind the recovery message
     uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
     with:
-      env-name: ${{ github.ref == 'refs/heads/staging' && 'staging prerelease' || 'release' }}
+      env-name: "release"
       status: ${{ contains(needs.*.result, 'failure') && 'failed' || 'recovered' }}
       runs-on: ubuntu-latest
     secrets: inherit

--- a/.github/workflows/staging-unfreeze.yml
+++ b/.github/workflows/staging-unfreeze.yml
@@ -1,4 +1,8 @@
 name: Staging Unfreeze
+
+# run-tree-ok: release-train hook runs only when a main-targeted PR closes;
+# ordinary PR validation does not handle that event action.
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,6 @@ permissions:
 on:
   pull_request:
     branches: [main,staging]
-  push:
-    branches: [main,staging]
 
 jobs:
   run-tests:
@@ -26,21 +24,3 @@ jobs:
 
       - name: Run E2E tests (stub)
         run: uv run --extra dev pytest tests/e2e/ -v
-
-  notify:
-    # Alert the eng channel if CI fails on a direct push to main/staging. PR runs
-    # are skipped — the author sees those directly.
-    # One job covers both outcomes: a `uses:` job cannot branch on status, so
-    # the aggregate result picks the failed or recovered message, and a
-    # cancelled run stays silent.
-    needs: [run-tests]
-    if: ${{ !cancelled() && !contains(needs.*.result, 'cancelled') && github.event_name == 'push' }}
-    permissions:
-      contents: read
-      actions: read  # the prior-run lookup behind the recovery message
-    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
-    with:
-      env-name: "CI"
-      status: ${{ contains(needs.*.result, 'failure') && 'failed' || 'recovered' }}
-      runs-on: ubuntu-latest
-    secrets: inherit


### PR DESCRIPTION
## Problem

cowork-server staging depends on Anton changes before they reach `anton/main`. Anton currently publishes only stable packages from `main`, so downstream staging has had to use a mutable Git branch or hand-pin a commit. That makes the cross-repository release train difficult to reproduce and promote.

## Design

Give Anton separate, branch-owned package publishing workflows, consistent with the other release-train repositories:

- `release.yml` remains production-only: pushes to `main` validate, create a stable CalVer release, publish it to PyPI, and run live release e2e;
- the new `publish-staging.yml` is staging-only: pushes to `staging` validate, create a PEP 440 `rc` release, and publish it to PyPI;
- `tests.yml` remains the pull-request validation workflow; branch-push validation belongs to the corresponding publishing workflow, avoiding duplicate disconnected run trees;
- both publishing streams run the full unit + stub-e2e suite before creating a tag or publishing;
- live API e2e remains production-only so staging commits do not consume external API capacity;
- permissions and failure/recovery notifications remain scoped to each release stream.

This gives downstream repositories immutable Anton artifacts while preserving the intuitive branch relationship: Anton staging produces RCs for cowork-server staging, and Anton main produces stable packages for cowork-server main.

## One-time PyPI setup required

Before merging, add an additional Trusted Publisher to the PyPI `anton-agent` project with:

- owner: `mindsdb`
- repository: `anton`
- workflow: `publish-staging.yml`
- environment: `pypi`

PyPI binds trusted publishing to the workflow filename. The existing `release.yml` publisher remains unchanged for production; the staging workflow needs its own publisher identity. No API token or other long-lived credential is introduced.

## Downstream and merge order

The coordinated [cowork-server #255](https://github.com/mindsdb/cowork-server/pull/255) resolves the published Anton package whose release tag points to the exact corresponding branch HEAD. Its tests, images, and RC wheel then consume that one immutable Anton artifact.

1. Register the `publish-staging.yml` Trusted Publisher.
2. Merge this PR into Anton staging and wait for its RC to publish.
3. Merge cowork-server #255 into cowork-server staging.

## Validation

- `actionlint` 1.7.12 passes for all changed workflows.
- YAML parsing and whitespace checks pass.
- Workflow graph validation passes across all 10 workflows: each event produces exactly one run tree.
- Anton test suite: 1,427 passed, 17 skipped.
- A simulated `v2.26.7.30.1rc1` tag builds the expected wheel and sdist.

Tracks [ENG-1159](https://linear.app/mindsdb/issue/ENG-1159).