### PR TITLE
ENG-836: verifier detects environment walls — tail-biased truncation + STUCK definition

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -195,7 +195,19 @@ class _VerifierVerdict(BaseModel):
             "including when it implied success but the data its answer actually "
             "depends on errored or came back empty and was never recovered.\n"
             "- STUCK: a hard blocker prevents completion (missing credentials, an "
-            "unavailable service, or a permission the assistant does not have)."
+            "unavailable service, or a permission the assistant does not have). "
+            # Environment walls must be named explicitly or the verifier files
+            # them under INCOMPLETE and force-continues into the wall: measured
+            # 0-1/12 STUCK without the sentences below vs 12/12 with them, on
+            # the same blocked-task transcript, with unblocked-unfinished and
+            # errored-but-recovered controls unmoved (ENG-836 live A/B,
+            # 2026-08-04).
+            "This includes environment walls: an OS-level package, driver, or "
+            "system library the task requires but that cannot be installed in "
+            "this environment (no root/sudo, package manager blocked). Repeated "
+            "failed workarounds for the same underlying blocker mean STUCK, not "
+            "INCOMPLETE — even if the assistant says it will try another "
+            "approach."
         )
     )
     reason: str = Field(description="One brief sentence explaining the verdict.")

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -363,7 +363,15 @@ def _clip_keep_cause(text: str, cap: int) -> str:
     head = cap // 3
     tail = cap - head
     elided = len(text) - head - tail
-    return f"{text[:head]}\n[... {elided} chars elided ...]\n{text[-tail:]}"
+    marker = f"\n[... {elided} chars elided ...]\n"
+    # Near-threshold inputs: when the marker costs at least what it removes,
+    # clipping would EXPAND the text (a 401-char input at cap=400 came back
+    # ~428 chars with a "[... 1 chars elided ...]" in the middle). Pass those
+    # through whole — same worst-case output bound, and the invariant becomes
+    # "clipping never returns more characters than it was given" (#305 review).
+    if len(text) <= cap + len(marker):
+        return text
+    return f"{text[:head]}{marker}{text[-tail:]}"
 
 
 def _render_tool_result_content(content, cap: int) -> str:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -335,15 +335,36 @@ _SOLVABILITY_CLAUSE = (
 )
 
 
+def _clip_keep_cause(text: str, cap: int) -> str:
+    """Clip ``text`` to ~``cap`` chars keeping both ends, biased to the tail.
+
+    A failing tool result names its cause at the END — a traceback's final
+    line is the one that says ``libodbc.so.2: cannot open shared object
+    file`` — while the head carries what ran and the ``[error]`` marker. A
+    plain ``text[:cap]`` therefore showed the verifier the shape of a failure
+    but discarded its cause, which is how an unrecoverable environment wall
+    kept getting judged INCOMPLETE instead of STUCK (ENG-836). Keep a small
+    head, elide the middle, and spend most of the budget on the tail.
+    """
+    if len(text) <= cap:
+        return text
+    head = cap // 3
+    tail = cap - head
+    elided = len(text) - head - tail
+    return f"{text[:head]}\n[... {elided} chars elided ...]\n{text[-tail:]}"
+
+
 def _render_tool_result_content(content, cap: int) -> str:
     """Render a tool_result's content as bounded plain text.
 
     Never serializes raw payloads: a multimodal result (e.g. read_image) can
     carry megabytes of base64, so we keep only text blocks and mark images with
     a placeholder rather than ``json.dumps``-ing the whole thing (ENG-716).
+    Oversize content is clipped tail-biased so a failure's cause survives
+    (ENG-836).
     """
     if isinstance(content, str):
-        return content[:cap] or "(empty result)"
+        return _clip_keep_cause(content, cap) or "(empty result)"
     if isinstance(content, list):
         parts: list[str] = []
         for block in content:
@@ -353,8 +374,9 @@ def _render_tool_result_content(content, cap: int) -> str:
                 parts.append((block.get("text") or "").strip())
             elif block.get("type") in ("image", "image_url"):
                 parts.append("[image]")
