### PR TITLE
ENG-1288: per-turn token cost counter — log line + turn_completed analytics event

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -5,21 +5,36 @@ configured analytics URL.  The request carries the action name, a timestamp,
 an anonymous machine fingerprint, and whatever the caller passes as
 ``extra`` query parameters.  No conversation content, ever.
 
-Identifier policy (updated for ENG-1288)
-========================================
+Where these events actually land
+================================
 
-Events were originally fingerprint-only, i.e. anonymous in the strong sense:
-nothing on the wire could be tied back to a user.  ``turn_completed`` (the
-per-turn cost event) is the first caller to send an opaque **join key** —
-``conversation_id``, the same value emitted as ``Langfuse-Session-Id`` — so a
-turn's cost can be tied to its trace when investigating a runaway.
+The collector lambda RELAYS into PostHog — verified 2026-08-06 against
+project 355390 ("Anton"), where anton's events appear tagged
+``source = mindsdb-zoominfo-lambda``.  Two consequences worth knowing before
+adding a caller:
 
-That makes these events *pseudonymous*, not anonymous: the id itself carries
-no personal data, but anyone holding BOTH collector data and Langfuse access
-can resolve it to a user (Langfuse traces are tagged with user emails).  Both
-are internal systems with their own access controls, and the join is the
-point of the field — but the distinction is deliberate and documented here so
-the next caller doesn't assume this channel is unlinkable.
+* **Every ``extra`` kwarg becomes a queryable PostHog event property.**  Not
+  an allowlist — ``ds_connect_success`` carries its ``engine=postgres``
+  through, and ``turn_completed`` carries its full token breakdown.  So the
+  parameter names here ARE the analytics schema; renaming one silently breaks
+  whatever queries or dashboards read it.
+* **``distinct_id`` is the ``aid`` fingerprint, so these events are
+  per-INSTALL, not per-user.**  They do not join to the Keycloak ``sub`` that
+  the console, the desktop renderer's PostHog client, and the billing mirror
+  all key on.  Per-user questions need either that identified client or the
+  ``conversation_id`` -> Langfuse -> user hop.
+* PostHog additionally enriches server-side with IP and GeoIP.
+
+Identifier policy
+=================
+
+Events were originally fingerprint-only.  ``turn_completed`` (the per-turn
+cost event) also sends an opaque **join key** — ``conversation_id``, the same
+value emitted as ``Langfuse-Session-Id`` — so a turn's cost can be tied to
+its trace when investigating a runaway.  The id carries no personal data on
+its own; resolving it to a person requires Langfuse access, and Langfuse
+already holds the full conversation content for the same session, so this
+adds no disclosure that path doesn't already have.
 
 Still never sent, by any caller: message text, prompts, tool output, file
 paths, credentials, hostnames, or email addresses.

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -1,9 +1,28 @@
-"""Fire-and-forget anonymous analytics events.
+"""Fire-and-forget analytics events.
 
 Every call spawns a daemon thread that issues a single GET request to the
-configured analytics URL.  The request carries only the action name, a
-timestamp, and an anonymous machine fingerprint — no PII, no payload
-beyond what the query string contains.
+configured analytics URL.  The request carries the action name, a timestamp,
+an anonymous machine fingerprint, and whatever the caller passes as
+``extra`` query parameters.  No conversation content, ever.
+
+Identifier policy (updated for ENG-1288)
+========================================
+
+Events were originally fingerprint-only, i.e. anonymous in the strong sense:
+nothing on the wire could be tied back to a user.  ``turn_completed`` (the
+per-turn cost event) is the first caller to send an opaque **join key** —
+``conversation_id``, the same value emitted as ``Langfuse-Session-Id`` — so a
+turn's cost can be tied to its trace when investigating a runaway.
+
+That makes these events *pseudonymous*, not anonymous: the id itself carries
+no personal data, but anyone holding BOTH collector data and Langfuse access
+can resolve it to a user (Langfuse traces are tagged with user emails).  Both
+are internal systems with their own access controls, and the join is the
+point of the field — but the distinction is deliberate and documented here so
+the next caller doesn't assume this channel is unlinkable.
+
+Still never sent, by any caller: message text, prompts, tool output, file
+paths, credentials, hostnames, or email addresses.
 
 Guarantees:
   • Never blocks the caller.

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -1884,7 +1884,13 @@ async def _chat_loop(
                         elif isinstance(event, StreamContextCompacted):
                             display.show_context_compacted(event.message)
                         elif isinstance(event, StreamComplete):
-                            total_input += event.response.usage.input_tokens
+                            # ALL prompt-side tokens, not just the fresh ones:
+                            # `input_tokens` became fresh-only when cache
+                            # components were split out (ENG-1288), so reading
+                            # it alone would silently shrink this counter on
+                            # warm-cache turns — the same number it showed
+                            # before the split is `context_tokens`.
+                            total_input += event.response.usage.context_tokens
                             total_output += event.response.usage.output_tokens
 
                 elapsed = time.monotonic() - t0

--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -232,6 +232,11 @@ class AnthropicProvider(LLMProvider):
                 input_tokens=input_tokens,
                 output_tokens=response.usage.output_tokens,
                 context_pressure=compute_context_pressure(model, input_tokens),
+                # Anthropic reports cache activity as separate fields and its
+                # input_tokens already excludes them — pass through as-is
+                # (ENG-1288). getattr-guarded: absent on older SDK responses.
+                cache_read_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
+                cache_creation_tokens=getattr(response.usage, "cache_creation_input_tokens", 0) or 0,
             ),
             stop_reason=response.stop_reason,
         )
@@ -266,6 +271,8 @@ class AnthropicProvider(LLMProvider):
         tool_calls: list[ToolCall] = []
         input_tokens = 0
         output_tokens = 0
+        cache_read_tokens = 0
+        cache_creation_tokens = 0
         stop_reason: str | None = None
 
         # Track content blocks by index for tool correlation
@@ -285,6 +292,8 @@ class AnthropicProvider(LLMProvider):
                         usage = event.message.usage
                         input_tokens = usage.input_tokens
                         output_tokens = getattr(usage, "output_tokens", 0)
+                        cache_read_tokens = getattr(usage, "cache_read_input_tokens", 0) or 0
+                        cache_creation_tokens = getattr(usage, "cache_creation_input_tokens", 0) or 0
 
                     elif event.type == "content_block_start":
                         idx = event.index
@@ -402,6 +411,8 @@ class AnthropicProvider(LLMProvider):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     context_pressure=compute_context_pressure(model, input_tokens),
+                    cache_read_tokens=cache_read_tokens,
+                    cache_creation_tokens=cache_creation_tokens,
                 ),
                 stop_reason=stop_reason,
             )

--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
-from .provider import LLMProvider, LLMResponse, StreamEvent
+from .provider import LLMProvider, LLMResponse, StreamComplete, StreamEvent
 
 if TYPE_CHECKING:
     from anton.config.settings import AntonSettings
@@ -56,6 +57,26 @@ class LLMClient:
         self._router_provider = router_provider or coding_provider
         self._router_model = router_model or coding_model
         self._max_tokens = max_tokens
+        # ENG-1288: optional per-call usage observer. Every LLM call this
+        # client makes — plan/plan_stream (planning), code + structured
+        # coding calls like the completion verifier (coding), summarize/gate
+        # (router) — reports (role, model, usage) here. The session installs
+        # its per-turn cost accumulator; None means nobody is counting.
+        # Accounting must never break a call: notification is wrapped and
+        # swallowed (see _notify_usage).
+        self.usage_listener = None  # Callable[[str, str, Usage], None] | None
+
+    def _notify_usage(self, role: str, model: str, usage) -> None:
+        listener = self.usage_listener
+        if listener is None:
+            return
+        try:
+            listener(role, model, usage)
+        except Exception:
+            # A broken accumulator must never kill the turn it's counting.
+            logging.getLogger(__name__).warning(
+                "usage_listener raised — turn cost undercounted", exc_info=True
+            )
 
     async def plan(
         self,
@@ -66,7 +87,7 @@ class LLMClient:
         max_tokens: int | None = None,
         native_web_tools: set[str] | None = None,
     ) -> LLMResponse:
