### PR TITLE
ENG-1155: hand-back diagnoses persist as streamed; latch dead verifiers

### DIFF
--- a/anton/core/llm/structured.py
+++ b/anton/core/llm/structured.py
@@ -29,7 +29,6 @@ the subprocess already imports from `anton.core.*` at boot.
 
 from __future__ import annotations
 
-from typing import Any, NoReturn
 import logging
 from typing import Any, Awaitable, Callable, NoReturn
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -211,11 +211,21 @@ class _VerifierVerdict(BaseModel):
 #
 # 2048 is sized from a measured distribution, not one sample: 16 identical calls
 # spanned 245–1654 output tokens (median ~290). That 6.7x per-call spread is also
-# why there is no "this model can't do it" latch — one truncation is a tail
-# sample, not proof about the next turn — and why the 4096 retry exists rather
-# than a single bigger budget. 1024 was measurably too small. Nothing pays for
-# headroom it doesn't use; first-party models answer in 43–115 tokens either way.
+# why *truncation* never latches — one truncation is a tail sample, not proof
+# about the next turn — and why the 4096 retry exists rather than a single bigger
+# budget. 1024 was measurably too small. Nothing pays for headroom it doesn't
+# use; first-party models answer in 43–115 tokens either way.
+#
+# A *hard* failure does latch, which is a different claim: a 400 rejecting the
+# forced `tool_choice` is a statement about the model, not about this transcript
+# (ENG-1095/ENG-1155). See `_verifier_latched`.
 _VERIFIER_TOKEN_BUDGETS = (2048, 4096)
+
+# Turns a latched session skips before spending one verdict call to see whether
+# the cause has gone away (user switched model, gateway fix shipped). Without a
+# re-probe the latch is permanent for the session and "reset on a successful
+# verdict" can never fire, since a latched session makes no verdict calls.
+_VERIFIER_LATCH_REPROBE_TURNS = 10
 
 # Appended to the verifier system prompt. Shortens the preamble on narrating
 # models but is not sufficient alone (0/3 at 256 with it), so it pairs with the
@@ -474,6 +484,7 @@ class ChatSession:
         # failure twice in a row latches, a successful verdict clears it.
         self._verifier_hard_failures = 0
         self._verifier_latched = False
+        self._verifier_latch_skips = 0
         self._context_pressure_threshold = s.context_pressure_threshold
         self._max_consecutive_errors = s.max_consecutive_errors
         self._resilience_nudge_at = s.resilience_nudge_at
@@ -2470,14 +2481,22 @@ class ChatSession:
         # task isn't actually done yet.
         continuation = 0
         _max_rounds_hit = False
-        # True once the verification block has put the assistant reply in
-        # history, so the post-loop fallback knows not to append it a second
-        # time (ENG-1155 double-append).
+        # Set per verification-loop iteration (see below): tells the post-loop
+        # fallback the current reply is already in history, so it must not append
+        # it a second time (ENG-1155 double-append).
         _reply_persisted = False
         import logging as _logging
         _verifier_log = _logging.getLogger(__name__)
 
         while True:  # Completion verification loop
+            # Per-iteration, NOT per-turn: the flag means "the reply currently in
+            # `llm_response` is already in history". A continuation replaces
+            # `llm_response`, so a stale True would make the post-loop fallback
+            # skip a reply that was never persisted — dropping the answer the
+            # user just read on any INCOMPLETE turn whose continuation needs no
+            # tools (tool_round stays 0, so the loop breaks at the gate below
+            # before the append).
+            _reply_persisted = False
             tool_round = 0
             error_streak: dict[str, int] = {}
             resilience_nudged: set[str] = set()
@@ -2923,14 +2942,31 @@ class ChatSession:
             # (ENG-1155). The turn ends on the model's own answer, which is
             # already in history — unverified, but that beats a per-turn
             # interruption we know the cause of.
+            # Re-probe occasionally so the latch can't outlive its cause: the
+            # user may switch off the broken model mid-session, or the gateway
+            # fix may land. Without this, "reset on a successful verdict" is
+            # unreachable — a latched session skips every verdict call, so there
+            # is never another success to reset on. A failed re-probe stays
+            # latched and does NOT re-diagnose (the >=2 branch below breaks
+            # before the diagnosis), so the cost is one verdict call per
+            # _VERIFIER_LATCH_REPROBE_TURNS turns.
             if self._verifier_latched:
+                self._verifier_latch_skips += 1
+                if self._verifier_latch_skips < _VERIFIER_LATCH_REPROBE_TURNS:
+                    _verifier_log.info(
+                        "completion-verifier skipped — latched after %d consecutive "
+                        "hard failures (skip %d/%d before re-probe); "
+                        "continuation=%d/%d tool_rounds=%d",
+                        self._verifier_hard_failures, self._verifier_latch_skips,
+                        _VERIFIER_LATCH_REPROBE_TURNS, continuation,
+                        self._max_continuations, tool_round,
+                    )
+                    break
                 _verifier_log.info(
-                    "completion-verifier skipped — latched after %d consecutive "
-                    "hard failures; continuation=%d/%d tool_rounds=%d",
-                    self._verifier_hard_failures, continuation,
-                    self._max_continuations, tool_round,
+                    "completion-verifier re-probing after %d skipped verifications",
+                    self._verifier_latch_skips,
                 )
-                break
+                self._verifier_latch_skips = 0
 
             # Ask the cheap coding model to self-assess completion over a compact,
             # text-rendered view of the recent conversation: enough context for

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2985,8 +2985,9 @@ class ChatSession:
                 self._verifier_latch_skips += 1
                 if self._verifier_latch_skips < _VERIFIER_LATCH_REPROBE_TURNS:
                     _verifier_log.info(
-                        "completion-verifier skipped — latched after %d consecutive "
-                        "hard failures (skip %d/%d before re-probe); "
+                        "completion-verifier skipped — latched after %d hard "
+                        "failures with no successful verdict between them "
+                        "(skip %d/%d before re-probe); "
                         "continuation=%d/%d tool_rounds=%d",
                         self._verifier_hard_failures, self._verifier_latch_skips,
                         _VERIFIER_LATCH_REPROBE_TURNS, continuation,

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import httpx
 import random
 from collections.abc import AsyncIterator, Callable
 from dataclasses import asdict, dataclass, field, replace
@@ -220,6 +221,25 @@ class _VerifierVerdict(BaseModel):
 # forced `tool_choice` is a statement about the model, not about this transcript
 # (ENG-1095/ENG-1155). See `_verifier_latched`.
 _VERIFIER_TOKEN_BUDGETS = (2048, 4096)
+
+# Verdict-call failures that are transient by nature rather than statements about
+# the model's capability. The latch exists for a model that *cannot* produce a
+# verdict (kimi-K3 rejecting the forced `tool_choice` with a 400, ENG-1095); a
+# dropped connection or a read timeout says nothing about that, and counting it
+# would let two blips switch verification off for a whole re-probe window
+# (review: pnewsam on #299).
+#
+# `TransientProviderError` is ENG-673's typed mapping and is listed first for
+# intent, though `OSError` already covers it (it subclasses `ConnectionError`).
+# `OSError` also covers `asyncio.TimeoutError`, which is `TimeoutError` — an
+# `OSError` subclass — on 3.11+. `httpx.TransportError` covers the transport the
+# OpenAI SDK uses, which is reachable when an error escapes the SDK's own
+# wrapping. Anything outside this set still latches, bounded by the re-probe.
+_TRANSIENT_VERDICT_ERRORS: tuple[type[BaseException], ...] = (
+    TransientProviderError,
+    OSError,
+    httpx.TransportError,
+)
 
 # Turns a latched session skips before spending one verdict call to see whether
 # the cause has gone away (user switched model, gateway fix shipped). Without a
@@ -1562,8 +1582,8 @@ class ChatSession:
             log.warning(
                 "%s diagnosis returned no content — nothing appended; history "
                 "keeps its existing tail (the pre-verification reply on the "
-                "verifier paths, the final tool-call message on the "
-                "max-tool-rounds path)",
+                "verifier paths, the injected SYSTEM pause message on the "
+                "max-tool-rounds path, since the cap block appends that last)",
                 label,
             )
 
@@ -3044,15 +3064,16 @@ class ChatSession:
                     )
                     if not retrying:
                         break