-        return (" ".join(p for p in parts if p)[:cap]) or "[non-text result]"
-    return str(content)[:cap]
+        joined = " ".join(p for p in parts if p)
+        return _clip_keep_cause(joined, cap) or "[non-text result]"
+    return _clip_keep_cause(str(content), cap)
 
 
 def _render_verify_transcript(

--- a/tests/test_verifier_verdict_schema.py
+++ b/tests/test_verifier_verdict_schema.py
@@ -1,0 +1,45 @@
+"""Pins the _VerifierVerdict STUCK definition's environment-wall coverage (ENG-836).
+
+Honest scope note: these are wording pins, not behavioural coverage — they
+exist so a later edit can't silently drop the sentences whose effect was
+measured live (0-1/12 STUCK without them vs 12/12 with them on a blocked-task
+transcript, controls unmoved; see the 2026-08-04 A/B on ENG-836). Behavioural
+verifier coverage is ENG-1211's scope.
+"""
+
+from __future__ import annotations
+
+from anton.core.session import _VerifierVerdict
+
+
+def _status_description() -> str:
+    return _VerifierVerdict.model_fields["status"].description
+
+
+def test_stuck_definition_names_environment_walls():
+    desc = _status_description()
+    # The uninstallable-OS-dependency case (no root, package manager blocked)
+    # must be named INSIDE the STUCK bullet — the ENG-836 incident class.
+    stuck = desc[desc.index("- STUCK:"):]
+    assert "cannot be installed" in stuck
+    assert "no root/sudo" in stuck
+    assert "package manager blocked" in stuck
+
+
+def test_stuck_definition_covers_repeated_workarounds():
+    # The blocked loop's signature: the assistant keeps proposing another
+    # approach to the same wall. Without this sentence the assistant's own
+    # "Next I'll retry..." narration satisfies INCOMPLETE's "could keep going
+    # on its own" and the loop force-continues into the wall.
+    stuck = _status_description()
+    stuck = stuck[stuck.index("- STUCK:"):]
+    assert "Repeated failed workarounds for the same underlying blocker" in stuck
+    assert "even if the assistant says it will try another approach" in stuck
+
+
+def test_recovered_error_rule_is_intact():
+    # ENG-1134's guard must survive the STUCK extension: a tool error the
+    # assistant recovered from stays COMPLETE-eligible.
+    desc = _status_description()
+    assert "RECOVERED" in desc
+    assert "do NOT mark a turn incomplete just because an earlier tool call failed" in desc

--- a/tests/test_verify_transcript.py
+++ b/tests/test_verify_transcript.py
@@ -52,15 +52,49 @@ def test_omits_internal_system_injections():
     assert "build the dashboard" in out
 
 
-def test_truncates_large_tool_output():
-    big = "x" * 5000
+def test_truncates_large_tool_output_keeping_both_ends():
+    # Direction matters, not just the cap: a homogeneous fixture ("x" * 5000)
+    # cannot tell head-truncation from tail-truncation, and head-truncation is
+    # exactly the ENG-836 bug. Mark both ends and assert both survive.
+    big = "HEAD_MARKER " + "x" * 5000 + " CAUSE_MARKER"
     history = [
         {"role": "user", "content": "run it"},
         {"role": "user", "content": [{"type": "tool_result", "content": big}]},
     ]
     out = _render_verify_transcript(history, tool_cap=400)
-    # Tool output is capped so the verify call stays cheap.
+    # Tool output is capped so the verify call stays cheap...
     assert out.count("x") <= 400
+    # ...but the clip keeps the head (what ran / the [error] marker) AND the
+    # tail (the cause), eliding the middle.
+    assert "HEAD_MARKER" in out
+    assert "CAUSE_MARKER" in out
+    assert "chars elided" in out
+
+
+def test_traceback_cause_survives_truncation():
+    # Regression for ENG-836: the verifier judged an unrecoverable environment
+    # wall INCOMPLETE because head-truncation kept the traceback preamble and
+    # discarded the final line naming the missing system library. The fixture
+    # must exceed tool_cap with the cause at the END, shaped like the real
+    # pyodbc failure — a short tidy error string would pass either way.
+    frames = "".join(
+        f'  File "/app/step_{i}.py", line {i * 7}, in run\n    connect()\n'
+        for i in range(12)
+    )
+    traceback = (
+        "Traceback (most recent call last):\n"
+        + frames
+        + "ImportError: libodbc.so.2: cannot open shared object file: "
+        "No such file or directory"
+    )
+    assert len(traceback) > 400
+    history = [
+        {"role": "user", "content": "build the KPI dashboard against Azure SQL"},
+        {"role": "user", "content": [{"type": "tool_result", "content": traceback}]},
+    ]
+    out = _render_verify_transcript(history, tool_cap=400)
+    assert "libodbc.so.2: cannot open shared object file" in out
+    assert "Traceback (most recent call last):" in out
 
 
 def test_empty_history_is_safe():

--- a/tests/test_verify_transcript.py
+++ b/tests/test_verify_transcript.py
@@ -25,7 +25,11 @@ def test_keeps_prior_turn_context_for_referential_followups():
     assert "now do the same for the other file" in out
 
 
-def test_includes_truncated_tool_result_evidence():
+def test_includes_tool_result_evidence_verbatim_when_short():
+    # Short results (under tool_cap) reach the verifier untouched — this pins
+    # the ENG-716 "content, not just ok/error" property. It does NOT exercise
+    # truncation; direction-of-truncation coverage lives in
+    # test_truncates_large_tool_output_keeping_both_ends.
     history = [
         {"role": "user", "content": "how many open PRs?"},
         {"role": "assistant", "content": [{"type": "tool_use", "name": "scratchpad"}]},

--- a/tests/test_verify_transcript.py
+++ b/tests/test_verify_transcript.py
@@ -75,6 +75,22 @@ def test_truncates_large_tool_output_keeping_both_ends():
     assert "chars elided" in out
 
 
+def test_near_threshold_output_passes_through_whole():
+    # A 401-char result at cap=400 must come back verbatim, not "clipped" into
+    # ~428 chars with a "[... 1 chars elided ...]" in the middle — the marker
+    # may never cost more than it removes (#305 review nit). The invariant:
+    # clipping never returns more characters than it was given.
+    near = "BEGIN " + "y" * 395 + " END"  # just over the 400 cap
+    assert 400 < len(near) < 430
+    history = [
+        {"role": "user", "content": "run it"},
+        {"role": "user", "content": [{"type": "tool_result", "content": near}]},
+    ]
+    out = _render_verify_transcript(history, tool_cap=400)
+    assert near in out
+    assert "chars elided" not in out
+
+
 def test_traceback_cause_survives_truncation():
     # Regression for ENG-836: the verifier judged an unrecoverable environment
     # wall INCOMPLETE because head-truncation kept the traceback preamble and


### PR DESCRIPTION
## What

Two measured changes so the completion verifier recognizes an unrecoverable environment wall (missing OS driver, no root) and stops instead of force-continuing:

1. **Tail-biased tool-result truncation.** `_render_tool_result_content` clipped oversize tool results with `content[:cap]` at `tool_cap = 400` — head truncation. A traceback's decisive final line (`libodbc.so.2: cannot open shared object file`, `Permission denied`) is exactly what got discarded: the verifier saw the shape of a failure and was denied its cause. Now: keep a small head (`cap // 3` — what ran, the `[error]` marker), elide the middle with a marker, spend the rest on the tail.
2. **STUCK definition names environment walls** (ticket fix #2). Appended to the `_VerifierVerdict` STUCK bullet, shipped verbatim as A/B-tested: *"This includes environment walls: an OS-level package, driver, or system library the task requires but that cannot be installed in this environment (no root/sudo, package manager blocked). Repeated failed workarounds for the same underlying blocker mean STUCK, not INCOMPLETE — even if the assistant says it will try another approach."*

## Why — measured, not assumed

[ENG-836](https://linear.app/mindsdb/issue/ENG-836): a Pro user's environmentally-blocked task burned ~5M tokens on INCOMPLETE-driven continuations. Live A/B against the prod gateway on `haiku` (the tier-default coding model), production verify call byte-for-byte, Kiranam-shaped fixture, n=12/arm — full method + verdict transcripts on the ticket (2026-08-04 comment):

| Truncation | STUCK schema | STUCK verdicts |
|---|---|---|
| head-clip (prod today) | original | **0/12** |
| tail-biased (commit 1) | original | 1/12 — verifier cites "no sudo/apt access" and still says INCOMPLETE |
| tail-biased | extended (commit 3) | **12/12** |
| head-clip | extended | 12/12 (this fixture's assistant narrates the blocker; see below) |
| controls (extended schema) | | unfinished-unblocked stays INCOMPLETE 12/12; errored-but-recovered stays COMPLETE 12/12 (ENG-1134-compatible) |

The schema wording is the binding lever for the verdict; the truncation fix is the evidence guarantee for failures the assistant does NOT narrate or actively misreads (the real session's 404-page-parsed-as-valid-archive class) and is what puts the precise cause into the `reason` string feeding the user-facing STUCK diagnosis.

## Tests

- Truncation **direction** is now pinned: the old `"x" * 5000` fixture couldn't distinguish head- from tail-clipping (reverting the fix broke nothing). Re-fixtured with `HEAD_MARKER`/`CAUSE_MARKER` + elision assert, plus `test_traceback_cause_survives_truncation` (>400-char pyodbc-shaped traceback, cause at the end).
- Schema wording pinned in a new `tests/test_verifier_verdict_schema.py` — labeled honestly as wording pins (behavioural verifier coverage is ENG-1211's scope), including a guard that ENG-1134's recovered-error rule survived the edit. New file deliberately, to avoid churn against ENG-1155's #299 which extends `test_verifier_failsafe.py` heavily.
- Verifier/session suites: 164 passed. Full suite: 1462 passed; the 2 `test_chat_scratchpad.py` failures pre-exist on clean `origin/staging` (and don't fail in CI).

## Interaction with ENG-1155 (#299, merging)

No textual conflict (#299 doesn't touch the verdict schema or the renderer) and no semantic overlap: 1155's latch handles the verifier *call itself* dying (hard provider failures), this PR changes what a *working* verifier concludes. Complementary in the right direction — #299 also fixed the STUCK hand-back path this PR makes fire more often.

## Notes

- Clip output can exceed `cap` by the ~30-char elision marker — bounded, negligible against the post-ENG-1081 budgets.
- Security pass: string clipping + prompt wording in an internal verifier call — no new input surface, no secrets in logs or output.

## Still open on the ticket

Feasibility-aware cap-exhaustion message (re-scope item 3), repeated-run regression eval in cowork_evals, and the deferred original fixes #3/#4 — though the 12/12 result suggests re-measuring after this lands before building them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)