-        return await self._planning_provider.complete(
+        response = await self._planning_provider.complete(
             model=self._planning_model,
             system=system,
             messages=messages,
@@ -74,6 +95,8 @@ class LLMClient:
             max_tokens=max_tokens or self._max_tokens,
             native_web_tools=native_web_tools,
         )
+        self._notify_usage("planning", self._planning_model, response.usage)
+        return response
 
     async def plan_stream(
         self,
@@ -92,6 +115,10 @@ class LLMClient:
             max_tokens=max_tokens or self._max_tokens,
             native_web_tools=native_web_tools,
         ):
+            if isinstance(event, StreamComplete):
+                self._notify_usage(
+                    "planning", self._planning_model, event.response.usage
+                )
             yield event
 
     @property
@@ -109,6 +136,11 @@ class LLMClient:
         trusted at the cap (ENG-1082).
         """
         return self._max_tokens
+
+    @property
+    def planning_model(self) -> str:
+        """The model name used for planning / the user-facing turn loop."""
+        return self._planning_model
 
     @property
     def coding_provider(self) -> LLMProvider:
@@ -139,7 +171,7 @@ class LLMClient:
         max_tokens: int | None = None,
         native_web_tools: set[str] | None = None,
     ) -> LLMResponse:
-        return await self._coding_provider.complete(
+        response = await self._coding_provider.complete(
             model=self._coding_model,
             system=system,
             messages=messages,
@@ -147,6 +179,8 @@ class LLMClient:
             max_tokens=max_tokens or self._max_tokens,
             native_web_tools=native_web_tools,
         )
+        self._notify_usage("coding", self._coding_model, response.usage)
+        return response
 
     async def summarize(
         self,
@@ -161,12 +195,14 @@ class LLMClient:
         (the router_* kwargs default to the coding role in __init__), so
         this is behavior-preserving unless a distinct model is selected.
         """
-        return await self._router_provider.complete(
+        response = await self._router_provider.complete(
             model=self._router_model,
             system=system,
             messages=messages,
             max_tokens=max_tokens or self._max_tokens,
         )
+        self._notify_usage("router", self._router_model, response.usage)
+        return response
 
     async def gate(
         self,
@@ -182,7 +218,7 @@ class LLMClient:
         No ``native_web_tools``: the thalamus must never do work itself,
         only answer from context or delegate.
         """
-        return await self._router_provider.complete(
+        response = await self._router_provider.complete(
             model=self._router_model,
             system=system,
             messages=messages,
@@ -190,6 +226,8 @@ class LLMClient:
             tool_choice=tool_choice,
             max_tokens=max_tokens or self._max_tokens,
         )
+        self._notify_usage("router", self._router_model, response.usage)
+        return response
 
     async def _generate_object_with(
         self,
@@ -226,6 +264,15 @@ class LLMClient:
             tools=[tool],
             tool_choice={"type": "tool", "name": tool["name"]},
             max_tokens=budget,
+        )
+        # Count BEFORE the no-tool-call raise below: a structured call that
+        # failed (and its bigger-budget retry) still spent real tokens
+        # (ENG-1288). Role is coding for both generate_object variants today;
+        # derive it from the provider/model actually used.
+        self._notify_usage(
+            "planning" if model == self._planning_model else "coding",
+            model,
+            response.usage,
         )
 
         if not response.tool_calls:

--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -66,8 +66,18 @@ class LLMClient:
         # swallowed (see _notify_usage).
         self.usage_listener = None  # Callable[[str, str, Usage], None] | None
 
-    def _notify_usage(self, role: str, model: str, usage) -> None:
-        listener = self.usage_listener
+    def _notify_usage(self, role: str, model: str, usage, listener=None) -> None:
+        """Report one call's usage to the turn-cost accumulator.
+
+        ``listener`` must be the reference captured when the call was ISSUED,
+        not read here at completion time. End-of-turn fire-and-forget work
+        (cerebellum flush, identity update, scratchpad consolidation) shares
+        this client, so on a long-lived-session host a fast follow-up message
+        arms turn N+1's listener while turn N's flush is still in flight —
+        resolving late booked that usage into the wrong turn (#309 review).
+        Captured-at-issue means background calls started while disarmed book
+        nowhere, which is what ``turn_cost``'s docstring already promises.
+        """
         if listener is None:
             return
         try:
@@ -87,6 +97,7 @@ class LLMClient:
         max_tokens: int | None = None,
         native_web_tools: set[str] | None = None,
     ) -> LLMResponse:
+        listener = self.usage_listener
         response = await self._planning_provider.complete(
             model=self._planning_model,
             system=system,
@@ -95,7 +106,7 @@ class LLMClient:
             max_tokens=max_tokens or self._max_tokens,
             native_web_tools=native_web_tools,
         )
-        self._notify_usage("planning", self._planning_model, response.usage)
+        self._notify_usage("planning", self._planning_model, response.usage, listener)
         return response
 
     async def plan_stream(
@@ -107,6 +118,7 @@ class LLMClient:
         max_tokens: int | None = None,
         native_web_tools: set[str] | None = None,
     ) -> AsyncIterator[StreamEvent]:
+        listener = self.usage_listener
         async for event in self._planning_provider.stream(
             model=self._planning_model,
             system=system,
@@ -117,7 +129,7 @@ class LLMClient:
         ):
             if isinstance(event, StreamComplete):
                 self._notify_usage(
-                    "planning", self._planning_model, event.response.usage
+                    "planning", self._planning_model, event.response.usage, listener
                 )
             yield event
 
@@ -171,6 +183,7 @@ class LLMClient:
         max_tokens: int | None = None,
         native_web_tools: set[str] | None = None,
     ) -> LLMResponse:
+        listener = self.usage_listener
         response = await self._coding_provider.complete(
             model=self._coding_model,
             system=system,
@@ -179,7 +192,7 @@ class LLMClient:
             max_tokens=max_tokens or self._max_tokens,
             native_web_tools=native_web_tools,
         )
-        self._notify_usage("coding", self._coding_model, response.usage)
+        self._notify_usage("coding", self._coding_model, response.usage, listener)
         return response
 
     async def summarize(
@@ -195,13 +208,14 @@ class LLMClient:
         (the router_* kwargs default to the coding role in __init__), so
         this is behavior-preserving unless a distinct model is selected.
         """
+        listener = self.usage_listener
         response = await self._router_provider.complete(
             model=self._router_model,
             system=system,
             messages=messages,
             max_tokens=max_tokens or self._max_tokens,
         )
-        self._notify_usage("router", self._router_model, response.usage)
+        self._notify_usage("router", self._router_model, response.usage, listener)
         return response
 
     async def gate(
@@ -218,6 +232,7 @@ class LLMClient:
         No ``native_web_tools``: the thalamus must never do work itself,
         only answer from context or delegate.
         """
+        listener = self.usage_listener
         response = await self._router_provider.complete(
             model=self._router_model,
             system=system,
@@ -226,7 +241,7 @@ class LLMClient:
             tool_choice=tool_choice,
             max_tokens=max_tokens or self._max_tokens,
         )
-        self._notify_usage("router", self._router_model, response.usage)
+        self._notify_usage("router", self._router_model, response.usage, listener)
         return response
 
     async def _generate_object_with(
@@ -257,6 +272,7 @@ class LLMClient:
 
         budget = max_tokens or self._max_tokens
 
+        listener = self.usage_listener
         response = await provider.complete(
             model=model,
             system=system,
@@ -273,6 +289,7 @@ class LLMClient:
             "planning" if model == self._planning_model else "coding",
             model,
             response.usage,
+            listener,
         )
 
         if not response.tool_calls:

--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -250,6 +250,7 @@ class LLMClient:
         *,
         provider: LLMProvider,
         model: str,
+        role: str,
         system: str,
         messages: list[dict],
         max_tokens: int | None,
@@ -283,14 +284,13 @@ class LLMClient:
         )
         # Count BEFORE the no-tool-call raise below: a structured call that
         # failed (and its bigger-budget retry) still spent real tokens
-        # (ENG-1288). Role is coding for both generate_object variants today;
-        # derive it from the provider/model actually used.
-        self._notify_usage(
-            "planning" if model == self._planning_model else "coding",
-            model,
-            response.usage,
-            listener,
-        )
+        # (ENG-1288). The role is PASSED, not inferred from model equality:
+        # deployments exist where planning and coding resolve to the same
+        # model (cowork-server's Gemini defaults are identical across all
+        # three roles), and inference collapsed every generate_object_code
+        # call — verifier verdicts, compaction, identity extraction — into
+        # `planning`, defeating the split this exists to provide (#309 review).
+        self._notify_usage(role, model, response.usage, listener)
 
         if not response.tool_calls:
             # Shared with the scratchpad's sync twin so both paths classify the
@@ -369,6 +369,7 @@ class LLMClient:
             schema_class,
             provider=self._planning_provider,
             model=self._planning_model,
+            role="planning",
             system=system,
             messages=messages,
             max_tokens=max_tokens,
@@ -395,6 +396,7 @@ class LLMClient:
             schema_class,
             provider=self._coding_provider,
             model=self._coding_model,
+            role="coding",
             system=system,
             messages=messages,
             max_tokens=max_tokens,

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -718,6 +718,38 @@ def build_chat_completion_kwargs(
     return kwargs
 
 
+def _split_cached_input(usage) -> tuple[int, int]:
+    """Return (fresh_input_tokens, cache_read_tokens) from an OpenAI-shaped usage.
+
+    OpenAI's prompt/input token count INCLUDES cached tokens, unlike
+    Anthropic's which excludes them — subtract the cached share out so
+    ``Usage`` components mean the same thing on every provider (ENG-1288).
+    Handles both naming schemes: chat.completions (``prompt_tokens`` +
+    ``prompt_tokens_details.cached_tokens``) and the Responses API
+    (``input_tokens`` + ``input_tokens_details.cached_tokens``). Cache
+    WRITES are not exposed on OpenAI-compatible surfaces at all — creation
+    stays 0 there, a stated ENG-1288 gap.
+    """
+    if usage is None:
+        return 0, 0
+
+    def _as_int(value) -> int:
+        # Gateways and test doubles put non-numeric junk in usage fields;
+        # anything that isn't a real number counts as 0, never a crash.
+        return value if isinstance(value, int) else 0
+
+    total = _as_int(getattr(usage, "prompt_tokens", None)) or _as_int(
+        getattr(usage, "input_tokens", None)
+    )
+    details = (
+        getattr(usage, "prompt_tokens_details", None)
+        or getattr(usage, "input_tokens_details", None)
+    )
+    cached = _as_int(getattr(details, "cached_tokens", None)) if details is not None else 0
+    cached = min(cached, total)  # defensive: never negative fresh input
+    return total - cached, cached
+
+
 class OpenAIProvider(LLMProvider):
     name: str = "openai"
 
@@ -974,14 +1006,17 @@ class OpenAIProvider(LLMProvider):
         )
 
         usage_obj = response.usage
-        input_tokens = usage_obj.prompt_tokens if usage_obj else 0
+        input_tokens, cache_read_tokens = _split_cached_input(usage_obj)
         return LLMResponse(
             content=content_text,
             tool_calls=tool_calls,
             usage=Usage(
                 input_tokens=input_tokens,
                 output_tokens=usage_obj.completion_tokens if usage_obj else 0,
-                context_pressure=compute_context_pressure(model, input_tokens),
+                context_pressure=compute_context_pressure(
+                    model, input_tokens + cache_read_tokens
+                ),
+                cache_read_tokens=cache_read_tokens,
             ),
             stop_reason=choice.finish_reason,
         )
@@ -1032,6 +1067,7 @@ class OpenAIProvider(LLMProvider):
         tool_calls: list[ToolCall] = []
         input_tokens = 0
         output_tokens = 0
+        cache_read_tokens = 0
         stop_reason: str | None = None
 
         # Track tool call deltas by index
@@ -1048,7 +1084,7 @@ class OpenAIProvider(LLMProvider):
             stream_started = True
             async for chunk in stream:
                 if chunk.usage:
-                    input_tokens = chunk.usage.prompt_tokens
+                    input_tokens, cache_read_tokens = _split_cached_input(chunk.usage)
                     output_tokens = chunk.usage.completion_tokens
 
                 if not chunk.choices:
@@ -1220,7 +1256,10 @@ class OpenAIProvider(LLMProvider):
                 usage=Usage(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
-                    context_pressure=compute_context_pressure(model, input_tokens),
+                    context_pressure=compute_context_pressure(
+                        model, input_tokens + cache_read_tokens
+                    ),
+                    cache_read_tokens=cache_read_tokens,
                 ),
                 stop_reason=stop_reason,
             )
@@ -1339,6 +1378,7 @@ class OpenAIProvider(LLMProvider):
         tool_calls: list[ToolCall] = []
         input_tokens = 0
         output_tokens = 0
+        cache_read_tokens = 0
         stop_reason: str | None = None
 
         # Map output_index → in-flight function-call state. Responses API uses
@@ -1424,7 +1464,7 @@ class OpenAIProvider(LLMProvider):
                     if final_response is not None:
                         usage = getattr(final_response, "usage", None)
                         if usage is not None:
-                            input_tokens = getattr(usage, "input_tokens", 0) or 0
+                            input_tokens, cache_read_tokens = _split_cached_input(usage)
                             output_tokens = getattr(usage, "output_tokens", 0) or 0
                         stop_reason = getattr(final_response, "status", None)
         except openai.BadRequestError as exc:
@@ -1490,7 +1530,10 @@ class OpenAIProvider(LLMProvider):
                 usage=Usage(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
-                    context_pressure=compute_context_pressure(model, input_tokens),
+                    context_pressure=compute_context_pressure(
+                        model, input_tokens + cache_read_tokens
+                    ),
+                    cache_read_tokens=cache_read_tokens,
                 ),
                 stop_reason=stop_reason,
             )
@@ -1531,7 +1574,7 @@ def _parse_response_object(response, model: str) -> LLMResponse:
     # `or 0` guards an explicit None (the attr is present but null) — the
     # Responses API returns usage.input_tokens=None on web-search responses,
     # which a bare getattr default does NOT catch. Mirrors the streaming path.
-    input_tokens = (getattr(usage, "input_tokens", 0) or 0) if usage else 0
+    input_tokens, cache_read_tokens = _split_cached_input(usage)
     output_tokens = (getattr(usage, "output_tokens", 0) or 0) if usage else 0
 
     status = getattr(response, "status", None)
@@ -1545,7 +1588,10 @@ def _parse_response_object(response, model: str) -> LLMResponse:
         usage=Usage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            context_pressure=compute_context_pressure(model, input_tokens),
+            context_pressure=compute_context_pressure(
+                model, input_tokens + cache_read_tokens
+            ),
+            cache_read_tokens=cache_read_tokens,
         ),
         stop_reason=status,
     )

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -718,20 +718,29 @@ def build_chat_completion_kwargs(
     return kwargs
 
 
-def _split_cached_input(usage) -> tuple[int, int]:
-    """Return (fresh_input_tokens, cache_read_tokens) from an OpenAI-shaped usage.
+def _split_cached_input(usage) -> tuple[int, int, int]:
+    """Return (fresh_input, cache_read, cache_write) from an OpenAI-shaped usage.
 
-    OpenAI's prompt/input token count INCLUDES cached tokens, unlike
-    Anthropic's which excludes them — subtract the cached share out so
+    OpenAI-dialect prompt counts are INCLUSIVE of cache activity, unlike
+    Anthropic's which excludes it — subtract both cached buckets out so
     ``Usage`` components mean the same thing on every provider (ENG-1288).
+
+    Both cache buckets are real on our own gateway: mindshub_inference
+    publishes ``prompt_tokens_details.{cached_tokens, cache_write_tokens}``
+    and composes ``prompt_tokens = fresh + reads + writes``
+    (``minds/schemas/chat.py``, ``minds/inference/types.py``). Reading only
+    ``cached_tokens`` left the write share misfiled as fresh input and
+    reported ``cache_creation_tokens`` as a constant 0 on the majority
+    production surface — which breaks per-component dollar weighting (writes
+    bill at a premium) and any "is caching working" query (#309 review).
+
     Handles both naming schemes: chat.completions (``prompt_tokens`` +
-    ``prompt_tokens_details.cached_tokens``) and the Responses API
-    (``input_tokens`` + ``input_tokens_details.cached_tokens``). Cache
-    WRITES are not exposed on OpenAI-compatible surfaces at all — creation
-    stays 0 there, a stated ENG-1288 gap.
+    ``prompt_tokens_details``) and the Responses API (``input_tokens`` +
+    ``input_tokens_details``). A third-party endpoint that omits the write
+    field simply reports 0 for it.
     """
     if usage is None:
-        return 0, 0
+        return 0, 0, 0
 
     def _as_int(value) -> int:
         # Gateways and test doubles put non-numeric junk in usage fields;
@@ -745,9 +754,15 @@ def _split_cached_input(usage) -> tuple[int, int]:
         getattr(usage, "prompt_tokens_details", None)
         or getattr(usage, "input_tokens_details", None)
     )
-    cached = _as_int(getattr(details, "cached_tokens", None)) if details is not None else 0
-    cached = min(cached, total)  # defensive: never negative fresh input
-    return total - cached, cached
+    read = _as_int(getattr(details, "cached_tokens", None)) if details is not None else 0
+    write = (
+        _as_int(getattr(details, "cache_write_tokens", None)) if details is not None else 0
+    )
+    # Clamp jointly: a malformed payload must never yield negative fresh input.
+    if read + write > total:
+        read = min(read, total)
+        write = max(0, total - read)
+    return total - read - write, read, write
 
 
 class OpenAIProvider(LLMProvider):
@@ -1006,17 +1021,22 @@ class OpenAIProvider(LLMProvider):
         )
 
         usage_obj = response.usage
-        input_tokens, cache_read_tokens = _split_cached_input(usage_obj)
+        input_tokens, cache_read_tokens, cache_creation_tokens = _split_cached_input(
+            usage_obj
+        )
         return LLMResponse(
             content=content_text,
             tool_calls=tool_calls,
             usage=Usage(
                 input_tokens=input_tokens,
                 output_tokens=usage_obj.completion_tokens if usage_obj else 0,
+                # All prompt-side tokens, exactly as before this split existed
+                # (the OpenAI dialect's prompt_tokens is cache-inclusive).
                 context_pressure=compute_context_pressure(
-                    model, input_tokens + cache_read_tokens
+                    model, input_tokens + cache_read_tokens + cache_creation_tokens
                 ),
                 cache_read_tokens=cache_read_tokens,
+                cache_creation_tokens=cache_creation_tokens,
             ),
             stop_reason=choice.finish_reason,
         )
@@ -1068,6 +1088,7 @@ class OpenAIProvider(LLMProvider):
         input_tokens = 0
         output_tokens = 0
         cache_read_tokens = 0
+        cache_creation_tokens = 0
         stop_reason: str | None = None
 
         # Track tool call deltas by index
@@ -1084,7 +1105,11 @@ class OpenAIProvider(LLMProvider):
             stream_started = True
             async for chunk in stream:
                 if chunk.usage:
-                    input_tokens, cache_read_tokens = _split_cached_input(chunk.usage)
+                    (
+                        input_tokens,
+                        cache_read_tokens,
+                        cache_creation_tokens,
+                    ) = _split_cached_input(chunk.usage)
                     output_tokens = chunk.usage.completion_tokens
 
                 if not chunk.choices:
@@ -1257,9 +1282,10 @@ class OpenAIProvider(LLMProvider):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     context_pressure=compute_context_pressure(
-                        model, input_tokens + cache_read_tokens
+                        model, input_tokens + cache_read_tokens + cache_creation_tokens
                     ),
                     cache_read_tokens=cache_read_tokens,
+                    cache_creation_tokens=cache_creation_tokens,
                 ),
                 stop_reason=stop_reason,
             )
@@ -1379,6 +1405,7 @@ class OpenAIProvider(LLMProvider):
         input_tokens = 0
         output_tokens = 0
         cache_read_tokens = 0
+        cache_creation_tokens = 0
         stop_reason: str | None = None
 
         # Map output_index → in-flight function-call state. Responses API uses
@@ -1464,7 +1491,11 @@ class OpenAIProvider(LLMProvider):
                     if final_response is not None:
                         usage = getattr(final_response, "usage", None)
                         if usage is not None:
-                            input_tokens, cache_read_tokens = _split_cached_input(usage)
+                            (
+                                input_tokens,
+                                cache_read_tokens,
+                                cache_creation_tokens,
+                            ) = _split_cached_input(usage)
                             output_tokens = getattr(usage, "output_tokens", 0) or 0
                         stop_reason = getattr(final_response, "status", None)
         except openai.BadRequestError as exc:
@@ -1531,9 +1562,10 @@ class OpenAIProvider(LLMProvider):
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     context_pressure=compute_context_pressure(
-                        model, input_tokens + cache_read_tokens
+                        model, input_tokens + cache_read_tokens + cache_creation_tokens
                     ),
                     cache_read_tokens=cache_read_tokens,
+                    cache_creation_tokens=cache_creation_tokens,
                 ),
                 stop_reason=stop_reason,
             )
@@ -1574,7 +1606,7 @@ def _parse_response_object(response, model: str) -> LLMResponse:
     # `or 0` guards an explicit None (the attr is present but null) — the
     # Responses API returns usage.input_tokens=None on web-search responses,
     # which a bare getattr default does NOT catch. Mirrors the streaming path.
-    input_tokens, cache_read_tokens = _split_cached_input(usage)
+    input_tokens, cache_read_tokens, cache_creation_tokens = _split_cached_input(usage)
     output_tokens = (getattr(usage, "output_tokens", 0) or 0) if usage else 0
 
     status = getattr(response, "status", None)
@@ -1589,9 +1621,10 @@ def _parse_response_object(response, model: str) -> LLMResponse:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             context_pressure=compute_context_pressure(
-                model, input_tokens + cache_read_tokens
+                model, input_tokens + cache_read_tokens + cache_creation_tokens
             ),
             cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
         ),
         stop_reason=status,
     )

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -23,9 +23,33 @@ class ToolCall:
 
 @dataclass
 class Usage:
+    """Token usage for one LLM call, normalized across providers (ENG-1288).
+
+    Component semantics are UNIFORM regardless of provider:
+    - ``input_tokens``: fresh (non-cached) prompt tokens only. Anthropic's
+      ``input_tokens`` already excludes cache activity; OpenAI's
+      ``prompt_tokens`` INCLUDES cached tokens, so the OpenAI provider
+      subtracts ``cached_tokens`` out — without that, the same call would
+      report different components depending on the wire format.
+    - ``cache_read_tokens`` / ``cache_creation_tokens``: prompt tokens served
+      from / written to the provider prompt cache. OpenAI-compatible
+      endpoints expose only the read side (``prompt_tokens_details.
+      cached_tokens``); creation stays 0 there — a stated gap, not a bug.
+    - Total context for a call = input + cache_read + cache_creation
+      (cache tokens ARE context; dropping them understates a warm-cache
+      call by ~10x).
+    """
+
     input_tokens: int = 0
     output_tokens: int = 0
     context_pressure: float = 0.0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+