-                except TransientProviderError as exc:
+                except _TRANSIENT_VERDICT_ERRORS as exc:
                     # Explicitly NOT a latch candidate. The latch is for a model
                     # that cannot produce a verdict at all (kimi-K3 rejecting the
                     # forced tool_choice with a 400, ENG-1095) — a statement about
-                    # capability. A typed transient error is the opposite claim:
-                    # retryable, and already retried upstream (ENG-673). Counting
-                    # it would let two provider blips disable verification for the
-                    # rest of the session. The turn still gets its honest
-                    # diagnosis (ENG-1079); it just doesn't latch.
+                    # capability. A transient failure is the opposite claim:
+                    # retryable, and typed ones are already retried upstream
+                    # (ENG-673). Counting them would let two provider blips
+                    # disable verification for a whole re-probe window. The turn
+                    # still gets its honest diagnosis (ENG-1079); it just doesn't
+                    # latch. See `_TRANSIENT_VERDICT_ERRORS` for what qualifies.
                     verdict_failure = "transient"
                     _verifier_log.info(
                         "completion-verifier verdict=TRANSIENT budget=%d error=%s",
@@ -3100,17 +3121,23 @@ class ChatSession:
                         # buys nothing once the cause is known to recur. One
                         # diagnosis per session (ENG-1155).
                         #
-                        # "Hard" = neither truncation nor a typed
-                        # TransientProviderError (see that except-clause above —
-                        # typed transients never latch). Untyped provider blips
-                        # (a generic ConnectionError, say) still count: two of
-                        # those in a row do latch, bounded by the re-probe
-                        # un-latching within _VERIFIER_LATCH_REPROBE_TURNS once
-                        # the provider recovers.
+                        # "Hard" = neither truncation nor anything in
+                        # `_TRANSIENT_VERDICT_ERRORS` (see that except-clause
+                        # above). Connection drops and timeouts are transient and
+                        # never latch; what remains is the shape ENG-1095 has —
+                        # a provider that rejects the call itself.
+                        #
+                        # Not strictly "consecutive" either: the counter is reset
+                        # only by a *successful* verdict, so hard → truncated →
+                        # hard still latches on the second hard failure. That is
+                        # deliberate — only a real verdict proves the model can
+                        # produce one, and a truncation in between is no evidence
+                        # that it can (review: pnewsam on #299).
                         self._verifier_latched = True
                         _verifier_log.info(
-                            "completion-verifier latched after %d consecutive hard "
-                            "failures — skipping further verification this session",
+                            "completion-verifier latched after %d hard failures with "
+                            "no successful verdict between them — skipping further "
+                            "verification this session",
                             self._verifier_hard_failures,
                         )
                         break

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1560,8 +1560,10 @@ class ChatSession:
             self._append_history({"role": "assistant", "content": text})
         else:
             log.warning(
-                "%s diagnosis returned no content — history falls back to the "
-                "pre-verification reply",
+                "%s diagnosis returned no content — nothing appended; history "
+                "keeps its existing tail (the pre-verification reply on the "
+                "verifier paths, the final tool-call message on the "
+                "max-tool-rounds path)",
                 label,
             )
 
@@ -2946,10 +2948,19 @@ class ChatSession:
             # user may switch off the broken model mid-session, or the gateway
             # fix may land. Without this, "reset on a successful verdict" is
             # unreachable — a latched session skips every verdict call, so there
-            # is never another success to reset on. A failed re-probe stays
-            # latched and does NOT re-diagnose (the >=2 branch below breaks
+            # is never another success to reset on. A hard-failing re-probe stays
+            # latched and does NOT re-diagnose (the latched branch below breaks
             # before the diagnosis), so the cost is one verdict call per
             # _VERIFIER_LATCH_REPROBE_TURNS turns.
+            # A re-probe that TRUNCATES (or hits a typed TransientProviderError)
+            # instead is intended to fall through to the honest diagnosis below,
+            # and it leaves the latch set: neither counts toward or against the
+            # latch (truncation is a tail sample, see _VERIFIER_TOKEN_BUDGETS;
+            # typed transients never latch by definition), so only a successful
+            # verdict clears it. A latched session re-probing into a
+            # persistently-verbose model therefore diagnoses once per re-probe
+            # cycle rather than never — matching "every truncated turn keeps its
+            # honest diagnosis".
             if self._verifier_latched:
                 self._verifier_latch_skips += 1
                 if self._verifier_latch_skips < _VERIFIER_LATCH_REPROBE_TURNS:
@@ -3071,6 +3082,16 @@ class ChatSession:
             else:
                 if verdict_failure == "hard":
                     self._verifier_hard_failures += 1
+                    if self._verifier_latched:
+                        # A failed re-probe: the cause is still there. Stay
+                        # latched with its own log line — re-announcing "latched
+                        # after N failures" with an ever-growing N would read as
+                        # a new event each cycle. No re-diagnosis (one per
+                        # session, ENG-1155).
+                        _verifier_log.info(
+                            "completion-verifier re-probe failed — staying latched"
+                        )
+                        break
                     if self._verifier_hard_failures >= 2:
                         # Second hard failure in a row: the first could have been
                         # transient, this one establishes the pattern. Latch and
@@ -3078,6 +3099,14 @@ class ChatSession:
                         # "checking in" message plus a second full-history call
                         # buys nothing once the cause is known to recur. One
                         # diagnosis per session (ENG-1155).
+                        #
+                        # "Hard" = neither truncation nor a typed
+                        # TransientProviderError (see that except-clause above —
+                        # typed transients never latch). Untyped provider blips
+                        # (a generic ConnectionError, say) still count: two of
+                        # those in a row do latch, bounded by the re-probe
+                        # un-latching within _VERIFIER_LATCH_REPROBE_TURNS once
+                        # the provider recovers.
                         self._verifier_latched = True
                         _verifier_log.info(
                             "completion-verifier latched after %d consecutive hard "

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -466,6 +466,14 @@ class ChatSession:
         self._max_tool_rounds = s.max_tool_rounds
         self._max_continuations = s.max_continuations
         self._verify_min_tool_rounds = s.verify_min_tool_rounds
+        # Latch for a verifier that fails the same hard way every turn — e.g.
+        # kimi-K3 rejecting forced `tool_choice` with a 400 (ENG-1095), which
+        # fails on every verdict call until the gateway fix lands. Without the
+        # latch, each multi-step turn pays a full-history diagnosis call and
+        # shows the "checking in" message (ENG-1155). Session-scoped: a hard
+        # failure twice in a row latches, a successful verdict clears it.
+        self._verifier_hard_failures = 0
+        self._verifier_latched = False
         self._context_pressure_threshold = s.context_pressure_threshold
         self._max_consecutive_errors = s.max_consecutive_errors
         self._resilience_nudge_at = s.resilience_nudge_at
@@ -1512,6 +1520,40 @@ class ChatSession:
         self.hard_truncate_history()
         return await self._llm.plan(messages=factory_validated(), **kwargs)
 
+    async def _stream_handback_diagnosis(self, *, system: str, label: str):
+        """Stream a hand-back diagnosis and persist exactly what the user read.
+
+        All three hand-back paths (STUCK, budget-exhausted, verifier-call
+        failure) stream a model-generated message and then stop the turn. The
+        message must be captured into history, because it — not the reply the
+        verifier rejected — is what the user actually saw. Persisting it also
+        keeps `history[-1]` an assistant message, which is what stops the
+        post-loop fallback from re-appending the stale reply (ENG-1155).
+
+        An empty diagnosis is logged rather than appended: an empty assistant
+        turn would recreate the same out-of-sync history this exists to fix,
+        and stale-but-real beats blank.
+        """
+        log = logging.getLogger(__name__)
+        diagnosis_response = None
+        async for event in self.plan_stream_with_recovery(system=system):
+            yield event
+            if isinstance(event, StreamComplete):
+                diagnosis_response = event
+        text = (
+            (diagnosis_response.response.content or "").strip()
+            if diagnosis_response is not None
+            else ""
+        )
+        if text:
+            self._append_history({"role": "assistant", "content": text})
+        else:
+            log.warning(
+                "%s diagnosis returned no content — history falls back to the "
+                "pre-verification reply",
+                label,
+            )
+
     async def plan_stream_with_recovery(
         self,
         *,
@@ -2428,6 +2470,10 @@ class ChatSession:
         # task isn't actually done yet.
         continuation = 0
         _max_rounds_hit = False
+        # True once the verification block has put the assistant reply in
+        # history, so the post-loop fallback knows not to append it a second
+        # time (ENG-1155 double-append).
+        _reply_persisted = False
         import logging as _logging
         _verifier_log = _logging.getLogger(__name__)
 
@@ -2461,7 +2507,16 @@ class ChatSession:
                             ),
                         }
                     )
