### PR TITLE
ENG-1276: explicit tool-failure outcomes drive the error streak, not text search

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2141,6 +2141,12 @@ class ChatSession:
                         else b
                         for b in result
                     ]
+                    # NOTE for whoever migrates the first multimodal handler to declare
+                    # ok=False: the streak climbs here, but the resilience-nudge and
+                    # circuit-breaker TEXT are only appended by _apply_error_tracking
+                    # on the string path — this branch skips it, so the model is never
+                    # told to stop retrying. When that handler exists, append the nudge
+                    # as an extra {"type": "text"} block here (#308 review).
                     if outcome.ok is False:
                         error_streak[tc.name] = error_streak.get(tc.name, 0) + 1
                     else:
@@ -2930,6 +2936,12 @@ class ChatSession:
                             else b
                             for b in result_text
                         ]
+                        # NOTE for whoever migrates the first multimodal handler to declare
+                        # ok=False: the streak climbs here, but the resilience-nudge and
+                        # circuit-breaker TEXT are only appended by _apply_error_tracking
+                        # on the string path — this branch skips it, so the model is never
+                        # told to stop retrying. When that handler exists, append the nudge
+                        # as an extra {"type": "text"} block here (#308 review).
                         if tool_ok is False:
                             error_streak[tc.name] = error_streak.get(tc.name, 0) + 1
                         else:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2131,18 +2131,21 @@ class ChatSession:
                 if isinstance(result, list):
                     # Multimodal tool result — scrub credentials from text
                     # blocks; image-block payloads are raw bytes and have
-                    # nothing to scrub. A list result signals success, so
-                    # mirror the success branch of `_apply_error_tracking`
-                    # and reset the streak instead of running the full
-                    # string-only nudge logic.
+                    # nothing to scrub. A list result signals success unless
+                    # the handler explicitly said otherwise (ENG-1276), so
+                    # mirror the matching branch of `_apply_error_tracking`
+                    # instead of running the full string-only nudge logic.
                     content: "str | list[dict]" = [
                         {**b, "text": scrub_credentials(b.get("text", ""))}
                         if b.get("type") == "text"
                         else b
                         for b in result
                     ]
