### PR TITLE
ENG-1279: report anton's own version on MindsHub traces

### DIFF
--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -877,6 +877,16 @@ class OpenAIProvider(LLMProvider):
             extra["turn_id"] = ctx.turn_id
         if ctx.harness:
             extra["harness"] = ctx.harness
+        # Our own build (ENG-1279). The router lifts this onto the trace's
+        # native `version` field, the only form the Langfuse metrics API can
+        # group by — so "did this fix change behaviour in production?" becomes
+        # a query instead of a guess about release dates. Set here rather than
+        # by the host so it is also correct for anton standalone (CLI, hub
+        # instances, evals) and so it wins over a host that reports a stale
+        # value: only anton knows which anton is running.
+        from anton import __version__ as _anton_version
+
+        extra["anton_version"] = _anton_version
         if extra:
             headers["Langfuse-Metadata"] = json.dumps(extra)
         return headers or None

--- a/tests/test_trace_headers.py
+++ b/tests/test_trace_headers.py
@@ -63,3 +63,37 @@ def test_tags_are_sanitized():
 
 def test_no_trace_context_returns_none():
     assert _provider()._build_trace_headers() is None
+
+
+def test_anton_version_is_always_reported():
+    """ENG-1279: every trace must carry the build that produced it.
+
+    The router lifts `anton_version` onto the Langfuse trace's native
+    `version` field, which is what a metrics query can group by — so this
+    key is what makes a release's effect measurable.
+    """
+    from anton import __version__
+
+    headers = _headers_for(TraceContext(harness="anton"))
+    meta = json.loads(headers["Langfuse-Metadata"])
+    assert meta["anton_version"] == __version__
+
+
+def test_anton_version_reported_even_with_no_other_metadata():
+    # A turn with no session/turn/harness identity still identifies its build:
+    # otherwise standalone anton (CLI, hub instance) would be unattributable.
+    headers = _headers_for(TraceContext())
+    assert headers is not None
+    assert "anton_version" in json.loads(headers["Langfuse-Metadata"])
+
+
+def test_caller_cannot_spoof_anton_version():
+    # Only anton knows which anton is running; a host reporting a stale
+    # value (version skew between cowork-server and its anton pin) must lose.
+    from anton import __version__
+
+    headers = _headers_for(
+        TraceContext(harness="anton", metadata={"anton_version": "1.0.0-spoof"})
+    )
+    meta = json.loads(headers["Langfuse-Metadata"])
+    assert meta["anton_version"] == __version__


### PR DESCRIPTION
## What

Anton reports its own version on every MindsHub-bound LLM call, as `anton_version` in the `Langfuse-Metadata` header it already sends.

Part of ENG-1279 (3 PRs — see **Merge order**).

## Why

Nothing on a trace said which build produced it, so "did this fix change behaviour in production?" could only be asked by *date*. That stopped working on 3 August, when eleven anton fixes shipped in one release and three of them touched the same completion verifier. It also blocks the verifier-verdict and compaction metric work: both produce numbers that silently mix two populations if a release lands mid-window.

The gateway ([mindshub_inference#388](https://github.com/mindsdb/mindshub_inference/pull/388)) lifts this key onto the Langfuse trace's native `version` field — the only form the metrics API can group by (`metadata.<key>` is rejected as a dimension; verified against prod).

## How

One key added in `_build_trace_headers`, alongside the existing `turn_id` / `harness` built-ins.

Two deliberate choices:

- **Set in anton, not by the host.** Only anton knows which anton is loaded, so this stays correct for anton standalone (CLI, hub instances, evals) where there is no cowork-server, and it *wins* over a host reporting a stale value during version skew. cowork-server reports the key too — the built-ins-win ordering means anton's value overwrites it whenever anton is new enough to have this change.
- **Not sent to third-party providers.** Emission stays behind the existing `_emit_trace_headers` gate (MindsHub base URLs, or explicit `ANTON_LANGFUSE_HEADERS=1`), so a BYOK/Azure/ollama user's logs don't gain our build string.

Side effect worth naming: a `TraceContext` with no session/turn/harness now yields a `Langfuse-Metadata` header where it previously yielded no headers at all. That's intended — a turn with no identity should still identify its build — and covered by a test.

## Testing

`tests/test_trace_headers.py`:
- version is always reported, and equals `anton.__version__`
- reported even when the trace context carries nothing else
- a caller-supplied `anton_version` cannot spoof it (the skew case)

7 passed.

## Security

- New outbound data is one version string, and only to MindsHub (or an endpoint the user explicitly opted in via `ANTON_LANGFUSE_HEADERS=1`). No credentials, paths, or user content added.
- It's self-reported by definition; the gateway sanitizes and truncates it before it reaches a queryable field, and server-derived identity still wins there — so this cannot be used to reattribute someone else's traces.

## Merge order

1. [mindshub_inference#388](https://github.com/mindsdb/mindshub_inference/pull/388) (gateway lift)
2. **this PR**
3. cowork-server (server version + install channel)

Independent branches, no stacking; any order is safe (an unlifted key just sits in trace metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
