### PR TITLE
ENG-1166: keep publish/datasource tools on resumed + rebuilt sessions

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -68,7 +68,7 @@ from anton.commands.skills import (
     handle_skills_list,
 )
 from anton.commands.share import handle_share_export, handle_share_import, handle_share_status, handle_share_history
-from anton.tools import CONNECT_DATASOURCE_TOOL, PUBLISH_TOOL
+from anton.tools import DEFAULT_SESSION_TOOLS
 from anton.utils.prompt import (
     prompt_or_cancel,
     prompt_minds_api_key,
@@ -1357,7 +1357,7 @@ async def _chat_loop(
         proactive_dashboards=settings.proactive_dashboards,
         act_first=settings.act_first,
         output_dir=settings.artifacts_dir,
-        tools=[CONNECT_DATASOURCE_TOOL, PUBLISH_TOOL],
+        tools=list(DEFAULT_SESSION_TOOLS),
         web_search_enabled=settings.web_search_enabled,
         web_fetch_enabled=settings.web_fetch_enabled,
     ))

--- a/anton/chat_session.py
+++ b/anton/chat_session.py
@@ -89,6 +89,7 @@ def rebuild_session(
     from anton.core.llm.client import LLMClient
     from anton.chat import ChatSession
     from anton.core.session import ChatSessionConfig
+    from anton.tools import DEFAULT_SESSION_TOOLS
 
     state["llm_client"] = LLMClient.from_settings(settings)
 
@@ -118,6 +119,10 @@ def rebuild_session(
         proactive_dashboards=settings.proactive_dashboards,
         act_first=settings.act_first,
         output_dir=settings.artifacts_dir,
+        # ENG-1166: without this, resumed / post-settings-change sessions
+        # register only core tools and silently lose publish_or_preview +
+        # connect_new_datasource. Mirror the fresh-session builder (chat.py).
+        tools=list(DEFAULT_SESSION_TOOLS),
         web_search_enabled=settings.web_search_enabled,
         web_fetch_enabled=settings.web_fetch_enabled,
     ))

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -674,3 +674,12 @@ PUBLISH_TOOL = ToolDef(
         "(no need to ask again)."
     ),
 )
+
+
+# Extra (non-core) tools every interactive anton session registers. Kept as a
+# single source so the fresh-session builder (chat.py) and the resume/settings
+# rebuild builder (chat_session.py::rebuild_session) can't drift — ENG-1166,
+# where rebuild_session omitted these and every resumed session silently lost
+# publish_or_preview + connect_new_datasource. Callers pass list(...) so each
+# session gets its own copy rather than sharing this module-level list.
+DEFAULT_SESSION_TOOLS = [CONNECT_DATASOURCE_TOOL, PUBLISH_TOOL]

--- a/tests/test_session_tools.py
+++ b/tests/test_session_tools.py
@@ -1,0 +1,34 @@
+"""ENG-1166 regression: resumed / rebuilt sessions must register the same
+extra tools as fresh sessions.
+
+The bug: `chat.py` (fresh session) passed `tools=[CONNECT_DATASOURCE_TOOL,
+PUBLISH_TOOL]`, but `chat_session.py::rebuild_session` (used by `/resume` and
+after a settings/model change) built its config with NO `tools=` argument — so
+every resumed session silently lost `publish_or_preview` + `connect_new_datasource`
+and could no longer publish. Both builders now derive their extra-tool list from
+the single `DEFAULT_SESSION_TOOLS` source; these tests guard against re-drift.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import anton
+from anton.tools import DEFAULT_SESSION_TOOLS
+
+_ANTON_DIR = Path(anton.__file__).parent
+
+
+def test_default_session_tools_includes_publish_and_datasource():
+    names = {t.name for t in DEFAULT_SESSION_TOOLS}
+    assert "publish_or_preview" in names
+    assert "connect_new_datasource" in names
+
+
+def test_both_session_builders_use_the_shared_tool_list():
+    # Drift guard: if either builder stops referencing DEFAULT_SESSION_TOOLS,
+    # they can diverge again (which is exactly how resumed sessions lost the
+    # publish tool). Read source rather than import chat.py (heavy).
+    fresh = (_ANTON_DIR / "chat.py").read_text()
+    rebuild = (_ANTON_DIR / "chat_session.py").read_text()
+    assert "DEFAULT_SESSION_TOOLS" in fresh, "fresh session builder (chat.py) must use the shared tool list"
+    assert "DEFAULT_SESSION_TOOLS" in rebuild, "rebuild_session (chat_session.py) must use the shared tool list"


### PR DESCRIPTION
## What

`rebuild_session` (`anton/chat_session.py`) — used by **`/resume`** (`commands/session.py` `restore_session`) **and, per its docstring, after any settings/model change** — built its `ChatSessionConfig` with **no `tools=` argument**. Since `config.tools` feeds `ChatSession._extra_tools` (registered in `_build_tools`), a rebuilt session registered only *core* tools and silently dropped **`publish_or_preview`** and **`connect_new_datasource`**.

Symptom: publishing from a resumed session fails with `Tool 'publish_or_preview' failed: Tool publish_or_preview not found`, while a **fresh** session (`chat.py:1360`, which *did* pass `tools=[CONNECT_DATASOURCE_TOOL, PUBLISH_TOOL]`) works. Reported in ENG-798 (misdiagnosed by the agent as a "platform outage" — see ENG-1165).

## Root cause = drift

Two session builders, one maintained tool list:
- `chat.py` (fresh) → had the tools.
- `chat_session.py::rebuild_session` (resume / settings-change) → didn't.

## Fix

Extract the extra-tool list to a single source — `DEFAULT_SESSION_TOOLS` in `anton/tools.py` — and use it in **both** builders (`list(...)` so each session gets its own copy). Now they can't diverge again. Adds `tests/test_session_tools.py`: asserts the list contains both tools and that **both** builders reference the shared constant (drift guard).

## Verification

- All three files compile; `DEFAULT_SESSION_TOOLS` → `['connect_new_datasource', 'publish_or_preview']`.
- New regression tests pass (2 passed).
- Confirmed live during triage: publish backend was up the whole time (`view.mindshub.ai/list`→200, `auth`→valid) — the failure was purely the missing tool registration on resume.

## Scope / not covered

- **Desktop (`cowork-server`) is unaffected** — it never calls `rebuild_session`, and its harness (`anton_harness/harness.py`) always registers a (cowork-flavored) publish tool. Verified.
- **Heads-up, separate audit:** there's a *third* builder, `runtime.py::build_chat_session`, which defaults `tools=[]` unless a caller passes `extra_tools`. Its callers (cron/headless/scheduled?) should be audited to confirm they pass the tool list — out of scope here, worth a follow-up.
- A full `rebuild_session` integration test would need to mock its network call (`refresh_knowledge`); the included source-level drift guard covers the actual failure mode cheaply. Follow-up welcome.

## Repro

1. Fresh `anton` session → publish → works.
2. `anton` → `/resume` any session → publish → `Tool publish_or_preview not found` (before this fix).
3. Likely also: fresh session → change model mid-session → publish → same (same `rebuild_session` path).

Fixes ENG-1166. Origin ENG-798. Companion (agent fabrication/diagnosability) ENG-1165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)