-                    error_streak[tc.name] = 0
-                    resilience_nudged.discard(tc.name)
+                    if outcome.ok is False:
+                        error_streak[tc.name] = error_streak.get(tc.name, 0) + 1
+                    else:
+                        error_streak[tc.name] = 0
+                        resilience_nudged.discard(tc.name)
                 else:
                     result = scrub_credentials(result)
                     result = self._apply_error_tracking(
@@ -2917,18 +2920,21 @@ class ChatSession:
                     if isinstance(result_text, list):
                         # Multimodal tool result — scrub credentials from text
                         # blocks (image payloads carry no secrets). A list
-                        # result signals success, so mirror the success
-                        # branch of `_apply_error_tracking` and reset the
-                        # streak instead of running the full string-only
-                        # nudge logic.
+                        # result signals success unless the handler explicitly
+                        # said otherwise (ENG-1276), so mirror the matching
+                        # branch of `_apply_error_tracking` instead of running
+                        # the full string-only nudge logic.
                         scrubbed_blocks = [
                             {**b, "text": scrub_credentials(b.get("text", ""))}
                             if b.get("type") == "text"
                             else b
                             for b in result_text
                         ]
-                        error_streak[tc.name] = 0
-                        resilience_nudged.discard(tc.name)
+                        if tool_ok is False:
+                            error_streak[tc.name] = error_streak.get(tc.name, 0) + 1
+                        else:
+                            error_streak[tc.name] = 0
+                            resilience_nudged.discard(tc.name)
                         if self._episodic is not None:
                             self._episodic.log_turn(
                                 self._turn_count + 1,
@@ -2938,8 +2944,8 @@ class ChatSession:
                             )
                         self._acc_observe(
                             "tool_result",
-                            {"name": tc.name, "success": True, "error": ""},
-                            severity=1,
+                            {"name": tc.name, "success": tool_ok is not False, "error": ""},
+                            severity=5 if tool_ok is False else 1,
                             round_idx=tool_round,
                         )
                         tool_results.append(

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -58,7 +58,7 @@ from anton.core.llm.tracing import (
     set_trace_context,
 )
 from anton.core.backends.manager import ScratchpadManager
-from anton.core.tools.registry import ToolRegistry
+from anton.core.tools.registry import ToolOutcome, ToolRegistry
 from anton.core.tools.tool_defs import (
     CREATE_ARTIFACT_TOOL,
     LAUNCH_BACKEND_TOOL,
@@ -741,18 +741,40 @@ class ChatSession:
         tool_name: str,
         error_streak: dict[str, int],
         resilience_nudged: set[str],
+        ok: bool | None = None,
     ) -> str:
-        """Track consecutive errors per tool and append nudge/circuit-breaker messages."""
-        is_error = any(
-            marker in result_text
-            for marker in (
-                "[error]",
-                "Task failed:",
-                "failed",
-                "timed out",
-                "Rejected:",
+        """Track consecutive errors per tool and append nudge/circuit-breaker messages.
+
+        ``ok`` is the handler's own verdict (see ``ToolOutcome``, ENG-1276).
+        When present it decides outright — the tool knew whether it failed and
+        the result never needed to be re-classified by reading it. ``None``
+        means an unmigrated handler: fall back to the legacy substring match,
+        and log when that fallback classifies an error so the remaining call
+        sites are discoverable. The substring match misclassifies in both
+        directions — a success printing "0 records failed" increments the
+        streak, and a genuine failure using none of the five phrases RESETS
+        it, which is how the ENG-836 driver ping-pong (interleaved false
+        "successes") kept the breaker asleep at ~4.95M tokens.
+        """
+        if ok is not None:
+            is_error = not ok
+        else:
+            is_error = any(
+                marker in result_text
+                for marker in (
+                    "[error]",
+                    "Task failed:",
+                    "failed",
+                    "timed out",
+                    "Rejected:",
+                )
             )
-        )
+            if is_error:
+                logger.info(
+                    "tool-failure classified by text fallback for '%s' — "
+                    "handler not yet migrated to ToolOutcome (ENG-1276)",
+                    tool_name,
+                )
         if is_error:
             error_streak[tool_name] = error_streak.get(tool_name, 0) + 1
         else:
@@ -2093,11 +2115,18 @@ class ChatSession:
             tool_results: list[dict] = []
             for tc in response.tool_calls:
                 try:
-                    result = await self.tool_registry.dispatch_tool(
+                    outcome = await self.tool_registry.dispatch_tool(
                         self, tc.name, tc.input
                     )
                 except Exception as exc:
-                    result = f"Tool '{tc.name}' failed: {exc}"
+                    # A raise is a definitive failure verdict — no text
+                    # classification needed (ENG-1276).
+                    outcome = ToolOutcome(
+                        content=f"Tool '{tc.name}' failed: {exc}",
+                        ok=False,
+                        reason=type(exc).__name__,
+                    )
+                result = outcome.content
 
                 if isinstance(result, list):
                     # Multimodal tool result — scrub credentials from text
@@ -2121,6 +2150,7 @@ class ChatSession:
                         tc.name,
                         error_streak,
                         resilience_nudged,
+                        ok=outcome.ok,
                     )
                     content = result
 
@@ -2731,12 +2761,17 @@ class ChatSession:
 
                     _tool_t0 = _time.monotonic()
 
+                    # The handler's own failure verdict, when it gave one —
+                    # drives the error streak instead of text matching
+                    # (ENG-1276). None = unmigrated handler → legacy fallback.
+                    tool_ok: bool | None = None
                     try:
                         if tc.name == "scratchpad" and tc.input.get("action") == "exec":
                             # Inline streaming exec — yields progress events
                             prep = await prepare_scratchpad_exec(self, tc.input)
-                            if isinstance(prep, str):
-                                result_text = prep
+                            if isinstance(prep, ToolOutcome):
+                                result_text = prep.content
+                                tool_ok = prep.ok
                             else:
                                 (
                                     pad,
@@ -2783,6 +2818,14 @@ class ChatSession:
                                     if cell
                                     else "No result produced."
                                 )
+                                # The runtime's verdict, not a text guess: a
+                                # cell with a raised error/timeout/kill failed;
+                                # stderr-only output (warnings) is not a
+                                # failure for streak purposes. A cancelled
+                                # exec (cell is None) stays None — neither
+                                # success nor failure (ENG-1276).
+                                if cell is not None:
+                                    tool_ok = not (cell.error or "").strip()
                                 if cell is not None:
                                     self._record_cell_explainability(
                                         pad_name=tc.input.get("name", ""),
@@ -2827,9 +2870,11 @@ class ChatSession:
                             if self._escape_watcher:
                                 self._escape_watcher.pause()
                             try:
-                                result_text = await self.tool_registry.dispatch_tool(
+                                _outcome = await self.tool_registry.dispatch_tool(
                                     self, tc.name, tc.input
                                 )
+                                result_text = _outcome.content
+                                tool_ok = _outcome.ok
                             finally:
                                 if self._escape_watcher:
                                     self._escape_watcher.resume()
@@ -2843,9 +2888,11 @@ class ChatSession:
                                 phase="tool_start",
                                 message=tc.name,
                             )
-                            result_text = await self.tool_registry.dispatch_tool(
+                            _outcome = await self.tool_registry.dispatch_tool(
                                 self, tc.name, tc.input
                             )
+                            result_text = _outcome.content
+                            tool_ok = _outcome.ok
                             _tool_elapsed = _time.monotonic() - _tool_t0
                             yield StreamTaskProgress(
                                 phase="tool_done",
@@ -2863,7 +2910,9 @@ class ChatSession:
                                     + result_text
                                 )
                     except Exception as exc:
+                        # A raise is a definitive failure verdict (ENG-1276).
                         result_text = f"Tool '{tc.name}' failed: {exc}"
+                        tool_ok = False
 
                     if isinstance(result_text, list):
                         # Multimodal tool result — scrub credentials from text
@@ -2911,20 +2960,21 @@ class ChatSession:
                         )
                     result_text = scrub_credentials(result_text)
                     result_text = self._apply_error_tracking(
-                        result_text, tc.name, error_streak, resilience_nudged
+                        result_text, tc.name, error_streak, resilience_nudged,
+                        ok=tool_ok,
                     )
-                    # ACC: tool_result emit. Heuristic success-detection
-                    # from the result text — anton-core does not have a
-                    # structured success/error envelope at this layer,
-                    # so we look for the conventional "Tool 'X' failed"
-                    # prefix that the exception branch above sets, plus
-                    # any handler that prefixed its return with "Error:"
-                    # or the dispatcher's own error-tracking markers.
-                    _failed = (
-                        f"Tool '{tc.name}' failed:" in result_text
-                        or result_text.startswith("Error:")
-                        or "ERROR:" in result_text[:200].upper()
-                    )
+                    # ACC: tool_result emit. Prefer the handler's own verdict
+                    # (ENG-1276); heuristic text-detection only for handlers
+                    # that haven't declared one — the conventional
+                    # "Tool 'X' failed" prefix plus "Error:"-prefixed returns.
+                    if tool_ok is not None:
+                        _failed = not tool_ok
+                    else:
+                        _failed = (
+                            f"Tool '{tc.name}' failed:" in result_text
+                            or result_text.startswith("Error:")
+                            or "ERROR:" in result_text[:200].upper()
+                        )
                     self._acc_observe(
                         "tool_result",
                         {

--- a/anton/core/tools/registry.py
+++ b/anton/core/tools/registry.py
@@ -1,10 +1,41 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from anton.core.session import ChatSession
     from anton.core.tools.tool_defs import ToolDef
+
+
+@dataclass
+class ToolOutcome:
+    """A tool result plus the handler's own verdict on whether it failed.
+
+    The failure signal drives the per-tool error streak (resilience nudge at
+    2, circuit breaker at 5). It used to be re-derived by substring-matching
+    the result text, which misclassified in both directions: a success whose
+    output contained the word "failed" incremented the streak, and a genuine
+    failure whose text lacked all five marker phrases RESET it — the
+    mechanism behind the ENG-836 runaway, where interleaved false
+    "successes" kept the breaker asleep for ~50 minutes (ENG-1276).
+
+    ``ok``:
+      - True/False — the handler's explicit verdict; classification uses it
+        directly.
+      - None — the handler hasn't been migrated; the dispatcher falls back
+        to the legacy substring match and logs when that fallback classifies
+        an error, so remaining call sites are discoverable rather than
+        assumed.
+
+    ``reason`` is a short, machine-comparable cause (exception type, missing
+    library name). Unused by the streak itself today; it is the input the
+    ENG-1286 root-cause thrash breaker keys on.
+    """
+
+    content: str | list[dict]
+    ok: bool | None = None
+    reason: str = field(default="")
 
 
 class ToolRegistry:
@@ -30,12 +61,21 @@ class ToolRegistry:
 
     async def dispatch_tool(
         self, session: "ChatSession", tool_name: str, tc_input: dict
-    ) -> "str | list[dict]":
-        """Dispatch a tool call by name. Returns result text or multimodal blocks."""
+    ) -> ToolOutcome:
+        """Dispatch a tool call by name.
+
+        Always returns a ``ToolOutcome``. Handlers that return a plain string
+        or multimodal block list are wrapped with ``ok=None`` (not yet
+        migrated → legacy substring classification applies); handlers that
+        return a ``ToolOutcome`` declare their own verdict (ENG-1276).
+        """
         tool_def = next((t for t in self._tools if t.name == tool_name), None)
         if tool_def is None:
             raise ValueError(f"Tool {tool_name} not found")
-        return await tool_def.handler(session, tc_input)
+        result = await tool_def.handler(session, tc_input)
+        if isinstance(result, ToolOutcome):
+            return result
+        return ToolOutcome(content=result)
 
     def unregister_tool(self, name: str) -> None:
         """Remove a tool by name. No-op if not found."""

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from anton.core.backends.base import Cell
+from anton.core.tools.registry import ToolOutcome
 from anton.core.utils.scratchpad import (
     prepare_scratchpad_exec,
     format_cell_result,
@@ -397,13 +398,27 @@ async def handle_memorize(session: ChatSession, tc_input: dict) -> str:
     return "Memory updated: " + "; ".join(descriptions)
 
 
-async def handle_scratchpad(session: ChatSession, tc_input: dict) -> str:
-    """Dispatch a scratchpad tool call by action."""
+async def handle_scratchpad(
+    session: ChatSession, tc_input: dict
+) -> str | ToolOutcome:
+    """Dispatch a scratchpad tool call by action.
+
+    The exec path returns a ``ToolOutcome`` carrying the runtime's own
+    failure verdict, so the error streak doesn't re-classify the result by
+    reading it (ENG-1276). The other actions still return plain strings
+    (legacy substring classification).
+    """
     action = tc_input.get("action", "")
     name = tc_input.get("name", "")
 
     if not name:
-        return "Scratchpad name is required."
+        # Explicit failure: this text has no legacy marker phrase, so the
+        # substring fallback used to RESET the streak on it (ENG-1276).
+        return ToolOutcome(
+            content="Scratchpad name is required.",
+            ok=False,
+            reason="scratchpad_missing_name",
+        )
 
     # ACC emit helper: use the session's safe wrapper if it exists,
     # otherwise no-op. Defined as a local closure so each emit site
@@ -421,7 +436,7 @@ async def handle_scratchpad(session: ChatSession, tc_input: dict) -> str:
         # paths. A str return is a message the call should not run past
         # (empty code, single-scratchpad challenge, or install failure).
         result = await prepare_scratchpad_exec(session, tc_input)
-        if isinstance(result, str):
+        if isinstance(result, ToolOutcome):
             return result
         pad, code, description, estimated_time, estimated_seconds = result
 
@@ -453,13 +468,27 @@ async def handle_scratchpad(session: ChatSession, tc_input: dict) -> str:
             # Post-execute ACC event (killed vs result) via the shared helper —
             # the streaming path emits the same.
             observe_scratchpad_cell(session, name, cell)
-        return format_cell_result(cell)
+        # The runtime's verdict: a raised error/timeout/kill is a failure;
+        # stderr-only output (warnings) is not, and stdout containing words
+        # like "failed" is not either — the streak reads this flag, never the
+        # text (ENG-1276). The reason is the traceback's LAST line (the cause),
+        # the machine-comparable key ENG-1286's thrash breaker will consume.
+        error = (cell.error or "").strip() if cell is not None else ""
+        return ToolOutcome(
+            content=format_cell_result(cell),
+            ok=not error,
+            reason=error.splitlines()[-1][:160] if error else "",
+        )
 
     elif action == "view":
         # get_or_create: new ChatSession has empty _pads but replayed cells on the
         # manager — same hydration path as exec so view works on the first tool call.
         pad = await session._scratchpads.get_or_create(name)
-        return pad.view()
+        # ok=True: viewing succeeded even when the notebook being viewed
+        # contains old "[error]" cells — the substring fallback used to count
+        # a successful view of a failed cell as a fresh tool failure
+        # (ENG-1276 false positive).
+        return ToolOutcome(content=pad.view(), ok=True)
 
     elif action == "reset":
         pad = session._scratchpads.pads.get(name)
@@ -480,7 +509,9 @@ async def handle_scratchpad(session: ChatSession, tc_input: dict) -> str:
         # get_or_create: dump must materialize the runtime from replayed cells when this
         # is the first scratchpad call in a new session (pads.get would miss every time).
         pad = await session._scratchpads.get_or_create(name)
-        return pad.render_notebook()
+        # ok=True for the same reason as view: rendering a notebook whose
+        # cells include past "[error]" output is a success, not a failure.
+        return ToolOutcome(content=pad.render_notebook(), ok=True)
 
     elif action == "install":
         packages = tc_input.get("packages", [])

--- a/anton/core/utils/scratchpad.py
+++ b/anton/core/utils/scratchpad.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
+from anton.core.tools.registry import ToolOutcome
+
 if TYPE_CHECKING:
     from anton.core.session import ChatSession
 
@@ -45,8 +47,10 @@ async def prepare_scratchpad_exec(session: ChatSession, tc_input: dict):
     """Validate and prepare a scratchpad exec call.
 
     Returns (pad, code, description, estimated_time, estimated_seconds) or
-    a str message if the call should not run (empty code, a single-scratchpad
-    challenge, or a failed package install).
+    a ToolOutcome whose content is the message when the call should not run
+    (empty code, a single-scratchpad challenge, or a failed package install).
+    The outcome carries the explicit failure verdict, so the error streak no
+    longer depends on the message's wording (ENG-1276).
 
     This is the SHARED entry point for both exec paths — `handle_scratchpad`
     (CLI) and the inline streaming exec in `ChatSession.turn_stream` (cowork)
@@ -61,17 +65,21 @@ async def prepare_scratchpad_exec(session: ChatSession, tc_input: dict):
         # to run nothing — it's the large-payload drop: an oversized `code`
         # argument gets truncated to "" in transit. Returning a bare "no
         # code" here used to read as a no-op, so the model would retry the
-        # same oversized cell. Make the failure self-correcting and ensure
-        # it reads as an error (note the word "failed") so the per-tool
-        # error streak in _apply_error_tracking counts it toward the
-        # circuit breaker instead of silently resetting.
+        # same oversized cell. The explicit ok=False is what counts it toward
+        # the circuit breaker — the message's wording no longer matters to
+        # classification (it used to need the word "failed" for the substring
+        # matcher, ENG-1276).
         _acc_observe(session, "scratchpad_empty_code", {"name": name}, severity=7)
-        return (
-            "Scratchpad exec failed: the `code` argument was empty. This usually "
-            "means the code payload was too large and got truncated in transit. "
-            "Do NOT retry the same large cell — instead write the output to disk in "
-            "small append steps (open(path, 'a'), keep each cell's string under ~5KB), "
-            "or generate the content inside the cell rather than passing a big literal."
+        return ToolOutcome(
+            content=(
+                "Scratchpad exec failed: the `code` argument was empty. This usually "
+                "means the code payload was too large and got truncated in transit. "
+                "Do NOT retry the same large cell — instead write the output to disk in "
+                "small append steps (open(path, 'a'), keep each cell's string under ~5KB), "
+                "or generate the content inside the cell rather than passing a big literal."
+            ),
+            ok=False,
+            reason="scratchpad_empty_code",
         )
 
     # Single-scratchpad guard: the agent should reuse ONE scratchpad per task.
@@ -117,14 +125,20 @@ async def prepare_scratchpad_exec(session: ChatSession, tc_input: dict):
     if name not in known and known and not confirm_new and not challenged_before:
         session._scratchpad_challenged = True
         existing = "', '".join(sorted(known))
-        return (
-            f"You already have an active scratchpad ('{existing}') with live state "
-            f"(imports, variables, fetched data). Starting a new one named '{name}' "
-            "creates a SEPARATE, empty environment — nothing from the existing "
-            "scratchpad is available there, so you'd re-import and re-fetch. Reuse the "
-            "existing scratchpad for this task; it is stateful across cells. If you "
-            "genuinely need an isolated environment, call scratchpad exec again with "
-            "confirm_new_scratchpad=true."
+        # ok=True: the challenge is guidance, not a tool failure — it must
+        # not count toward the error streak (it previously relied on its
+        # wording happening to avoid the substring markers, ENG-1276).
+        return ToolOutcome(
+            content=(
+                f"You already have an active scratchpad ('{existing}') with live state "
+                f"(imports, variables, fetched data). Starting a new one named '{name}' "
+                "creates a SEPARATE, empty environment — nothing from the existing "
+                "scratchpad is available there, so you'd re-import and re-fetch. Reuse the "
+                "existing scratchpad for this task; it is stateful across cells. If you "
+                "genuinely need an isolated environment, call scratchpad exec again with "
+                "confirm_new_scratchpad=true."
+            ),
+            ok=True,
         )
     seen.add(name)
     if manager is not None and hasattr(manager, "record_agent_pad"):
@@ -139,8 +153,13 @@ async def prepare_scratchpad_exec(session: ChatSession, tc_input: dict):
     packages = tc_input.get("packages", [])
     if packages:
         install_result = await pad.install_packages(packages)
+        # The substring check against install_packages' message is this
+        # handler's own protocol with the runtime (its return shape predates
+        # ToolOutcome); the verdict it produces is explicit from here on out.
         if "Install failed" in install_result or "timed out" in install_result:
-            return install_result
+            return ToolOutcome(
+                content=install_result, ok=False, reason="package_install_failed"
+            )
 
     description = tc_input.get("one_line_description", "")
     estimated_seconds = tc_input.get("estimated_execution_time_seconds", 0)

--- a/tests/test_cerebellum_e2e.py
+++ b/tests/test_cerebellum_e2e.py
@@ -28,7 +28,19 @@ from anton.core.memory.cerebellum import (
     _LessonDraft,
 )
 from anton.core.memory.hippocampus import Engram
-from anton.core.tools.tool_handlers import handle_scratchpad
+from anton.core.tools.registry import ToolOutcome
+from anton.core.tools.tool_handlers import handle_scratchpad as _handle_scratchpad
+
+async def handle_scratchpad(session, tc_input):
+    """Test shim: unwrap ToolOutcome so string assertions keep reading the text.
+
+    Handlers migrated to explicit outcomes (ENG-1276) return ToolOutcome; these
+    tests assert on the human-readable content. Outcome-field coverage lives in
+    test_tool_outcome_tracking.py.
+    """
+    result = await _handle_scratchpad(session, tc_input)
+    return result.content if isinstance(result, ToolOutcome) else result
+
 
 
 def _build_session_with_cerebellum(

--- a/tests/test_scratchpad_observer_dispatch.py
+++ b/tests/test_scratchpad_observer_dispatch.py
@@ -21,9 +21,21 @@ from anton.core.backends.base import Cell
 from anton.core.tools.tool_handlers import (
     _fire_post_execute,
     _fire_pre_execute,
-    handle_scratchpad,
+    handle_scratchpad as _handle_scratchpad,
 )
+from anton.core.tools.registry import ToolOutcome
 from anton.core.utils.scratchpad import observe_scratchpad_cell
+
+
+async def handle_scratchpad(session, tc_input):
+    """Test shim: unwrap ToolOutcome so string assertions keep reading the text.
+
+    Handlers migrated to explicit outcomes (ENG-1276) return ToolOutcome; these
+    tests assert on the human-readable content. Outcome-field coverage lives in
+    test_tool_outcome_tracking.py.
+    """
+    result = await _handle_scratchpad(session, tc_input)
+    return result.content if isinstance(result, ToolOutcome) else result
 
 
 class _RecordingAccSession:

--- a/tests/test_session_skills_init.py
+++ b/tests/test_session_skills_init.py
@@ -100,9 +100,9 @@ class TestDispatchRoundtrip:
         # Minimal session-like object — only `_skill_store` is read by the handler.
         session = SimpleNamespace(_skill_store=store_with_one_skill)
 
-        result = await registry.dispatch_tool(
+        result = (await registry.dispatch_tool(
             session, "recall_skill", {"label": "csv_summary"}
-        )
+        )).content
 
         assert "CSV Summary" in result
         assert "Load CSV" in result
@@ -118,9 +118,9 @@ class TestDispatchRoundtrip:
         registry.register_tool(RECALL_SKILL_TOOL)
         session = SimpleNamespace(_skill_store=store_with_one_skill)
 
-        result = await registry.dispatch_tool(
+        result = (await registry.dispatch_tool(
             session, "recall_skill", {"label": "nonexistent_xyz"}
-        )
+        )).content
 
         assert "NO MATCH" in result
         # Counter should NOT have moved

--- a/tests/test_skills_e2e.py
+++ b/tests/test_skills_e2e.py
@@ -137,9 +137,9 @@ async def test_full_skills_loop(console, store_root):
     registry.register_tool(RECALL_SKILL_TOOL)
     fresh_session = SimpleNamespace(_skill_store=fresh_store)
 
-    result = await registry.dispatch_tool(
+    result = (await registry.dispatch_tool(
         fresh_session, "recall_skill", {"label": "csv-summary"}
-    )
+    )).content
 
     assert "CSV Summary" in result
     assert "pandas.read_csv" in result
@@ -153,9 +153,9 @@ async def test_full_skills_loop(console, store_root):
     assert after_recall_1.stats.stage_1.last_used  # ISO timestamp present
 
     # ── Step 4: Recall again with a typo — closest_match recovers ───────
-    typo_result = await registry.dispatch_tool(
+    typo_result = (await registry.dispatch_tool(
         fresh_session, "recall_skill", {"label": "csv_sumary"}  # missing 'm'
-    )
+    )).content
     assert "⚠" in typo_result
     assert "csv-summary" in typo_result
     assert "pandas.read_csv" in typo_result  # full procedure still returned

--- a/tests/test_tool_outcome_tracking.py
+++ b/tests/test_tool_outcome_tracking.py
@@ -1,0 +1,203 @@
+"""Explicit tool-failure outcomes drive the error streak, not text search (ENG-1276).
+
+The per-tool failure streak (resilience nudge at 2, circuit breaker at 5) used
+to be derived by substring-matching five phrases against the result text. That
+misclassified in both directions: a success whose output contained "failed"
+incremented the streak, and a genuine failure using none of the phrases RESET
+it — the mechanism that kept the breaker asleep through the ENG-836 runaway
+(interleaved false "successes" cleared the counter for ~50 minutes).
+
+Covers each ENG-1276 Done-when bullet:
+- a successful result containing "failed" does not increment the streak
+- a genuine failure whose text lacks all five markers does increment it
+- unmigrated handlers (ok=None) keep the legacy substring behaviour, and the
+  fallback logs when it classifies an error so call sites stay discoverable
+- the ENG-350 empty-code rejection is counted by its explicit ok=False, not
+  by the word "failed" in its message, and still trips the breaker
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from anton.core.session import ChatSession
+from anton.core.tools.registry import ToolOutcome, ToolRegistry
+from anton.core.tools.tool_defs import ToolDef
+from anton.core.utils.scratchpad import prepare_scratchpad_exec
+
+
+def _session() -> ChatSession:
+    """A bare object carrying only what _apply_error_tracking reads."""
+    s = ChatSession.__new__(ChatSession)
+    s._resilience_nudge_at = 2
+    s._max_consecutive_errors = 5
+    return s
+
+
+def _track(s, text, *, ok, streak, nudged=None, tool="scratchpad"):
+    return ChatSession._apply_error_tracking(
+        s, text, tool, streak, nudged if nudged is not None else set(), ok=ok
+    )
+
+
+BREAKER_MARK = "times in a row. Stop retrying this approach."
+
+
+class TestExplicitOutcomeClassification:
+    def test_success_containing_failed_does_not_increment(self):
+        # The false positive: "[output]\n0 records failed validation" is a
+        # SUCCESS. Under substring matching it incremented the streak; the
+        # handler's ok=True verdict must win.
+        s, streak = _session(), {"scratchpad": 3}
+        _track(s, "[output]\n0 records failed validation", ok=True, streak=streak)
+        assert streak["scratchpad"] == 0
+
+    def test_failure_without_any_marker_increments(self):
+        # The false negative behind ENG-836: a genuine failure whose text
+        # uses none of the five phrases used to RESET the streak.
+        s, streak = _session(), {}
+        text = "HTTP 404: the requested .deb package does not exist"
+        _track(s, text, ok=False, streak=streak)
+        assert streak["scratchpad"] == 1
+
+    def test_interleaved_false_success_no_longer_resets(self):
+        # The Kiranam shape: error, "success" that achieved nothing but whose
+        # handler still reports the truth, error... With explicit outcomes the
+        # streak survives only through real successes.
+        s, streak, nudged = _session(), {}, set()
+        _track(s, "ImportError: libodbc.so.2 missing", ok=False, streak=streak, nudged=nudged)
+        _track(s, "downloaded page saved", ok=False, streak=streak, nudged=nudged)
+        _track(s, "E: Permission denied", ok=False, streak=streak, nudged=nudged)
+        assert streak["scratchpad"] == 3
+
+    def test_five_explicit_failures_trip_the_breaker(self):
+        s, streak, nudged = _session(), {}, set()
+        out = ""
+        for i in range(5):
+            # No marker phrase anywhere — classification is purely ok=False.
+            out = _track(s, f"clean failure text {i}", ok=False, streak=streak, nudged=nudged)
+        assert streak["scratchpad"] == 5
+        assert BREAKER_MARK in out
+
+    def test_explicit_success_resets_streak_and_nudge_latch(self):
+        s, streak, nudged = _session(), {"scratchpad": 4}, {"scratchpad"}
+        _track(s, "all good", ok=True, streak=streak, nudged=nudged)
+        assert streak["scratchpad"] == 0
+        assert "scratchpad" not in nudged
+
+
+class TestLegacyFallback:
+    def test_unmigrated_marker_text_still_counts(self):
+        # ok=None → the five-phrase substring match still applies, unchanged.
+        s, streak = _session(), {}
+        _track(s, "[error]\nTraceback ...", ok=None, streak=streak)
+        assert streak["scratchpad"] == 1
+
+    def test_unmigrated_clean_text_still_resets(self):
+        s, streak = _session(), {"scratchpad": 2}
+        _track(s, "fetched 200 OK", ok=None, streak=streak)
+        assert streak["scratchpad"] == 0
+
+    def test_fallback_classification_is_logged(self, caplog):
+        # The ticket's discoverability requirement: when the fallback (not an
+        # explicit outcome) classifies an error, it logs — so remaining
+        # unmigrated handlers can be found instead of assumed.
+        s, streak = _session(), {}
+        with caplog.at_level(logging.INFO, logger="anton.core.session"):
+            _track(s, "Task failed: boom", ok=None, streak=streak)
+        assert any("text fallback" in r.message for r in caplog.records)
+
+    def test_explicit_outcome_does_not_log_fallback(self, caplog):
+        s, streak = _session(), {}
+        with caplog.at_level(logging.INFO, logger="anton.core.session"):
+            _track(s, "clean failure text", ok=False, streak=streak)
+        assert not any("text fallback" in r.message for r in caplog.records)
+
+
+class TestRegistryEnvelope:
+    @pytest.mark.asyncio
+    async def test_plain_string_handler_wraps_as_unclassified(self):
+        registry = ToolRegistry()
+        registry.register_tool(
+            ToolDef(name="t", description="", input_schema={}, handler=AsyncMock(return_value="hi"))
+        )
+        outcome = await registry.dispatch_tool(SimpleNamespace(), "t", {})
+        assert isinstance(outcome, ToolOutcome)
+        assert outcome.content == "hi"
+        assert outcome.ok is None
+
+    @pytest.mark.asyncio
+    async def test_outcome_returning_handler_passes_through(self):
+        declared = ToolOutcome(content="nope", ok=False, reason="boom")
+        registry = ToolRegistry()
+        registry.register_tool(
+            ToolDef(name="t", description="", input_schema={}, handler=AsyncMock(return_value=declared))
+        )
+        outcome = await registry.dispatch_tool(SimpleNamespace(), "t", {})
+        assert outcome is declared
+
+    @pytest.mark.asyncio
+    async def test_multimodal_list_handler_wraps_content_intact(self):
+        blocks = [{"type": "image", "source": {}}]
+        registry = ToolRegistry()
+        registry.register_tool(
+            ToolDef(name="t", description="", input_schema={}, handler=AsyncMock(return_value=blocks))
+        )
+        outcome = await registry.dispatch_tool(SimpleNamespace(), "t", {})
+        assert outcome.content is blocks
+        assert outcome.ok is None
+
+
+def _exec_session() -> SimpleNamespace:
+    """Session stub for prepare_scratchpad_exec (guard + ACC reads only)."""
+    return SimpleNamespace(
+        _acc_observe=None,
+        _agent_scratchpad_names=set(),
+        _scratchpads=MagicMock(agent_pads=MagicMock(return_value=set())),
+        _scratchpad_challenged=False,
+    )
+
+
+class TestScratchpadOutcomes:
+    @pytest.mark.asyncio
+    async def test_empty_code_rejection_is_explicit_failure(self):
+        # ENG-350's rejection used to need the word "failed" in its text for
+        # the substring matcher to count it toward the breaker. The
+        # classification is now the ok flag, not the wording.
+        outcome = await prepare_scratchpad_exec(
+            _exec_session(), {"action": "exec", "name": "main", "code": "  "}
+        )
+        assert isinstance(outcome, ToolOutcome)
+        assert outcome.ok is False
+        assert outcome.reason == "scratchpad_empty_code"
+
+    def test_empty_code_rejection_trips_breaker_without_wording(self):
+        # Belt over the flag: five rejections reach the breaker even if the
+        # message were reworded to avoid every legacy marker phrase.
+        s, streak, nudged = _session(), {}, set()
+        out = ""
+        for _ in range(5):
+            out = _track(
+                s,
+                "the `code` argument was empty — write output in small steps",
+                ok=False,
+                streak=streak,
+                nudged=nudged,
+            )
+        assert BREAKER_MARK in out
+
+    @pytest.mark.asyncio
+    async def test_single_scratchpad_challenge_is_not_a_failure(self):
+        # The challenge is guidance; it must not count toward the streak.
+        # Previously that depended on its wording avoiding the marker phrases.
+        session = _exec_session()
+        session._agent_scratchpad_names = {"dash"}
+        outcome = await prepare_scratchpad_exec(
+            session, {"action": "exec", "name": "report", "code": "print(1)"}
+        )
+        assert isinstance(outcome, ToolOutcome)
+        assert outcome.ok is True


### PR DESCRIPTION
# ENG-1276: explicit tool-failure outcomes drive the error streak, not text search

anton decided whether a tool result was a failure by searching its text for five phrases (`[error]`, `Task failed:`, `failed`, `timed out`, `Rejected:`). That drives the per-tool failure streak → resilience nudge (at 2) → circuit breaker (at 5), and it misclassified in both directions. The false-negative direction is the mechanism behind the ENG-836 runaway: genuine failures whose text lacked the phrases **reset** the streak, so ~50 minutes of driver ping-pong with interleaved false "successes" never counted to five. The error taxonomy was being carried in prose — ENG-350's rejection message literally had a comment saying the word "failed" was there so the matcher would count it.

[Linear ENG-1276](https://linear.app/mindsdb/issue/ENG-1276)

## What changed

1. **`ToolOutcome` envelope** (`registry.py`): `dispatch_tool` now always returns `ToolOutcome(content, ok, reason)`. Handlers returning plain `str | list` wrap as `ok=None` (unmigrated); handlers can declare their verdict by returning an outcome. `reason` is a short machine-comparable cause — unused by the streak, but it is the input the ENG-1286 root-cause thrash breaker will key on.
2. **`_apply_error_tracking(..., ok=None)`** (`session.py`): an explicit verdict decides outright; `ok=None` falls back to the legacy substring match **and logs when the fallback classifies an error**, so remaining unmigrated handlers are discoverable rather than assumed. Both turn paths (non-streaming + streaming) thread the outcome through; the session's own `except` branches are definitive `ok=False`; the streaming ACC `tool_result` emit prefers the verdict over its old text heuristic.
3. **Scratchpad migrated end-to-end** (the ENG-836 tool):
   - exec: `ok` comes from the runtime's own cell verdict (`cell.error`), `reason` is the traceback's **last line** (the cause). stderr-only warnings are not failures; stdout containing "failed" is not a failure.
   - ENG-350's empty-code rejection: counted by `ok=False`, the wording no longer matters (comment updated; the "must contain *failed*" workaround is dead).
   - single-scratchpad challenge: explicitly `ok=True` — guidance, not a failure (previously depended on its wording happening to avoid the markers).
   - view/dump: `ok=True` — rendering a notebook whose *old* cells contain `[error]` is a success; under substring matching a successful view of a failed cell counted as a fresh tool failure.

## Done-when → test map (`tests/test_tool_outcome_tracking.py`, 15 tests)

| Done-when | test |
|---|---|
| classification from the tool's own outcome | `TestExplicitOutcomeClassification` + registry envelope tests |
| success containing "failed" doesn't increment | `test_success_containing_failed_does_not_increment` |
| genuine failure lacking all five markers increments | `test_failure_without_any_marker_increments`, `test_five_explicit_failures_trip_the_breaker` |
| ENG-350 message counted without the word "failed" + still trips breaker | `test_empty_code_rejection_is_explicit_failure`, `test_empty_code_rejection_trips_breaker_without_wording` |
| fallback discoverability | `test_fallback_classification_is_logged` |

Also: `test_interleaved_false_success_no_longer_resets` pins the exact ENG-836 shape.

## Compatibility

- Unmigrated handlers (web tools, datasource, skills, …) keep byte-identical behavior via the `ok=None` fallback; the log line makes them findable for organic migration.
- Existing tests that call `handle_scratchpad`/`dispatch_tool` directly unwrap via a small shim; assertions unchanged.
- Full suite: 1458 passed locally (the 2 `test_chat_scratchpad` failures are a pre-existing local-sandbox quirk in this checkout — they fail identically on clean `origin/staging` and pass in CI).

## Security pass

No new inputs parsed, no secrets touched. `ToolOutcome.reason` carries at most the last line of a traceback (≤160 chars) and stays in-process — it is not logged and not sent to the model beyond what the result text already contained. The new fallback log line contains only the tool name, never result content.