+    @property
+    def context_tokens(self) -> int:
+        """Total prompt-side tokens the call carried (all three components)."""
+        return self.input_tokens + self.cache_read_tokens + self.cache_creation_tokens
 
 
 @dataclass

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -32,9 +32,11 @@ class Usage:
       subtracts ``cached_tokens`` out — without that, the same call would
       report different components depending on the wire format.
     - ``cache_read_tokens`` / ``cache_creation_tokens``: prompt tokens served
-      from / written to the provider prompt cache. OpenAI-compatible
-      endpoints expose only the read side (``prompt_tokens_details.
-      cached_tokens``); creation stays 0 there — a stated gap, not a bug.
+      from / written to the provider prompt cache. Both are populated on the
+      OpenAI dialect too — our gateway publishes
+      ``prompt_tokens_details.{cached_tokens, cache_write_tokens}`` — and are
+      subtracted out of ``prompt_tokens`` by ``_split_cached_input``. A
+      third-party endpoint that omits either field reports 0 for it.
     - Total context for a call = input + cache_read + cache_creation
       (cache tokens ARE context; dropping them understates a warm-cache
       call by ~10x).

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1778,7 +1778,19 @@ class ChatSession:
         if tc is None or tc.emitted:
             return
         tc.emitted = True  # the double-emit guard, now on the books themselves
-        if self._turn_cost is tc:
+        is_owner = self._turn_cost is tc
+        if tc.ended_monotonic is None:
+            # The owning turn is ending right now; a late finalizer is not — so
+            # it reports up to the last LLM call rather than up to whenever
+            # asyncio ran it (#309 review follow-up).
+            import time as _t
+
+            tc.ended_monotonic = (
+                _t.monotonic()
+                if is_owner or tc.last_activity_monotonic is None
+                else tc.last_activity_monotonic
+            )
+        if is_owner:
             self._turn_cost = None
             try:
                 self._llm.usage_listener = None
@@ -1809,7 +1821,9 @@ class ChatSession:
         elif exc is not None:
             tc.ended_by = "error"
 