-                    async for event in self.plan_stream_with_recovery(system=system):
+                    # Fourth hand-back path, same defect as the other three: the
+                    # reply above is already in history, so without capturing the
+                    # diagnosis the post-loop fallback appends that reply a second
+                    # time and the message the user actually read is lost
+                    # (ENG-1155 — this site is not named in the ticket, and it is
+                    # the highest-traffic one of the four).
+                    _reply_persisted = True
+                    async for event in self._stream_handback_diagnosis(
+                        system=system, label="max-tool-rounds"
+                    ):
                         yield event
                     break
 
@@ -2826,9 +2881,13 @@ class ChatSession:
             if tool_round < self._verify_min_tool_rounds or _max_rounds_hit:
                 break
 
-            # Append the assistant's final text so the verifier can see it
+            # Append the assistant's final text so the verifier can see it.
+            # Once this has run, the post-loop fallback must NOT append `reply`
+            # again — doing so is what put the rejected reply in history twice
+            # on every hand-back turn (ENG-1155).
             reply = llm_response.content or ""
             self._append_history({"role": "assistant", "content": reply})
+            _reply_persisted = True
 
             if continuation >= self._max_continuations:
                 # Budget exhausted — ask LLM to diagnose and present to user
@@ -2850,9 +2909,27 @@ class ChatSession:
                 yield StreamTaskProgress(
                     phase="analyzing", message="Diagnosing incomplete task..."
                 )
-                async for event in self.plan_stream_with_recovery(system=system):
+                async for event in self._stream_handback_diagnosis(
+                    system=system, label="budget-exhausted"
+                ):
                     yield event
                 # Consolidation still runs after diagnosis
+                break
+
+            # A verifier that already failed hard twice in a row will keep
+            # failing for the rest of the session (ENG-1095's forced-tool_choice
+            # 400 is per-model, not per-call). Skip the verdict rather than pay a
+            # full-history diagnosis every turn and show "checking in" each time
+            # (ENG-1155). The turn ends on the model's own answer, which is
+            # already in history — unverified, but that beats a per-turn
+            # interruption we know the cause of.
+            if self._verifier_latched:
+                _verifier_log.info(
+                    "completion-verifier skipped — latched after %d consecutive "
+                    "hard failures; continuation=%d/%d tool_rounds=%d",
+                    self._verifier_hard_failures, continuation,
+                    self._max_continuations, tool_round,
+                )
                 break
 
             # Ask the cheap coding model to self-assess completion over a compact,
@@ -2890,6 +2967,10 @@ class ChatSession:
                 + _VERIFIER_NO_PREAMBLE
             )
             verdict = None
