### PR TITLE
ENG-972 Add stable, human-readable labels to saved connections

### DIFF
--- a/anton/commands/datasource/connect.py
+++ b/anton/commands/datasource/connect.py
@@ -77,9 +77,12 @@ async def _reconnect_to_saved(
         engine_label = recon_engine_def.display_name
     else:
         engine_label = conn["engine"]
+    fields = vault.load(conn["engine"], conn["name"]) or {}
+    user_label = str(fields.get("_user_label", "")).strip()
+    label_suffix = f' (label "{user_label}")' if user_label else ""
     console.print()
     console.print(
-        f'[anton.success]        ✓ Reconnected to [bold]"{slug}"[/bold].[/]'
+        f'[anton.success]        ✓ Reconnected to [bold]"{slug}"[/bold]{label_suffix}.[/]'
     )
     console.print()
     if not from_tool_call:
@@ -87,7 +90,7 @@ async def _reconnect_to_saved(
             {
                 "role": "assistant",
                 "content": (
-                    f'I\'ve reconnected to the {engine_label} connection "{slug}" '
+                    f'I\'ve reconnected to the {engine_label} connection "{slug}"{label_suffix} '
                     f"in the Local Vault. I can now query this data source when needed."
                 ),
             }
@@ -291,11 +294,13 @@ async def handle_connect_datasource(
                 _telemetry("ds_connect_failed", engine=engine_def.engine)
                 return session
         conn_name = uuid.uuid4().hex[:8]
+        credentials["_user_label"] = default_user_label(vault, engine_def.engine)
         slug = save_connection(vault, engine_def, conn_name, credentials)
         _telemetry("ds_connect_success", engine=engine_def.engine)
         session._active_datasource = slug
+        label = credentials.get("_user_label", "")
         console.print(
-            f'        Saved to Local Vault as [bold]"{slug}"[/bold].'
+            f'        Saved as [bold]"{label}"[/bold] (slug [bold]"{slug}"[/bold]).'
         )
         console.print()
         console.print("[anton.muted]        Ready to query your data.[/]")
@@ -560,7 +565,10 @@ async def handle_connect_datasource(
             f'        Updated existing connection [bold]"{slug}"[/bold].'
         )
     else:
-        console.print(f'        Saved to Local Vault as [bold]"{slug}"[/bold].')
+        label = credentials.get("_user_label", "")
+        console.print(
+            f'        Saved as [bold]"{label}"[/bold] (slug [bold]"{slug}"[/bold]).'
+        )
 
     console.print()
     console.print("[anton.muted]        Ready to query your data.[/]")

--- a/anton/commands/datasource/connect.py
+++ b/anton/commands/datasource/connect.py
@@ -107,6 +107,7 @@ async def handle_connect_datasource(
     known_variables: dict[str, str] | None = None,
     from_tool_call: bool = False,
     vault: "DataVault | None" = None,
+    prefill_label: str | None = None,
 ) -> "ChatSession":
     """
     Connect a data source by entering credentials, either for a new name or re-entering for an existing one.
@@ -551,7 +552,7 @@ async def handle_connect_datasource(
             conn_name = uuid.uuid4().hex[:8]
         is_update = False
 
-        default_label = default_user_label(vault, engine_def.engine)
+        default_label = prefill_label or default_user_label(vault, engine_def.engine)
         user_label = await prompt_or_cancel("(anton) Label", default=default_label)
         if user_label is None:
             console.print("[anton.muted]Cancelled.[/]")

--- a/anton/commands/datasource/connect.py
+++ b/anton/commands/datasource/connect.py
@@ -397,6 +397,15 @@ async def handle_connect_datasource(
                 f"        {marker}[bold]{f.name}[/] "
                 f"[anton.muted]— {f.description} (optional)[/]"
             )
+        # `label` isn't one of `engine_def.fields` — it's prompted for
+        # separately after the per-engine fields are collected (see the
+        # `prompt_or_cancel("(anton) Label", ...)` call below) — but it's
+        # listed here too so the user knows it's coming and what it's for.
+        console.print(
+            "        • [bold]label[/] "
+            "[anton.muted]— a name to identify this connection later, "
+            "e.g. \"prod-db\" (optional, defaults to the engine name)[/]"
+        )
         console.print()
 
     while not collector.is_complete:

--- a/anton/commands/datasource/connect.py
+++ b/anton/commands/datasource/connect.py
@@ -10,6 +10,8 @@ from anton.connect_collector import ConnectionCollector, extract_variables
 from anton.core.datasources.data_vault import DataVault, LocalDataVault
 from anton.core.datasources.datasource_registry import DatasourceRegistry
 from anton.utils.datasources import (
+    default_user_label,
+    ensure_unique_user_label,
     find_matching_connection,
     parse_connection_slug,
     register_secret_vars,
@@ -525,6 +527,21 @@ async def handle_connect_datasource(
         while vault.load(engine_def.engine, conn_name) is not None:
             conn_name = uuid.uuid4().hex[:8]
         is_update = False
+
+        default_label = default_user_label(vault, engine_def.engine)
+        user_label = await prompt_or_cancel("(anton) Label", default=default_label)
+        if user_label is None:
+            console.print("[anton.muted]Cancelled.[/]")
+            console.print()
+            return session
+        # `prompt_or_cancel` already returns `default` when the user submits
+        # empty input in production — but this explicit fallback is kept
+        # anyway: it makes the "empty means accept the default" behavior a
+        # property of *this* code, not an assumption about prompt_or_cancel's
+        # internals that a test-time mock (which replaces the whole function)
+        # silently bypasses.
+        user_label = (user_label or "").strip() or default_label
+        credentials["_user_label"] = ensure_unique_user_label(vault, user_label)
 
     slug = f"{engine_def.engine}-{conn_name}"
 

--- a/anton/commands/datasource/connect.py
+++ b/anton/commands/datasource/connect.py
@@ -197,6 +197,21 @@ async def handle_connect_datasource(
                 _telemetry("ds_connect_failed", engine=edit_engine)
                 return session
 
+        current_label = credentials.get("_user_label") or credentials.get("_label") or ""
+        new_label = await prompt_or_cancel("(anton) Label", default=current_label)
+        if new_label is None:
+            return session
+        # Explicit fallback for the same reason as the /connect prompt in
+        # Task 5 — don't rely on prompt_or_cancel's own empty-input-returns-
+        # default behavior, since a test mock replacing the whole function
+        # bypasses it. Without this, an empty response here would overwrite
+        # an existing label with "".
+        new_label = (new_label or "").strip() or current_label
+        if new_label != current_label:
+            credentials["_user_label"] = ensure_unique_user_label(
+                vault, new_label, exclude=(edit_engine, edit_name)
+            )
+
         vault.save(edit_engine, edit_name, credentials)
         _telemetry("ds_connect_success", engine=edit_engine)
         restore_namespaced_env(vault)

--- a/anton/commands/datasource/connect.py
+++ b/anton/commands/datasource/connect.py
@@ -545,6 +545,10 @@ async def handle_connect_datasource(
 
     slug = f"{engine_def.engine}-{conn_name}"
 
+    if is_update:
+        existing = vault.load(engine_def.engine, conn_name) or {}
+        credentials = {**existing, **credentials}
+
     save_connection(vault, engine_def, conn_name, credentials)
     _telemetry("ds_connect_success", engine=engine_def.engine)
     session._active_datasource = slug

--- a/anton/commands/datasource/connect.py
+++ b/anton/commands/datasource/connect.py
@@ -500,6 +500,9 @@ async def handle_connect_datasource(
 
     if partial:
         auto_name = uuid.uuid4().hex[:8]
+        while vault.load(engine_def.engine, auto_name) is not None:
+            auto_name = uuid.uuid4().hex[:8]
+        credentials["_user_label"] = default_user_label(vault, engine_def.engine)
         vault.save(engine_def.engine, auto_name, credentials)
         slug = f"{engine_def.engine}-{auto_name}"
         console.print()

--- a/anton/commands/datasource/manage.py
+++ b/anton/commands/datasource/manage.py
@@ -80,8 +80,11 @@ async def handle_remove_data_source(console: "Console", slug: str, vault: DataVa
         for i, c in enumerate(connections, 1):
             conn_slug = f"{c['engine']}-{c['name']}"
             engine_def = registry.get(c["engine"])
-            label = engine_def.display_name if engine_def else c["engine"]
-            console.print(f"          [bold]{i:>2}.[/bold] {conn_slug} [dim]({label})[/]")
+            source_label = engine_def.display_name if engine_def else c["engine"]
+            fields = vault.load(c["engine"], c["name"]) or {}
+            user_label = str(fields.get("_user_label", "")).strip() or str(fields.get("_label", "")).strip()
+            prefix = f"{user_label} — " if user_label else ""
+            console.print(f"          [bold]{i:>2}.[/bold] {prefix}{conn_slug} [dim]({source_label})[/]")
         console.print()
         choices = [str(i) for i in range(1, len(connections) + 1)]
         pick = await prompt_or_cancel("(anton) Enter a number", choices=choices)

--- a/anton/commands/datasource/manage.py
+++ b/anton/commands/datasource/manage.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 def handle_list_data_sources(console: "Console", vault: DataVault | None = None) -> None:
     """Print all saved Local Vault connections in a table with status."""
     from rich.table import Table
+    from anton.utils.datasources import _connection_identity
 
     vault = vault or LocalDataVault()
     registry = DatasourceRegistry()
@@ -28,15 +29,25 @@ def handle_list_data_sources(console: "Console", vault: DataVault | None = None)
         return
 
     table = Table(title="Local Vault — Saved Connections", show_lines=False)
-    table.add_column("Name", style="bold")
+    table.add_column("Label", style="bold")
+    table.add_column("Slug")
     table.add_column("Source")
+    table.add_column("Identity")
     table.add_column("Status")
 
     for c in conns:
         slug = f"{c['engine']}-{c['name']}"
         engine_def = registry.get(c["engine"])
         source = engine_def.display_name if engine_def else c["engine"]
-        fields = vault.load(c["engine"], c["name"]) or {}
+        if hasattr(vault, "read_record"):
+            record = vault.read_record(c["engine"], c["name"]) or {}
+            fields = record.get("fields", {}) or {}
+            secure_keys = record.get("secure_keys")
+        else:
+            fields = vault.load(c["engine"], c["name"]) or {}
+            secure_keys = None
+        label = str(fields.get("_user_label", "")).strip() or str(fields.get("_label", "")).strip()
+        identity = _connection_identity(fields, secure_keys) or ""
 
         if engine_def and engine_def.auth_method != "choice":
             required = [f.name for f in engine_def.fields if f.required]
@@ -47,7 +58,7 @@ def handle_list_data_sources(console: "Console", vault: DataVault | None = None)
         else:
             status = "[green]saved[/]"
 
-        table.add_row(slug, source, status)
+        table.add_row(label, slug, source, identity, status)
 
     console.print(table)
     console.print()

--- a/anton/commands/datasource/verify.py
+++ b/anton/commands/datasource/verify.py
@@ -37,6 +37,8 @@ async def run_connection_test(
 
         vault.clear_ds_env()
         for key, value in credentials.items():
+            if key.startswith("_"):
+                continue
             os.environ[f"DS_{key.upper()}"] = value
         register_secret_vars(engine_def)  # flat mode, for scrubbing during test
 

--- a/anton/core/datasources/data_vault.py
+++ b/anton/core/datasources/data_vault.py
@@ -312,6 +312,10 @@ class LocalDataVault:
         flat=True: legacy flat vars, e.g. DS_HOST — use only during
         single-connection test_snippet execution.
 
+        `_`-prefixed fields (bookkeeping: `_user_label`, `_label`,
+        `_connector_id`, `_method`, `_picked_files`, ...) are never injected —
+        they aren't credentials and nothing reads them from an env var.
+
         Returns the {var: value} mapping, or None if connection not found.
         Use this when the env should reach only a specific subprocess (pass
         the result as an explicit `env`); use `inject_env` when the variables
@@ -323,10 +327,14 @@ class LocalDataVault:
         env: dict[str, str] = {}
         if flat:
             for key, value in fields.items():
+                if key.startswith("_"):
+                    continue
                 env[f"DS_{key.upper()}"] = value
         else:
             prefix = _slug_env_prefix(engine, name)
             for key, value in fields.items():
+                if key.startswith("_"):
+                    continue
                 env[f"{prefix}__{key.upper()}"] = value if isinstance(value, str) else str(value)
         return env
 

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -190,6 +190,9 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
                     conn_name = uuid.uuid4().hex[:8]
                     while vault.load(engine_def.engine, conn_name) is not None:
                         conn_name = uuid.uuid4().hex[:8]
+                    from anton.utils.datasources import default_user_label, ensure_unique_user_label
+                    requested_label = tc_input.get("user_label") or default_user_label(vault, engine_def.engine)
+                    test_credentials["_user_label"] = ensure_unique_user_label(vault, requested_label)
                 existing = vault.load(engine_def.engine, conn_name) or {}
                 merged = {**existing, **test_credentials}
                 slug = save_connection(vault, engine_def, conn_name, merged)
@@ -225,8 +228,9 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
                         "variables in scratchpad code — never embed raw values."
                     )
                     return _msg
+                label = merged.get("_user_label", "")
                 return (
-                    f"Saved connection `{slug}` to vault with fields: "
+                    f"Saved connection `{slug}` (label \"{label}\") to vault with fields: "
                     f"{', '.join(sorted(test_credentials.keys()))}. "
                     f"Future turns can reference this connection by its slug. "
                     f"Access credentials via DS_<FIELD> environment variables "
@@ -254,6 +258,7 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
         known_variables=known_variables or None,
         from_tool_call=True,
         vault=vault,
+        prefill_label=tc_input.get("user_label"),
     )
 
     # Check if a new connection was actually added
@@ -262,12 +267,16 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
 
     if new_connections:
         slug = next(iter(new_connections))
+        engine_saved, name_saved = slug.split("-", 1)
+        saved_fields = vault.load(engine_saved, name_saved) or {}
+        saved_label = saved_fields.get("_user_label", "")
         # ── Telemetry: connection succeeded ──────────────────────────
         if _settings:
             send_event(_settings, "ds_connect_success", engine=engine)
         return (
-            f"Successfully connected '{slug}'. The datasource is now available. "
-            f"Continue helping the user with their original request using this data source."
+            f"Successfully connected '{slug}' (label \"{saved_label}\"). The datasource is "
+            f"now available. Continue helping the user with their original request using "
+            f"this data source."
         )
 
     # Did the flow record a mid-flow redirect? Read it from the session
@@ -368,6 +377,15 @@ CONNECT_DATASOURCE_TOOL = ToolDef(
                     "user actually mentioned — never invent values."
                 ),
                 "additionalProperties": {"type": "string"},
+            },
+            "user_label": {
+                "type": "string",
+                "description": (
+                    "Optional human-readable label for this connection (e.g. 'prod-db'). "
+                    "If the user mentioned a name for it in chat, pass it here. If omitted, "
+                    "a default based on the engine is used (e.g. 'postgres', 'postgres 2' "
+                    "for a second connection to the same engine)."
+                ),
             },
         },
         "required": ["engine"],

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -244,7 +244,10 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
 
     from anton.commands.datasource import handle_connect_datasource
 
-    before = {f"{c['engine']}-{c['name']}" for c in vault.list_connections()}
+    # Track (engine, name) pairs rather than joined slugs: engine names may
+    # contain a dash (custom engines are free-form), so a joined string
+    # cannot be split back into its parts reliably.
+    before = {(c["engine"], c["name"]) for c in vault.list_connections()}
 
     # Clear any stale status from a previous run
     setattr(session, "_pending_connect_redirect", None)
@@ -262,12 +265,12 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
     )
 
     # Check if a new connection was actually added
-    after = {f"{c['engine']}-{c['name']}" for c in vault.list_connections()}
+    after = {(c["engine"], c["name"]) for c in vault.list_connections()}
     new_connections = after - before
 
     if new_connections:
-        slug = next(iter(new_connections))
-        engine_saved, name_saved = slug.split("-", 1)
+        engine_saved, name_saved = sorted(new_connections)[0]
+        slug = f"{engine_saved}-{name_saved}"
         saved_fields = vault.load(engine_saved, name_saved) or {}
         saved_label = saved_fields.get("_user_label", "")
         # ── Telemetry: connection succeeded ──────────────────────────

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -118,13 +118,17 @@ def _register_unregistered_connection_vars(vault: DataVault, engine: str, name: 
     conservative unknown-DS_* scrub — so harmless values like base_url
     surfaced as `[DS_..._BASE_URL]` markers in user-facing output (ENG-688).
     Classification: the record's stored ``secure_keys`` when present, else
-    the vault's canonical legacy secret-name heuristic.
+    the vault's canonical legacy secret-name heuristic. `_`-prefixed
+    bookkeeping fields are skipped entirely — they're never injected as env
+    vars (see `env_for()`), so registering them here would be dead weight.
     """
     record = vault.read_record(engine, name) if hasattr(vault, "read_record") else None
     fields = (record or {}).get("fields") or vault.load(engine, name) or {}
     secure_keys = (record or {}).get("secure_keys")
     prefix = _slug_env_prefix(engine, name)
     for field_name in fields:
+        if field_name.startswith("_"):
+            continue
         key = f"{prefix}__{field_name.upper()}"
         _DS_KNOWN_VARS.add(key)
         if is_secret_key(field_name, secure_keys):

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -186,6 +186,51 @@ def _parse_picked_files(raw: str | None) -> list[dict]:
     return [f for f in parsed if isinstance(f, dict) and f.get("id")]
 
 
+def _labels_by_connection(vault: "DataVault") -> dict[tuple[str, str], str]:
+    """Every connection's non-empty label, keyed by (engine, name).
+
+    Prefers `_user_label`; falls back to the legacy `_label` field so an
+    old connection's already-visible label still counts as "taken" when
+    computing a new one.
+    """
+    out: dict[tuple[str, str], str] = {}
+    for c in vault.list_connections():
+        fields = vault.load(c["engine"], c["name"]) or {}
+        label = (fields.get("_user_label") or fields.get("_label") or "").strip()
+        if label:
+            out[(c["engine"], c["name"])] = label
+    return out
+
+
+def ensure_unique_user_label(
+    vault: "DataVault", candidate: str, *, exclude: tuple[str, str] | None = None
+) -> str:
+    """Return `candidate`, or `candidate` with a numeric suffix if it's already
+    used by another connection anywhere in the vault (global uniqueness, not
+    scoped per engine).
+
+    `exclude=(engine, name)` removes that one connection's own label from the
+    collision set first — pass the connection being edited/re-saved so keeping
+    its label unchanged doesn't bump it to "label 2".
+    """
+    by_conn = _labels_by_connection(vault)
+    if exclude:
+        by_conn.pop(exclude, None)
+    existing = set(by_conn.values())
+    if candidate not in existing:
+        return candidate
+    n = 2
+    while f"{candidate} {n}" in existing:
+        n += 1
+    return f"{candidate} {n}"
+
+
+def default_user_label(vault: "DataVault", engine: str) -> str:
+    """Default label for a brand-new connection to `engine` — the engine id,
+    de-duplicated against every existing connection's label (any engine)."""
+    return ensure_unique_user_label(vault, engine)
+
+
 def build_datasource_context(vault: DataVault, active_only: str | None = None) -> str:
     """Build a system-prompt section listing available DS_* env vars by name.
 

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -252,6 +252,9 @@ def build_datasource_context(vault: DataVault, active_only: str | None = None) -
         return ""
     lines = ["\n\n## Connected Data Sources"]
     lines.append(
+        "Each connection has a Slug (a stable machine identifier, e.g. "
+        "`postgres-7e8971c3`) and a Label (a human-readable name the user "
+        "gave it, e.g. \"prod-db\"; may be unset). "
         "Credentials are pre-injected as namespaced DS_<ENGINE_NAME>__<FIELD> "
         "environment variables. Use them directly in scratchpad code "
         "(e.g. DS_POSTGRES_PROD_DB__HOST). "
@@ -297,7 +300,7 @@ def build_datasource_context(vault: DataVault, active_only: str | None = None) -
             fields.get("_label", "")
         ).strip()
 
-        lines.append(f"\n### `{slug}` — Label: {user_label or '(none)'}")
+        lines.append(f"\n### Slug: `{slug}` — Label: {user_label or '(none)'}")
         engine_def = registry.get(c["engine"])
         lines.append(f"Engine: {engine_def.display_name if engine_def else c['engine']}")
         # Same non-secret allowlist `_connection_identity()` encodes

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -259,7 +259,7 @@ def build_datasource_context(vault: DataVault, active_only: str | None = None) -
         "If you see `[DS_<NAME>]` patterns in scratchpad output, those are "
         "scrub-markers where a secret value was redacted before returning "
         "text to you — the actual value IS injected in the env var. Reference "
-        "it by name; never treat the bracket form as a literal credential "
+        "it by slug; never treat the bracket form as a literal credential "
         "or pass it back as a value to any tool.\n"
     )
     # Google Drive's drive.file OAuth scope only covers files the app created
@@ -268,6 +268,11 @@ def build_datasource_context(vault: DataVault, active_only: str | None = None) -
     # since a plain files.list()/files.search() call won't return them.
     google_drive_oauth_connected = False
     google_drive_picked_files: dict[str, list[dict]] = {}
+    # Hoisted out of the loop below: this function is rebuilt on every chat
+    # turn, and DatasourceRegistry() parses the full built-in + user
+    # datasources.md on every construction (no caching) — with N
+    # connections that was N full re-parses per turn before this change.
+    registry = DatasourceRegistry()
     for c in conns:
         slug = f"{c['engine']}-{c['name']}"
         if active_only and slug != active_only:
@@ -282,20 +287,35 @@ def build_datasource_context(vault: DataVault, active_only: str | None = None) -
             fields = vault.load(c["engine"], c["name"]) or {}
             secure_keys = None
         prefix = _slug_env_prefix(c["engine"], c["name"])
-        # Skip `_`-prefixed bookkeeping (`_connector_id`, `_method`, `_label`) —
-        # they're not credential env vars the agent should reference.
-        var_names = ", ".join(
+        # Skip `_`-prefixed bookkeeping (`_connector_id`, `_method`, `_label`,
+        # `_user_label`) — they're not credential env vars the agent should
+        # reference.
+        var_names = [
             f"{prefix}__{k.upper()}" for k in fields if not k.startswith("_")
-        )
-        # Prefer a user/agent-assigned label ("Support"); otherwise the derived
-        # non-secret identity (email / host).
-        identity = str(fields.get("_label", "")).strip() or _connection_identity(
-            fields, secure_keys
-        )
-        head = f"`{slug}` ({c['engine']})"
-        if identity:
-            head += f" — {identity}"
-        lines.append(f"- {head} → {var_names}")
+        ]
+        user_label = str(fields.get("_user_label", "")).strip() or str(
+            fields.get("_label", "")
+        ).strip()
+
+        lines.append(f"\n### `{slug}` — Label: {user_label or '(none)'}")
+        engine_def = registry.get(c["engine"])
+        lines.append(f"Engine: {engine_def.display_name if engine_def else c['engine']}")
+        # Same non-secret allowlist `_connection_identity()` encodes
+        # (host/database/email, secure_keys-gated) — inlined here as
+        # independent lines instead of one collapsed string.
+        host = str(fields.get("host", "")).strip()
+        database = str(fields.get("database", "")).strip()
+        email = str(fields.get("email", "")).strip() or str(fields.get("account_email", "")).strip()
+        if host and "host" not in (secure_keys or []):
+            lines.append(f"Host: {host}")
+        if database and "database" not in (secure_keys or []):
+            lines.append(f"Database: {database}")
+        if email and "email" not in (secure_keys or []) and "account_email" not in (secure_keys or []):
+            lines.append(f"Account: {email}")
+        lines.append("Credential env vars:")
+        for var in var_names:
+            lines.append(f" - {var}")
+
         if c["engine"] == "google_drive":
             if fields.get("auth_type") == "oauth":
                 google_drive_oauth_connected = True

--- a/tests/test_data_vault.py
+++ b/tests/test_data_vault.py
@@ -252,3 +252,16 @@ def test_resolve_modify_merge_heuristic_picks_up_unknown_secrets(vault: LocalDat
     assert merged == {"host": "db.x", "weird_password": "p"}
     assert "weird_password" in secure_keys
     assert "host" not in secure_keys
+
+
+class TestEnvForFiltersBookkeepingFields:
+    def test_underscore_prefixed_fields_excluded(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        vault.save(
+            "postgres", "a1b2c3",
+            {"host": "db.example.com", "_user_label": "postgres 2", "_connector_id": "postgres"},
+        )
+        env = vault.env_for("postgres", "a1b2c3")
+        assert "DS_POSTGRES_A1B2C3__HOST" in env
+        assert not any(k.endswith("__USER_LABEL") for k in env)
+        assert not any(k.endswith("__CONNECTOR_ID") for k in env)

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -665,6 +665,7 @@ class TestHandleConnectDatasource:
                 "prod_db",
                 "alice",
                 "s3cr3t",
+                "",  # Label prompt: accept the default
             ]
         )
 
@@ -686,6 +687,7 @@ class TestHandleConnectDatasource:
         assert saved is not None
         assert saved["host"] == "db.example.com"
         assert saved["password"] == "s3cr3t"
+        assert saved["_user_label"] == "postgresql"
         assert result._history
         last = result._history[-1]
         assert last["role"] == "assistant"
@@ -759,8 +761,8 @@ class TestHandleConnectDatasource:
 
         # Only the engine selection prompt should fire. After that, the
         # collector is already complete and the flow proceeds directly
-        # to the connection test.
-        responses = iter(["PostgreSQL"])
+        # to the connection test, then the Label prompt (trailing "" = accept default).
+        responses = iter(["PostgreSQL", ""])
 
         with (
             patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
@@ -832,10 +834,9 @@ class TestHandleConnectDatasource:
             "user: alice\n"
             "password: s3cr3t"
         )
-        # Only two user inputs needed: the engine pick, then the paste
-        # at the first credential prompt. The collector becomes complete
-        # immediately after extraction, so no further prompts are issued.
-        responses = iter(["PostgreSQL", pasted])
+        # Engine pick, then the paste at the first credential prompt, then
+        # the Label prompt (trailing "" = accept default) after the test.
+        responses = iter(["PostgreSQL", pasted, ""])
 
         with (
             patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
@@ -901,6 +902,7 @@ class TestHandleConnectDatasource:
                 "prod_db",
                 "alice",
                 "s3cr3t",
+                "",  # Label prompt: accept the default
             ]
         )
 
@@ -1044,6 +1046,7 @@ class TestHandleConnectDatasource:
                 "prod_db",
                 "alice",
                 "s3cr3t",
+                "",  # Label prompt: accept the default
             ]
         )
 
@@ -1074,7 +1077,7 @@ class TestHandleConnectDatasource:
         pad = make_pad()
         session._scratchpads.get_or_create = AsyncMock(return_value=pad)
 
-        responses = iter(["HubSpot", "1", "pat-na1-abc123"])
+        responses = iter(["HubSpot", "1", "pat-na1-abc123", ""])  # trailing "" = Label prompt
 
         with (
             patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
@@ -1128,6 +1131,7 @@ class TestHandleConnectDatasource:
                 "PostgreSQL",
                 "host=db.example.com port=5432 database=prod_db user=alice",
                 "s3cr3t",  # only password remains → single-field prompt
+                "",  # Label prompt: accept the default
             ]
         )
 
@@ -1259,6 +1263,7 @@ class TestHandleConnectDatasource:
                 "prod_db",
                 "alice",
                 "s3cr3t",
+                "",  # Label prompt: accept the default
             ]
         )
 
@@ -1320,6 +1325,7 @@ class TestHandleConnectDatasource:
                 "PostgreSQL",
                 "help",
                 "host=db.example.com port=5432 database=prod_db user=alice password=s3cr3t",
+                "",  # Label prompt: accept the default
             ]
         )
 
@@ -1365,8 +1371,8 @@ class TestHandleConnectDatasource:
 
         # Pre-fill everything except password → the while-loop hits the
         # single-field branch for 'password'. First response is 'help',
-        # second is the actual password.
-        responses = iter(["PostgreSQL", "help", "s3cr3t"])
+        # second is the actual password, then the Label prompt.
+        responses = iter(["PostgreSQL", "help", "s3cr3t", ""])
 
         with (
             patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
@@ -1428,6 +1434,7 @@ class TestHandleConnectDatasource:
                 "prod_db",
                 "alice",
                 "s3cr3t",
+                "",  # Label prompt: accept the default
             ]
         )
 
@@ -1487,6 +1494,7 @@ class TestHandleConnectDatasource:
                 "PostgreSQL",
                 "host=db.example.com port=5432 database=prod_db user=alice",
                 "s3cr3t",
+                "",  # Label prompt: accept the default
             ]
         )
 
@@ -1553,6 +1561,82 @@ class TestHandleConnectDatasource:
         assert saved.get("port") == "5432"
         assert "database" not in saved
         session._scratchpads.get_or_create.assert_not_called()
+
+
+class TestUserLabelOnNewConnection:
+    @pytest.mark.asyncio
+    async def test_default_label_accepted_on_enter(self, registry, vault_dir, make_session):
+        session = make_session()
+        console = MagicMock()
+        vault = LocalDataVault(vault_dir=vault_dir)
+        responses = iter([
+            "PostgreSQL", "db.example.com", "5432", "prod_db", "alice", "s3cr3t", "",
+        ])  # trailing "" = Enter on the Label prompt, accepts the default
+
+        with (
+            patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
+            patch("anton.commands.datasource.connect.DatasourceRegistry", return_value=registry),
+            patch(
+                "anton.commands.datasource.connect.prompt_or_cancel",
+                new=AsyncMock(side_effect=lambda *a, **kw: next(responses)),
+            ),
+            patch("anton.commands.datasource.connect.run_connection_test", new=AsyncMock(return_value=True)),
+        ):
+            await handle_connect_datasource(console, session._scratchpads, session)
+
+        conns = vault.list_connections()
+        assert len(conns) == 1
+        fields = vault.load(conns[0]["engine"], conns[0]["name"])
+        assert fields["_user_label"] == "postgresql"
+
+    @pytest.mark.asyncio
+    async def test_custom_label_deduplicated(self, registry, vault_dir, make_session):
+        session = make_session()
+        console = MagicMock()
+        vault = LocalDataVault(vault_dir=vault_dir)
+        vault.save("postgresql", "existing", {"host": "x", "_user_label": "prod-db"})
+        responses = iter([
+            "PostgreSQL", "db.example.com", "5432", "other_db", "alice", "s3cr3t", "prod-db",
+        ])
+
+        with (
+            patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
+            patch("anton.commands.datasource.connect.DatasourceRegistry", return_value=registry),
+            patch(
+                "anton.commands.datasource.connect.prompt_or_cancel",
+                new=AsyncMock(side_effect=lambda *a, **kw: next(responses)),
+            ),
+            patch("anton.commands.datasource.connect.run_connection_test", new=AsyncMock(return_value=True)),
+        ):
+            await handle_connect_datasource(console, session._scratchpads, session)
+
+        conns = [c for c in vault.list_connections() if c["name"] != "existing"]
+        assert len(conns) == 1
+        fields = vault.load(conns[0]["engine"], conns[0]["name"])
+        assert fields["_user_label"] == "prod-db 2"
+
+    @pytest.mark.asyncio
+    async def test_esc_on_label_prompt_cancels_whole_flow(self, registry, vault_dir, make_session):
+        session = make_session()
+        console = MagicMock()
+        vault = LocalDataVault(vault_dir=vault_dir)
+        responses = iter(["PostgreSQL", "db.example.com", "5432", "prod_db", "alice", "s3cr3t"])
+
+        async def _side_effect(*a, **kw):
+            try:
+                return next(responses)
+            except StopIteration:
+                return None  # simulates Esc on the Label prompt
+
+        with (
+            patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
+            patch("anton.commands.datasource.connect.DatasourceRegistry", return_value=registry),
+            patch("anton.commands.datasource.connect.prompt_or_cancel", new=AsyncMock(side_effect=_side_effect)),
+            patch("anton.commands.datasource.connect.run_connection_test", new=AsyncMock(return_value=True)),
+        ):
+            await handle_connect_datasource(console, session._scratchpads, session)
+
+        assert vault.list_connections() == []
 
 
 class TestCredentialScrubbing:
@@ -1624,6 +1708,7 @@ class TestCredentialScrubbing:
                 "mydb",
                 "alice",
                 secret_pw,
+                "",  # Label prompt: accept the default
             ]
         )
 
@@ -2155,6 +2240,7 @@ class TestEnvActivationCollisionFree:
                 "prod_db",
                 "alice",
                 "s3cr3t",
+                "",  # Label prompt: accept the default
             ]
         )
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -2099,7 +2099,10 @@ class TestHandleListDataSources:
         )
 
         buf = io.StringIO()
-        rich_console = Console(file=buf, highlight=False, markup=False)
+        # Widened: the table now has 5 columns (Label, Slug, Source,
+        # Identity, Status), not 3 — the default width truncates Slug/Status
+        # with an ellipsis otherwise.
+        rich_console = Console(file=buf, highlight=False, markup=False, width=120)
 
         with patch("anton.commands.datasource.manage.DatasourceRegistry", return_value=registry):
             handle_list_data_sources(rich_console, vault=vault)
@@ -2115,13 +2118,31 @@ class TestHandleListDataSources:
         vault.save("postgresql", "partial", {"host": "db.example.com"})
 
         buf = io.StringIO()
-        rich_console = Console(file=buf, highlight=False, markup=False)
+        rich_console = Console(file=buf, highlight=False, markup=False, width=120)
 
         with patch("anton.commands.datasource.manage.DatasourceRegistry", return_value=registry):
             handle_list_data_sources(rich_console, vault=vault)
 
         output = buf.getvalue()
         assert "incomplete" in output.lower()
+
+
+class TestListShowsLabelAndIdentity:
+    def test_list_table_has_label_slug_identity_columns(self, vault_dir):
+        vault = LocalDataVault(vault_dir=vault_dir)
+        vault.save(
+            "postgresql", "a1b2c3",
+            {"host": "db.example.com", "database": "prod_db", "_user_label": "prod-db"},
+        )
+        console = Console(file=io.StringIO(), width=120)
+        handle_list_data_sources(console, vault)
+        output = console.file.getvalue()
+        assert "Label" in output
+        assert "Slug" in output
+        assert "Identity" in output
+        assert "prod-db" in output
+        assert "postgresql-a1b2c3" in output
+        assert "db.example.com/prod_db" in output
 
 
 class TestHandleTestDatasource:

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1639,6 +1639,36 @@ class TestUserLabelOnNewConnection:
         assert vault.list_connections() == []
 
 
+class TestReconnectPreservesBookkeepingFields:
+    @pytest.mark.asyncio
+    async def test_user_label_survives_reconnect(self, registry, vault_dir, make_session):
+        session = make_session()
+        console = MagicMock()
+        vault = LocalDataVault(vault_dir=vault_dir)
+        vault.save(
+            "postgresql", "existing",
+            {"host": "db.example.com", "port": "5432", "database": "prod_db",
+             "user": "alice", "password": "old", "_user_label": "prod-db"},
+        )
+        # find_matching_connection recognizes this as the same connection via name_from=database
+        responses = iter(["PostgreSQL", "db.example.com", "5432", "prod_db", "alice", "new-pass"])
+
+        with (
+            patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
+            patch("anton.commands.datasource.connect.DatasourceRegistry", return_value=registry),
+            patch(
+                "anton.commands.datasource.connect.prompt_or_cancel",
+                new=AsyncMock(side_effect=lambda *a, **kw: next(responses)),
+            ),
+            patch("anton.commands.datasource.connect.run_connection_test", new=AsyncMock(return_value=True)),
+        ):
+            await handle_connect_datasource(console, session._scratchpads, session)
+
+        fields = vault.load("postgresql", "existing")
+        assert fields["_user_label"] == "prod-db"
+        assert fields["password"] == "new-pass"
+
+
 class TestCredentialScrubbing:
     """_scrub_credentials and _register_secret_vars — flat and namespaced modes."""
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -2145,6 +2145,33 @@ class TestListShowsLabelAndIdentity:
         assert "db.example.com/prod_db" in output
 
 
+class TestRemovePickerShowsLabel:
+    @pytest.mark.asyncio
+    async def test_picker_shows_label_when_present(self, registry, vault_dir):
+        vault = LocalDataVault(vault_dir=vault_dir)
+        vault.save("postgresql", "a1b2c3", {"host": "x", "_user_label": "prod-db"})
+        # Real Console over an in-memory buffer, not MagicMock — robust
+        # against markup ever being added between the label and the slug.
+        buffer = io.StringIO()
+        console = Console(file=buffer, width=120)
+        # Two prompts fire in sequence: "Enter a number" (pick connection #1),
+        # then the "Remove '...'?" confirm ("n" = decline, so nothing is
+        # deleted — only the picker's rendered list matters for this test).
+        responses = iter(["1", "n"])
+
+        with (
+            patch("anton.commands.datasource.manage.DatasourceRegistry", return_value=registry),
+            patch(
+                "anton.commands.datasource.manage.prompt_or_cancel",
+                new=AsyncMock(side_effect=lambda *a, **kw: next(responses)),
+            ),
+        ):
+            await handle_remove_data_source(console, "", vault)
+
+        printed = buffer.getvalue()
+        assert "prod-db — postgresql-a1b2c3" in printed
+
+
 class TestHandleTestDatasource:
     @pytest.mark.asyncio
     async def test_success_path(self, vault_dir, registry, make_cell, make_pad):

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1724,6 +1724,87 @@ class TestConnectionMessagesIncludeLabel:
         assert "postgresql-" in printed
 
 
+class TestEditPromptsForLabelAfterTest:
+    @pytest.mark.asyncio
+    async def test_edit_sets_new_label(self, registry, vault_dir, make_session):
+        session = make_session()
+        console = MagicMock()
+        vault = LocalDataVault(vault_dir=vault_dir)
+        vault.save(
+            "postgresql", "existing",
+            {"host": "db.example.com", "port": "5432", "database": "prod_db",
+             "user": "alice", "password": "s3cr3t"},
+        )
+        # `/edit` prompts for EVERY field in `active_fields`, not just
+        # required ones (`connect.py:189`, `for f in active_fields:` — no
+        # `required` filter). The test fixture's `postgresql` engine has SIX
+        # fields (host, port, database, user, password, schema — `schema` is
+        # `required: false`), so six responses are consumed before the Label
+        # prompt is even reached — not five. This is genuinely different from
+        # `/connect` (Task 5's tests), which prompts sequentially only for
+        # *required* fields and stops as soon as `collector.is_complete`.
+        responses = iter([
+            "db.example.com", "5432", "prod_db", "alice", "s3cr3t", "",  # schema: keep empty
+            "prod-db",  # the new Label
+        ])
+        poc = AsyncMock(side_effect=lambda *a, **kw: next(responses))
+
+        with (
+            patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
+            patch("anton.commands.datasource.connect.DatasourceRegistry", return_value=registry),
+            # `/edit` collects per-field values through prompt_field_value()
+            # in helpers.py, which calls the prompt_or_cancel bound *in that
+            # module* — patching only connect.py's reference leaves
+            # helpers.py reading real stdin and the test hangs. Patch all
+            # three modules that import it, matching the existing pattern in
+            # this file.
+            patch("anton.commands.datasource.connect.prompt_or_cancel", new=poc),
+            patch("anton.commands.datasource.helpers.prompt_or_cancel", new=poc),
+            patch("anton.commands.datasource.verify.prompt_or_cancel", new=poc),
+            patch("anton.commands.datasource.connect.run_connection_test", new=AsyncMock(return_value=True)),
+        ):
+            await handle_connect_datasource(
+                console, session._scratchpads, session, datasource_name="postgresql-existing"
+            )
+
+        fields = vault.load("postgresql", "existing")
+        assert fields["_user_label"] == "prod-db"
+
+    @pytest.mark.asyncio
+    async def test_edit_keeping_label_does_not_bump_suffix(self, registry, vault_dir, make_session):
+        session = make_session()
+        console = MagicMock()
+        vault = LocalDataVault(vault_dir=vault_dir)
+        vault.save(
+            "postgresql", "existing",
+            {"host": "db.example.com", "port": "5432", "database": "prod_db",
+             "user": "alice", "password": "s3cr3t", "_user_label": "prod-db"},
+        )
+        # "" on the Label prompt = keep the current value. The mock replaces
+        # prompt_or_cancel entirely, so its production "empty input returns
+        # default" behavior does NOT apply here — the implementation itself
+        # must fall back to `current_label` on an empty/None response, or
+        # this "" would be saved as the label verbatim. Six responses for the
+        # six `active_fields`, then "" for Label.
+        responses = iter(["db.example.com", "5432", "prod_db", "alice", "s3cr3t", "", ""])
+        poc = AsyncMock(side_effect=lambda *a, **kw: next(responses))
+
+        with (
+            patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
+            patch("anton.commands.datasource.connect.DatasourceRegistry", return_value=registry),
+            patch("anton.commands.datasource.connect.prompt_or_cancel", new=poc),
+            patch("anton.commands.datasource.helpers.prompt_or_cancel", new=poc),
+            patch("anton.commands.datasource.verify.prompt_or_cancel", new=poc),
+            patch("anton.commands.datasource.connect.run_connection_test", new=AsyncMock(return_value=True)),
+        ):
+            await handle_connect_datasource(
+                console, session._scratchpads, session, datasource_name="postgresql-existing"
+            )
+
+        fields = vault.load("postgresql", "existing")
+        assert fields["_user_label"] == "prod-db"  # not "prod-db 2", and not ""
+
+
 class TestCredentialScrubbing:
     """_scrub_credentials and _register_secret_vars — flat and namespaced modes."""
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1787,8 +1787,12 @@ class TestActiveDatasourceScoping:
 
         ctx = build_datasource_context(vault)
 
-        assert "postgres-prod_db" in ctx
-        assert "(postgres)" in ctx
+        # New per-connection block format: slug leads (backticked), engine
+        # display name is its own line rather than a parenthetical next to
+        # the slug. "postgres" is a registered engine (display_name
+        # "PostgreSQL" in the real registry this test doesn't mock).
+        assert "`postgres-prod_db`" in ctx
+        assert "Engine: PostgreSQL" in ctx
 
     def test_multi_source_context_shows_both_connections(self, vault_dir):
         """Both connections are visible in the context with their namespaced vars."""

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -646,6 +646,31 @@ class TestHandleConnectDatasource:
         session._scratchpads.get_or_create.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_partial_save_sets_default_label_without_prompting(
+        self, registry, vault_dir, make_session
+    ):
+        session = make_session()
+        console = MagicMock()
+        vault = LocalDataVault(vault_dir=vault_dir)
+        responses = iter(["PostgreSQL", "skip"])
+
+        with (
+            patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
+            patch("anton.commands.datasource.connect.DatasourceRegistry", return_value=registry),
+            patch(
+                "anton.commands.datasource.connect.prompt_or_cancel",
+                new=AsyncMock(side_effect=lambda *a, **kw: next(responses)),
+            ),
+        ):
+            await handle_connect_datasource(console, session._scratchpads, session)
+
+        conns = vault.list_connections()
+        assert len(conns) == 1
+        fields = vault.load(conns[0]["engine"], conns[0]["name"])
+        assert fields["_user_label"] == "postgresql"
+        # exactly 2 responses were consumed — proves no Label prompt fired
+
+    @pytest.mark.asyncio
     async def test_successful_connection_saves_and_injects_history(
         self, registry, vault_dir, make_session, make_cell, make_pad
     ):

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1694,6 +1694,36 @@ class TestReconnectPreservesBookkeepingFields:
         assert fields["password"] == "new-pass"
 
 
+class TestConnectionMessagesIncludeLabel:
+    @pytest.mark.asyncio
+    async def test_save_message_includes_label(self, registry, vault_dir, make_session):
+        session = make_session()
+        # A real Console rendering to an in-memory buffer, not a MagicMock —
+        # so the assertion checks what a user actually sees (rich markup like
+        # `[bold]` stripped/rendered), not the raw f-string containing literal
+        # `[bold]...[/bold]` tags, which would never match a plain substring
+        # check.
+        buffer = io.StringIO()
+        console = Console(file=buffer, width=120)
+        vault = LocalDataVault(vault_dir=vault_dir)
+        responses = iter(["PostgreSQL", "db.example.com", "5432", "prod_db", "alice", "s3cr3t", "prod-db"])
+
+        with (
+            patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
+            patch("anton.commands.datasource.connect.DatasourceRegistry", return_value=registry),
+            patch(
+                "anton.commands.datasource.connect.prompt_or_cancel",
+                new=AsyncMock(side_effect=lambda *a, **kw: next(responses)),
+            ),
+            patch("anton.commands.datasource.connect.run_connection_test", new=AsyncMock(return_value=True)),
+        ):
+            await handle_connect_datasource(console, session._scratchpads, session)
+
+        printed = buffer.getvalue()
+        assert 'Saved as "prod-db"' in printed
+        assert "postgresql-" in printed
+
+
 class TestCredentialScrubbing:
     """_scrub_credentials and _register_secret_vars — flat and namespaced modes."""
 
@@ -3474,7 +3504,10 @@ class TestCustomDatasourceRequiredFieldsPolicy:
         conns = vault.list_connections()
         assert len(conns) == 1, "Custom datasource must be saved even with empty credentials"
         saved = vault.load(conns[0]["engine"], conns[0]["name"])
-        assert saved == {}, "Empty credentials dict should be saved"
+        # No credential fields were saved — only the bookkeeping `_user_label`,
+        # silently defaulted to the engine id (every connection gets one now,
+        # including this custom/ad-hoc path — no special-casing).
+        assert saved == {"_user_label": "weirdapi"}, "Only the default label should be saved"
         assert result is session
 
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1723,6 +1723,29 @@ class TestConnectionMessagesIncludeLabel:
         assert 'Saved as "prod-db"' in printed
         assert "postgresql-" in printed
 
+    @pytest.mark.asyncio
+    async def test_needs_list_explains_label_field(self, registry, vault_dir, make_session):
+        session = make_session()
+        buffer = io.StringIO()
+        console = Console(file=buffer, width=120)
+        vault = LocalDataVault(vault_dir=vault_dir)
+        responses = iter(["PostgreSQL", "db.example.com", "5432", "prod_db", "alice", "s3cr3t", ""])
+
+        with (
+            patch("anton.commands.datasource.connect.LocalDataVault", return_value=vault),
+            patch("anton.commands.datasource.connect.DatasourceRegistry", return_value=registry),
+            patch(
+                "anton.commands.datasource.connect.prompt_or_cancel",
+                new=AsyncMock(side_effect=lambda *a, **kw: next(responses)),
+            ),
+            patch("anton.commands.datasource.connect.run_connection_test", new=AsyncMock(return_value=True)),
+        ):
+            await handle_connect_datasource(console, session._scratchpads, session)
+
+        printed = buffer.getvalue()
+        assert "needs:" in printed
+        assert 'label — a name to identify this connection later, e.g. "prod-db" (optional, defaults to the engine name)' in printed
+
 
 class TestEditPromptsForLabelAfterTest:
     @pytest.mark.asyncio

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -4494,3 +4494,68 @@ class TestPromptCopyConsistency:
         assert "[y/n]" not in label
         assert "[reconnect/cancel]" not in label
         assert "(y/n" in label or _PROMPT_RECONNECT_CANCEL in label
+
+
+class TestToolConnectResultParsing:
+    """The connect_new_datasource tool must report the saved label correctly.
+
+    After the interactive flow returns, the tool wrapper diffs the vault
+    to find the connection that was just added, then loads it back to
+    read `_user_label`. It must carry (engine, name) through as a pair:
+    joining them into an "engine-name" slug and splitting on the first
+    dash misattributes the parts whenever the engine name contains a
+    dash (custom engines are free-form, e.g. "optima-api").
+
+    LocalDataVault happens to mask this — it resolves a record by the
+    concatenated path `sanitize(engine)-sanitize(name)`, which is
+    unchanged by a misplaced split — so this test uses a vault that
+    keys on (engine, name) separately, as the DataVault protocol allows.
+    """
+
+    class _KeyedVault:
+        """Minimal DataVault keying records on the (engine, name) tuple."""
+
+        def __init__(self):
+            self._records: dict[tuple[str, str], dict[str, str]] = {}
+
+        def save(self, engine, name, credentials, *, secure_keys=None):
+            self._records[(engine, name)] = dict(credentials)
+
+        def load(self, engine, name):
+            return self._records.get((engine, name))
+
+        def list_connections(self):
+            return [
+                {"engine": e, "name": n, "created_at": ""}
+                for e, n in self._records
+            ]
+
+    @pytest.mark.asyncio
+    async def test_hyphenated_engine_reports_saved_label(self, make_session):
+        from anton import tools as anton_tools
+
+        session = make_session()
+        session._console = MagicMock()
+        vault = self._KeyedVault()
+        session._data_vault = vault
+
+        async def _fake_flow(*args, **kwargs):
+            vault.save(
+                "optima-api",
+                "a12345",
+                {"token": "s3cr3t", "_user_label": "Optima 1"},
+            )
+
+        with (
+            patch("anton.analytics.send_event", new=MagicMock()),
+            patch(
+                "anton.commands.datasource.handle_connect_datasource",
+                new=AsyncMock(side_effect=_fake_flow),
+            ),
+        ):
+            result = await anton_tools.handle_connect_datasource(
+                session, {"engine": "optima-api"}
+            )
+
+        assert "optima-api-a12345" in result
+        assert 'label "Optima 1"' in result

--- a/tests/test_datasource_context_identity.py
+++ b/tests/test_datasource_context_identity.py
@@ -49,7 +49,8 @@ class TestBuildContext:
 
         # Identity is shown so the agent can pick the right account.
         assert "support@acme.com" in ctx
-        assert "db.acme.com/sales" in ctx
+        assert "Host: db.acme.com" in ctx
+        assert "Database: sales" in ctx
         # Secrets are never in the prompt (only their DS_* var name).
         assert "SECRETVAL123" not in ctx
         assert "PGSECRET" not in ctx
@@ -75,15 +76,69 @@ class TestBuildContext:
         assert "__LABEL" not in ctx
         assert "DS_GMAIL_SUPPORT__EMAIL" in ctx  # real fields still listed
 
-    def test_label_preferred_over_email(self, tmp_path):
+    def test_label_and_email_both_shown(self, tmp_path):
         v = LocalDataVault(tmp_path)
         v.save(
             "gmail", "support",
             {"email": "regtr@mail.com", "app_password": "x", "_label": "Support"},
         )
         ctx = build_datasource_context(v)
-        assert "Support" in ctx       # the human label is shown
-        assert "regtr@mail.com" not in ctx  # label preferred over the opaque email
+        assert "Label: Support" in ctx
+        assert "Account: regtr@mail.com" in ctx
+
+
+class TestUserLabelInPrompt:
+    def test_user_label_preferred_over_legacy_label(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save(
+            "gmail", "support",
+            {"email": "reg@mail.com", "app_password": "x", "_label": "Old", "_user_label": "Support"},
+        )
+        ctx = build_datasource_context(v)
+        assert "Label: Support" in ctx
+        assert "Old" not in ctx
+
+    def test_legacy_label_still_shown_when_no_user_label(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save(
+            "gmail", "support",
+            {"email": "reg@mail.com", "app_password": "x", "_label": "Support"},
+        )
+        ctx = build_datasource_context(v)
+        assert "Label: Support" in ctx
+
+    def test_no_label_shows_none(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("postgres", "a1b2c3", {"host": "db.example.com", "database": "demo"})
+        ctx = build_datasource_context(v)
+        assert "Label: (none)" in ctx
+
+    def test_slug_leads_the_block_in_backticks(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("postgres", "a1b2c3", {"host": "db.example.com", "database": "demo", "_user_label": "prod-db"})
+        ctx = build_datasource_context(v)
+        assert "### `postgres-a1b2c3` — Label: prod-db" in ctx
+
+    def test_per_field_lines_present(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("postgres", "a1b2c3", {"host": "db.example.com", "database": "demo", "_user_label": "prod-db"})
+        ctx = build_datasource_context(v)
+        assert "Host: db.example.com" in ctx
+        assert "Database: demo" in ctx
+        assert "DS_POSTGRES_A1B2C3__HOST" in ctx
+
+    def test_user_label_not_listed_as_env_var(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("postgres", "a1b2c3", {"host": "x", "_user_label": "prod-db"})
+        ctx = build_datasource_context(v)
+        assert "__USER_LABEL" not in ctx
+
+    def test_reference_by_slug_wording(self, tmp_path):
+        v = LocalDataVault(tmp_path)
+        v.save("postgres", "a1b2c3", {"host": "x"})
+        ctx = build_datasource_context(v)
+        assert "Reference it by slug;" in ctx
+        assert "Reference it by name;" not in ctx
 
 
 class TestParsePickedFiles:

--- a/tests/test_datasource_context_identity.py
+++ b/tests/test_datasource_context_identity.py
@@ -117,7 +117,7 @@ class TestUserLabelInPrompt:
         v = LocalDataVault(tmp_path)
         v.save("postgres", "a1b2c3", {"host": "db.example.com", "database": "demo", "_user_label": "prod-db"})
         ctx = build_datasource_context(v)
-        assert "### `postgres-a1b2c3` — Label: prod-db" in ctx
+        assert "### Slug: `postgres-a1b2c3` — Label: prod-db" in ctx
 
     def test_per_field_lines_present(self, tmp_path):
         v = LocalDataVault(tmp_path)

--- a/tests/test_run_connection_test_env_filter.py
+++ b/tests/test_run_connection_test_env_filter.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from anton.commands.datasource.verify import run_connection_test
+from anton.core.datasources.data_vault import LocalDataVault
+from anton.core.datasources.datasource_registry import DatasourceEngine, DatasourceField
+
+
+@pytest.mark.asyncio
+async def test_underscore_prefixed_credentials_not_injected_as_env(tmp_path):
+    vault = LocalDataVault(vault_dir=tmp_path / "vault")
+    engine_def = DatasourceEngine(
+        engine="postgresql",
+        display_name="PostgreSQL",
+        fields=[DatasourceField(name="host", required=True, description="host")],
+        test_snippet="print('ok')",
+    )
+    console = MagicMock()
+    scratchpads = MagicMock()
+    pad = AsyncMock()
+    pad.reset = AsyncMock()
+    pad.install_packages = AsyncMock(return_value="")
+
+    # `run_connection_test()` calls `restore_namespaced_env(vault)` in a
+    # `finally` block right after the snippet runs — that clears os.environ
+    # and reinjects it from the vault, so asserting on os.environ *after*
+    # the function returns would see post-restore state, not what the test
+    # snippet actually saw. Capture DS_* env at execution time instead, via
+    # the mock the code actually calls (`pad.execute`, not `pad.run`).
+    captured: dict[str, str] = {}
+
+    async def _execute(_snippet):
+        captured.update({k: v for k, v in os.environ.items() if k.startswith("DS_")})
+        return MagicMock(stdout="ok", stderr="", error=None)
+
+    pad.execute = AsyncMock(side_effect=_execute)
+    scratchpads.get_or_create = AsyncMock(return_value=pad)
+
+    credentials = {"host": "db.example.com", "_user_label": "postgres 2"}
+    await run_connection_test(
+        console, scratchpads, vault, engine_def, credentials, engine_def.fields
+    )
+    assert "DS__USER_LABEL" not in captured
+    assert captured.get("DS_HOST") == "db.example.com"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -447,3 +447,65 @@ class TestNonInteractiveSave:
             await handle_connect_datasource(session, {"engine": "postgres"})
         interactive.assert_called_once()
         assert session._data_vault.list_connections() == []
+
+
+class TestConnectToolUserLabel:
+    @pytest.mark.asyncio
+    async def test_non_interactive_uses_passed_label(self, vault_dir):
+        session = _make_session(vault_dir)
+        with _patch_test_ok():
+            result = await handle_connect_datasource(
+                session,
+                {
+                    "engine": "postgres",
+                    "known_variables": {
+                        "host": "db.example.com", "database": "sales",
+                        "user": "admin", "password": "x",
+                    },
+                    "user_label": "prod-db",
+                },
+            )
+        vault = session._data_vault
+        conns = vault.list_connections()
+        fields = vault.load(conns[0]["engine"], conns[0]["name"])
+        assert fields["_user_label"] == "prod-db"
+        assert "prod-db" in result
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_defaults_when_no_label_passed(self, vault_dir):
+        session = _make_session(vault_dir)
+        with _patch_test_ok():
+            await handle_connect_datasource(
+                session,
+                {
+                    "engine": "postgres",
+                    "known_variables": {
+                        "host": "db.example.com", "database": "sales",
+                        "user": "admin", "password": "x",
+                    },
+                },
+            )
+        vault = session._data_vault
+        conns = vault.list_connections()
+        fields = vault.load(conns[0]["engine"], conns[0]["name"])
+        assert fields["_user_label"] == "postgres"
+
+    @pytest.mark.asyncio
+    async def test_interactive_branch_prefills_label_and_reports_it(self, vault_dir):
+        """When the model passes user_label with no known_variables, the
+        interactive delegate receives it as prefill_label, and the tool's
+        success message reports whatever ended up saved."""
+        session = _make_session(vault_dir)
+
+        async def _side_effect(console, scratchpads, sess, **kwargs):
+            assert kwargs.get("prefill_label") == "prod-db"
+            sess._data_vault.save("postgres", "abc12345", {"host": "x", "_user_label": "prod-db"})
+            return sess
+
+        interactive = AsyncMock(side_effect=_side_effect)
+        with patch("anton.commands.datasource.handle_connect_datasource", new=interactive):
+            result = await handle_connect_datasource(
+                session, {"engine": "postgres", "user_label": "prod-db"}
+            )
+        interactive.assert_called_once()
+        assert "prod-db" in result

--- a/tests/test_user_label.py
+++ b/tests/test_user_label.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from anton.core.datasources.data_vault import LocalDataVault
+from anton.utils.datasources import default_user_label, ensure_unique_user_label
+
+
+def _save(vault, engine, name, user_label=None, label=None):
+    fields = {"host": "x"}
+    if user_label is not None:
+        fields["_user_label"] = user_label
+    if label is not None:
+        fields["_label"] = label
+    vault.save(engine, name, fields)
+
+
+class TestEnsureUniqueUserLabel:
+    def test_returns_candidate_when_no_collision(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        assert ensure_unique_user_label(vault, "postgres") == "postgres"
+
+    def test_suffixes_on_collision_with_user_label(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        _save(vault, "postgres", "a1b2c3", user_label="postgres")
+        assert ensure_unique_user_label(vault, "postgres") == "postgres 2"
+
+    def test_suffixes_on_collision_with_legacy_label(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        _save(vault, "gmail", "abc123", label="Support")
+        assert ensure_unique_user_label(vault, "Support") == "Support 2"
+
+    def test_skips_taken_suffix_too(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        _save(vault, "postgres", "a1", user_label="postgres")
+        _save(vault, "postgres", "a2", user_label="postgres 2")
+        assert ensure_unique_user_label(vault, "postgres") == "postgres 3"
+
+    def test_uniqueness_is_global_not_per_engine(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        _save(vault, "postgres", "a1", user_label="prod-db")
+        assert ensure_unique_user_label(vault, "prod-db") == "prod-db 2"
+
+    def test_empty_labels_excluded_from_collision_set(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        vault.save("postgres", "a1", {"host": "x"})  # no _user_label, no _label
+        assert ensure_unique_user_label(vault, "postgres") == "postgres"
+
+    def test_exclude_lets_a_connection_keep_its_own_label(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        _save(vault, "postgres", "a1", user_label="prod-db")
+        result = ensure_unique_user_label(
+            vault, "prod-db", exclude=("postgres", "a1")
+        )
+        assert result == "prod-db"
+
+    def test_exclude_only_removes_that_connection(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        _save(vault, "postgres", "a1", user_label="prod-db")
+        _save(vault, "postgres", "a2", user_label="prod-db")  # pre-existing dup
+        result = ensure_unique_user_label(
+            vault, "prod-db", exclude=("postgres", "a1")
+        )
+        # a2 still holds "prod-db", so the excluded a1's rename still collides with it
+        assert result == "prod-db 2"
+
+
+class TestDefaultUserLabel:
+    def test_returns_engine_id_when_unused(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        assert default_user_label(vault, "postgres") == "postgres"
+
+    def test_returns_deduplicated_suggestion(self, tmp_path):
+        vault = LocalDataVault(vault_dir=tmp_path / "vault")
+        _save(vault, "postgres", "a1", user_label="postgres")
+        assert default_user_label(vault, "postgres") == "postgres 2"


### PR DESCRIPTION
Sibling PRs:
https://github.com/mindsdb/cowork/pull/552
https://github.com/mindsdb/cowork-server/pull/264

Connections saved in the local vault get a persistent, unique `user_label` (e.g. "prod-db") instead of only the auto-generated slug (e.g. `postgres-7e8971c3`).

- `/connect` prompts for a Label on new connections; `/edit` prompts for one after a successful test
- Save/update/reconnect messages now show the label alongside the slug
- `/list` gains Label and Identity columns, renames Name to Slug
- `/remove` picker shows the label
- System prompt's connected-datasource section is restructured per-connection, showing Label, Engine, Host/Database/Account, and credential env vars
- `connect_new_datasource` tool accepts and reports `user_label`
- Fixed an env-var leak where `_`-prefixed bookkeeping fields (including labels) could be injected as `DS_*` env vars and get scrubbed as false-positive secrets

No breaking changes — connections without a label still work, falling back to the slug.

<img width="714" height="541" alt="image" src="https://github.com/user-attachments/assets/30709db1-d64c-4cd4-8c08-3d483570166c" />