-        turn_index = self._turn_count + 1
+        # Stamped at books-open; the live lookup remains only for bare-session
+        # tests and the legacy non-streaming path.
+        turn_index = tc.turn_index or (self._turn_count + 1)
         logger.info(
             "turn_cost session=%s turn=%d ended_by=%s tokens_total=%d "
             "input=%d output=%d cache_read=%d cache_creation=%d "
@@ -2256,7 +2270,7 @@ class ChatSession:
         # emission happens at both returns; an exception propagating out of
         # this method skips emission (stated gap: the CLI path's error exits
         # go unreported rather than restructuring the method around it).
-        self._turn_cost = TurnCost()
+        self._turn_cost = TurnCost(turn_index=self._turn_count + 1)
         self._llm.usage_listener = self._turn_cost.add
 
         user_msg_str = (
@@ -2517,7 +2531,7 @@ class ChatSession:
         # Open the turn's cost books and listen at the LLM-client narrow
         # waist — planning, coding (incl. verifier verdicts), and router
         # calls all report here (ENG-1288).
-        self._turn_cost = TurnCost()
+        self._turn_cost = TurnCost(turn_index=self._turn_count + 1)
         _turn_cost_books = self._turn_cost
         self._llm.usage_listener = self._turn_cost.add
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -467,6 +467,22 @@ def _render_verify_transcript(
     return "\n".join(line for _, line in kept) or "(no conversation)"
 
 
+def _role_model(tc: TurnCost, role: str) -> str:
+    """Model that ran ``role`` this turn ("" if the role never ran)."""
+    slice_ = tc.by_role.get(role)
+    return slice_.model if slice_ else ""
+
+
+def _role_tokens(tc: TurnCost, role: str) -> str:
+    slice_ = tc.by_role.get(role)
+    return str(slice_.tokens if slice_ else 0)
+
+
+def _role_calls(tc: TurnCost, role: str) -> str:
+    slice_ = tc.by_role.get(role)
+    return str(slice_.calls if slice_ else 0)
+
+
 def _build_verify_request(
     history: list[dict], user_message: str | None
 ) -> tuple[str, list[dict]]:
@@ -1777,11 +1793,16 @@ class ChatSession:
         logger.info(
             "turn_cost session=%s turn=%d ended_by=%s tokens_total=%d "
             "input=%d output=%d cache_read=%d cache_creation=%d "
-            "llm_calls=%d rounds=%d continuations=%d peak_context=%d duration_ms=%d",
+            "llm_calls=%d rounds=%d continuations=%d peak_context=%d duration_ms=%d "
+            "by_role=%s",
             self._session_id, turn_index, tc.ended_by, tc.total_tokens,
             tc.input_tokens, tc.output_tokens, tc.cache_read_tokens,
             tc.cache_creation_tokens, tc.llm_calls, tc.rounds,
             tc.continuations, tc.peak_context_tokens, tc.duration_ms,
+            ",".join(
+                f"{role}={s.model}:{s.tokens}/{s.calls}"
+                for role, s in sorted(tc.by_role.items())
+            ) or "-",
         )
 
         # Analytics sink — same settings-resolution pattern as the
@@ -1813,8 +1834,25 @@ class ChatSession:
                 continuations=str(tc.continuations),
                 peak_context_tokens=str(tc.peak_context_tokens),
                 duration_ms=str(tc.duration_ms),
-                planning_model=str(self._llm.planning_model or ""),
-                coding_model=str(self._llm.coding_model or ""),
+                # Per-role attribution: which model actually ran each role and
+                # what it spent. `<role>_model` is the model the USER was on
+                # for the conversational loop (planning) — the configured names
+                # can drift from what ran, and dollars are only computable from
+                # (model, tokens) pairs since a turn mixes rates. Roles are a
+                # closed set, so these stay flat and queryable.
+                planning_model=_role_model(tc, "planning") or str(
+                    self._llm.planning_model or ""
+                ),
+                planning_tokens=_role_tokens(tc, "planning"),
+                planning_calls=_role_calls(tc, "planning"),
+                coding_model=_role_model(tc, "coding") or str(
+                    self._llm.coding_model or ""
+                ),
+                coding_tokens=_role_tokens(tc, "coding"),
+                coding_calls=_role_calls(tc, "coding"),
+                router_model=_role_model(tc, "router"),
+                router_tokens=_role_tokens(tc, "router"),
+                router_calls=_role_calls(tc, "router"),
                 # Configured provider name (anthropic / openai /
                 # openai-compatible): separates gateway traffic from BYOK in
                 # queries. The finer per-model provider split is a follow-up.

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1726,7 +1726,7 @@ class ChatSession:
         self.hard_truncate_history()
         return await self._llm.plan(messages=factory_validated(), **kwargs)
 
-    def _emit_turn_cost(self) -> None:
+    def _emit_turn_cost(self, expected: TurnCost | None = None) -> None:
         """Close the turn's cost books: disarm the listener, resolve the
         terminal path, and emit the two reporting sinks (ENG-1288).
 
@@ -1745,6 +1745,13 @@ class ChatSession:
         tc = self._turn_cost
         if tc is None:
             return
+        if expected is not None and tc is not expected:
+            # A late async-generator finalizer for an ABANDONED turn: asyncio
+            # runs it in a fresh task long after the fact, by which point a
+            # newer turn may own the books. Closing those would emit the next
+            # turn's partial totals mid-turn and leave it uncounted. Only the
+            # turn that opened these books may close them (#309 review).
+            return
         self._turn_cost = None
         try:
             self._llm.usage_listener = None
@@ -1755,7 +1762,13 @@ class ChatSession:
         cancelled = bool(
             getattr(self, "_cancel_event", None) and self._cancel_event.is_set()
         )
-        if isinstance(exc, GeneratorExit) or cancelled:
+        # asyncio.CancelledError is the SHAPE USER STOP TAKES on the primary
+        # host: cowork-server's RunHandle.cancel() calls task.cancel(), which
+        # raises it inside the suspended generator frame — and nothing there
+        # sets `_cancel_event` (that's anton's CLI only). Without it every
+        # Stop filed as "error" (#309 review). GeneratorExit covers the
+        # narrower case where the cancel lands exactly at a yield boundary.
+        if isinstance(exc, (GeneratorExit, asyncio.CancelledError)) or cancelled:
             tc.ended_by = "cancelled"
         elif exc is not None:
             tc.ended_by = "error"
@@ -2232,9 +2245,14 @@ class ChatSession:
 
         while response.tool_calls:
             tool_round += 1
-            if self._turn_cost is not None:
-                self._turn_cost.rounds = tool_round
+            if self._turn_cost is not None and tool_round <= self._max_tool_rounds:
+                self._turn_cost.rounds += 1
             if tool_round > self._max_tool_rounds:
+                # Mirror turn_stream's cap mark (#309 review) — this path is
+                # public API even without in-repo callers, and the books are
+                # wired here too.
+                if self._turn_cost is not None:
+                    self._turn_cost.ended_by = "round_cap"
                 self._append_history(
                     {"role": "assistant", "content": response.content or ""}
                 )
@@ -2437,6 +2455,7 @@ class ChatSession:
         # waist — planning, coding (incl. verifier verdicts), and router
         # calls all report here (ENG-1288).
         self._turn_cost = TurnCost()
+        _turn_cost_books = self._turn_cost
         self._llm.usage_listener = self._turn_cost.add
 
         try:
@@ -2572,7 +2591,14 @@ class ChatSession:
                         # again with the error context now in history
                         continue
                     else:
-                        # Exhausted retries — stop and summarize for the user
+                        # Exhausted retries — stop and summarize for the user.
+                        # Mark the terminal: the apology below is yielded as
+                        # ordinary text and nothing is in flight when the
+                        # finally runs, so without this the turn reported
+                        # "completed" — undercounting the most common failure
+                        # mode in any error-rate query (#309 review).
+                        if self._turn_cost is not None:
+                            self._turn_cost.ended_by = "retry_exhausted"
                         self._append_history(
                             {
                                 "role": "user",
@@ -2615,8 +2641,19 @@ class ChatSession:
                 self._active_explainability.finalize(
                     "".join(assistant_text_parts)[:2000]
                 )
-            reset_trace_context(_trace_token)
-            self._emit_turn_cost()
+            # Emit BEFORE reset_trace_context: on an abandoned generator the
+            # finalizer runs in a copied context, where resetting a token
+            # created elsewhere raises ValueError — which used to abort this
+            # finally and drop the turn's books entirely (#309 review). The
+            # guard passes the books this turn opened so a late finalizer
+            # can't close a newer turn's.
+            self._emit_turn_cost(expected=_turn_cost_books)
+            try:
+                reset_trace_context(_trace_token)
+            except ValueError:
+                # Cross-context finalizer — the ContextVar copy dies with the
+                # task anyway, so there is nothing to restore.
+                pass
 
         # Log assistant response to episodic memory
         if self._episodic is not None and assistant_text_parts:
@@ -2829,8 +2866,14 @@ class ChatSession:
 
             while llm_response.tool_calls:
                 tool_round += 1
-                if self._turn_cost is not None:
-                    self._turn_cost.rounds = tool_round
+                # Accumulate, don't assign: `tool_round` is loop-local and
+                # resets to 0 on every verifier-forced continuation, so
+                # assigning reported only the last continuation's rounds —
+                # breaking the metric for exactly the expensive shape it
+                # exists to classify. Counted before the cap check so a
+                # capped turn reports the cap, not cap+1 (#309 review).
+                if self._turn_cost is not None and tool_round <= self._max_tool_rounds:
+                    self._turn_cost.rounds += 1
                 if tool_round > self._max_tool_rounds:
                     _max_rounds_hit = True
                     if self._turn_cost is not None:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import json
 import logging
 import re
+import sys
 from typing import TYPE_CHECKING, List, Literal
 import os
 
@@ -59,6 +60,7 @@ from anton.core.llm.tracing import (
 )
 from anton.core.backends.manager import ScratchpadManager
 from anton.core.tools.registry import ToolOutcome, ToolRegistry
+from anton.core.turn_cost import TurnCost
 from anton.core.tools.tool_defs import (
     CREATE_ARTIFACT_TOOL,
     LAUNCH_BACKEND_TOOL,
@@ -642,6 +644,10 @@ class ChatSession:
         self._history_store = config.history_store
         self._session_id = config.session_id
         self._harness = config.harness
+        # Per-turn token cost books (ENG-1288). Created and armed at each
+        # turn's start; emitted and disarmed in the turn's finally. None
+        # outside a turn.
+        self._turn_cost: TurnCost | None = None
         # Set per-turn by `turn_stream` so any LLM call made during that
         # turn can read the current turn identifier (used by telemetry /
         # langfuse propagation in the provider layer).
@@ -1720,6 +1726,99 @@ class ChatSession:
         self.hard_truncate_history()
         return await self._llm.plan(messages=factory_validated(), **kwargs)
 
+    def _emit_turn_cost(self) -> None:
+        """Close the turn's cost books: disarm the listener, resolve the
+        terminal path, and emit the two reporting sinks (ENG-1288).
+
+        Called from the turn's ``finally`` so it fires on every exit —
+        normal completion, hand-backs, generator close (client disconnect /
+        cancel), and errors. The in-flight exception, if any, wins the
+        ``ended_by`` resolution; explicit marks set at the terminal sites
+        (round_cap / handback_*) survive a clean exit; everything else is
+        "completed".
+
+        Post-turn background work (cerebellum flush, identity extraction)
+        runs after this and is deliberately NOT attributed to any turn —
+        the listener is disarmed here precisely so late usage can't leak
+        into the next turn's books (stated ENG-1288 gap).
+        """
+        tc = self._turn_cost
+        if tc is None:
+            return
+        self._turn_cost = None
+        try:
+            self._llm.usage_listener = None
+        except Exception:
+            pass
+
+        exc = sys.exc_info()[1]
+        cancelled = bool(
+            getattr(self, "_cancel_event", None) and self._cancel_event.is_set()
+        )
+        if isinstance(exc, GeneratorExit) or cancelled:
+            tc.ended_by = "cancelled"
+        elif exc is not None:
+            tc.ended_by = "error"
+
+        turn_index = self._turn_count + 1
+        logger.info(
+            "turn_cost session=%s turn=%d ended_by=%s tokens_total=%d "
+            "input=%d output=%d cache_read=%d cache_creation=%d "
+            "llm_calls=%d rounds=%d continuations=%d peak_context=%d duration_ms=%d",
+            self._session_id, turn_index, tc.ended_by, tc.total_tokens,
+            tc.input_tokens, tc.output_tokens, tc.cache_read_tokens,
+            tc.cache_creation_tokens, tc.llm_calls, tc.rounds,
+            tc.continuations, tc.peak_context_tokens, tc.duration_ms,
+        )
+
+        # Analytics sink — same settings-resolution pattern as the
+        # ds_connect_* events (anton/tools.py): the session's settings when
+        # the host provided AntonSettings, else a fresh resolve so
+        # analytics_enabled / the CI drop still apply. send_event is
+        # fire-and-forget and never raises. Numbers, names, and IDs only —
+        # never conversation content (ENG-1288).
+        try:
+            settings = getattr(self, "_settings", None)
+            if settings is None or not hasattr(settings, "analytics_enabled"):
+                from anton.config.settings import AntonSettings
+
+                settings = AntonSettings()
+            from anton import __version__ as _anton_version
+            from anton.analytics import send_event
+
+            send_event(
+                settings,
+                "turn_completed",
+                ended_by=tc.ended_by,
+                tokens_total=str(tc.total_tokens),
+                input_tokens=str(tc.input_tokens),
+                output_tokens=str(tc.output_tokens),
+                cache_read_tokens=str(tc.cache_read_tokens),
+                cache_creation_tokens=str(tc.cache_creation_tokens),
+                llm_calls=str(tc.llm_calls),
+                rounds=str(tc.rounds),
+                continuations=str(tc.continuations),
+                peak_context_tokens=str(tc.peak_context_tokens),
+                duration_ms=str(tc.duration_ms),
+                planning_model=str(self._llm.planning_model or ""),
+                coding_model=str(self._llm.coding_model or ""),
+                # Configured provider name (anthropic / openai /
+                # openai-compatible): separates gateway traffic from BYOK in
+                # queries. The finer per-model provider split is a follow-up.
+                llm_provider=str(getattr(settings, "planning_provider", "") or ""),
+                harness=str(self._harness or ""),
+                anton_version=_anton_version,
+                # Join keys: the same session/turn identity the MindsHub
+                # trace headers carry, so an analytics row links back to
+                # its Langfuse trace (and through it, to the user) for
+                # forensics.
+                conversation_id=str(self._session_id or ""),
+                turn_index=str(turn_index),
+            )
+        except Exception:
+            # Reporting must never affect the turn that just ran.
+            pass
+
     async def _stream_handback_diagnosis(self, *, system: str, label: str):
         """Stream a hand-back diagnosis and persist exactly what the user read.
 
@@ -2076,6 +2175,14 @@ class ChatSession:
         user_input = _scrub_user_input(user_input)
         self._append_history({"role": "user", "content": user_input})
 
+        # Open the turn's cost books (ENG-1288) — same contract as
+        # turn_stream. This non-streaming path has no wrapping finally, so
+        # emission happens at both returns; an exception propagating out of
+        # this method skips emission (stated gap: the CLI path's error exits
+        # go unreported rather than restructuring the method around it).
+        self._turn_cost = TurnCost()
+        self._llm.usage_listener = self._turn_cost.add
+
         user_msg_str = (
             user_input
             if isinstance(user_input, str)
@@ -2097,6 +2204,7 @@ class ChatSession:
                     self._cortex.maybe_vacuum()
                 self._schedule_cerebellum_flush()
                 self._schedule_acc_flush()
+                self._emit_turn_cost()
                 return decision.text
             if decision is not None and decision.skills:
                 self._inject_recalled_skills(decision.skills)
@@ -2124,6 +2232,8 @@ class ChatSession:
 
         while response.tool_calls:
             tool_round += 1
+            if self._turn_cost is not None:
+                self._turn_cost.rounds = tool_round
             if tool_round > self._max_tool_rounds:
                 self._append_history(
                     {"role": "assistant", "content": response.content or ""}
@@ -2248,6 +2358,7 @@ class ChatSession:
         self._schedule_cerebellum_flush()
         self._schedule_acc_flush()
 
+        self._emit_turn_cost()
         return reply
 
     async def turn_stream(
@@ -2321,6 +2432,12 @@ class ChatSession:
                 metadata=trace_metadata or None,
             )
         )
+
+        # Open the turn's cost books and listen at the LLM-client narrow
+        # waist — planning, coding (incl. verifier verdicts), and router
+        # calls all report here (ENG-1288).
+        self._turn_cost = TurnCost()
+        self._llm.usage_listener = self._turn_cost.add
 
         try:
             # Cheap front-model routing (ENG-648). Text-only turns first
@@ -2499,6 +2616,7 @@ class ChatSession:
                     "".join(assistant_text_parts)[:2000]
                 )
             reset_trace_context(_trace_token)
+            self._emit_turn_cost()
 
         # Log assistant response to episodic memory
         if self._episodic is not None and assistant_text_parts:
@@ -2711,8 +2829,12 @@ class ChatSession:
 
             while llm_response.tool_calls:
                 tool_round += 1
+                if self._turn_cost is not None:
+                    self._turn_cost.rounds = tool_round
                 if tool_round > self._max_tool_rounds:
                     _max_rounds_hit = True
+                    if self._turn_cost is not None:
+                        self._turn_cost.ended_by = "round_cap"
                     self._acc_observe(
                         "cap_exhausted",
                         {"cap": self._max_tool_rounds},
@@ -3165,6 +3287,8 @@ class ChatSession:
                 yield StreamTaskProgress(
                     phase="analyzing", message="Diagnosing incomplete task..."
                 )
+                if self._turn_cost is not None:
+                    self._turn_cost.ended_by = "handback_budget"
                 async for event in self._stream_handback_diagnosis(
                     system=system, label="budget-exhausted"
                 ):
@@ -3360,6 +3484,8 @@ class ChatSession:
                     phase="analyzing",
                     message="Something went wrong — checking in with you...",
                 )
+                if self._turn_cost is not None:
+                    self._turn_cost.ended_by = "handback_verifier_failure"
                 async for event in self._stream_handback_diagnosis(
                     system=system, label="verifier-failure"
                 ):
@@ -3398,6 +3524,8 @@ class ChatSession:
                 yield StreamTaskProgress(
                     phase="analyzing", message="Diagnosing blocked task..."
                 )
+                if self._turn_cost is not None:
+                    self._turn_cost.ended_by = "handback_stuck"
                 async for event in self._stream_handback_diagnosis(
                     system=system, label="stuck"
                 ):
@@ -3406,6 +3534,8 @@ class ChatSession:
 
             # INCOMPLETE — continue working
             continuation += 1
+            if self._turn_cost is not None:
+                self._turn_cost.continuations = continuation
             self._append_history(
                 {
                     "role": "user",

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1887,9 +1887,11 @@ class ChatSession:
                 router_model=_role_model(tc, "router"),
                 router_tokens=_role_tokens(tc, "router"),
                 router_calls=_role_calls(tc, "router"),
-                # Should always be 0. Emitted anyway so the per-role sum
-                # reconciles with tokens_total even if a future caller passes
-                # an unexpected role — a non-zero value here is the alarm.
+                # Should always be 0. Emitted so the per-role sum reconciles
+                # with tokens_total for ANY role a caller passes — `TurnCost.add`
+                # folds anything outside `EVENT_ROLES` into this bucket, so a
+                # novel role shows up here rather than vanishing. A non-zero
+                # value is the alarm that some caller invented a role.
                 unknown_tokens=_role_tokens(tc, UNKNOWN_ROLE),
                 unknown_calls=_role_calls(tc, UNKNOWN_ROLE),
                 # Configured provider name (anthropic / openai /

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2531,7 +2531,15 @@ class ChatSession:
         # Open the turn's cost books and listen at the LLM-client narrow
         # waist — planning, coding (incl. verifier verdicts), and router
         # calls all report here (ENG-1288).
-        self._turn_cost = TurnCost(turn_index=self._turn_count + 1)
+        # Stamp the SAME expression the trace context uses above — including an
+        # explicit host-supplied `turn_id`. Deriving it independently from
+        # `_turn_count` was correct only by accident (no host passes `turn_id`
+        # today); the moment one does, the cost event and the Langfuse trace
+        # would name different turns, which is the defect this stamping exists
+        # to prevent. Consistent by construction, not by coincidence.
+        self._turn_cost = TurnCost(
+            turn_index=turn_id if turn_id is not None else self._turn_count + 1
+        )
         _turn_cost_books = self._turn_cost
         self._llm.usage_listener = self._turn_cost.add
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -60,7 +60,7 @@ from anton.core.llm.tracing import (
 )
 from anton.core.backends.manager import ScratchpadManager
 from anton.core.tools.registry import ToolOutcome, ToolRegistry
-from anton.core.turn_cost import TurnCost
+from anton.core.turn_cost import UNKNOWN_ROLE, TurnCost
 from anton.core.tools.tool_defs import (
     CREATE_ARTIFACT_TOOL,
     LAUNCH_BACKEND_TOOL,
@@ -465,6 +465,12 @@ def _render_verify_transcript(
     kept = convo[-max_convo:] + tools[-max_tool:]
     kept.sort(key=lambda entry: entry[0])
     return "\n".join(line for _, line in kept) or "(no conversation)"
+
+
+# Distinguishes "caller captured no exception" (a clean turn — authoritative)
+# from "caller didn't tell us" (fall back to sys.exc_info()). A plain None
+# default would conflate them and re-open the leak this closes.
+_EXC_UNSET = object()
 
 
 def _role_model(tc: TurnCost, role: str) -> str:
@@ -1742,7 +1748,11 @@ class ChatSession:
         self.hard_truncate_history()
         return await self._llm.plan(messages=factory_validated(), **kwargs)
 
-    def _emit_turn_cost(self, expected: TurnCost | None = None) -> None:
+    def _emit_turn_cost(
+        self,
+        expected: TurnCost | None = None,
+        exc: BaseException | None | object = _EXC_UNSET,
+    ) -> None:
         """Close the turn's cost books: disarm the listener, resolve the
         terminal path, and emit the two reporting sinks (ENG-1288).
 
@@ -1758,23 +1768,33 @@ class ChatSession:
         the listener is disarmed here precisely so late usage can't leak
         into the next turn's books (stated ENG-1288 gap).
         """
-        tc = self._turn_cost
-        if tc is None:
+        # Report the books this call was handed. A late async-generator
+        # finalizer for an ABANDONED turn runs in a fresh task long after the
+        # fact, by which point a newer turn may own the shared slot — but the
+        # stale books still hold a complete, real turn, and dropping them lost
+        # exactly the runaway the user just cancelled (#309 review). So: emit
+        # whichever books came in, and let only the OWNING turn clear the slot.
+        tc = expected if expected is not None else self._turn_cost
+        if tc is None or tc.emitted:
             return
-        if expected is not None and tc is not expected:
-            # A late async-generator finalizer for an ABANDONED turn: asyncio
-            # runs it in a fresh task long after the fact, by which point a
-            # newer turn may own the books. Closing those would emit the next
-            # turn's partial totals mid-turn and leave it uncounted. Only the
-            # turn that opened these books may close them (#309 review).
-            return
-        self._turn_cost = None
-        try:
-            self._llm.usage_listener = None
-        except Exception:
-            pass
+        tc.emitted = True  # the double-emit guard, now on the books themselves
+        if self._turn_cost is tc:
+            self._turn_cost = None
+            try:
+                self._llm.usage_listener = None
+            except Exception:
+                pass
 
-        exc = sys.exc_info()[1]
+        # A caller that captured its own exception is authoritative — including
+        # when it captured NOTHING (a clean turn), which is why this needs a
+        # sentinel rather than `if exc is None`. `sys.exc_info()` returns
+        # whatever the thread is CURRENTLY handling, including an exception the
+        # caller had already caught before invoking the turn, and reading it on
+        # a clean turn reported `error` for one that succeeded. The lookup
+        # remains only for the legacy non-streaming `turn()`, which has no
+        # wrapping handler to capture from (#309 review).
+        if exc is _EXC_UNSET:
+            exc = sys.exc_info()[1]
         cancelled = bool(
             getattr(self, "_cancel_event", None) and self._cancel_event.is_set()
         )
@@ -1853,6 +1873,11 @@ class ChatSession:
                 router_model=_role_model(tc, "router"),
                 router_tokens=_role_tokens(tc, "router"),
                 router_calls=_role_calls(tc, "router"),
+                # Should always be 0. Emitted anyway so the per-role sum
+                # reconciles with tokens_total even if a future caller passes
+                # an unexpected role — a non-zero value here is the alarm.
+                unknown_tokens=_role_tokens(tc, UNKNOWN_ROLE),
+                unknown_calls=_role_calls(tc, UNKNOWN_ROLE),
                 # Configured provider name (anthropic / openai /
                 # openai-compatible): separates gateway traffic from BYOK in
                 # queries. The finer per-model provider split is a follow-up.
@@ -2496,6 +2521,7 @@ class ChatSession:
         _turn_cost_books = self._turn_cost
         self._llm.usage_listener = self._turn_cost.add
 
+        _turn_exc: BaseException | None = None
         try:
             # Cheap front-model routing (ENG-648). Text-only turns first
             # hit the thalamus model, which either answers trivial/from-
@@ -2674,6 +2700,13 @@ class ChatSession:
                             assistant_text_parts.append(fallback)
                             yield StreamTextDelta(text=fallback)
                         break
+        except BaseException as _e:
+            # Capture, don't classify — the finally needs to know whether THIS
+            # turn failed, rather than asking the interpreter what the thread
+            # happens to be handling (#309 review). Covers GeneratorExit and
+            # CancelledError too, both BaseException, both real turn endings.
+            _turn_exc = _e
+            raise
         finally:
             if self._active_explainability is not None:
                 self._active_explainability.finalize(
@@ -2685,7 +2718,7 @@ class ChatSession:
             # finally and drop the turn's books entirely (#309 review). The
             # guard passes the books this turn opened so a late finalizer
             # can't close a newer turn's.
-            self._emit_turn_cost(expected=_turn_cost_books)
+            self._emit_turn_cost(expected=_turn_cost_books, exc=_turn_exc)
             try:
                 reset_trace_context(_trace_token)
             except ValueError:

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -140,10 +140,15 @@ class TurnCost:
         self.cache_creation_tokens += usage.cache_creation_tokens
         self.peak_context_tokens = max(self.peak_context_tokens, usage.context_tokens)
         self.last_activity_monotonic = time.monotonic()
-        # An empty role lands in `unknown`, which the event emits alongside the
-        # three real roles — so the per-role sum always reconciles with
-        # `total_tokens` instead of silently losing a bucket (#309 review).
-        slice_ = self.by_role.setdefault(role or UNKNOWN_ROLE, RoleCost())
+        # Any role the event doesn't emit — empty OR novel (a future caller
+        # passing e.g. "verifier") — is folded into `unknown`. Keying on the
+        # raw role instead would put those tokens in a bucket nothing reads:
+        # they'd vanish from the per-role breakdown AND leave `unknown` at 0,
+        # so the reconciliation would break with no alarm (#309 review).
+        # The role's *name* is lost when folded; its tokens are not, and that
+        # is the invariant that has to hold.
+        key = role if role in EVENT_ROLES else UNKNOWN_ROLE
+        slice_ = self.by_role.setdefault(key, RoleCost())
         slice_.observe(
             model,
             usage.input_tokens

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -112,7 +112,11 @@ class TurnCost:
     # real end, so it falls back to `last_activity_monotonic` (the last LLM
     # call) — understating but bounded, rather than measuring up to whenever
     # asyncio happened to run the finalizer, which inflates the field a runaway
-    # query sorts on.
+    # query sorts on. Known residual: a turn abandoned BEFORE its first LLM call
+    # has no watermark, so its duration still runs to finalizer time. Accepted —
+    # it has `llm_calls == 0` and `tokens_total == 0`, so it is trivially
+    # excluded from any cost or runaway query, which is the only consumer that
+    # reads duration.
     ended_monotonic: float | None = None
     last_activity_monotonic: float | None = None
     # Per-role attribution. A turn routinely mixes an expensive planning model

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -103,6 +103,18 @@ class TurnCost:
     # books it was handed even when a newer turn already owns the slot
     # (#309 review).
     emitted: bool = False
+    # Per-turn facts stamped at books-OPEN, not read at emit. A late finalizer
+    # emits books whose turn ended long ago, and reading live session state
+    # there gave the abandoned turn a LATER, unrelated turn's index — the
+    # cost→Langfuse hop then pointed at the wrong turn (#309 review follow-up).
+    turn_index: int = 0
+    # When the turn ended. None until resolved. A late finalizer cannot know the
+    # real end, so it falls back to `last_activity_monotonic` (the last LLM
+    # call) — understating but bounded, rather than measuring up to whenever
+    # asyncio happened to run the finalizer, which inflates the field a runaway
+    # query sorts on.
+    ended_monotonic: float | None = None
+    last_activity_monotonic: float | None = None
     # Per-role attribution. A turn routinely mixes an expensive planning model
     # with a cheap coding model (the completion verifier runs on the latter),
     # so a single blended token total cannot be priced at any one rate —
@@ -123,6 +135,7 @@ class TurnCost:
         self.cache_read_tokens += usage.cache_read_tokens
         self.cache_creation_tokens += usage.cache_creation_tokens
         self.peak_context_tokens = max(self.peak_context_tokens, usage.context_tokens)
+        self.last_activity_monotonic = time.monotonic()
         # An empty role lands in `unknown`, which the event emits alongside the
         # three real roles — so the per-role sum always reconciles with
         # `total_tokens` instead of silently losing a bucket (#309 review).
@@ -147,4 +160,9 @@ class TurnCost:
 
     @property
     def duration_ms(self) -> int:
-        return int((time.monotonic() - self.started_monotonic) * 1000)
+        end = (
+            self.ended_monotonic
+            if self.ended_monotonic is not None
+            else time.monotonic()
+        )
+        return int((end - self.started_monotonic) * 1000)

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -43,6 +43,33 @@ from anton.core.llm.provider import Usage
 
 
 @dataclass
+class RoleCost:
+    """One role's slice of a turn: which model ran it and what it spent.
+
+    Roles are a closed set (planning / coding / router), which is why the turn
+    event can carry this as flat properties instead of a nested blob.
+
+    ``model`` is the alias anton REQUESTED. The gateway may resolve or fail
+    over to a different model server-side and does not report that back on the
+    response (``LLMResponse`` carries no model field), so this is the client's
+    intent, not proof of what served the call — Langfuse holds the latter.
+    Normally one model per role per turn; if a role somehow sees more, they are
+    joined with ``|`` so the ambiguity is visible rather than silently dropping
+    one (a joined value means per-model dollar math for that role is unsafe).
+    """
+
+    model: str = ""
+    tokens: int = 0
+    calls: int = 0
+
+    def observe(self, model: str, tokens: int) -> None:
+        if model and model not in self.model.split("|"):
+            self.model = f"{self.model}|{model}" if self.model else model
+        self.tokens += tokens
+        self.calls += 1
+
+
+@dataclass
 class TurnCost:
     """Running token totals for one turn. Mutated only via ``add`` plus the
     session's explicit shape/outcome writes (rounds, continuations, ended_by).
@@ -65,14 +92,19 @@ class TurnCost:
     # the turn didn't end on its own terms.
     ended_by: str = "completed"
     started_monotonic: float = field(default_factory=time.monotonic)
+    # Per-role attribution. A turn routinely mixes an expensive planning model
+    # with a cheap coding model (the completion verifier runs on the latter),
+    # so a single blended token total cannot be priced at any one rate —
+    # dollars are only computable from (model, tokens) pairs, which this
+    # provides. Also the only place the router model is recorded at all.
+    by_role: dict[str, RoleCost] = field(default_factory=dict)
 
     def add(self, role: str, model: str, usage: Usage) -> None:
         """Count one LLM call. Installed as ``LLMClient.usage_listener``.
 
-        ``role``/``model`` are accepted (they're the listener contract and
-        what a future per-role breakdown would key on) but not yet stored
-        per-role — the turn event carries the client's planning/coding model
-        names instead.
+        Records both the turn total and the per-``role`` slice, so the event
+        can answer "which model was this user actually on" and "what did each
+        model cost" rather than only a blended sum.
         """
         self.llm_calls += 1
         self.input_tokens += usage.input_tokens
@@ -80,6 +112,14 @@ class TurnCost:
         self.cache_read_tokens += usage.cache_read_tokens
         self.cache_creation_tokens += usage.cache_creation_tokens
         self.peak_context_tokens = max(self.peak_context_tokens, usage.context_tokens)
+        slice_ = self.by_role.setdefault(role or "unknown", RoleCost())
+        slice_.observe(
+            model,
+            usage.input_tokens
+            + usage.output_tokens
+            + usage.cache_read_tokens
+            + usage.cache_creation_tokens,
+        )
 
     @property
     def total_tokens(self) -> int:

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -10,7 +10,12 @@ instead of at each call site.
 
 Consumers, in order:
 - observability: one structured log line + one ``turn_completed`` analytics
-  event per turn (see ``ChatSession._emit_turn_cost``);
+  event per turn (see ``ChatSession._emit_turn_cost``). The event relays into
+  PostHog project 355390, where each field lands as a queryable property —
+  one event per turn also makes turn VOLUME countable, not just cost. The
+  field names are therefore a published schema: renaming one breaks queries
+  downstream. Identity there is per-install (``aid``), so per-user cost needs
+  the ``conversation_id`` -> Langfuse hop;
 - ENG-1286's per-turn spend ceiling: reads ``total_tokens`` mid-turn.
 
 Component semantics follow ``Usage`` (normalized across providers): input

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -42,8 +42,16 @@ from dataclasses import dataclass, field
 from anton.core.llm.provider import Usage
 
 
-# Roles the event reports. `unknown` catches an empty/unexpected role so the
-# per-role token sum always equals the turn total; it should stay empty.
+# The roles the event reports — a closed set, which is what lets the event carry
+# per-role figures as flat properties. `TurnCost.add` folds any role outside it
+# (empty, None, novel, or a case/whitespace variant) into `unknown`, so the
+# per-role token sum always equals the turn total.
+#
+# `unknown` is EXPECTED to stay at zero, not guaranteed to: a non-zero value is
+# the alarm that some caller invented a role, and the fold is what keeps that
+# alarm's tokens from disappearing instead. The folded role's name is lost, but
+# the log line keeps the model (`unknown=haiku:320/1`), which is usually enough
+# to find the caller.
 UNKNOWN_ROLE = "unknown"
 EVENT_ROLES = ("planning", "coding", "router", UNKNOWN_ROLE)
 

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -42,6 +42,12 @@ from dataclasses import dataclass, field
 from anton.core.llm.provider import Usage
 
 
+# Roles the event reports. `unknown` catches an empty/unexpected role so the
+# per-role token sum always equals the turn total; it should stay empty.
+UNKNOWN_ROLE = "unknown"
+EVENT_ROLES = ("planning", "coding", "router", UNKNOWN_ROLE)
+
+
 @dataclass
 class RoleCost:
     """One role's slice of a turn: which model ran it and what it spent.
@@ -92,6 +98,11 @@ class TurnCost:
     # the turn didn't end on its own terms.
     ended_by: str = "completed"
     started_monotonic: float = field(default_factory=time.monotonic)
+    # Set when these books have been reported. Replaces "the shared slot is
+    # None" as the double-emit guard, because a late finalizer now emits the
+    # books it was handed even when a newer turn already owns the slot
+    # (#309 review).
+    emitted: bool = False
     # Per-role attribution. A turn routinely mixes an expensive planning model
     # with a cheap coding model (the completion verifier runs on the latter),
     # so a single blended token total cannot be priced at any one rate —
@@ -112,7 +123,10 @@ class TurnCost:
         self.cache_read_tokens += usage.cache_read_tokens
         self.cache_creation_tokens += usage.cache_creation_tokens
         self.peak_context_tokens = max(self.peak_context_tokens, usage.context_tokens)
-        slice_ = self.by_role.setdefault(role or "unknown", RoleCost())
+        # An empty role lands in `unknown`, which the event emits alongside the
+        # three real roles — so the per-role sum always reconciles with
+        # `total_tokens` instead of silently losing a bucket (#309 review).
+        slice_ = self.by_role.setdefault(role or UNKNOWN_ROLE, RoleCost())
         slice_.observe(
             model,
             usage.input_tokens

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -1,0 +1,91 @@
+"""Per-turn token cost accounting (ENG-1288).
+
+The turn is the measured unit: one ``turn_stream()``/``turn()`` invocation
+end to end, including planning and tool-loop calls, the completion
+verifier's verdict calls, verifier-forced continuations, hand-back
+diagnosis streams, and in-turn history compaction. The session installs
+``TurnCost.add`` as the LLMClient's ``usage_listener`` at turn start, so
+every call that flows through the client is counted at one narrow waist
+instead of at each call site.
+
+Consumers, in order:
+- observability: one structured log line + one ``turn_completed`` analytics
+  event per turn (see ``ChatSession._emit_turn_cost``);
+- ENG-1286's per-turn spend ceiling: reads ``total_tokens`` mid-turn.
+
+Component semantics follow ``Usage`` (normalized across providers): input
+is fresh prompt tokens, cache reads/writes are separate, and total context
+for a call is their sum. Kept raw and separate deliberately — consumers
+weight them differently (cache reads are ~10x cheaper for dollars but count
+full-weight against the gateway TPM limiter).
+
+Stated gaps (by design, documented on ENG-1288):
+- usage on errored/aborted calls may be absent from the provider — the turn
+  undercounts rather than crashes;
+- LLM use inside scratchpad user code (``get_llm``) happens in a separate
+  process and is never seen here;
+- post-turn background work (cerebellum flush, identity extraction) runs
+  after the turn's books close and is not attributed to any turn;
+- retried calls count every attempt — retries cost real money.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+from anton.core.llm.provider import Usage
+
+
+@dataclass
+class TurnCost:
+    """Running token totals for one turn. Mutated only via ``add`` plus the
+    session's explicit shape/outcome writes (rounds, continuations, ended_by).
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    llm_calls: int = 0
+    # Largest single-call context (input + cache_read + cache_creation) seen
+    # this turn. Together with ``rounds`` this classifies expensive turns by
+    # shape: few rounds x huge context (bloat) vs many rounds x modest
+    # context (thrash) — cost = rounds x context (ENG-578).
+    peak_context_tokens: int = 0
+    rounds: int = 0
+    continuations: int = 0
+    # Terminal path of the turn. Default holds unless the session marks a
+    # specific exit; ``_emit_turn_cost`` overrides with cancelled/error when
+    # the turn didn't end on its own terms.
+    ended_by: str = "completed"
+    started_monotonic: float = field(default_factory=time.monotonic)
+
+    def add(self, role: str, model: str, usage: Usage) -> None:
+        """Count one LLM call. Installed as ``LLMClient.usage_listener``.
+
+        ``role``/``model`` are accepted (they're the listener contract and
+        what a future per-role breakdown would key on) but not yet stored
+        per-role — the turn event carries the client's planning/coding model
+        names instead.
+        """
+        self.llm_calls += 1
+        self.input_tokens += usage.input_tokens
+        self.output_tokens += usage.output_tokens
+        self.cache_read_tokens += usage.cache_read_tokens
+        self.cache_creation_tokens += usage.cache_creation_tokens
+        self.peak_context_tokens = max(self.peak_context_tokens, usage.context_tokens)
+
+    @property
+    def total_tokens(self) -> int:
+        """All four components summed — ENG-1286's ceiling reads this."""
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_creation_tokens
+        )
+
+    @property
+    def duration_ms(self) -> int:
+        return int((time.monotonic() - self.started_monotonic) * 1000)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import os
+
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from anton.core.llm.provider import LLMResponse, ProviderConnectionInfo, ToolCall, Usage
+
+# Tests that drive full turns now reach the turn-cost analytics sink
+# (ENG-1288): _emit_turn_cost falls back to a fresh AntonSettings(), whose
+# default analytics_url is the real collector. Kill analytics for the whole
+# suite so no test run — local or CI — ever fires a real event. (CI is also
+# dropped by send_event's own CI detection; this covers local dev runs.)
+os.environ.setdefault("ANTON_ANALYTICS_ENABLED", "false")
 
 
 def make_mock_llm() -> AsyncMock:

--- a/tests/test_turn_cost.py
+++ b/tests/test_turn_cost.py
@@ -475,3 +475,101 @@ class TestPerRoleAttribution:
         assert kw["planning_tokens"] == "0"
         assert kw["router_model"] == ""            # no router configured name
         assert kw["router_calls"] == "0"
+
+
+class TestRoleIsPassedNotInferred:
+    """Role must not be derived from model equality (#309 review).
+
+    Deployments run one model for several roles — cowork-server's Gemini
+    defaults are identical across planning/coding/router — and inferring the
+    role from `model == planning_model` booked every generate_object_code call
+    (verifier verdicts, compaction, identity extraction) to `planning`,
+    collapsing exactly the split this exists to provide.
+    """
+
+    @pytest.mark.asyncio
+    async def test_structured_coding_call_books_to_coding_when_models_match(self):
+        from pydantic import BaseModel
+
+        class _S(BaseModel):
+            x: str
+
+        provider = AsyncMock()
+        provider.complete.return_value = LLMResponse(
+            content="",
+            tool_calls=[
+                type("TC", (), {"input": {"x": "y"}, "name": "_S", "id": "1"})()
+            ],
+            usage=_usage(1000, 100),
+        )
+        same = "gemini-3.6-flash"
+        client = LLMClient(
+            planning_provider=provider, planning_model=same,
+            coding_provider=provider, coding_model=same,
+        )
+        tc = TurnCost()
+        client.usage_listener = tc.add
+        try:
+            await client.generate_object_code(_S, system="s", messages=[])
+        except Exception:
+            pass  # unwrapping the stub tool call may fail; the booking is the point
+        assert "coding" in tc.by_role, (
+            f"coding call booked to {list(tc.by_role)} — role was inferred, not passed"
+        )
+        assert "planning" not in tc.by_role
+
+    @pytest.mark.asyncio
+    async def test_structured_planning_call_books_to_planning_when_models_match(self):
+        from pydantic import BaseModel
+
+        class _S(BaseModel):
+            x: str
+
+        provider = AsyncMock()
+        provider.complete.return_value = LLMResponse(
+            content="", tool_calls=[], usage=_usage(500, 50)
+        )
+        same = "gemini-3.6-flash"
+        client = LLMClient(
+            planning_provider=provider, planning_model=same,
+            coding_provider=provider, coding_model=same,
+        )
+        tc = TurnCost()
+        client.usage_listener = tc.add
+        with pytest.raises(Exception):
+            await client.generate_object(_S, system="s", messages=[])
+        assert "planning" in tc.by_role and "coding" not in tc.by_role
+
+
+class TestUnknownRoleReconciles:
+    """An unexpected role must not silently vanish from the breakdown (#309
+    review): it is emitted, so per-role tokens always sum to tokens_total."""
+
+    def test_unknown_bucket_is_emitted(self):
+        s = _bare_session()
+        s._turn_cost.add("", "mystery-model", _usage(400, 20))
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        kw = send.call_args.kwargs
+        assert kw["unknown_tokens"] == "420"
+        assert kw["unknown_calls"] == "1"
+        per_role = sum(
+            int(kw[f"{r}_tokens"])
+            for r in ("planning", "coding", "router", "unknown")
+        )
+        assert per_role == int(kw["tokens_total"]), "per-role sum must reconcile"
+
+    def test_reconciliation_holds_with_every_role_populated(self):
+        s = _bare_session()
+        s._turn_cost.add("planning", "sonnet", _usage(1000, 100, 500))
+        s._turn_cost.add("coding", "haiku", _usage(200, 20))
+        s._turn_cost.add("router", "mindshub_air", _usage(50, 5))
+        s._turn_cost.add("", "mystery", _usage(10, 1))
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        kw = send.call_args.kwargs
+        per_role = sum(
+            int(kw[f"{r}_tokens"])
+            for r in ("planning", "coding", "router", "unknown")
+        )
+        assert per_role == int(kw["tokens_total"]) == 1886

--- a/tests/test_turn_cost.py
+++ b/tests/test_turn_cost.py
@@ -1,0 +1,270 @@
+"""Per-turn token cost accounting (ENG-1288).
+
+Covers the Done-when list:
+- the accumulator counts every call the LLMClient makes (planning stream,
+  coding, router, and the verifier's structured calls — including failed
+  ones, which still cost money);
+- the running total is readable mid-turn (ENG-1286's ceiling surface);
+- the books reset per turn on a long-lived session;
+- ended_by resolution per terminal path;
+- the analytics event carries numbers/names/IDs only, via send_event.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from anton.core.llm.client import LLMClient
+from anton.core.llm.provider import (
+    LLMResponse,
+    StreamComplete,
+    StreamTextDelta,
+    Usage,
+)
+from anton.core.session import ChatSession
+from anton.core.turn_cost import TurnCost
+
+
+def _usage(inp=100, out=10, cr=0, cc=0) -> Usage:
+    return Usage(
+        input_tokens=inp,
+        output_tokens=out,
+        cache_read_tokens=cr,
+        cache_creation_tokens=cc,
+    )
+
+
+class TestTurnCostAccumulator:
+    def test_add_sums_components_and_counts_calls(self):
+        tc = TurnCost()
+        tc.add("planning", "sonnet", _usage(100, 10, 500, 20))
+        tc.add("coding", "haiku", _usage(50, 5))
+        assert tc.input_tokens == 150
+        assert tc.output_tokens == 15
+        assert tc.cache_read_tokens == 500
+        assert tc.cache_creation_tokens == 20
+        assert tc.llm_calls == 2
+        assert tc.total_tokens == 150 + 15 + 500 + 20
+
+    def test_peak_context_includes_cache_components(self):
+        # A warm-cache call has tiny fresh input but a huge cached prompt —
+        # peak context must reflect what the call actually carried, or a
+        # 190k-context call reads as ~2k (the cache-blindness misread).
+        tc = TurnCost()
+        tc.add("planning", "sonnet", _usage(2_000, 10, 180_000, 8_000))
+        tc.add("planning", "sonnet", _usage(50_000, 10))
+        assert tc.peak_context_tokens == 190_000
+
+    def test_usage_context_tokens_property(self):
+        assert _usage(100, 99, 400, 25).context_tokens == 525
+
+
+class TestClientUsageListener:
+    def _client(self, provider: AsyncMock) -> LLMClient:
+        return LLMClient(
+            planning_provider=provider,
+            planning_model="planner",
+            coding_provider=provider,
+            coding_model="coder",
+        )
+
+    @pytest.mark.asyncio
+    async def test_plan_and_code_and_summarize_notify(self):
+        provider = AsyncMock()
+        provider.complete.return_value = LLMResponse(content="ok", usage=_usage())
+        client = self._client(provider)
+        seen: list[tuple[str, str]] = []
+        client.usage_listener = lambda role, model, usage: seen.append((role, model))
+
+        await client.plan(system="s", messages=[])
+        await client.code(system="s", messages=[])
+        await client.summarize(system="s", messages=[])
+        await client.gate(system="s", messages=[])
+
+        assert seen == [
+            ("planning", "planner"),
+            ("coding", "coder"),
+            ("router", "coder"),   # router defaults to the coding role
+            ("router", "coder"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_plan_stream_notifies_on_stream_complete(self):
+        provider = AsyncMock()
+
+        async def _stream(**kwargs):
+            yield StreamTextDelta(text="hi")
+            yield StreamComplete(
+                response=LLMResponse(content="hi", usage=_usage(inp=42))
+            )
+
+        provider.stream = MagicMock(side_effect=lambda **kw: _stream(**kw))
+        client = self._client(provider)
+        tc = TurnCost()
+        client.usage_listener = tc.add
+
+        async for _ in client.plan_stream(system="s", messages=[]):
+            pass
+
+        assert tc.llm_calls == 1
+        assert tc.input_tokens == 42
+
+    @pytest.mark.asyncio
+    async def test_failed_structured_call_still_counts(self):
+        # The verifier's verdict call costs tokens even when the model never
+        # reaches the forced tool call (ENG-1081's failure shape). Counting
+        # happens BEFORE the no-tool-call raise.
+        from pydantic import BaseModel
+
+        class _Schema(BaseModel):
+            x: str
+
+        provider = AsyncMock()
+        provider.complete.return_value = LLMResponse(
+            content="narration, no tool call", usage=_usage(inp=300, out=256)
+        )
+        client = self._client(provider)
+        tc = TurnCost()
+        client.usage_listener = tc.add
+
+        with pytest.raises(Exception):
+            await client.generate_object_code(_Schema, system="s", messages=[])
+
+        assert tc.llm_calls == 1
+        assert tc.output_tokens == 256
+
+    @pytest.mark.asyncio
+    async def test_listener_exception_never_breaks_the_call(self):
+        provider = AsyncMock()
+        provider.complete.return_value = LLMResponse(content="ok", usage=_usage())
+        client = self._client(provider)
+
+        def _boom(role, model, usage):
+            raise RuntimeError("broken accumulator")
+
+        client.usage_listener = _boom
+        response = await client.plan(system="s", messages=[])
+        assert response.content == "ok"
+
+
+def _bare_session(**overrides) -> ChatSession:
+    """Minimal object carrying exactly what _emit_turn_cost reads."""
+    s = ChatSession.__new__(ChatSession)
+    s._turn_cost = overrides.pop("turn_cost", TurnCost())
+    s._llm = MagicMock()
+    s._llm.planning_model = "planner"
+    s._llm.coding_model = "coder"
+    s._session_id = "conv-123"
+    s._harness = "cowork"
+    s._turn_count = 4
+    s._cancel_event = overrides.pop("cancel_event", MagicMock(is_set=lambda: False))
+    s._settings = overrides.pop("settings", None)
+    for k, v in overrides.items():
+        setattr(s, k, v)
+    return s
+
+
+class TestEmitTurnCost:
+    def test_emits_log_and_event_with_join_keys(self, caplog):
+        s = _bare_session()
+        s._turn_cost.add("planning", "planner", _usage(100, 10, 50, 5))
+        with patch("anton.analytics.send_event") as send:
+            with caplog.at_level(logging.INFO, logger="anton.core.session"):
+                s._emit_turn_cost()
+        assert any("turn_cost" in r.message for r in caplog.records)
+        assert send.called
+        kwargs = send.call_args.kwargs
+        assert kwargs["conversation_id"] == "conv-123"
+        assert kwargs["turn_index"] == "5"
+        assert kwargs["tokens_total"] == str(100 + 10 + 50 + 5)
+        assert kwargs["ended_by"] == "completed"
+        assert kwargs["planning_model"] == "planner"
+        # Numbers, names, and IDs only — nothing that could carry content.
+        for value in kwargs.values():
+            assert isinstance(value, str) and len(value) < 200
+
+    def test_books_close_and_listener_disarms(self):
+        s = _bare_session()
+        with patch("anton.analytics.send_event"):
+            s._emit_turn_cost()
+        assert s._turn_cost is None
+        assert s._llm.usage_listener is None
+        # Second emit is a no-op, not a duplicate event.
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        assert not send.called
+
+    def test_explicit_terminal_marks_survive_clean_exit(self):
+        s = _bare_session()
+        s._turn_cost.ended_by = "handback_stuck"
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        assert send.call_args.kwargs["ended_by"] == "handback_stuck"
+
+    def test_inflight_exception_resolves_to_error(self):
+        s = _bare_session()
+        with patch("anton.analytics.send_event") as send:
+            try:
+                raise ValueError("boom")
+            except ValueError:
+                s._emit_turn_cost()
+        assert send.call_args.kwargs["ended_by"] == "error"
+
+    def test_cancel_event_resolves_to_cancelled(self):
+        s = _bare_session(cancel_event=MagicMock(is_set=lambda: True))
+        s._turn_cost.ended_by = "round_cap"  # cancel wins over explicit marks
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        assert send.call_args.kwargs["ended_by"] == "cancelled"
+
+    def test_settings_without_analytics_fields_falls_back(self):
+        # A host passing bare CoreSettings (no analytics_* fields) must not
+        # crash emission — the tools.py fallback pattern resolves a fresh
+        # AntonSettings (whose analytics_enabled env guard then applies).
+        s = _bare_session(settings=object())
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        assert send.called
+
+
+class TestTurnResetsBooks:
+    @pytest.mark.asyncio
+    async def test_each_turn_starts_fresh_books(self, monkeypatch):
+        # Long-lived session (CLI): turn N+1 must not inherit turn N's totals.
+        # Drive the real turn() twice with a text-only response and compare
+        # the emitted totals.
+        from tests.conftest import make_mock_llm
+
+        llm = make_mock_llm()
+        llm.plan.return_value = LLMResponse(content="hi", usage=_usage(inp=100))
+
+        from anton.core.session import ChatSessionConfig
+
+        session = ChatSession(ChatSessionConfig(llm_client=llm))
+        monkeypatch.setattr(session, "_router_enabled", False, raising=False)
+
+        books: list[TurnCost] = []
+        totals: list[int] = []
+        real_emit = session._emit_turn_cost
+
+        def _spy():
+            if session._turn_cost is not None:
+                books.append(session._turn_cost)
+                # Simulate this turn having counted something, so cross-turn
+                # leakage would be visible in the next turn's starting total
+                # (the mocked client never fires the listener itself).
+                session._turn_cost.add("planning", "planner", _usage(inp=100))
+                totals.append(session._turn_cost.total_tokens)
+            real_emit()
+
+        monkeypatch.setattr(session, "_emit_turn_cost", _spy)
+        await session.turn("one")
+        await session.turn("two")
+
+        assert len(books) == 2
+        assert books[0] is not books[1], "turn 2 must open fresh books"
+        assert totals[0] == totals[1], "totals must not accumulate across turns"

--- a/tests/test_turn_cost.py
+++ b/tests/test_turn_cost.py
@@ -398,3 +398,80 @@ class TestListenerCapturedAtIssueTime:
 
         assert turn_two.llm_calls == 0, "late call must not book into the next turn"
         assert turn_one.llm_calls == 1, "it belongs to the turn that issued it"
+
+
+class TestPerRoleAttribution:
+    """Which model the user was actually on, and what each model cost.
+
+    The turn total alone can't be priced: a turn routinely mixes an expensive
+    planning model with the cheap coding model the verifier runs on, so dollars
+    are only computable from (model, tokens) pairs.
+    """
+
+    def test_role_slices_track_model_tokens_and_calls(self):
+        tc = TurnCost()
+        tc.add("planning", "sonnet", _usage(1000, 200))
+        tc.add("planning", "sonnet", _usage(500, 100))
+        tc.add("coding", "haiku", _usage(300, 50))
+        assert tc.by_role["planning"].model == "sonnet"
+        assert tc.by_role["planning"].tokens == 1800
+        assert tc.by_role["planning"].calls == 2
+        assert tc.by_role["coding"].model == "haiku"
+        assert tc.by_role["coding"].tokens == 350
+        # Role slices must reconcile with the turn total, or dollar math
+        # computed per-role silently disagrees with the headline number.
+        assert sum(s.tokens for s in tc.by_role.values()) == tc.total_tokens
+
+    def test_role_slices_include_cache_components(self):
+        tc = TurnCost()
+        tc.add("planning", "sonnet", _usage(100, 10, 5000, 200))
+        assert tc.by_role["planning"].tokens == 5310
+        assert tc.by_role["planning"].tokens == tc.total_tokens
+
+    def test_multiple_models_in_one_role_are_visible_not_dropped(self):
+        # Shouldn't happen, but silently keeping one would make the role's
+        # dollar math wrong with no way to tell. A joined value is the signal.
+        tc = TurnCost()
+        tc.add("coding", "haiku", _usage(100, 10))
+        tc.add("coding", "mindshub_air", _usage(100, 10))
+        assert tc.by_role["coding"].model == "haiku|mindshub_air"
+        assert tc.by_role["coding"].calls == 2
+
+    def test_verifier_call_is_attributed_to_the_coding_role(self):
+        # The completion verifier runs on the coding model — its cost must be
+        # separable from the user-facing loop's.
+        tc = TurnCost()
+        tc.add("planning", "sonnet", _usage(50_000, 500))
+        tc.add("coding", "haiku", _usage(2_000, 60))
+        assert tc.by_role["coding"].tokens == 2_060
+        assert tc.by_role["planning"].tokens == 50_500
+
+    def test_event_carries_the_model_that_actually_ran(self):
+        s = _bare_session()
+        # Configured says one thing; what ran says another. The event must
+        # report what ran — that's "the model the user was on".
+        s._llm.planning_model = "configured-sonnet"
+        s._turn_cost.add("planning", "opus", _usage(100, 10))
+        s._turn_cost.add("coding", "haiku", _usage(20, 5))
+        s._turn_cost.add("router", "mindshub_air", _usage(10, 2))
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        kw = send.call_args.kwargs
+        assert kw["planning_model"] == "opus"
+        assert kw["planning_tokens"] == "110"
+        assert kw["planning_calls"] == "1"
+        assert kw["coding_model"] == "haiku"
+        assert kw["coding_tokens"] == "25"
+        # The router model is recorded nowhere else.
+        assert kw["router_model"] == "mindshub_air"
+        assert kw["router_tokens"] == "12"
+
+    def test_event_falls_back_to_configured_name_when_a_role_never_ran(self):
+        s = _bare_session()
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        kw = send.call_args.kwargs
+        assert kw["planning_model"] == "planner"   # configured
+        assert kw["planning_tokens"] == "0"
+        assert kw["router_model"] == ""            # no router configured name
+        assert kw["router_calls"] == "0"

--- a/tests/test_turn_cost.py
+++ b/tests/test_turn_cost.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -268,3 +269,132 @@ class TestTurnResetsBooks:
         assert len(books) == 2
         assert books[0] is not books[1], "turn 2 must open fresh books"
         assert totals[0] == totals[1], "totals must not accumulate across turns"
+
+
+class TestCacheSplitAcrossProviders:
+    """The two headline invariants of the cache split (#309 review: the
+    no-subtract mutation survived all 1474 tests, so both were unpinned).
+
+    1. ``input_tokens`` means FRESH prompt tokens on every provider — the
+       OpenAI dialect's cache-inclusive ``prompt_tokens`` gets both cached
+       buckets subtracted out.
+    2. ``context_pressure`` keeps its exact pre-split value: all prompt-side
+       tokens, cached or not. Getting this wrong triggers premature
+       compaction on gateway traffic.
+    """
+
+    def _chat_usage(self, prompt=1000, cached=800, written=0, completion=50):
+        return SimpleNamespace(
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=cached, cache_write_tokens=written
+            ),
+        )
+
+    def test_chat_shape_subtracts_cached_share(self):
+        from anton.core.llm.openai import _split_cached_input
+
+        assert _split_cached_input(self._chat_usage()) == (200, 800, 0)
+
+    def test_gateway_shape_splits_reads_and_writes(self):
+        # mindshub_inference publishes both buckets and composes
+        # prompt_tokens = fresh + reads + writes.
+        from anton.core.llm.openai import _split_cached_input
+
+        usage = self._chat_usage(prompt=100, cached=30, written=10)
+        assert _split_cached_input(usage) == (60, 30, 10)
+
+    def test_responses_api_shape_uses_input_token_names(self):
+        from anton.core.llm.openai import _split_cached_input
+
+        usage = SimpleNamespace(
+            input_tokens=1000,
+            output_tokens=10,
+            input_tokens_details=SimpleNamespace(
+                cached_tokens=800, cache_write_tokens=50
+            ),
+        )
+        assert _split_cached_input(usage) == (150, 800, 50)
+
+    def test_no_details_means_all_fresh(self):
+        from anton.core.llm.openai import _split_cached_input
+
+        assert _split_cached_input(SimpleNamespace(prompt_tokens=500)) == (500, 0, 0)
+
+    def test_malformed_payload_never_yields_negative_fresh_input(self):
+        from anton.core.llm.openai import _split_cached_input
+
+        usage = self._chat_usage(prompt=100, cached=900, written=900)
+        fresh, read, write = _split_cached_input(usage)
+        assert fresh == 0 and read + write <= 100
+
+    @pytest.mark.asyncio
+    async def test_provider_reports_split_and_unchanged_context_pressure(self):
+        # End to end through the real provider: components split, and
+        # context_pressure computed on ALL prompt tokens (1000), which is
+        # exactly what it was before the split existed.
+        from anton.core.llm.openai import OpenAIProvider
+        from anton.core.llm.provider import compute_context_pressure
+
+        provider = OpenAIProvider(api_key="k")
+        completion = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="hi", tool_calls=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=self._chat_usage(prompt=1000, cached=750, written=50),
+        )
+        provider._client = MagicMock()
+        provider._client.chat = MagicMock()
+        provider._client.chat.completions = MagicMock()
+        provider._client.chat.completions.create = AsyncMock(return_value=completion)
+
+        response = await provider.complete(
+            model="sonnet", system="s", messages=[{"role": "user", "content": "hi"}]
+        )
+        assert response.usage.input_tokens == 200
+        assert response.usage.cache_read_tokens == 750
+        assert response.usage.cache_creation_tokens == 50
+        assert response.usage.context_tokens == 1000
+        assert response.usage.context_pressure == compute_context_pressure("sonnet", 1000)
+
+
+class TestListenerCapturedAtIssueTime:
+    @pytest.mark.asyncio
+    async def test_background_call_started_before_disarm_books_nowhere(self):
+        # End-of-turn background work (cerebellum flush, identity update)
+        # shares the client. A call issued during turn N that lands after
+        # turn N+1 armed its books must NOT land in turn N+1 (#309 review).
+        release = asyncio.Event()
+        provider = AsyncMock()
+
+        async def _slow_complete(**kwargs):
+            await release.wait()
+            return LLMResponse(content="late", usage=_usage(inp=999))
+
+        provider.complete = AsyncMock(side_effect=_slow_complete)
+        client = LLMClient(
+            planning_provider=provider,
+            planning_model="planner",
+            coding_provider=provider,
+            coding_model="coder",
+        )
+
+        turn_one = TurnCost()
+        client.usage_listener = turn_one.add
+        task = asyncio.create_task(client.code(system="s", messages=[]))
+        await asyncio.sleep(0)  # let the call reach the await
+
+        # Turn 1 ends: books close, listener disarms. Turn 2 opens its own.
+        client.usage_listener = None
+        turn_two = TurnCost()
+        client.usage_listener = turn_two.add
+
+        release.set()
+        await task
+
+        assert turn_two.llm_calls == 0, "late call must not book into the next turn"
+        assert turn_one.llm_calls == 1, "it belongs to the turn that issued it"

--- a/tests/test_turn_cost.py
+++ b/tests/test_turn_cost.py
@@ -559,6 +559,26 @@ class TestUnknownRoleReconciles:
         )
         assert per_role == int(kw["tokens_total"]), "per-role sum must reconcile"
 
+    def test_novel_role_folds_into_unknown_rather_than_vanishing(self):
+        # The nit Paul caught: `role or UNKNOWN_ROLE` only caught a FALSY role.
+        # A novel non-empty role ("verifier") keyed its own bucket, which the
+        # event never reads — so its tokens dropped from the breakdown AND left
+        # `unknown` at 0, breaking reconciliation with no alarm (#309 review).
+        s = _bare_session()
+        s._turn_cost.add("planning", "sonnet", _usage(100, 10))
+        s._turn_cost.add("verifier", "haiku", _usage(300, 20))   # invented role
+        assert "verifier" not in s._turn_cost.by_role
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        kw = send.call_args.kwargs
+        assert kw["unknown_tokens"] == "320", "novel role must surface in unknown"
+        assert kw["unknown_calls"] == "1"
+        per_role = sum(
+            int(kw[f"{r}_tokens"])
+            for r in ("planning", "coding", "router", "unknown")
+        )
+        assert per_role == int(kw["tokens_total"]) == 430
+
     def test_reconciliation_holds_with_every_role_populated(self):
         s = _bare_session()
         s._turn_cost.add("planning", "sonnet", _usage(1000, 100, 500))

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -1,0 +1,259 @@
+"""Terminal-path classification for the per-turn cost books (ENG-1288).
+
+Each test here corresponds to a #309 review finding that a real production
+exit filed the wrong ``ended_by`` (or emitted nothing at all). They drive the
+real ``turn_stream``/``turn`` rather than poking the classifier, because every
+one of these bugs lived in the wiring, not the arithmetic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_mock_llm
+
+from anton.core.llm.provider import (
+    LLMResponse,
+    StreamComplete,
+    StreamTextDelta,
+    ToolCall,
+    Usage,
+)
+from anton.core.session import ChatSession, ChatSessionConfig, _VerifierVerdict
+
+
+@pytest.fixture()
+def workspace():
+    base = Path(__file__).resolve().parents[1] / ".pytest-workspace"
+    base.mkdir(parents=True, exist_ok=True)
+    return MagicMock(base=base)
+
+
+def _text(text: str = "done") -> LLMResponse:
+    return LLMResponse(
+        content=text, tool_calls=[], usage=Usage(input_tokens=10, output_tokens=5),
+        stop_reason="end_turn",
+    )
+
+
+def _tool_call(i: int = 1) -> LLMResponse:
+    return LLMResponse(
+        content="working",
+        tool_calls=[ToolCall(id=f"tc_{i}", name="scratchpad",
+                             input={"action": "view", "name": "main"})],
+        usage=Usage(input_tokens=10, output_tokens=5),
+        stop_reason="tool_use",
+    )
+
+
+class _Iter:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _stub_tools(session) -> None:
+    """Answer every tool call in-process.
+
+    These tests only need the tool LOOP to turn over; letting the real
+    scratchpad handler run would spawn a venv/subprocess per test (slow, and
+    it leaks event-loop teardown noise).
+    """
+    from anton.core.tools.registry import ToolOutcome
+
+    session.tool_registry.dispatch_tool = AsyncMock(
+        return_value=ToolOutcome(content="stubbed tool result", ok=True)
+    )
+
+
+def _ended_by(send_event_mock) -> str:
+    assert send_event_mock.called, "no turn_completed event emitted"
+    return send_event_mock.call_args.kwargs["ended_by"]
+
+
+async def test_task_cancel_reports_cancelled_not_error(workspace):
+    """cowork-server's Stop is ``task.cancel()`` → ``asyncio.CancelledError``
+    inside the suspended generator, and nothing there sets ``_cancel_event``.
+    Before the fix every user Stop on the primary host filed as ``error``.
+    """
+    mock_llm = make_mock_llm()
+    started = asyncio.Event()
+
+    def _hang(**kwargs):
+        async def _gen():
+            started.set()
+            await asyncio.sleep(30)  # cancelled here, mid-await
+            yield StreamComplete(response=_text())
+        return _gen()
+
+    mock_llm.plan_stream = _hang
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        async def _consume():
+            async for _ in session.turn_stream("hang please"):
+                pass
+
+        task = asyncio.create_task(_consume())
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert _ended_by(send) == "cancelled"
+        assert not session._cancel_event.is_set(), (
+            "guard: the fix must not depend on _cancel_event, which the "
+            "hosted path never sets"
+        )
+
+
+async def test_abandoned_generator_still_emits_exactly_once(workspace):
+    """CLI ESC abandons the generator without ``aclose()``. The deferred
+    finalizer runs in a copied context where ``reset_trace_context`` raises
+    ValueError — which used to abort the finally before emission, so an
+    ESC-cancelled turn was never counted at all.
+    """
+    mock_llm = make_mock_llm()
+
+    def _stream(**kwargs):
+        async def _gen():
+            yield StreamTextDelta(text="partial")
+            await asyncio.sleep(30)
+            yield StreamComplete(response=_text())
+        return _gen()
+
+    mock_llm.plan_stream = _stream
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        gen = session.turn_stream("start then abandon")
+        async for _ in gen:
+            break  # abandon mid-iteration, no aclose()
+        await gen.aclose()  # what asyncio's finalizer eventually does
+
+        assert send.call_count == 1
+        assert _ended_by(send) == "cancelled"
+
+
+async def test_late_finalizer_cannot_close_a_newer_turns_books(workspace):
+    """The books guard: a finalizer arriving after the next turn opened its
+    own books must no-op instead of emitting the new turn's partial totals.
+    """
+    from anton.core.turn_cost import TurnCost
+
+    session = ChatSession.__new__(ChatSession)
+    session._llm = MagicMock()
+    session._llm.planning_model = "p"
+    session._llm.coding_model = "c"
+    session._session_id = "s"
+    session._harness = "cowork"
+    session._turn_count = 1
+    session._cancel_event = MagicMock(is_set=lambda: False)
+    session._settings = None
+
+    stale, current = TurnCost(), TurnCost()
+    session._turn_cost = current
+    with patch("anton.analytics.send_event") as send:
+        session._emit_turn_cost(expected=stale)
+        assert not send.called
+        assert session._turn_cost is current, "current turn keeps its books"
+
+        session._emit_turn_cost(expected=current)
+        assert send.called
+
+
+async def test_exhausted_retries_is_not_reported_as_completed(workspace):
+    """Every LLM call failing → the retry loop yields an apology and breaks.
+    Nothing is in flight in the finally, so the default ``completed`` used to
+    hold — filing the most common failure mode as a clean turn.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.plan_stream = MagicMock(side_effect=RuntimeError("provider down"))
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("do something"):
+            pass
+
+    assert _ended_by(send) == "retry_exhausted"
+
+
+async def test_rounds_accumulate_across_verifier_continuations(workspace):
+    """``tool_round`` is loop-local and resets on each continuation, so
+    assigning it reported only the last continuation's rounds — breaking the
+    rounds x context shape metric for exactly the expensive turns it exists
+    to classify.
+    """
+    mock_llm = make_mock_llm()
+    # 2 tool rounds, reply; INCOMPLETE verdict; 1 tool round, reply; COMPLETE.
+    plans = [
+        _Iter([StreamComplete(response=_tool_call(1))]),
+        _Iter([StreamComplete(response=_tool_call(2))]),
+        _Iter([StreamComplete(response=_text("first pass"))]),
+        _Iter([StreamComplete(response=_tool_call(3))]),
+        _Iter([StreamComplete(response=_text("second pass"))]),
+    ]
+    mock_llm.plan_stream = MagicMock(side_effect=lambda **kw: plans.pop(0))
+    verdicts = [
+        _VerifierVerdict(status="INCOMPLETE", reason="more to do"),
+        _VerifierVerdict(status="COMPLETE", reason="done"),
+    ]
+    mock_llm.generate_object_code = AsyncMock(side_effect=verdicts)
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    _stub_tools(session)
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("multi-step task"):
+            pass
+
+    kwargs = send.call_args.kwargs
+    assert kwargs["continuations"] == "1"
+    assert kwargs["rounds"] == "3", (
+        f"rounds must span continuations (2 + 1), got {kwargs['rounds']}"
+    )
+
+
+async def test_round_cap_reports_the_cap_not_cap_plus_one(workspace):
+    mock_llm = make_mock_llm()
+    mock_llm.plan_stream = MagicMock(
+        side_effect=lambda **kw: _Iter([StreamComplete(response=_tool_call())])
+    )
+    mock_llm.generate_object_code = AsyncMock(
+        return_value=_VerifierVerdict(status="COMPLETE", reason="ok")
+    )
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    _stub_tools(session)
+    session._max_tool_rounds = 2
+
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("loop forever"):
+            pass
+
+    kwargs = send.call_args.kwargs
+    assert kwargs["ended_by"] == "round_cap"
+    assert kwargs["rounds"] == "2", f"cap is 2, reported {kwargs['rounds']}"
+
+
+async def test_non_streaming_turn_marks_round_cap(workspace):
+    mock_llm = make_mock_llm()
+    mock_llm.plan = AsyncMock(return_value=_tool_call())
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    _stub_tools(session)
+    session._max_tool_rounds = 1
+    session._router_enabled = False
+
+    with patch("anton.analytics.send_event") as send:
+        await session.turn("loop forever")
+
+    assert _ended_by(send) == "round_cap"

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -119,10 +119,15 @@ async def test_task_cancel_reports_cancelled_not_error(workspace):
 
 
 async def test_abandoned_generator_still_emits_exactly_once(workspace):
-    """CLI ESC abandons the generator without ``aclose()``. The deferred
-    finalizer runs in a copied context where ``reset_trace_context`` raises
-    ValueError — which used to abort the finally before emission, so an
-    ESC-cancelled turn was never counted at all.
+    """Abandoning mid-iteration still books the turn exactly once, as
+    ``cancelled``.
+
+    Scope note (#309 fix-verification): this is the SAME-TASK abandon path.
+    ``aclose()`` here runs the ``finally`` in the original context, so
+    ``reset_trace_context`` succeeds and the cross-context ValueError never
+    fires — this test therefore does NOT cover the emit-before-reset fix.
+    That mechanism is pinned by
+    ``test_emit_survives_reset_trace_context_valueerror`` below; keep both.
     """
     mock_llm = make_mock_llm()
 
@@ -139,11 +144,38 @@ async def test_abandoned_generator_still_emits_exactly_once(workspace):
     with patch("anton.analytics.send_event") as send:
         gen = session.turn_stream("start then abandon")
         async for _ in gen:
-            break  # abandon mid-iteration, no aclose()
-        await gen.aclose()  # what asyncio's finalizer eventually does
+            break  # abandon mid-iteration
+        # Same-task close — NOT what a deferred finalizer does (that runs in a
+        # fresh task with a copied context); see the scope note above.
+        await gen.aclose()
 
         assert send.call_count == 1
         assert _ended_by(send) == "cancelled"
+
+
+async def test_emit_survives_reset_trace_context_valueerror(workspace):
+    """The real deferred-finalizer condition: ``reset_trace_context`` raises.
+
+    asyncio runs an abandoned async generator's ``finally`` in a fresh task
+    with a COPIED context, where resetting a token created elsewhere raises
+    ``ValueError: Token ... created in a different Context``. That used to
+    abort the finally before emission — so an ESC-cancelled CLI turn was
+    never counted at all. Patching the raise is deliberate: the ValueError
+    *is* the mechanism, and forcing a genuine deferred finalizer is
+    timing-dependent and flaky by comparison (#309 fix-verification).
+    """
+    mock_llm = make_mock_llm()
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    def _boom(_token):
+        raise ValueError("Token was created in a different Context")
+
+    with patch("anton.core.session.reset_trace_context", side_effect=_boom), \
+         patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("hello"):
+            pass
+
+        assert send.call_count == 1, "books must emit even when reset raises"
 
 
 async def test_late_finalizer_cannot_close_a_newer_turns_books(workspace):

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -385,3 +385,93 @@ async def test_callers_already_handled_exception_is_not_reported_as_error(worksp
                 pass
 
     assert _ended_by(send) == "completed"
+
+
+async def test_abandoned_turn_keeps_its_own_index_not_a_later_turns(workspace):
+    """Per-turn facts are stamped at books-open, not read at emit.
+
+    A late finalizer emits books whose turn ended long ago; reading
+    ``self._turn_count`` there gave the abandoned turn a LATER, unrelated
+    turn's index (#309 review follow-up). Sequence: abandon turn 1 → finish
+    turn 2 → finalize turn 1 → finish turn 3.
+
+    Note on uniqueness, which is NOT what this asserts: ``_turn_count``
+    advances only after a turn completes, so an abandoned turn and its
+    successor legitimately share an index — and the Langfuse trace context
+    derives its ``turn_id`` from the *same* expression (``session.py`` where
+    ``TraceContext`` is built). So a shared index means "two attempts at one
+    conversational turn" on both sides, and the cost→trace hop stays
+    consistent. Claiming `(conversation_id, turn_index)` were a unique event
+    key would have been wrong; it is a join key.
+    """
+    mock_llm = make_mock_llm()
+    hang = asyncio.Event()
+
+    def _stream(**kwargs):
+        async def _gen():
+            yield StreamTextDelta(text="partial")
+            await hang.wait()
+            yield StreamComplete(response=_text())
+        return _gen()
+
+    def _quick(**kwargs):
+        return _Iter([StreamComplete(response=_text("done"))])
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        mock_llm.plan_stream = _stream
+        abandoned = session.turn_stream("turn one — abandoned")
+        async for _ in abandoned:
+            break                                    # turn 1 left open
+
+        mock_llm.plan_stream = _quick
+        async for _ in session.turn_stream("turn two"):
+            pass                                     # completes -> _turn_count 1
+
+        await abandoned.aclose()                     # turn 1's late finalizer
+
+        async for _ in session.turn_stream("turn three"):
+            pass
+
+    events = [(c.kwargs["ended_by"], c.kwargs["turn_index"]) for c in send.call_args_list]
+    assert len(events) == 3, f"expected 3 events, got {events}"
+
+    # The abandoned turn is the cancelled one. It opened as turn 1 and must
+    # still say 1 — reading live state at emit would report 2 (turn 3's).
+    cancelled = [idx for ended, idx in events if ended == "cancelled"]
+    assert cancelled == ["1"], f"abandoned turn drifted to a later index: {events}"
+
+
+async def test_late_emit_duration_is_bounded_by_last_activity(workspace):
+    """A late finalizer must not measure duration up to whenever asyncio ran
+    it — that inflates the field a runaway query sorts on. With no owning turn
+    ending, the last LLM call is the bounded approximation used instead.
+    """
+    from anton.core.turn_cost import TurnCost
+
+    session = ChatSession.__new__(ChatSession)
+    session._llm = MagicMock()
+    session._llm.planning_model = "p"
+    session._llm.coding_model = "c"
+    session._session_id = "conv"
+    session._harness = "cli"
+    session._turn_count = 5
+    session._cancel_event = MagicMock(is_set=lambda: False)
+    session._settings = None
+
+    stale = TurnCost(turn_index=2)
+    stale.add("planning", "sonnet", Usage(input_tokens=10, output_tokens=1))
+    stale.last_activity_monotonic = stale.started_monotonic + 0.010  # ~10ms of work
+    session._turn_cost = TurnCost(turn_index=6)                      # newer owner
+
+    await asyncio.sleep(0.05)  # the finalizer fires much later
+
+    with patch("anton.analytics.send_event") as send:
+        session._emit_turn_cost(expected=stale)
+
+    kw = send.call_args.kwargs
+    assert kw["turn_index"] == "2"
+    assert int(kw["duration_ms"]) < 40, (
+        f"duration measured to finalizer time, not turn end: {kw['duration_ms']}ms"
+    )

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -195,14 +195,27 @@ async def test_late_finalizer_cannot_close_a_newer_turns_books(workspace):
     session._settings = None
 
     stale, current = TurnCost(), TurnCost()
+    stale.add("planning", "sonnet", Usage(input_tokens=777, output_tokens=3))
     session._turn_cost = current
     with patch("anton.analytics.send_event") as send:
+        # The invariant is narrow: a late finalizer must not close a NEWER
+        # turn's books — NOT that it must emit nothing. The stale books hold a
+        # complete, real turn (often the runaway the user just cancelled), so
+        # they get reported; only the owning turn may clear the shared slot
+        # (#309 review — the earlier version of this test codified the drop).
+        session._emit_turn_cost(expected=stale)
+        assert send.called, "the abandoned turn must still be counted"
+        assert send.call_args.kwargs["tokens_total"] == "780"
+        assert session._turn_cost is current, "current turn keeps its books"
+
+        # Re-emitting the same books is still a no-op (now via `emitted`).
+        send.reset_mock()
         session._emit_turn_cost(expected=stale)
         assert not send.called
-        assert session._turn_cost is current, "current turn keeps its books"
 
         session._emit_turn_cost(expected=current)
         assert send.called
+        assert session._turn_cost is None, "the owner clears the slot"
 
 
 async def test_exhausted_retries_is_not_reported_as_completed(workspace):
@@ -289,3 +302,86 @@ async def test_non_streaming_turn_marks_round_cap(workspace):
         await session.turn("loop forever")
 
     assert _ended_by(send) == "round_cap"
+
+
+# ---------------------------------------------------------------------------
+# The three hand-back terminals. Every one of these marks survived deletion
+# with the suite green (#309 review mutation run) — and they are precisely the
+# "expensive turn ended badly" values the `group by ended_by` contract needs.
+# ---------------------------------------------------------------------------
+
+
+def _verdict_llm(status: str, *, tool_rounds: int = 1):
+    """A mock client whose turn does `tool_rounds` rounds then gets `status`."""
+    mock_llm = make_mock_llm()
+    plans = [_Iter([StreamComplete(response=_tool_call(i))]) for i in range(tool_rounds)]
+    plans.append(_Iter([StreamComplete(response=_text("reply"))]))
+    # Any further re-entries (continuations) just reply again.
+    def _next_plan(**kw):
+        return plans.pop(0) if plans else _Iter(
+            [StreamComplete(response=_text("reply again"))]
+        )
+    mock_llm.plan_stream = MagicMock(side_effect=_next_plan)
+    mock_llm.generate_object_code = AsyncMock(
+        return_value=_VerifierVerdict(status=status, reason="because")
+    )
+    return mock_llm
+
+
+async def test_stuck_verdict_reports_handback_stuck(workspace):
+    session = ChatSession(
+        ChatSessionConfig(llm_client=_verdict_llm("STUCK"), workspace=workspace)
+    )
+    _stub_tools(session)
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("connect to the database"):
+            pass
+    assert _ended_by(send) == "handback_stuck"
+
+
+async def test_exhausted_continuations_report_handback_budget(workspace):
+    # INCOMPLETE forever + no continuation budget = the budget-exhausted
+    # hand-back, the path ENG-1155 rewrote.
+    session = ChatSession(
+        ChatSessionConfig(llm_client=_verdict_llm("INCOMPLETE"), workspace=workspace)
+    )
+    _stub_tools(session)
+    session._max_continuations = 0
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("do a multi-part job"):
+            pass
+    assert _ended_by(send) == "handback_budget"
+
+
+async def test_verifier_failure_reports_handback_verifier_failure(workspace):
+    # The verdict call itself failing (ENG-1079's fail-safe), not a verdict.
+    mock_llm = _verdict_llm("COMPLETE")
+    mock_llm.generate_object_code = AsyncMock(side_effect=RuntimeError("provider hiccup"))
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    _stub_tools(session)
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("run my script"):
+            pass
+    assert _ended_by(send) == "handback_verifier_failure"
+
+
+async def test_callers_already_handled_exception_is_not_reported_as_error(workspace):
+    """`sys.exc_info()` returns whatever the thread is handling — including an
+    exception the CALLER already caught. Asking the interpreter instead of
+    capturing this turn's own exception reported `error` for a clean turn
+    (#309 review). Latent today; `ended_by` is what error-rate queries key on.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.plan_stream = MagicMock(
+        side_effect=lambda **kw: _Iter([StreamComplete(response=_text("hi"))])
+    )
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        try:
+            raise ValueError("caller's own, already-handled error")
+        except ValueError:
+            async for _ in session.turn_stream("hello"):
+                pass
+
+    assert _ended_by(send) == "completed"

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -475,3 +475,28 @@ async def test_late_emit_duration_is_bounded_by_last_activity(workspace):
     assert int(kw["duration_ms"]) < 40, (
         f"duration measured to finalizer time, not turn end: {kw['duration_ms']}ms"
     )
+
+
+async def test_host_supplied_turn_id_is_what_the_event_reports(workspace):
+    """The cost event's turn_index must equal the trace's turn_id.
+
+    `turn_stream(turn_id=...)` exists so a host can supply its own identifier
+    "so downstream telemetry can correlate" — and the trace context prefers it.
+    Deriving the books' index independently from `_turn_count` agreed only
+    because no host passes `turn_id` today; if one did, the cost event and the
+    Langfuse trace would name different turns — the exact defect the stamping
+    exists to prevent (#309 review follow-up, second pass).
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.plan_stream = MagicMock(
+        side_effect=lambda **kw: _Iter([StreamComplete(response=_text("hi"))])
+    )
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("hello", turn_id=4242):
+            pass
+
+    assert send.call_args.kwargs["turn_index"] == "4242", (
+        "the event must report the host's turn_id, not the internal counter"
+    )


### PR DESCRIPTION
# ENG-1288: per-turn token cost counter — anton finally knows what a turn spent

Nobody knows what a turn costs: the Kiranam session (~3.72M tokens, ~50 min) was discovered weeks later via manual Langfuse archaeology. This PR gives the runtime its own books — the primitive under the ENG-1286 spend ceiling, cost-per-task analytics, and runaway alerting.

[Linear ENG-1288](https://linear.app/mindsdb/issue/ENG-1288) — the full measurement contract (turn = measured unit; round = read-point + shape stats; conversation = derived; task v1 ≔ conversation; two-ledger doctrine) lives on the ticket.

## What's in here

1. **`Usage` gains cache components, normalized across providers.** `cache_read_tokens` / `cache_creation_tokens` + a `context_tokens` property (cache tokens ARE context — a warm-cache 190k call is not a 2k call). Anthropic passes its native fields through (its `input_tokens` already excludes cache activity); OpenAI-shaped usage **subtracts `cached_tokens` out of `prompt_tokens`** so `input` means fresh tokens on every provider (`_split_cached_input`, junk-tolerant for gateway quirks/test doubles). `context_pressure` keeps its exact old value on the OpenAI path (fresh + cached) — no compaction behavior change.

2. **`LLMClient.usage_listener`** — one narrow waist. `plan` / `plan_stream` (planning), `code` + `_generate_object_with` (coding — the completion verifier's verdict calls, **counted before the no-tool-call raise**: a failed structured call still costs money, ENG-1081's shape), `summarize` / `gate` (router). A listener that raises is swallowed with a warning — accounting must never kill the turn it's counting.

3. **`TurnCost`** (`anton/core/turn_cost.py`) — four raw components + `llm_calls` + shape stats (`rounds`, `peak_context_tokens`, `continuations`) + `ended_by` + duration. `total_tokens` is ENG-1286's mid-turn read surface.

   **Per-role attribution** (added 2026-08-06 on request): `<role>_model` / `<role>_tokens` / `<role>_calls` for the closed role set `planning` / `coding` / `router`. Answers two questions the blended total can't:
   - *"which model was the user on"* — `planning_model` reports the model that **actually ran** the conversational loop, falling back to the configured name only if the role never ran.
   - *correct dollar math* — a turn routinely mixes an expensive planning model with the cheap coding model the verifier runs on, so one token count can't be priced at any single rate; dollars need `(model, tokens)` pairs. Router cost is recorded here for the first time (it appeared in no sink before).

   Role slices are asserted to reconcile with the turn total; two models in one role join with `|` so ambiguous per-role pricing is visible rather than one model being silently dropped. **Limit:** this is the alias anton *requested* — the gateway can resolve or fail over server-side and doesn't report that back (`LLMResponse` carries no model field), so Langfuse stays truth for what served a call.

4. **Session wiring** — books open at turn start (both `turn_stream` and CLI `turn()`), terminal sites mark `ended_by` (`round_cap`, `handback_stuck`, `handback_budget`, `handback_verifier_failure`), and `_emit_turn_cost` closes the books in the turn's `finally`: in-flight exception → `error`, cancel/GeneratorExit → `cancelled`, explicit marks survive clean exits, else `completed`. Emission disarms the listener so post-turn background work (cerebellum flush, identity extraction) can't leak into the next turn's books.

5. **Two reporting sinks** — a structured `turn_cost` log line, and a `turn_completed` analytics event through the existing `send_event` channel (same settings-resolution pattern as the `ds_connect_*` events; `analytics_enabled` opt-out and CI-drop apply). Event carries **numbers, names, and IDs only** — components, shape, `ended_by`, models, provider, harness, `anton_version`, and `conversation_id` + `turn_index` **join** keys that address the turn's Langfuse trace. (A join key, *not* a unique event key: `_turn_count` advances only after a turn completes, so an abandoned turn and its retry legitimately share an index — and the Langfuse trace context derives its `turn_id` from the same expression, so both sides agree it's two attempts at one conversational turn.)

6. **Test-suite guard**: `conftest.py` sets `ANTON_ANALYTICS_ENABLED=false` suite-wide — full-turn stub tests now reach the emission path, and no test run may ever fire a real collector event.

## Deviations from the ticket (will comment there)

- **The analytics channel is anton's anonymous collector (aid-keyed), not an identified PostHog client** — anton has no PostHog surface and its analytics module is anonymous by deliberate design. User-level joins go event → `conversation_id`/`turn_index` → Langfuse trace → user identity. The ticket's "Keycloak sub on the event" line was wrong at this layer.
- ~~**`cache_creation_tokens` = 0 on OpenAI-compatible surfaces** (incl. the gateway) — the wire format exposes only the read side.~~ **Retracted 2026-08-05 — this was factually wrong.** `mindshub_inference@origin/main` publishes `prompt_tokens_details.{cached_tokens, cache_write_tokens}` with `prompt_tokens = fresh + reads + writes`; the split now reads both buckets (review finding 3, fixed in `c0d5a30`). Third-party endpoints that omit the write field report 0 for it.
- **`origin` (interactive/channel/scheduled) not emitted** — not derivable inside anton today; `harness` is. Fast follow if hosts start passing it.

## Tests

14 new in `test_turn_cost.py`: accumulator math incl. cache-blind-peak guard; listener wiring per role; failed-verifier-call counting; listener-exception isolation; `ended_by` resolution per terminal (error / cancelled / explicit marks / completed); books close + double-emit no-op; bare-`CoreSettings` fallback; fresh-books-per-turn on a long-lived session (distinct instances, non-cumulative totals). Full suite: 1472 passed (+e2e 39) — the 2 `test_chat_scratchpad` failures are the known pre-existing local-sandbox quirk, failing identically on clean staging.

## Security pass

No content ever leaves the process: the event is integers, model/provider names, harness, version, and opaque IDs; the log line is the same. Analytics respects the existing opt-out + CI drop; emission is fire-and-forget and exception-isolated both directions (listener → call, emission → turn). No new inputs parsed, no secrets touched.