+            # Truncation vs hard failure decides whether this counts toward the
+            # latch: a blown budget is a tail sample of one model's verbosity,
+            # an identical hard error twice is a capability problem (ENG-1155).
+            verdict_failure: str | None = None
             for attempt, budget in enumerate(_VERIFIER_TOKEN_BUDGETS):
                 try:
                     verdict = await self._llm.generate_object_code(
@@ -2907,6 +2988,7 @@ class ChatSession:
                     retrying = exc.truncated and attempt + 1 < len(
                         _VERIFIER_TOKEN_BUDGETS
                     )
+                    verdict_failure = "truncated" if exc.truncated else "hard"
                     _verifier_log.info(
                         "completion-verifier verdict=%s budget=%d output_tokens=%d "
                         "stop_reason=%s retrying=%s",
@@ -2920,6 +3002,7 @@ class ChatSession:
                     # collapse into one "verifier unavailable" line — but never
                     # the exception message, which can carry conversation
                     # content (ENG-1081).
+                    verdict_failure = "hard"
                     _verifier_log.info(
                         "completion-verifier verdict=ERROR budget=%d error=%s",
                         budget, _safe_error_detail(exc),
@@ -2927,12 +3010,30 @@ class ChatSession:
                     break
 
             if verdict is not None:
+                # A working verdict clears the latch: whatever was failing
+                # (transient provider error, a model the user has since changed)
+                # is no longer failing.
+                self._verifier_hard_failures = 0
+                self._verifier_latched = False
                 status = verdict.status
                 reason = verdict.reason.strip()
             else:
-                # Verifier failed — fail safe by treating the turn as done rather
-                # than forcing a continuation the user never asked for.
-                status, reason = "COMPLETE", "verifier unavailable"
+                if verdict_failure == "hard":
+                    self._verifier_hard_failures += 1
+                    if self._verifier_hard_failures >= 2:
+                        # Second hard failure in a row: the first could have been
+                        # transient, this one establishes the pattern. Latch and
+                        # skip the diagnosis on this turn too — a second
+                        # "checking in" message plus a second full-history call
+                        # buys nothing once the cause is known to recur. One
+                        # diagnosis per session (ENG-1155).
+                        self._verifier_latched = True
+                        _verifier_log.info(
+                            "completion-verifier latched after %d consecutive hard "
+                            "failures — skipping further verification this session",
+                            self._verifier_hard_failures,
+                        )
+                        break
                 # The verifier call failed on every budget it was given —
                 # truncated past the last retry, an unusable tool call, or a
                 # provider error (the per-attempt logs above carry the detail).
@@ -2964,34 +3065,10 @@ class ChatSession:
                     phase="analyzing",
                     message="Something went wrong — checking in with you...",
                 )
-                diagnosis_response = None
-                async for event in self.plan_stream_with_recovery(system=system):
+                async for event in self._stream_handback_diagnosis(
+                    system=system, label="verifier-failure"
+                ):
                     yield event
-                    if isinstance(event, StreamComplete):
-                        diagnosis_response = event
-                # Persist the actual message the user just saw — not the stale
-                # pre-verification `reply` the post-loop fallback below would
-                # otherwise re-append, which would leave history (and thus the
-                # model's own memory of what it just told the user) out of sync
-                # with what was streamed.
-                diagnosis_text = (
-                    (diagnosis_response.response.content or "").strip()
-                    if diagnosis_response is not None
-                    else ""
-                )
-                if diagnosis_text:
-                    self._append_history(
-                        {"role": "assistant", "content": diagnosis_text}
-                    )
-                else:
-                    # An empty diagnosis would silently recreate the exact
-                    # out-of-sync history this path exists to fix (the
-                    # post-loop fallback re-appends the stale reply). Make it
-                    # visible rather than circular.
-                    _verifier_log.warning(
-                        "verifier-failure diagnosis returned no content — "
-                        "history falls back to the pre-verification reply"
-                    )
                 break
 
             _verifier_log.info(
@@ -3026,7 +3103,9 @@ class ChatSession:
                 yield StreamTaskProgress(
                     phase="analyzing", message="Diagnosing blocked task..."
                 )
-                async for event in self.plan_stream_with_recovery(system=system):
+                async for event in self._stream_handback_diagnosis(
+                    system=system, label="stuck"
+                ):
                     yield event
                 break
 
@@ -3063,9 +3142,13 @@ class ChatSession:
             llm_response = response.response
             # Loop back to the top of the completion verification loop
 
-        # Text-only final response — append to history (if not already appended
-        # by the verification block above).
-        if not self._history or self._history[-1].get("role") != "assistant":
+        # Text-only final response — append to history, unless the verification
+        # block already did. The old role-based guard was not enough: on a
+        # hand-back turn the last entry is the SYSTEM injection, so this fired
+        # and appended the rejected reply a second time (ENG-1155).
+        if not _reply_persisted and (
+            not self._history or self._history[-1].get("role") != "assistant"
+        ):
             reply = llm_response.content or ""
             self._append_history({"role": "assistant", "content": reply})
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3033,6 +3033,21 @@ class ChatSession:
                     )
                     if not retrying:
                         break
+                except TransientProviderError as exc:
+                    # Explicitly NOT a latch candidate. The latch is for a model
+                    # that cannot produce a verdict at all (kimi-K3 rejecting the
+                    # forced tool_choice with a 400, ENG-1095) — a statement about
+                    # capability. A typed transient error is the opposite claim:
+                    # retryable, and already retried upstream (ENG-673). Counting
+                    # it would let two provider blips disable verification for the
+                    # rest of the session. The turn still gets its honest
+                    # diagnosis (ENG-1079); it just doesn't latch.
+                    verdict_failure = "transient"
+                    _verifier_log.info(
+                        "completion-verifier verdict=TRANSIENT budget=%d error=%s",
+                        budget, _safe_error_detail(exc),
+                    )
+                    break
                 except Exception as exc:
                     # Enough to tell the failure modes apart — four used to
                     # collapse into one "verifier unavailable" line — but never

--- a/tests/e2e/scenarios/test_loop_safety.py
+++ b/tests/e2e/scenarios/test_loop_safety.py
@@ -123,6 +123,74 @@ def test_waiting_verdict_stops_without_continuation(cfg, stub, tmp_path):
     ), "verifier did not receive the current request header"
 
 
+@pytest.mark.stub_only
+def test_stuck_verdict_diagnoses_without_continuation(cfg, stub, tmp_path):
+    # STUCK was the one verdict with no end-to-end coverage at all — the stub
+    # helper existed and nothing called it. It is also one of the two paths
+    # ENG-1155 refactors, so pin the behaviour before touching it: a hard
+    # blocker must produce a real diagnosis and must NOT force a continuation.
+    stub.queue_tool_call("scratchpad", {"action": "exec", "name": "c", "code": "print(1)"})
+    stub.queue_text("I tried to connect but there are no credentials. STUCK_REPLY")
+    stub.queue_verification_stuck("no database credentials are configured")
+    stub.queue_text("STUCK_DIAGNOSIS: no DB credentials — set DB_URL and I'll retry.")
+    result = run_anton(["--folder", str(tmp_path)], ["query my database", "exit"],
+                       env=base_env(stub), timeout=cfg.timeout(30))
+
+    assert_exit_ok(result)
+    assert_not_output(result, "Traceback (most recent call last)")
+    # The user reads the diagnosis, not the rejected reply, as the turn's answer.
+    assert_output(result, "STUCK_DIAGNOSIS")
+    # STUCK is a stop, not unfinished work.
+    assert not any(
+        "Continue working on the original request" in json.dumps(r.get("messages", []))
+        for r in stub.requests
+    ), "STUCK verdict must not trigger a continuation injection"
+    assert any(
+        "determined this task is stuck" in json.dumps(r.get("messages", []))
+        for r in stub.requests
+    ), f"STUCK diagnosis request not found. Request count: {stub.request_count}"
+
+
+@pytest.mark.stub_only
+def test_stuck_diagnosis_reaches_the_next_turns_history(cfg, stub, tmp_path):
+    # ENG-1155: the diagnosis is streamed to the user but never captured, so the
+    # post-loop fallback re-appends the stale pre-verification reply instead.
+    # Observable end-to-end: on the NEXT turn the model is handed a history in
+    # which it never said the thing the user just read — and said the rejected
+    # reply twice.
+    stub.queue_tool_call("scratchpad", {"action": "exec", "name": "c", "code": "print(1)"})
+    stub.queue_text("I tried to connect but there are no credentials. STUCK_REPLY")
+    stub.queue_verification_stuck("no database credentials are configured")
+    stub.queue_text("STUCK_DIAGNOSIS: no DB credentials — set DB_URL and I'll retry.")
+    # Second turn: single text round, so it stops below verify_min_tool_rounds
+    # and needs no verdict. Its request carries the history we care about.
+    stub.queue_text("Understood. SECOND_TURN_DONE")
+    result = run_anton(["--folder", str(tmp_path)],
+                       ["query my database", "ok thanks", "exit"],
+                       env=base_env(stub), timeout=cfg.timeout(40))
+
+    assert_exit_ok(result)
+    assert_not_output(result, "Traceback (most recent call last)")
+    assert_output(result, "SECOND_TURN_DONE")
+
+    followups = [
+        json.dumps(r.get("messages", []))
+        for r in stub.requests
+        if "ok thanks" in json.dumps(r.get("messages", []))
+    ]
+    assert followups, f"follow-up turn never reached the model. Count: {stub.request_count}"
+    history = followups[0]
+    stale = history.count("STUCK_REPLY")
+    assert "STUCK_DIAGNOSIS" in history, (
+        "the diagnosis the user read is absent from the next turn's history — "
+        f"the model has no memory of what it just told the user (stale reply "
+        f"appears {stale}x)"
+    )
+    assert stale <= 1, (
+        f"the rejected pre-verification reply was appended {stale}x"
+    )
+
+
 def test_session_exits_within_timeout(cfg, stub, tmp_path):
     stub.queue_text("Quick reply. QUICK_EXIT")
     stub.queue_verification_ok()

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -322,6 +322,201 @@ async def test_budget_exhausted_diagnosis_is_persisted_as_streamed(workspace):
         await session.close()
 
 
+def _make_session(workspace, mock_llm) -> ChatSession:
+    return ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+
+def _tool_then_text_plan(diagnosis: str = "DIAGNOSIS: internal check failed."):
+    """plan_stream factory replaying one tool round, a reply, then a diagnosis —
+    reset per turn so the same session can run several turns."""
+    state = {"n": 0}
+
+    def plan(**kwargs):
+        state["n"] += 1
+        if state["n"] == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Running.", "exec", "main", "print(1)"))
+            ])
+        if state["n"] == 2:
+            return _FakeAsyncIter([StreamComplete(response=_text_response("REPLY"))])
+        return _FakeAsyncIter([StreamComplete(response=_text_response(diagnosis))])
+
+    return plan, state
+
+
+async def test_deterministic_hard_failure_latches_after_one_diagnosis(workspace, caplog):
+    """ENG-1155: kimi-K3 rejects the forced `tool_choice` with a 400 on EVERY
+    verdict call (ENG-1095), so the ENG-1079 diagnosis path would fire on every
+    multi-step turn — a full-history planning call plus a "checking in" message
+    each time. The session must latch instead: one diagnosis, then skip.
+    """
+    import logging
+
+    mock_llm = make_mock_llm()
+    verdict_calls = 0
+
+    async def always_400(_schema, *, system, messages, max_tokens):
+        nonlocal verdict_calls
+        verdict_calls += 1
+        raise RuntimeError("400 tool_choice not supported")
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=always_400)
+    session = _make_session(workspace, mock_llm)
+
+    diagnoses = 0
+    try:
+        with caplog.at_level(logging.INFO):
+            for turn in range(4):
+                plan, state = _tool_then_text_plan()
+                mock_llm.plan_stream = plan
+                async for _ in session.turn_stream(f"do step {turn}"):
+                    pass
+                # A third plan_stream call on a turn == the diagnosis fired.
+                if state["n"] >= 3:
+                    diagnoses += 1
+
+        assert diagnoses == 1, (
+            f"expected exactly one diagnosis per session, got {diagnoses}"
+        )
+        # Turns 1 and 2 call the verifier (the 2nd establishes the pattern);
+        # turns 3 and 4 must not pay for it at all.
+        assert verdict_calls == 2, (
+            f"latched session kept calling the verifier ({verdict_calls} calls)"
+        )
+        assert session._verifier_latched is True
+        assert any("latched after 2 consecutive hard failures" in r.message
+                   for r in caplog.records), "the latch must announce itself once"
+        skips = [r for r in caplog.records
+                 if "completion-verifier skipped — latched" in r.message]
+        assert len(skips) == 2, (
+            f"expected one skip log per skipped verification, got {len(skips)}"
+        )
+    finally:
+        await session.close()
+
+
+async def test_truncation_does_not_latch(workspace):
+    """A blown budget is one model being verbose on one transcript — a tail
+    sample, not a capability problem. Only hard failures latch (ENG-1155);
+    truncation keeps its ENG-1081 retry ladder and its honest diagnosis.
+    """
+    from anton.core.llm.provider import StructuredOutputError
+
+    mock_llm = make_mock_llm()
+
+    async def always_truncated(_schema, *, system, messages, max_tokens):
+        raise StructuredOutputError(
+            "no tool call", truncated=True, output_tokens=max_tokens,
+            max_tokens=max_tokens, stop_reason="stop",
+        )
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=always_truncated)
+    session = _make_session(workspace, mock_llm)
+
+    diagnoses = 0
+    try:
+        for turn in range(3):
+            plan, state = _tool_then_text_plan()
+            mock_llm.plan_stream = plan
+            async for _ in session.turn_stream(f"do step {turn}"):
+                pass
+            if state["n"] >= 3:
+                diagnoses += 1
+
+        assert session._verifier_latched is False, "truncation must not latch"
+        assert diagnoses == 3, (
+            f"every truncated turn still gets its honest diagnosis, got {diagnoses}"
+        )
+    finally:
+        await session.close()
+
+
+async def test_successful_verdict_clears_the_latch_counter(workspace):
+    """One hard failure then a working verdict is a transient blip — the counter
+    must reset, or two unrelated failures an hour apart would latch the session.
+    """
+    mock_llm = make_mock_llm()
+    outcomes = [
+        RuntimeError("400 once"),
+        _VerifierVerdict(status="COMPLETE", reason="done"),
+        RuntimeError("400 again"),
+    ]
+
+    async def scripted(_schema, *, system, messages, max_tokens):
+        item = outcomes.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=scripted)
+    session = _make_session(workspace, mock_llm)
+    try:
+        for turn in range(3):
+            plan, _ = _tool_then_text_plan()
+            mock_llm.plan_stream = plan
+            async for _ in session.turn_stream(f"do step {turn}"):
+                pass
+
+        # fail, succeed, fail → never two in a row.
+        assert session._verifier_latched is False
+        assert session._verifier_hard_failures == 1
+    finally:
+        await session.close()
+
+
+async def test_max_tool_rounds_diagnosis_is_persisted_as_streamed(workspace):
+    """The tool-round circuit breaker is a FOURTH hand-back path with the same
+    desync — not named in ENG-1155, and the highest-traffic of the four (the
+    25-round cap fires on real sessions far more often than STUCK does).
+
+    It appends the reply, injects a SYSTEM pause, streams a diagnosis, and never
+    captures it — so the post-loop fallback re-appends the reply.
+    """
+    mock_llm = make_mock_llm()
+    # Verifier is never reached on this path (_max_rounds_hit skips verification).
+    mock_llm.generate_object_code = AsyncMock(
+        side_effect=AssertionError("no verdict call on the max-rounds path")
+    )
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            # Keep calling tools until the cap trips.
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response(
+                    "STALE_PRE_VERIFICATION_REPLY", "exec", "main", "print(1)"))
+            ])
+        return _FakeAsyncIter([
+            StreamComplete(response=_text_response(
+                "DIAGNOSIS: I've used my step budget. Here's where I got to."
+            ))
+        ])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session._max_tool_rounds = 1
+    try:
+        async for _ in session.turn_stream("do lots of steps"):
+            pass
+
+        texts = _assistant_texts(session)
+        assert any("DIAGNOSIS:" in t for t in texts), (
+            "the cap diagnosis the user read is missing from history"
+        )
+        assert "DIAGNOSIS:" in texts[-1], (
+            f"history ends on the stale reply, not the diagnosis: {texts[-1]!r}"
+        )
+        assert sum("STALE_PRE_VERIFICATION_REPLY" in t for t in texts) <= 1, (
+            "the stale reply was appended twice"
+        )
+    finally:
+        await session.close()
+
+
 async def test_empty_diagnosis_is_logged_not_circular(workspace, caplog):
     """Review follow-up: an empty diagnosis must not silently recreate the
     out-of-sync history this path fixes — it logs, and the post-loop fallback

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -517,6 +517,109 @@ async def test_max_tool_rounds_diagnosis_is_persisted_as_streamed(workspace):
         await session.close()
 
 
+async def test_text_only_continuation_answer_is_not_dropped(workspace):
+    """Self-review catch. `_reply_persisted` must be per-iteration, not per-turn.
+
+    INCOMPLETE → the continuation finishes the answer with no tool calls →
+    `tool_round` stays 0 → the loop breaks at the verify_min_tool_rounds gate
+    BEFORE appending the new reply. A turn-scoped flag would still be True from
+    the first iteration, so the post-loop fallback would skip, and the answer the
+    user just read would vanish from history. That is the same defect ENG-1155
+    fixes, introduced on the continuation path.
+    """
+    mock_llm = make_mock_llm()
+    verdicts = [_VerifierVerdict(status="INCOMPLETE", reason="not done yet")]
+
+    async def verdict(_schema, *, system, messages, max_tokens):
+        return verdicts.pop(0) if verdicts else _VerifierVerdict(
+            status="COMPLETE", reason="done"
+        )
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=verdict)
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Working.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            return _FakeAsyncIter([StreamComplete(response=_text_response("FIRST_DRAFT"))])
+        # Continuation needs no tools — it just finishes writing.
+        return _FakeAsyncIter([
+            StreamComplete(response=_text_response("FINAL_ANSWER_USER_READ"))
+        ])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    try:
+        async for _ in session.turn_stream("write me a summary"):
+            pass
+
+        texts = _assistant_texts(session)
+        assert any("FINAL_ANSWER_USER_READ" in t for t in texts), (
+            "the continuation's answer — what the user actually read — is missing "
+            f"from history; assistant turns held: {texts}"
+        )
+        assert "FINAL_ANSWER_USER_READ" in texts[-1]
+    finally:
+        await session.close()
+
+
+async def test_latched_verifier_reprobes_and_can_recover(workspace):
+    """Self-review catch. A latched session makes no verdict calls, so "reset on a
+    successful verdict" is unreachable and the latch outlives its cause — the user
+    switches off the broken model and verification stays dead for the session.
+
+    After `_VERIFIER_LATCH_REPROBE_TURNS` skips it must spend one call; if that
+    succeeds, the latch clears.
+    """
+    from anton.core.session import _VERIFIER_LATCH_REPROBE_TURNS
+
+    mock_llm = make_mock_llm()
+    calls = {"n": 0}
+    # Two hard failures to latch, then every later call succeeds (the user has
+    # switched to a model whose forced tool_choice works).
+    async def scripted(_schema, *, system, messages, max_tokens):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise RuntimeError("400 tool_choice not supported")
+        return _VerifierVerdict(status="COMPLETE", reason="done")
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=scripted)
+    session = _make_session(workspace, mock_llm)
+    try:
+        for turn in range(2):
+            plan, _ = _tool_then_text_plan()
+            mock_llm.plan_stream = plan
+            async for _ in session.turn_stream(f"step {turn}"):
+                pass
+        assert session._verifier_latched is True, "two hard failures must latch"
+        assert calls["n"] == 2
+
+        # Run exactly enough turns to consume the skip budget and re-probe.
+        for turn in range(_VERIFIER_LATCH_REPROBE_TURNS):
+            plan, _ = _tool_then_text_plan()
+            mock_llm.plan_stream = plan
+            async for _ in session.turn_stream(f"more {turn}"):
+                pass
+
+        assert calls["n"] == 3, (
+            f"expected exactly one re-probe call after {_VERIFIER_LATCH_REPROBE_TURNS} "
+            f"skips, verifier was called {calls['n']}x total"
+        )
+        assert session._verifier_latched is False, (
+            "a successful re-probe must clear the latch"
+        )
+        assert session._verifier_hard_failures == 0
+    finally:
+        await session.close()
+
+
 async def test_empty_diagnosis_is_logged_not_circular(workspace, caplog):
     """Review follow-up: an empty diagnosis must not silently recreate the
     out-of-sync history this path fixes — it logs, and the post-loop fallback

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -620,6 +620,47 @@ async def test_latched_verifier_reprobes_and_can_recover(workspace):
         await session.close()
 
 
