### PR TITLE
ENG-1234: Dependabot config + scope guard so a dependency bump can't smuggle source changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+# Dependabot configuration (ENG-1234).
+#
+# NOTE ON `target-branch` — deliberately absent.
+#
+# PRs in this repo normally branch from `staging` and target `staging`, so
+# pointing Dependabot at `staging` looks like the obvious thing to do. It is not:
+# Dependabot *security* updates only run against the default branch, and GitHub's
+# docs state that for security updates "you should not specify a target-branch".
+# Setting it would silence the security PRs this repo actually relies on (7 open
+# alerts when this file was written).
+#
+# The consequence is that security PRs arrive based on `main`. Merge them into
+# `main` and let the weekly sync carry them into `staging` — do NOT retarget them
+# at `staging`. Retargeting is what caused anton#293, where a postcss bump in
+# /docs reverted merged verifier code in `anton/core/session.py`: the branch came
+# from `main`, `staging` had moved on, and the resulting conflict was resolved by
+# keeping both sides.
+#
+# This file does not prevent that on its own — the CI scope guard in ENG-1234
+# does. What it buys is explicit ecosystems, grouping, PR limits and labels
+# instead of defaults.
+#
+# Python is intentionally not listed. `uv` is not a valid package-ecosystem
+# value, and running `pip` against a uv.lock project risks PRs that edit
+# pyproject.toml without regenerating the lock. Tracked in ENG-1234.
+version: 2
+updates:
+  # Docs site (Docusaurus). Dev-only — these packages are not shipped in the
+  # anton wheel, which is why the blast radius of anton#293 was zero.
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    # One PR per batch of routine bumps rather than one per package. Security
+    # updates are unaffected by grouping and still arrive individually.
+    groups:
+      docs-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # Workflow actions. Pinned action versions rot quietly and are a supply-chain
+  # surface, so keep them current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/scripts/check_dependency_pr_scope.py
+++ b/.github/scripts/check_dependency_pr_scope.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Fail a dependency-bump PR that touches anything but manifests and lockfiles.
+
+Why this exists (ENG-1234): anton#293 was titled "bump postcss from 8.5.15 to
+8.5.25 in /docs" and also reverted merged verifier code in
+`anton/core/session.py` — re-adding the silent fail-safe ENG-1079 had deleted.
+The branch came from `main`, the PR was retargeted at `staging`, the resulting
+conflict was resolved by keeping both sides, and a squash merge hid all of it
+under the postcss title.
+
+No amount of Dependabot configuration prevents that: security updates must be
+based on the default branch (GitHub's docs say not to set `target-branch` for
+them), so cross-branch merges will keep happening. What is preventable is a
+dependency PR silently carrying source changes. This turns that into a red check.
+
+Logic lives here rather than inline in the workflow so it can be tested against
+a real diff — see tests/test_dependency_pr_scope.py, which feeds it #293's
+actual file list.
+
+Usage:
+    git diff --name-only base...HEAD | check_dependency_pr_scope.py
+    check_dependency_pr_scope.py path/one path/two
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import PurePosixPath
+
+# Manifests and lockfiles a bump is allowed to rewrite, matched on basename so
+# nested projects (docs/, any future workspace) work without new entries.
+ALLOWED_BASENAMES = frozenset({
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "npm-shrinkwrap.json",
+    "pyproject.toml",
+    "uv.lock",
+    "poetry.lock",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "Pipfile",
+    "Pipfile.lock",
+    "go.mod",
+    "go.sum",
+    "Cargo.toml",
+    "Cargo.lock",
+})
+
+# The github-actions ecosystem bumps pinned action versions inside workflows,
+# and Dependabot may touch its own config.
+ALLOWED_PREFIXES = (".github/workflows/",)
+ALLOWED_EXACT = frozenset({".github/dependabot.yml", ".github/dependabot.yaml"})
+
+
+def is_allowed(path: str) -> bool:
+    path = path.strip()
+    if not path:
+        return True
+    if path in ALLOWED_EXACT:
+        return True
+    if path.startswith(ALLOWED_PREFIXES):
+        return True
+    return PurePosixPath(path).name in ALLOWED_BASENAMES
+
+
+def offenders(paths: list[str]) -> list[str]:
+    return [p.strip() for p in paths if p.strip() and not is_allowed(p)]
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:] if len(argv) > 1 else sys.stdin.read().splitlines()
+    bad = offenders(paths)
+    if not bad:
+        print(f"OK — {len([p for p in paths if p.strip()])} changed file(s), all manifests/lockfiles.")
+        return 0
+
+    print("Dependency PR is out of scope. Files that are not manifests or lockfiles:")
+    for p in bad:
+        print(f"  {p}")
+    print(
+        "\nA dependency bump must not carry source changes. This usually means the "
+        "branch was based on a different branch than it targets, and a conflict was "
+        "resolved by keeping both sides — see ENG-1234 / anton#293.\n"
+        "Fix: rebase the branch onto its target branch and re-resolve, or split the "
+        "source changes into their own PR. Do not retarget a Dependabot security PR "
+        "at staging — merge it into main and let the weekly sync carry it."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/dependency-scope.yml
+++ b/.github/workflows/dependency-scope.yml
@@ -1,0 +1,59 @@
+name: Dependency PR scope
+
+# ENG-1234. A dependency bump must only touch manifests and lockfiles. anton#293
+# ("bump postcss ... in /docs") also reverted merged verifier code in
+# anton/core/session.py, and a squash merge hid it under the postcss title.
+#
+# Dependabot config cannot prevent this: security updates are based on the
+# default branch, so cross-branch merges — and therefore conflicts in unrelated
+# files — will keep happening. This makes the result visible instead of silent.
+
+permissions:
+  contents: read
+  pull-requests: read
+
+on:
+  pull_request:
+    branches: [main, staging]
+    # `labeled`/`unlabeled` matter because the check keys off the `dependencies`
+    # label, which is often added after the PR is opened.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  scope:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check scope of dependency PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          is_dep=false
+          case "$PR_AUTHOR" in
+            dependabot|dependabot\[bot\]|app/dependabot) is_dep=true ;;
+          esac
+          if printf '%s' "$PR_LABELS" | grep -q '"dependencies"'; then
+            is_dep=true
+          fi
+
+          if [ "$is_dep" != "true" ]; then
+            echo "Not a dependency PR (author=$PR_AUTHOR, labels=$PR_LABELS) — skipping."
+            exit 0
+          fi
+
+          # The API file list is what GitHub itself shows as the PR's changes,
+          # i.e. the diff against the merge base. That is precisely what exposed
+          # session.py in #293, so it is the right input.
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename' > changed.txt
+          echo "Changed files:"
+          sed 's/^/  /' changed.txt
+
+          python3 .github/scripts/check_dependency_pr_scope.py < changed.txt

