### PR TITLE
ENG-1169: Map M3 wallet denials (402/429) to TokenLimitExceeded so the out-of-credits card renders

### DIFF
--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -27,6 +27,7 @@ from .provider import (
     Usage,
     classify_transient,
     compute_context_pressure,
+    wallet_denial_code,
 )
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,9 @@ def _raise_for_status_error(
 
     - 401 → ConnectionError (invalid-key copy; cowork-server keys on this phrase).
     - 429 WITH a quota ``detail`` → TokenLimitExceeded (keeps its own card).
+    - 402/429 with an M3 gate wallet code (``wallet_empty`` /
+      ``included_allowance_exhausted``, body or X-MindsHub-Reason header)
+      → TokenLimitExceeded (ENG-1169). Code-exact: BYOK 402s stay generic.
     - overloaded/api_error (incl. the mid-stream HTTP-200 case), 5xx, plain 429
       → TransientProviderError (retryable — see ENG-673).
     - anything else → the generic "temporarily unavailable" ConnectionError.
@@ -58,6 +62,30 @@ def _raise_for_status_error(
         msg = f"Server returned 429 — {body['detail']}"
         msg += " Visit https://console.mindshub.ai to upgrade or to top up your tokens."
         raise TokenLimitExceeded(msg) from exc
+
+    # MindsHub M3 wallet taxonomy (ENG-1169) — same branch as the openai twin
+    # so the mapping can't drift. Today the gateway's anthropic-dialect lane
+    # strips both the code and the X-MindsHub-* headers (tracked separately),
+    # so this fires only against a fixed gateway or a proxy that preserves
+    # them — but a wallet denial that DOES arrive here must hit the credits
+    # card, not the generic copy. Code/reason-exact: a BYOK Anthropic billing
+    # error carries neither and stays generic.
+    gate_reason = ""
+    if getattr(exc, "response", None) is not None:
+        gate_reason = exc.response.headers.get("x-mindshub-reason", "")
+    wallet_code = wallet_denial_code(body) or (
+        gate_reason if gate_reason in ("wallet_empty", "included_allowance_exhausted") else None
+    )
+    if exc.status_code in (402, 429) and wallet_code:
+        what = (
+            "your MindsHub credits are used up."
+            if wallet_code == "wallet_empty"
+            else "your included token allowance is exhausted."
+        )
+        raise TokenLimitExceeded(
+            f"Server returned {exc.status_code} — {what} Add credits at "
+            "https://console.mindshub.ai/settings/organization/billing to continue."
+        ) from exc
 
     transient = classify_transient(exc.status_code, body, provider=provider, model=model)
     if transient is not None:

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -1131,6 +1131,24 @@ class OpenAIProvider(LLMProvider):
             # must classify it here or it surfaces as an opaque generic error on
             # the OpenAI/MindsHub path (ENG-673, Sam's review). Body type sits at
             # the top level (SDK-unwrapped); classify_transient handles that shape.
+            # Out-of-credits smuggled into an open stream (defensive — the M3
+            # gate denies pre-stream today): permanent, so it must fail fast
+            # onto the credits card, not enter the 30s stream_error backoff
+            # and surface as a misleading "provider overloaded" (ENG-1169).
+            # Checked BEFORE the transient classifier — permanent-first, the
+            # same policy as the request-time mapper — so a wallet denial that
+            # also carries a transient-looking `type` still fails fast.
+            wallet_code = wallet_denial_code(getattr(exc, "body", None))
+            if wallet_code:
+                what = (
+                    "Your MindsHub credits are used up"
+                    if wallet_code == "wallet_empty"
+                    else "Your included token allowance is exhausted"
+                )
+                raise TokenLimitExceeded(
+                    f"{what} — add credits at "
+                    "https://console.mindshub.ai/settings/organization/billing to continue."
+                ) from exc
             transient = classify_transient(
                 getattr(exc, "status_code", None), getattr(exc, "body", None),
                 provider="The model provider", model=model,
@@ -1141,15 +1159,6 @@ class OpenAIProvider(LLMProvider):
                     transient.code, scrub_credentials(str(getattr(exc, "body", "")))[:500],
                 )
                 raise transient from exc
-            # Out-of-credits smuggled into an open stream (defensive — the M3
-            # gate denies pre-stream today): permanent, so it must fail fast
-            # onto the credits card, not enter the 30s stream_error backoff
-            # and surface as a misleading "provider overloaded" (ENG-1169).
-            if wallet_denial_code(getattr(exc, "body", None)):
-                raise TokenLimitExceeded(
-                    "You're out of MindsHub credits. Add credits at "
-                    "https://console.mindshub.ai/settings/organization/billing to continue."
-                ) from exc
             raise TransientProviderError(
                 "The model provider failed mid-response — try again in a moment.",
                 provider="The model provider", code="stream_error",
@@ -1434,6 +1443,24 @@ class OpenAIProvider(LLMProvider):
             # Bare mid-stream SSE error (no status_code) — not an APIStatusError,
             # so it slips past the handlers above; the SDK already consumed the
             # 200 and never retried it → the session must back off (ENG-673).
+            # Out-of-credits smuggled into an open stream (defensive — the M3
+            # gate denies pre-stream today): permanent, so it must fail fast
+            # onto the credits card, not enter the 30s stream_error backoff
+            # and surface as a misleading "provider overloaded" (ENG-1169).
+            # Checked BEFORE the transient classifier — permanent-first, the
+            # same policy as the request-time mapper — so a wallet denial that
+            # also carries a transient-looking `type` still fails fast.
+            wallet_code = wallet_denial_code(getattr(exc, "body", None))
+            if wallet_code:
+                what = (
+                    "Your MindsHub credits are used up"
+                    if wallet_code == "wallet_empty"
+                    else "Your included token allowance is exhausted"
+                )
+                raise TokenLimitExceeded(
+                    f"{what} — add credits at "
+                    "https://console.mindshub.ai/settings/organization/billing to continue."
+                ) from exc
             transient = classify_transient(
                 getattr(exc, "status_code", None), getattr(exc, "body", None),
                 provider="The model provider", model=model,
@@ -1444,15 +1471,6 @@ class OpenAIProvider(LLMProvider):
                     transient.code, scrub_credentials(str(getattr(exc, "body", "")))[:500],
                 )
                 raise transient from exc
-            # Out-of-credits smuggled into an open stream (defensive — the M3
-            # gate denies pre-stream today): permanent, so it must fail fast
-            # onto the credits card, not enter the 30s stream_error backoff
-            # and surface as a misleading "provider overloaded" (ENG-1169).
-            if wallet_denial_code(getattr(exc, "body", None)):
-                raise TokenLimitExceeded(
-                    "You're out of MindsHub credits. Add credits at "
-                    "https://console.mindshub.ai/settings/organization/billing to continue."
-                ) from exc
             raise TransientProviderError(
                 "The model provider failed mid-response — try again in a moment.",
                 provider="The model provider", code="stream_error",

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -32,6 +32,7 @@ from .provider import (
     Usage,
     classify_transient,
     compute_context_pressure,
+    wallet_denial_code,
 )
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,9 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
       - 429 with a quota detail → TokenLimitExceeded, checked first so a body
         carrying both ``detail`` and a structured code stays token_limit
         (quota keeps its own card downstream).
+      - 402/429 with an M3 gate wallet code (``wallet_empty`` /
+        ``included_allowance_exhausted``, body or X-MindsHub-Reason header)
+        → TokenLimitExceeded (ENG-1169). Code-exact: BYOK 402s stay generic.
       - anything else → the generic "temporarily unavailable" ConnectionError.
 
     Body-shape tolerance (ENG-747): the OpenAI SDK UNWRAPS the error
@@ -113,6 +117,36 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
         raise TokenLimitExceeded(
             "Server returned 429 — your OpenAI quota is exhausted. Check your plan "
             "and billing at https://platform.openai.com."
+        ) from exc
+
+    # MindsHub M3 wallet taxonomy (ENG-1169): the authorization gate denies
+    # out-of-credits as 402 ``wallet_empty`` and a spent free allowance as 429
+    # ``included_allowance_exhausted`` — the latter carries NO FastAPI
+    # ``detail``, so the legacy 429 branch above never sees it. Both are
+    # permanent for the identical request: without this branch the 402 fell
+    # to the generic "temporarily unavailable" ConnectionError, got auto-
+    # retried, and was finally rendered as assistant prose — the out-of-
+    # credits card never showed and the user had no path to refill.
+    # TokenLimitExceeded fails fast (the session re-raises it unretried) and
+    # cowork-server maps it to the ``token_limit`` card. The X-MindsHub-Reason
+    # header is the fallback discriminator for a body that lost its code
+    # (e.g. an anthropic-dialect proxy); detection stays code/reason-exact so
+    # BYOK 402s fall through to the generic copy, never the credits card.
+    gate_reason = ""
+    if getattr(exc, "response", None) is not None:
+        gate_reason = exc.response.headers.get("x-mindshub-reason", "")
+    wallet_code = wallet_denial_code(raw_body) or (
+        gate_reason if gate_reason in ("wallet_empty", "included_allowance_exhausted") else None
+    )
+    if exc.status_code in (402, 429) and wallet_code:
+        what = (
+            "your MindsHub credits are used up."
+            if wallet_code == "wallet_empty"
+            else "your included token allowance is exhausted."
+        )
+        raise TokenLimitExceeded(
+            f"Server returned {exc.status_code} — {what} Add credits at "
+            "https://console.mindshub.ai/settings/organization/billing to continue."
         ) from exc
 
     if exc.status_code == 403 and code in ("model_access_denied", "model_disabled"):
@@ -1107,6 +1141,15 @@ class OpenAIProvider(LLMProvider):
                     transient.code, scrub_credentials(str(getattr(exc, "body", "")))[:500],
                 )
                 raise transient from exc
+            # Out-of-credits smuggled into an open stream (defensive — the M3
+            # gate denies pre-stream today): permanent, so it must fail fast
+            # onto the credits card, not enter the 30s stream_error backoff
+            # and surface as a misleading "provider overloaded" (ENG-1169).
+            if wallet_denial_code(getattr(exc, "body", None)):
+                raise TokenLimitExceeded(
+                    "You're out of MindsHub credits. Add credits at "
+                    "https://console.mindshub.ai/settings/organization/billing to continue."
+                ) from exc
             raise TransientProviderError(
                 "The model provider failed mid-response — try again in a moment.",
                 provider="The model provider", code="stream_error",
@@ -1401,6 +1444,15 @@ class OpenAIProvider(LLMProvider):
                     transient.code, scrub_credentials(str(getattr(exc, "body", "")))[:500],
                 )
                 raise transient from exc
+            # Out-of-credits smuggled into an open stream (defensive — the M3
+            # gate denies pre-stream today): permanent, so it must fail fast
+            # onto the credits card, not enter the 30s stream_error backoff
+            # and surface as a misleading "provider overloaded" (ENG-1169).
+            if wallet_denial_code(getattr(exc, "body", None)):
+                raise TokenLimitExceeded(
+                    "You're out of MindsHub credits. Add credits at "
+                    "https://console.mindshub.ai/settings/organization/billing to continue."
+                ) from exc
             raise TransientProviderError(
                 "The model provider failed mid-response — try again in a moment.",
                 provider="The model provider", code="stream_error",

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -442,7 +442,10 @@ def wallet_denial_code(body: Any) -> str | None:
     b = body if isinstance(body, dict) else {}
     err = b.get("error") if isinstance(b.get("error"), dict) else {}
     code = b.get("code") or err.get("code")
-    return code if code in _WALLET_DENIAL_CODES else None
+    # isinstance first: `in` on a frozenset HASHES the value, so a hostile/buggy
+    # endpoint sending a list `code` would otherwise TypeError the classifier
+    # (every other wire-value membership check in these mappers uses tuples).
+    return code if isinstance(code, str) and code in _WALLET_DENIAL_CODES else None
 
 
 def classify_transient(

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -484,9 +484,12 @@ def classify_transient(
     if status_code == 429 and not b.get("detail"):
         # Plain rate-limit ("slow down"), NOT an out-of-quota 429. Quota 429s are
         # mapped upstream (gateway dialect carries a `detail`, OpenAI's carries
-        # ``insufficient_quota``); the guard here is defense for direct callers —
-        # a billing failure is permanent and must never enter the retry loop.
+        # ``insufficient_quota``, the M3 gate's allowance 429 carries a wallet
+        # code); the guards here are defense for direct callers — a billing
+        # failure is permanent and must never enter the retry loop (ENG-1169).
         if etype == "insufficient_quota":
+            return None
+        if wallet_denial_code(b):
             return None
         return TransientProviderError(
             f"{provider or 'The model provider'} is rate-limiting requests.",

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -420,6 +420,30 @@ _TRANSIENT_ERROR_TYPES = frozenset(
     {"overloaded_error", "overloaded", "api_error", "server_error", "service_unavailable"}
 )
 
+# The MindsHub M3 authorization gate's out-of-credits deny codes (ENG-1169):
+# ``wallet_empty`` rides a 402, ``included_allowance_exhausted`` a 429 (with NO
+# FastAPI ``detail``, so the legacy 429-quota branch never sees it). Both are
+# permanent for the identical request — they belong on the out-of-credits card,
+# never in the retry loop. The gate's velocity 429 (``rate_limited``) is NOT
+# here on purpose: that one means "slow down", and stays transient.
+_WALLET_DENIAL_CODES = frozenset({"wallet_empty", "included_allowance_exhausted"})
+
+
+def wallet_denial_code(body: Any) -> str | None:
+    """The M3 gate's out-of-credits code carried in an error body, if any.
+
+    Reads ``code`` from both dialects — the SDK-unwrapped top level (OpenAI
+    SDK peels the ``error`` envelope, ENG-747) and the wire envelope
+    (Anthropic SDK / proxies that deliver it unmodified). Detection is
+    code-exact on purpose: BYOK 402s (e.g. OpenRouter's insufficient-credits
+    402) carry no such code and must stay generic — the remedy there is the
+    user's own provider billing, not MindsHub credits.
+    """
+    b = body if isinstance(body, dict) else {}
+    err = b.get("error") if isinstance(b.get("error"), dict) else {}
+    code = b.get("code") or err.get("code")
+    return code if code in _WALLET_DENIAL_CODES else None
+
 
 def classify_transient(
     status_code: int | None, body: Any, *, provider: str = "", model: str = ""

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -555,3 +555,13 @@ def test_anthropic_byok_402_stays_generic():
     with pytest.raises(ConnectionError) as err:
         _raise_anthropic(exc, model="claude-sonnet")
     assert not isinstance(err.value, TokenLimitExceeded)
+
+
+def test_429_wallet_code_never_transient():
+    # Defense for direct classify_transient callers (the mid-stream paths):
+    # the M3 allowance 429 has no `detail`, so without the code-exact guard
+    # it would classify as a retryable plain rate-limit — same precedent as
+    # the insufficient_quota guard above (ENG-1169 self-review).
+    body = {"message": "allowance exhausted", "type": "rate_limit_error",
+            "code": "included_allowance_exhausted"}
+    assert classify_transient(429, body, provider="gw", model="sonnet") is None

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -21,10 +21,12 @@ shipped dead. If the SDK's behavior ever changes, these tests notice;
 hand-built fixtures cannot.
 """
 
+import anthropic
 import httpx
 import openai
 import pytest
 
+from anton.core.llm.anthropic import _raise_for_status_error as _raise_anthropic
 from anton.core.llm.openai import _raise_for_status_error
 from anton.core.llm.provider import (
     EndpointConfigurationError,
@@ -32,18 +34,21 @@ from anton.core.llm.provider import (
     TokenLimitExceeded,
     TransientProviderError,
     classify_transient,
+    wallet_denial_code,
 )
 
 
-def _sdk_error(status_code, json_body=None, text_body=None):
+def _sdk_error(status_code, json_body=None, text_body=None, headers=None):
     """Real `openai.APIStatusError`, built by the pinned SDK from a raw HTTP
     response — exactly what production call sites catch and hand to the
     mapper. This is the load-bearing difference from the original suite."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         if text_body is not None:
-            return httpx.Response(status_code, text=text_body)
-        return httpx.Response(status_code, json=json_body if json_body is not None else {})
+            return httpx.Response(status_code, text=text_body, headers=headers)
+        return httpx.Response(
+            status_code, json=json_body if json_body is not None else {}, headers=headers
+        )
 
     client = openai.OpenAI(
         base_url="http://gateway.test/v1",
@@ -381,3 +386,172 @@ def test_404_model_message_without_terminator_is_normalized():
         _raise_for_status_error(exc, "foo")
     assert "available. Switch models" in str(err.value)
     assert "available Switch" not in str(err.value)
+
+
+# ── the M3 wallet taxonomy (ENG-1169) ─────────────────────────────────
+
+def _gateway_402(code="wallet_empty", headers=None):
+    """The M3 gateway's out-of-credits 402, byte-shaped like
+    `minds/inference/errors.py:wallet_empty` (OpenAI lanes)."""
+    return _sdk_error(402, json_body={"error": {
+        "message": "Your wallet has no balance to cover the model 'sonnet'.",
+        "type": "invalid_request_error",
+        "param": None,
+        "code": code,
+    }}, headers=headers)
+
+
+def test_gateway_402_wallet_empty_maps_to_token_limit():
+    # The live shape: body code AND the X-MindsHub-Reason header. Before
+    # ENG-1169 this fell to the generic "temporarily unavailable" copy, got
+    # auto-retried, and the out-of-credits card never rendered.
+    exc = _gateway_402(headers={
+        "X-MindsHub-Reason": "wallet_empty",
+        "X-MindsHub-Recovery-Url": "/billing",
+    })
+    with pytest.raises(TokenLimitExceeded) as err:
+        _raise_for_status_error(exc, "sonnet")
+    msg = str(err.value)
+    assert "402" in msg and "credit" in msg.lower()
+    assert "temporarily unavailable" not in msg
+    assert "billing" in msg
+
+
+def test_gateway_402_body_code_alone_maps_to_token_limit():
+    # No headers (a proxy stripped them) — the body code is enough.
+    exc = _gateway_402()
+    with pytest.raises(TokenLimitExceeded):
+        _raise_for_status_error(exc, "sonnet")
+
+
+def test_gateway_402_header_alone_maps_to_token_limit():
+    # Code-less body (the anthropic-dialect lane strips it) but the
+    # X-MindsHub-Reason header survives — header is the fallback discriminator.
+    exc = _sdk_error(
+        402,
+        json_body={"error": {"message": "Your wallet has no balance.",
+                             "type": "invalid_request_error"}},
+        headers={"X-MindsHub-Reason": "wallet_empty"},
+    )
+    with pytest.raises(TokenLimitExceeded):
+        _raise_for_status_error(exc, "sonnet")
+
+
+def test_byok_402_stays_generic():
+    # A non-gateway 402 (e.g. OpenRouter's insufficient-credits dialect)
+    # carries no wallet code — it must NOT get the MindsHub credits card/CTA;
+    # the remedy is the user's own provider billing. Mirrors cowork-server's
+    # test_byok_402_stays_generic.
+    exc = _sdk_error(402, json_body={"error": {
+        "message": "Insufficient credits. Add more at openrouter.ai.",
+        "code": 402,
+    }})
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert not isinstance(err.value, TokenLimitExceeded)
+    assert "402" in str(err.value)
+
+
+def test_gateway_429_allowance_exhausted_maps_to_token_limit():
+    # The M3 allowance 429 carries a structured code but NO FastAPI `detail`,
+    # so the legacy 429→TokenLimitExceeded branch misses it; before ENG-1169
+    # it was misclassified as a retryable rate limit and surfaced as
+    # "provider overloaded" after burning the backoff budget.
+    exc = _sdk_error(429, json_body={"error": {
+        "message": "Your included token allowance for 'sonnet' is exhausted.",
+        "type": "rate_limit_error",
+        "param": None,
+        "code": "included_allowance_exhausted",
+    }}, headers={"X-MindsHub-Reason": "included_allowance_exhausted"})
+    with pytest.raises(TokenLimitExceeded) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert "allowance" in str(err.value)
+
+
+def test_gateway_velocity_429_stays_transient():
+    # The gate's velocity 429 (`rate_limited`, ENG-878 TPM/RPM) means "slow
+    # down and retry" — it must stay transient, never the credits card.
+    exc = _sdk_error(429, json_body={"error": {
+        "message": "Rate limit exceeded for model 'sonnet'. Please slow down and retry.",
+        "type": "rate_limit_error",
+        "param": None,
+        "code": "rate_limited",
+    }}, headers={"X-MindsHub-Reason": "rate_limited", "Retry-After": "15"})
+    with pytest.raises(TransientProviderError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert err.value.code == "rate_limited"
+
+
+def test_wallet_denial_code_reads_both_dialects():
+    # The mid-stream guard reads the bare-APIError body directly: SDK-unwrapped
+    # (top-level code) AND wire-envelope (nested) shapes must both resolve.
+    assert wallet_denial_code({"code": "wallet_empty"}) == "wallet_empty"
+    assert (
+        wallet_denial_code({"error": {"code": "included_allowance_exhausted"}})
+        == "included_allowance_exhausted"
+    )
+    assert wallet_denial_code({"error": {"code": "rate_limited"}}) is None
+    assert wallet_denial_code({"code": 402}) is None
+    assert wallet_denial_code(None) is None
+    assert wallet_denial_code("<html>402</html>") is None
+
+
+# ── the anthropic twin (ENG-1169) ─────────────────────────────────────
+
+def _anthropic_sdk_error(status_code, json_body=None, headers=None):
+    """Real `anthropic.APIStatusError` from the pinned SDK — the anthropic
+    twin of `_sdk_error`. The anthropic SDK does NOT unwrap the error
+    envelope (unlike openai's), so `exc.body` is the wire shape."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code, json=json_body if json_body is not None else {}, headers=headers
+        )
+
+    client = anthropic.Anthropic(
+        base_url="http://gateway.test",
+        api_key="test-key",
+        max_retries=0,
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        client.messages.create(
+            model="claude-sonnet", max_tokens=1,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    except anthropic.APIStatusError as exc:
+        return exc
+    raise AssertionError(f"anthropic SDK did not raise for HTTP {status_code}")
+
+
+def test_anthropic_402_wallet_code_maps_to_token_limit():
+    # Wire-envelope code (the anthropic SDK stores the envelope unmodified).
+    exc = _anthropic_sdk_error(402, json_body={"type": "error", "error": {
+        "type": "invalid_request_error",
+        "message": "Your wallet has no balance to cover the model 'claude'.",
+        "code": "wallet_empty",
+    }})
+    with pytest.raises(TokenLimitExceeded):
+        _raise_anthropic(exc, model="claude-sonnet")
+
+
+def test_anthropic_402_header_alone_maps_to_token_limit():
+    # Today's live gateway anthropic lane strips the body code — if the
+    # header survives (proxy/fixed gateway), it must still map.
+    exc = _anthropic_sdk_error(402, json_body={"type": "error", "error": {
+        "type": "invalid_request_error",
+        "message": "Your wallet has no balance to cover the model 'claude'.",
+    }}, headers={"X-MindsHub-Reason": "wallet_empty"})
+    with pytest.raises(TokenLimitExceeded):
+        _raise_anthropic(exc, model="claude-sonnet")
+
+
+def test_anthropic_byok_402_stays_generic():
+    # No wallet code, no reason header → generic, never the credits card.
+    exc = _anthropic_sdk_error(402, json_body={"type": "error", "error": {
+        "type": "invalid_request_error",
+        "message": "Your credit balance is too low to access the Anthropic API.",
+    }})
+    with pytest.raises(ConnectionError) as err:
+        _raise_anthropic(exc, model="claude-sonnet")
+    assert not isinstance(err.value, TokenLimitExceeded)

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -565,3 +565,17 @@ def test_429_wallet_code_never_transient():
     body = {"message": "allowance exhausted", "type": "rate_limit_error",
             "code": "included_allowance_exhausted"}
     assert classify_transient(429, body, provider="gw", model="sonnet") is None
+
+
+def test_unhashable_code_never_crashes_the_classifier():
+    # A hostile/buggy OpenAI-compatible endpoint sending a NON-STRING `code`
+    # (e.g. a list) must fall through to the generic mapping — frozenset
+    # membership hashes the value, so without the isinstance guard this
+    # raised TypeError from inside the error classifier (ENG-1169 review).
+    assert wallet_denial_code({"code": ["wallet_empty"]}) is None
+    assert wallet_denial_code({"error": {"code": {"c": "wallet_empty"}}}) is None
+    exc = _sdk_error(402, json_body={"error": {"message": "denied", "code": ["wallet_empty"]}})
+    with pytest.raises(ConnectionError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert not isinstance(err.value, TokenLimitExceeded)
+    assert classify_transient(429, {"code": ["wallet_empty"]}) is not None  # plain-429 path intact

--- a/tests/test_transient_retry_e2e.py
+++ b/tests/test_transient_retry_e2e.py
@@ -28,6 +28,7 @@ from anton.core.llm.openai import OpenAIProvider
 from anton.core.llm.provider import (
     StreamComplete,
     StreamTextDelta,
+    TokenLimitExceeded,
     TransientProviderError,
 )
 
@@ -187,3 +188,51 @@ async def test_e2e_openai_midstream_error_is_transient():
     assert exc.session_backoff is True
     # server_error is in the transient set → classified by type, not a fallback.
     assert exc.code in ("server_error", "stream_error")
+
+
+# --------------------------------------------------------------------------- #
+# ENG-1169 — a wallet denial smuggled into an open stream fails fast to the
+# credits card, never the stream_error backoff / provider_overloaded card.
+# --------------------------------------------------------------------------- #
+
+# OpenAI chat.completions: one good chunk, then an SSE `error` carrying the M3
+# gate's wallet code. Surfaced by the SDK as a bare openai.APIError.
+_OAI_MIDSTREAM_WALLET = _sse(
+    'data: {"id":"1","object":"chat.completion.chunk","choices":'
+    '[{"index":0,"delta":{"content":"Hel"},"finish_reason":null}]}\n\n',
+    'data: {"error":{"message":"Your wallet has no balance to cover the model '
+    '\'sonnet\'.","type":"invalid_request_error","code":"wallet_empty"}}\n\n',
+)
+
+# Same, but the error ALSO carries a transient-looking `type` — the wallet
+# code must win (permanent-first): without the ordering guard this would
+# classify as api_error → 30s backoff → provider_overloaded.
+_OAI_MIDSTREAM_WALLET_TRANSIENT_TYPE = _sse(
+    'data: {"error":{"message":"Your wallet has no balance.",'
+    '"type":"api_error","code":"wallet_empty"}}\n\n',
+)
+
+
+async def test_e2e_openai_midstream_wallet_denial_is_token_limit():
+    prov = _openai_provider(_static(_OAI_MIDSTREAM_WALLET))
+    with pytest.raises(TokenLimitExceeded) as ei:
+        await _drain(prov)
+    assert "credit" in str(ei.value).lower()
+    assert "billing" in str(ei.value)
+
+
+async def test_e2e_openai_midstream_wallet_beats_transient_type():
+    prov = _openai_provider(_static(_OAI_MIDSTREAM_WALLET_TRANSIENT_TYPE))
+    with pytest.raises(TokenLimitExceeded):
+        await _drain(prov)
+
+
+async def test_e2e_openai_midstream_allowance_denial_is_token_limit():
+    body = _sse(
+        'data: {"error":{"message":"Your included token allowance is exhausted.",'
+        '"type":"rate_limit_error","code":"included_allowance_exhausted"}}\n\n',
+    )
+    prov = _openai_provider(_static(body))
+    with pytest.raises(TokenLimitExceeded) as ei:
+        await _drain(prov)
+    assert "allowance" in str(ei.value).lower()


### PR DESCRIPTION
## What

The M3 authorization gate (ENG-608, live ~Jul 20–27) denies out-of-credits as **402 `wallet_empty`** and a spent free allowance as **429 `included_allowance_exhausted`** (no FastAPI `detail`). anton's status-error mapper had no branch for either, so:

- the **402** fell to the generic "temporarily unavailable" ConnectionError, got auto-retried twice by `turn_stream` (with an "adjust your approach" note injected into history), and was finally **rendered as assistant prose** — the turn *succeeded*, `response.failed` was never emitted, and the ENG-562 out-of-credits card never showed. The user hit a hard paywall with no path to refill (live repro attached on the ticket).
- the **allowance 429** misclassified as a retryable plain rate limit → backoff → wrong `provider_overloaded` card.

## How

- **`wallet_denial_code()` helper in `provider.py`** — reads the code from both body dialects (SDK-unwrapped top level per ENG-747, and the wire envelope). Code-exact on purpose: the gate's velocity 429 (`rate_limited`, ENG-878) stays transient, and BYOK 402s (e.g. OpenRouter's insufficient-credits dialect) stay generic — mirroring cowork-server's `test_byok_402_stays_generic` decision.
- **Both mapper twins** (`openai.py` + `anthropic.py`): 402/429 + wallet code (body) or `X-MindsHub-Reason` header → `TokenLimitExceeded`, which `session.py` already re-raises unretried and cowork-server (since its Jul 27 release) already maps to the `token_limit` card.
- **Mid-stream defensive branch** on both openai stream paths: a wallet denial arriving inside an open stream fails fast onto the credits card instead of entering the 30s `stream_error` backoff (the gate denies pre-stream today; this is insurance).
- **Tests**: real-SDK fixtures only (`httpx.MockTransport`, the ENG-747 lesson — this exact class of card died in prod once from hand-built fixtures). 12 new tests: both dialects, header-only fallback (code-stripped anthropic lane), BYOK-402-stays-generic, velocity-429-stays-transient, and the `wallet_denial_code` unit matrix.

## Verification

- `pytest tests/ --ignore=tests/e2e`: **1406 passed**; the 2 `test_chat_scratchpad` failures are pre-existing on clean `origin/staging` (local sandbox blocks exec), verified by stash-and-rerun.
- Message copy keeps the `402`+`credit` phrasing so cowork-server's string heuristic also matches as a belt on version-skewed installs (isinstance on `TokenLimitExceeded` is the primary path).

## Security pass

Reviewed the changed surface: no new inputs are trusted — the wallet code is compared against a frozen allowlist (never interpolated into copy), provider body content is not echoed into user-facing messages (curated copy only), and the existing `scrub_credentials` logging path is unchanged. No secrets, no new endpoints.

## Delivery note

anton-only fix: reaches git-channel desktops on merge-to-main; PyPI-channel installs need a cowork-server bump (ENG-1094). Companion UI PR (single-CTA card) lands separately in cowork.

Ticket: ENG-1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)