+async def test_transient_provider_errors_never_latch(workspace):
+    """A typed transient error must not latch. The latch is for a model that
+    *cannot* produce a verdict (kimi-K3's forced-tool_choice 400, ENG-1095) — a
+    capability claim. `TransientProviderError` asserts the opposite: retryable,
+    already retried upstream (ENG-673). Counting it would let two provider blips
+    disable verification for the rest of the session.
+
+    Matters more once #297 (ENG-847) lands, which converts empty 200s into
+    `TransientProviderError` on the same providers the verdict call uses.
+    """
+    from anton.core.llm.provider import TransientProviderError
+
+    mock_llm = make_mock_llm()
+    calls = {"n": 0}
+
+    async def always_transient(_schema, *, system, messages, max_tokens):
+        calls["n"] += 1
+        raise TransientProviderError("provider returned an empty 200")
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=always_transient)
+    session = _make_session(workspace, mock_llm)
+    try:
+        for turn in range(4):
+            plan, _ = _tool_then_text_plan()
+            mock_llm.plan_stream = plan
+            async for _ in session.turn_stream(f"step {turn}"):
+                pass
+
+        assert session._verifier_latched is False, (
+            "transient provider errors must never latch the session"
+        )
+        assert session._verifier_hard_failures == 0
+        # Verification keeps being attempted every turn, rather than being
+        # switched off after two blips.
+        assert calls["n"] == 4, (
+            f"verifier should still be called every turn, got {calls['n']}"
+        )
+    finally:
+        await session.close()
+
+
 async def test_empty_diagnosis_is_logged_not_circular(workspace, caplog):
     """Review follow-up: an empty diagnosis must not silently recreate the
     out-of-sync history this path fixes — it logs, and the post-loop fallback

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -386,8 +386,21 @@ async def test_deterministic_hard_failure_latches_after_one_diagnosis(workspace,
             f"latched session kept calling the verifier ({verdict_calls} calls)"
         )
         assert session._verifier_latched is True
-        assert any("latched after 2 consecutive hard failures" in r.message
-                   for r in caplog.records), "the latch must announce itself once"
+        # Anchor on a substring unique to the ANNOUNCEMENT line. The previous
+        # assertion matched "latched after N consecutive hard failures", which
+        # the per-turn *skip* log also contained — so it passed on turns 3-4
+        # without ever guarding the announcement it was written for
+        # (review: pnewsam on #299).
+        announcements = [
+            r for r in caplog.records
+            if "skipping further verification this session" in r.message
+        ]
+        assert len(announcements) == 1, (
+            f"the latch must announce itself exactly once, got {len(announcements)}"
+        )
+        assert "no successful verdict between them" in announcements[0].message, (
+            f"announcement must state the real reset semantics: {announcements[0].message!r}"
+        )
         skips = [r for r in caplog.records
                  if "completion-verifier skipped — latched" in r.message]
         assert len(skips) == 2, (

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -661,6 +661,105 @@ async def test_transient_provider_errors_never_latch(workspace):
         await session.close()
 
 
+async def test_failed_reprobe_stays_latched_without_rediagnosis(workspace, caplog):
+    """The other half of the re-probe contract: when the cause is still there,
+    the re-probe fails, the session stays latched, and — critically — no second
+    diagnosis fires (one per session, ENG-1155). The next skip cycle then starts
+    over, so the steady-state cost of a permanently broken verifier is one
+    verdict call per `_VERIFIER_LATCH_REPROBE_TURNS` turns.
+    """
+    import logging
+
+    from anton.core.session import _VERIFIER_LATCH_REPROBE_TURNS
+
+    mock_llm = make_mock_llm()
+    calls = {"n": 0}
+
+    async def always_hard(_schema, *, system, messages, max_tokens):
+        calls["n"] += 1
+        raise RuntimeError("400 tool_choice not supported")
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=always_hard)
+    session = _make_session(workspace, mock_llm)
+
+    diagnoses = 0
+    try:
+        with caplog.at_level(logging.INFO):
+            # 2 latching turns, then two full skip-and-reprobe cycles.
+            for turn in range(2 + 2 * _VERIFIER_LATCH_REPROBE_TURNS):
+                plan, state = _tool_then_text_plan()
+                mock_llm.plan_stream = plan
+                async for _ in session.turn_stream(f"step {turn}"):
+                    pass
+                if state["n"] >= 3:
+                    diagnoses += 1
+
+        assert session._verifier_latched is True, "failed re-probe must stay latched"
+        assert diagnoses == 1, (
+            f"failed re-probes must not re-diagnose, got {diagnoses}"
+        )
+        # 2 latching calls + 1 failed re-probe per cycle.
+        assert calls["n"] == 4, (
+            f"expected 2 latching + 2 re-probe calls, got {calls['n']}"
+        )
+        reprobe_failures = [
+            r for r in caplog.records
+            if "re-probe failed — staying latched" in r.message
+        ]
+        assert len(reprobe_failures) == 2, (
+            "a failed re-probe must log its own line, not re-announce the latch"
+        )
+    finally:
+        await session.close()
+
+
+async def test_latched_truncating_reprobe_diagnoses_and_stays_latched(workspace):
+    """A latched session whose re-probe TRUNCATES (the user switched from a
+    hard-failing model to a persistently-verbose one) falls through to the
+    honest diagnosis and leaves the latch set — truncation never counts toward
+    or against the latch, so only a successful verdict clears it. Pins the
+    deliberate interaction between the latch and "every truncated turn keeps
+    its honest diagnosis" (see the re-probe comment in session.py).
+    """
+    from anton.core.llm.provider import StructuredOutputError
+    from anton.core.session import _VERIFIER_LATCH_REPROBE_TURNS
+
+    mock_llm = make_mock_llm()
+    calls = {"n": 0}
+
+    async def hard_then_truncated(_schema, *, system, messages, max_tokens):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise RuntimeError("400 tool_choice not supported")
+        raise StructuredOutputError(
+            "no tool call", truncated=True, output_tokens=max_tokens,
+            max_tokens=max_tokens, stop_reason="stop",
+        )
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=hard_then_truncated)
+    session = _make_session(workspace, mock_llm)
+
+    diagnoses = 0
+    try:
+        for turn in range(2 + _VERIFIER_LATCH_REPROBE_TURNS):
+            plan, state = _tool_then_text_plan()
+            mock_llm.plan_stream = plan
+            async for _ in session.turn_stream(f"step {turn}"):
+                pass
+            if state["n"] >= 3:
+                diagnoses += 1
+
+        assert session._verifier_latched is True, (
+            "a truncating re-probe must not clear the latch"
+        )
+        assert diagnoses == 2, (
+            f"expected the latch-time diagnosis plus one on the truncating "
+            f"re-probe, got {diagnoses}"
+        )
+    finally:
+        await session.close()
+
+
 async def test_empty_diagnosis_is_logged_not_circular(workspace, caplog):
     """Review follow-up: an empty diagnosis must not silently recreate the
     out-of-sync history this path fixes — it logs, and the post-loop fallback

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -18,7 +18,7 @@ import pytest
 
 from tests.conftest import make_mock_llm
 