--- a/tests/test_dependency_pr_scope.py
+++ b/tests/test_dependency_pr_scope.py
@@ -1,0 +1,89 @@
+"""The dependency-PR scope guard (ENG-1234).
+
+The regression it exists for is anton#293: a PR titled "chore(deps): bump postcss
+from 8.5.15 to 8.5.25 in /docs" that also reverted merged verifier code in
+`anton/core/session.py`. The first case below is that PR's real file list, so this
+test fails if the guard ever stops catching it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / ".github" / "scripts" / "check_dependency_pr_scope.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("dep_scope", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def guard():
+    assert _SCRIPT.exists(), f"guard script missing: {_SCRIPT}"
+    return _load()
+
+
+# The actual files anton#293 changed.
+PR_293_FILES = [
+    "anton/core/llm/structured.py",
+    "anton/core/session.py",
+    "docs/package-lock.json",
+]
+
+
+def test_catches_the_pr_293_regression(guard):
+    bad = guard.offenders(PR_293_FILES)
+    assert bad == ["anton/core/llm/structured.py", "anton/core/session.py"], (
+        "the guard must flag the source files #293 smuggled in"
+    )
+    assert guard.main(["prog", *PR_293_FILES]) == 1, "exit code must be non-zero"
+
+
+def test_a_clean_bump_passes(guard):
+    clean = ["docs/package.json", "docs/package-lock.json"]
+    assert guard.offenders(clean) == []
+    assert guard.main(["prog", *clean]) == 0
+
+
+@pytest.mark.parametrize("path", [
+    "docs/package.json",
+    "docs/package-lock.json",
+    "pyproject.toml",
+    "uv.lock",
+    # github-actions ecosystem bumps pinned versions inside workflows.
+    ".github/workflows/tests.yml",
+    ".github/dependabot.yml",
+    # Nested manifests must work on basename, so a new workspace needs no change.
+    "packages/web/package.json",
+])
+def test_manifests_and_lockfiles_are_allowed(guard, path):
+    assert guard.is_allowed(path), f"{path} should be allowed"
+
+
+@pytest.mark.parametrize("path", [
+    "anton/core/session.py",
+    "anton/core/llm/structured.py",
+    "tests/test_verifier_failsafe.py",
+    "docs/src/pages/index.js",
+    # A lookalike must not slip through on a substring match.
+    "anton/package_json_helper.py",
+    # Only real workflow files, not anything merely under .github/.
+    ".github/CODEOWNERS",
+])
+def test_source_files_are_rejected(guard, path):
+    assert not guard.is_allowed(path), f"{path} should be rejected"
+
+
+def test_empty_and_blank_input_is_not_a_failure(guard):
+    assert guard.offenders([]) == []
+    assert guard.offenders(["", "   ", "\n"]) == []


### PR DESCRIPTION
## What

Adds the missing `.github/dependabot.yml` **and** a CI guard that fails any dependency PR touching anything but manifests and lockfiles. The guard is the part that prevents recurrence; the config is hygiene.

## Why

anton#293 — *"chore(deps): bump postcss from 8.5.15 to 8.5.25 in /docs"* — merged into `staging` on 2026-08-03 and also reverted merged verifier code:

- `anton/core/session.py`: re-added `status, reason = "COMPLETE", "verifier unavailable"`, the silent fail-safe **ENG-1079 deliberately deleted**, placed directly above the comment explaining why it must not exist. That line is what produced the original "the agent dies silently" reports (ENG-1081: 24.9% of verdicts, 33 users).
- `anton/core/llm/structured.py`: a duplicate `from typing import Any, NoReturn`.

**No production impact** — the line was unreachable and never reached `main`; the 2026-08-02 release shipped correct code. Removed in #299. **This PR is about the mechanism.** There are **7 open Dependabot alerts**, so more of these PRs are coming.

How it happened, verified: Dependabot security PRs are based on the **default branch** (`main`); this one was **retargeted at `staging`**. Because the ENG-1081 hotfix exists as two different commits (`c51afe8` on main, `fc832d5` on staging — same code, unrelated identities), the merge base fell back to `c8de488`, the *previous* week's release. From there both sides had independently edited the same block of `session.py`, producing a real conflict, which a human resolved by **keeping both sides**. A squash merge then hid everything under the postcss title. `git merge-tree` confirms a clean merge would have been correct.

## The `target-branch` trap

The obvious fix — `target-branch: staging` — is **wrong**, and the config says so in a comment where the next person will read it. Dependabot **security** updates only run against the default branch, and GitHub's docs state that for them *"you should not specify a `target-branch`"*. Setting it would silence the security PRs this repo depends on.

So security PRs stay based on `main`. The rule that follows: **merge them into `main` and let the weekly sync carry them — do not retarget them at `staging`.**

## What's here

| file | purpose |
|---|---|
| `.github/scripts/check_dependency_pr_scope.py` | the check. In a script, not inline YAML, so it is testable against a real diff |
| `.github/workflows/dependency-scope.yml` | runs it for `dependabot`-authored or `dependencies`-labelled PRs |
| `tests/test_dependency_pr_scope.py` | 16 cases; the first is #293's actual file list |
| `.github/dependabot.yml` | npm `/docs` + `github-actions`, grouped, labelled, no `target-branch` |

Guard details worth reviewing:

- Keys off the **API file list** — the diff against the merge base, which is exactly what exposed `session.py` in #293.
- Listens to `labeled`/`unlabeled`, because the `dependencies` label is often added after opening.
- Matches manifests on **basename**, so a future workspace needs no config change. Negative cases cover the near-misses: `anton/package_json_helper.py` must not pass on a substring, and `.github/CODEOWNERS` must not pass just for being under `.github/`.

**Verified live against both real PRs:** #293 → exit 1 naming both source files; #294 (the clean `brace-expansion` security PR) → exit 0.

## Deliberately out of scope

- **Python ecosystem.** `uv` is not a valid `package-ecosystem` value, and `pip` against a `uv.lock` project risks PRs that edit `pyproject.toml` without regenerating the lock. Left for a deliberate decision in ENG-1234 rather than guessed at.
- **The root enabler.** A hotfix squashed into `main` and re-squashed into `staging` guarantees this conflict class for any branch crossing between them. Fixing that means changing the release convention — a bigger conversation, noted on the ticket.

## Timing

`dependabot.yml` is read from the **default branch**, so it takes effect after the next weekly release, not on merge. The workflow guard is active as soon as this lands, since workflows run from the PR's own branch.

## Security

Reviewed per convention. The workflow requests only `contents: read` and `pull-requests: read`, uses the default `GITHUB_TOKEN`, and runs on `pull_request` (not `pull_request_target`), so a fork PR cannot obtain write access or secrets. No PR-controlled string is interpolated into shell — author and labels arrive via `env`, and the file list is written to a file and piped to the script rather than expanded inline. The script only reads path strings; it never executes or opens the files it is judging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)