### PR TITLE
ENG-847:  fail loud on empty 200 in non-streaming complete (follow up of #258)

### DIFF
--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -27,6 +27,7 @@ from .provider import (
     Usage,
     classify_transient,
     compute_context_pressure,
+    raise_on_empty_response,
 )
 
 logger = logging.getLogger(__name__)
@@ -189,6 +190,11 @@ class AnthropicProvider(LLMProvider):
                 tool_calls.append(
                     ToolCall(id=block.id, name=block.name, input=block.input)
                 )
+
+        raise_on_empty_response(
+            content=content_text, tool_calls=tool_calls,
+            stop_reason=response.stop_reason, provider="Anthropic", model=model,
+        )
 
         input_tokens = response.usage.input_tokens
         return LLMResponse(

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -32,6 +32,7 @@ from .provider import (
     Usage,
     classify_transient,
     compute_context_pressure,
+    raise_on_empty_response,
 )
 
 logger = logging.getLogger(__name__)
@@ -933,6 +934,11 @@ class OpenAIProvider(LLMProvider):
                     )
                 )
 
+        raise_on_empty_response(
+            content=content_text, tool_calls=tool_calls,
+            stop_reason=choice.finish_reason, model=model,
+        )
+
         usage_obj = response.usage
         input_tokens = usage_obj.prompt_tokens if usage_obj else 0
         return LLMResponse(
@@ -1458,6 +1464,11 @@ def _parse_response_object(response, model: str) -> LLMResponse:
     input_tokens = (getattr(usage, "input_tokens", 0) or 0) if usage else 0
     output_tokens = (getattr(usage, "output_tokens", 0) or 0) if usage else 0
 
+    status = getattr(response, "status", None)
+    raise_on_empty_response(
+        content=content_text, tool_calls=tool_calls, stop_reason=status, model=model,
+    )
+
     return LLMResponse(
         content=content_text,
         tool_calls=tool_calls,
@@ -1466,5 +1477,5 @@ def _parse_response_object(response, model: str) -> LLMResponse:
             output_tokens=output_tokens,
             context_pressure=compute_context_pressure(model, input_tokens),
         ),
-        stop_reason=getattr(response, "status", None),
+        stop_reason=status,
     )

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -471,6 +471,32 @@ def classify_transient(
     return None
 
 
+def raise_on_empty_response(
+    *, content: str, tool_calls: list, stop_reason: str | None,
+    provider: str = "", model: str = "",
+) -> None:
+    """Fail loud on an empty 200: no content, no tool calls, no stop reason.
+
+    The non-streaming mirror of the streaming truncated-response guard (ENG-673).
+    An empty-from-start 200 is:
+
+    - a weak incident signal (real mid-incident silence surfaces as a dropped
+      connection / read timeout, which back off above), and
+    - a strong broken/misconfigured-endpoint signal.
+
+    So it fails fast (``session_backoff=False``) rather than looping the retry
+    budget — and, critically, raises instead of handing back an empty
+    ``LLMResponse`` the agent would misdiagnose as a backend outage.
+    """
+    if content or tool_calls or stop_reason is not None:
+        return
+    raise TransientProviderError(
+        f"{provider or 'The model provider'} returned an empty response — try again in a moment.",
+        provider=provider or "The model provider", code="empty_response",
+        session_backoff=False, model=model,
+    )
+
+
 class ModelUnavailableError(ConnectionError):
     """Raised when the gateway rejects the requested model with a structured 403.
 

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -518,7 +518,9 @@ def raise_on_empty_response(
     budget — and, critically, raises instead of handing back an empty
     ``LLMResponse`` the agent would misdiagnose as a backend outage.
     """
-    if content or tool_calls or stop_reason is not None:
+    # Empty-string stop_reason ("" — no real provider sends it) is treated as
+    # absent, same as None: a truthiness check keeps the guard from being fooled.
+    if content or tool_calls or stop_reason:
         return
     raise TransientProviderError(
         f"{provider or 'The model provider'} returned an empty response — try again in a moment.",

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -3,9 +3,55 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from anton.core.llm.anthropic import AnthropicProvider
 from anton.core.llm.openai import _parse_response_object
-from anton.core.llm.provider import LLMResponse, ToolCall, compute_context_pressure
+from anton.core.llm.provider import (
+    LLMResponse,
+    ToolCall,
+    TransientProviderError,
+    compute_context_pressure,
+    raise_on_empty_response,
+)
+
+
+def _output_text_item(text: str) -> SimpleNamespace:
+    """A minimal Responses API ``message`` item carrying one output_text block."""
+    return SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text=text)],
+    )
+
+
+class TestRaiseOnEmptyResponse:
+    def test_raises_on_empty_200(self):
+        # No content, no tool calls, no stop reason → the empty-200 failure mode.
+        with pytest.raises(TransientProviderError) as exc:
+            raise_on_empty_response(content="", tool_calls=[], stop_reason=None)
+        assert exc.value.code == "empty_response"
+        # Fail fast, don't loop the retry budget on a broken endpoint.
+        assert exc.value.session_backoff is False
+
+    def test_passthrough_with_content(self):
+        raise_on_empty_response(content="hi", tool_calls=[], stop_reason=None)
+
+    def test_passthrough_with_tool_calls(self):
+        raise_on_empty_response(
+            content="", tool_calls=[ToolCall(id="1", name="t", input={})], stop_reason=None
+        )
+
+    def test_passthrough_with_stop_reason(self):
+        # A real stop_reason means the provider terminated deliberately (e.g. a
+        # legitimately empty turn) — not a truncated/empty 200.
+        raise_on_empty_response(content="", tool_calls=[], stop_reason="stop")
+
+    def test_parse_response_object_raises_on_empty_200(self):
+        # End-to-end: an empty output with no status is the silent-empty 200 the
+        # guard exists to catch — it must raise, not return an empty LLMResponse.
+        response = SimpleNamespace(output=[], usage=None)
+        with pytest.raises(TransientProviderError):
+            _parse_response_object(response, "claude-sonnet-4-6")
 
 
 class TestComputeContextPressure:
@@ -31,7 +77,8 @@ class TestComputeContextPressure:
         # must coerce them to 0 (not pass None into compute_context_pressure)
         # and must not raise.
         response = SimpleNamespace(
-            output=[],
+            output=[_output_text_item("ok")],
+            status="completed",
             usage=SimpleNamespace(input_tokens=None, output_tokens=None),
         )
         result = _parse_response_object(response, "claude-sonnet-4-6")
@@ -42,7 +89,8 @@ class TestComputeContextPressure:
     def test_parse_response_object_keeps_real_usage_tokens(self):
         # Sanity: valid counts are preserved unchanged.
         response = SimpleNamespace(
-            output=[],
+            output=[_output_text_item("ok")],
+            status="completed",
             usage=SimpleNamespace(input_tokens=100_000, output_tokens=250),
         )
         result = _parse_response_object(response, "claude-sonnet-4-6")

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -46,6 +46,13 @@ class TestRaiseOnEmptyResponse:
         # legitimately empty turn) — not a truncated/empty 200.
         raise_on_empty_response(content="", tool_calls=[], stop_reason="stop")
 
+    def test_empty_string_stop_reason_counts_as_absent(self):
+        # An empty-string stop_reason is treated as absent (no real provider
+        # sends ""), so an otherwise-empty response still raises. Pins the
+        # truthiness predicate against a revert to `stop_reason is not None`.
+        with pytest.raises(TransientProviderError):
+            raise_on_empty_response(content="", tool_calls=[], stop_reason="")
+
     def test_parse_response_object_raises_on_empty_200(self):
         # End-to-end: an empty output with no status is the silent-empty 200 the
         # guard exists to catch — it must raise, not return an empty LLMResponse.


### PR DESCRIPTION
## Summary

Based on https://github.com/mindsdb/anton/pull/258#issuecomment-5063836574

Fail loud on an empty HTTP 200 in the non-streaming `complete()` paths. Previously they silently returned an empty `LLMResponse` (`content=''`, zero usage, `stop_reason=None`), which the agent misdiagnoses as a backend outage — the exact failure mode that made ENG-847 hard to triage.

This mirrors the guard the streaming path already has (`openai.py`, `code="truncated_stream"`) onto the three non-streaming return sites, as defense-in-depth follow-up flagged in review on #258.

## Changes

- **`provider.py`** — add shared helper `raise_on_empty_response(...)`. Raises `TransientProviderError(code="empty_response", session_backoff=False)` only when content, tool calls, and `stop_reason` are all empty. One helper so the mapping can't drift between providers.
- Wire it into the three non-streaming paths: OpenAI chat-completions `complete()`, OpenAI Responses path (`_parse_response_object`), and Anthropic `complete()`.

`session_backoff=False` matches the streaming carve-out: an empty-from-start 200 is a strong broken/misconfigured-endpoint signal, so it fails fast instead of looping the retry budget. `stop_reason` is the discriminator — a real 200 always carries one, so the guard only fires on a genuinely empty/truncated response, not a legitimately empty turn.

## Tests

- New `TestRaiseOnEmptyResponse`: raise on empty 200, passthrough for content / tool calls / real stop_reason, and end-to-end via `_parse_response_object`.
- Updated two existing `_parse_response_object` fixtures to include a realistic `status="completed"` (they previously omitted `status`, which is unrealistic for a completed Responses object).

All provider + transient-retry suites pass (112 tests).

Fixes https://linear.app/mindsdb/issue/ENG-847/scratchpad-web-search-silently-returns-empty-on-the-minds-cloud