-from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.session import ChatSession, ChatSessionConfig, _VerifierVerdict
 from anton.core.llm.provider import (
     LLMResponse,
     StreamComplete,
@@ -192,6 +192,132 @@ async def test_truncation_exhausting_every_budget_also_gets_the_diagnosis(worksp
             "exhausted budgets must fail toward the diagnosis, not a silent COMPLETE"
         )
         assert call_count == 3
+    finally:
+        await session.close()
+
+
+def _assistant_texts(session) -> list[str]:
+    return [
+        m["content"] for m in session.history
+        if m.get("role") == "assistant" and isinstance(m.get("content"), str)
+    ]
+
+
+async def test_stuck_diagnosis_is_persisted_as_streamed(workspace):
+    """ENG-1155: the STUCK path streams a model-generated diagnosis but never
+    captures it, so the post-loop fallback re-appends the *stale
+    pre-verification* reply. History — and therefore the model's memory of what
+    it just told the user — ends up out of sync on exactly the turn where the
+    user is being asked to make a decision.
+
+    #276 fixed this for the verifier-failure path; STUCK never got the same
+    treatment.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.generate_object_code = AsyncMock(
+        return_value=_VerifierVerdict(status="STUCK", reason="missing credentials")
+    )
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Running.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            # Pre-verification reply. The user never sees this as the turn's
+            # final word — the diagnosis below is what actually gets streamed.
+            return _FakeAsyncIter([
+                StreamComplete(response=_text_response("STALE_PRE_VERIFICATION_REPLY"))
+            ])
+        # The STUCK diagnosis — this is what the user reads.
+        return _FakeAsyncIter([
+            StreamComplete(
+                response=_text_response(
+                    "DIAGNOSIS: I couldn't reach the database — no credentials are "
+                    "configured. Add DB_URL and I'll retry."
+                )
+            )
+        ])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    try:
+        async for _ in session.turn_stream("query my database"):
+            pass
+
+        assert call_count == 3, "the STUCK path must generate a diagnosis"
+        texts = _assistant_texts(session)
+        assert any("DIAGNOSIS:" in t for t in texts), (
+            "the diagnosis the user actually read is missing from history"
+        )
+        # The turn's last assistant word in history must be what was streamed,
+        # not the reply the verifier rejected.
+        assert "DIAGNOSIS:" in texts[-1], (
+            f"history ends on the stale reply, not the diagnosis: {texts[-1]!r}"
+        )
+        assert sum("STALE_PRE_VERIFICATION_REPLY" in t for t in texts) <= 1, (
+            "the stale reply was appended twice (2831 + the post-loop fallback)"
+        )
+    finally:
+        await session.close()
+
+
+async def test_budget_exhausted_diagnosis_is_persisted_as_streamed(workspace):
+    """ENG-1155, same desync on the budget-exhausted path. `_max_continuations
+    = 0` makes the very first verification hit the exhausted branch, which
+    fires before any verdict call.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.generate_object_code = AsyncMock(
+        side_effect=AssertionError("no verdict call on the exhausted path")
+    )
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Running.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            return _FakeAsyncIter([
+                StreamComplete(response=_text_response("STALE_PRE_VERIFICATION_REPLY"))
+            ])
+        return _FakeAsyncIter([
+            StreamComplete(
+                response=_text_response(
+                    "DIAGNOSIS: I tried three times and the export step keeps "
+                    "failing. Here's what you can do next."
+                )
+            )
+        ])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session._max_continuations = 0
+    try:
+        async for _ in session.turn_stream("export my data"):
+            pass
+
+        assert call_count == 3, "the budget-exhausted path must generate a diagnosis"
+        texts = _assistant_texts(session)
+        assert any("DIAGNOSIS:" in t for t in texts), (
+            "the diagnosis the user actually read is missing from history"
+        )
+        assert "DIAGNOSIS:" in texts[-1], (
+            f"history ends on the stale reply, not the diagnosis: {texts[-1]!r}"
+        )
+        assert sum("STALE_PRE_VERIFICATION_REPLY" in t for t in texts) <= 1, (
+            "the stale reply was appended twice (2831 + the post-loop fallback)"
+        )
     finally:
         await session.close()
 

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -11,9 +11,11 @@ to proceed.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from tests.conftest import make_mock_llm
@@ -620,24 +622,33 @@ async def test_latched_verifier_reprobes_and_can_recover(workspace):
         await session.close()
 
 
-async def test_transient_provider_errors_never_latch(workspace):
-    """A typed transient error must not latch. The latch is for a model that
-    *cannot* produce a verdict (kimi-K3's forced-tool_choice 400, ENG-1095) — a
-    capability claim. `TransientProviderError` asserts the opposite: retryable,
-    already retried upstream (ENG-673). Counting it would let two provider blips
-    disable verification for the rest of the session.
+@pytest.mark.parametrize("exc_factory, label", [
+    (lambda: __import__("anton.core.llm.provider", fromlist=["x"]).TransientProviderError(
+        "provider returned an empty 200"), "typed"),
+    # Review finding (pnewsam on #299): an UNTYPED transient reaching the generic
+    # handler used to count as "hard". A timeout is not a statement about whether
+    # the model can produce a verdict.
+    (lambda: asyncio.TimeoutError("read timed out"), "asyncio-timeout"),
+    (lambda: ConnectionResetError("peer reset the connection"), "connection-reset"),
+    (lambda: httpx.ConnectError("failed to establish a connection"), "httpx-connect"),
+])
+async def test_transient_provider_errors_never_latch(workspace, exc_factory, label):
+    """No transient failure may latch — typed or untyped. The latch is for a model
+    that *cannot* produce a verdict (kimi-K3's forced-tool_choice 400, ENG-1095) —
+    a capability claim. A dropped connection or a timeout asserts the opposite:
+    retryable, and typed ones are already retried upstream (ENG-673). Counting
+    them would let two provider blips disable verification for a whole re-probe
+    window.
 
     Matters more once #297 (ENG-847) lands, which converts empty 200s into
     `TransientProviderError` on the same providers the verdict call uses.
     """
-    from anton.core.llm.provider import TransientProviderError
-
     mock_llm = make_mock_llm()
     calls = {"n": 0}
 
     async def always_transient(_schema, *, system, messages, max_tokens):
         calls["n"] += 1
-        raise TransientProviderError("provider returned an empty 200")
+        raise exc_factory()
 
     mock_llm.generate_object_code = AsyncMock(side_effect=always_transient)
     session = _make_session(workspace, mock_llm)


### PR DESCRIPTION
## What

Both ENG-1155 items, plus **a fourth hand-back site the ticket didn't name** and **two stale-base artifacts** that were sitting on `staging`.

**Six commits, read in order** — the first is the failing baseline, so the diff shows the defect caught and then closed:

| commit | contents |
|---|---|
| `fce54ea` | tests only; 3 deliberately failing. Establishes the bug. |
| `ae23b31` | the fix for both ENG-1155 items. |
| `3b7e2a2` | two defects found reviewing `ae23b31`, and their fixes. |
| `2044d8b` | third self-review finding: transient provider errors must not latch. |
| `d4b7785` | pins the failed and truncating re-probe paths; 3 comment/log accuracy fixes. |
| `1b19a1a` | addresses @pnewsam's review — widens the transient carve-out, corrects 2 comments. |

## 1. History desync (ticket bug #1)

`STUCK`, budget-exhausted **and the tool-round circuit breaker** each streamed a model-generated diagnosis and never captured it. The post-loop fallback guarded on `history[-1]["role"] != "assistant"` — after the SYSTEM injection the last entry is a *user* message, so it fired and re-appended the reply the verifier had just rejected.

History after a `STUCK` turn, before this PR:

```
[3] assistant  STALE_REPLY
[4] user       SYSTEM: Task verification determined this task is stuck…
[5] assistant  STALE_REPLY          ← appended a second time
```

So the message the user actually read was **absent entirely** (not substituted, as the ticket describes) and the rejected reply was present **twice**. The model's memory of "what I just told the user" was wrong on exactly the turns where the user is being asked to decide.

- New `_stream_handback_diagnosis()` — #276's capture-persist-guard block, now shared by all four paths instead of copied.
- `_reply_persisted` replaces the role-based fallback guard, which is what allowed the double-append. **Per verification-loop iteration, not per turn** — see the self-review note below; getting this wrong drops continuation answers.

### The fourth site

The **25-round tool cap** has the identical defect and is not in the ticket. It is also the **highest-traffic of the four** — the cap fires on real sessions far more often than `STUCK` does (`STUCK` is ~1.9% of verdicts). Fixed here rather than left as the one path the shared helper doesn't cover.

## 2. Latch (ticket item #2)

kimi-K3 rejects the forced `tool_choice` with a 400 on *every* verdict call (ENG-1095) until the gateway fix lands, so the ENG-1079 diagnosis path fired on every multi-step turn — a full-history planning call plus a "checking in" message each time.

Behaviour now:

- First hard failure → diagnose as before.
- Second consecutive hard failure → **latch without a second diagnosis**. One diagnosis per session, matching the ticket's "Done when".
- While latched → skip the verdict call, one log line per skipped verification.
- **Every `_VERIFIER_LATCH_REPROBE_TURNS` (10) skips → spend one verdict call.** Success clears the latch; failure stays latched and does not re-diagnose.

The re-probe is not in the ticket and is a **deliberate deviation**: the ticket asks for "reset on a successful verdict", which is unreachable as written, because a latched session makes no verdict calls. Without the re-probe the latch is permanent for the session — a user who switches off the broken model gets no verification for the rest of it.

**Truncation deliberately does not latch** — a blown budget is one model being verbose on one transcript, and it keeps its ENG-1081 retry ladder. Only hard failures count. (The `_VERIFIER_TOKEN_BUDGETS` comment asserting "there is no latch" was corrected — it's true of truncation, false in general, and a comment contradicting the code is how the watchdog print-vs-progress confusion started.)

## 3. Stale-base artifacts removed (unplanned)

PR #293 — a Dependabot **postcss bump in `/docs`** — was squash-merged from a stale base and carried two unrelated reverts into `staging` that are **not in `main`**:

- `status, reason = "COMPLETE", "verifier unavailable"` — the silent fail-safe **ENG-1079 deleted**, re-added at the top of the else-branch, directly above the comment explaining why it must not exist.
- a duplicate `from typing import Any, NoReturn` in `llm/structured.py`.

The first was **dead code** — the branch still diagnoses and `break`s, and `test_verifier_exception_yields_real_message_not_silent_stop` passes either way, so there was **no behaviour regression in prod**. It never reached `main`; the 2026-08-02 release (`v2.26.8.2.1`) shipped correct code. Removed here since it's in the block this PR rewrites. The tell that #293 was stale-based: its squash body contains ENG-1081's commit messages.

Worth a separate decision on how a `/docs` dependency bump reached `anton/core/session.py` at all.

## Self-review found two defects in this PR

Full write-up in [this comment](https://github.com/mindsdb/anton/pull/299#issuecomment-5173829295). Both were introduced by `ae23b31`, both fixed in `3b7e2a2`:

1. **`_reply_persisted` was turn-scoped** → on `INCOMPLETE` whose continuation finishes with no tool calls, the loop breaks before the append and the stale flag suppressed the fallback, so **the answer the user just read vanished from history**. Same class of bug as this PR fixes, re-introduced on the continuation path. The old role-based guard handled that case correctly (verified by reverting it).
2. **The latch's reset was unreachable** → dead code, latch outlived its cause. Fixed by the re-probe above.

Both existed because every test drove the verifier to a *terminal* verdict; nothing exercised `INCOMPLETE` → continuation → text-only finish. The existing e2e continuation test queues a tool call every round, so it misses it too. That gap is closed.

## Tests

**10 new** (8 in `test_verifier_failsafe.py`, 2 in `test_loop_safety.py`). **Every one verified to fail without its fix**, including reverting individual hunks for the max-rounds, per-iteration-flag and re-probe cases.

| | |
|---|---|
| unit | 1419 pass |
| e2e | 39 pass |
| pre-existing failures | 2 in `test_chat_scratchpad` — scratchpad subprocess under sandboxed pytest, **identical on clean `staging`**, verified by stash rather than assumed |

## Security

Reviewed per convention. No new endpoints, no deserialization, no path handling. The helper logs a label and a fixed string — never diagnosis content, history, or an exception message, keeping the ENG-1081 property that verifier logs carry no conversation content (`_safe_error_detail`). Latch state is per-session in memory, not persisted, and holds no user data. The removed silent-COMPLETE line was dead, so removing it cannot change what users see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

