### PR TITLE
Fix duplicated wording in Anthropic/OpenAI 404 error messages (ENG-1139)

### DIFF
--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -25,6 +25,7 @@ from .provider import (
     ToolCall,
     TransientProviderError,
     Usage,
+    classify_404,
     classify_transient,
     compute_context_pressure,
     wallet_denial_code,
@@ -49,6 +50,9 @@ def _raise_for_status_error(
     - 402/429 with an M3 gate wallet code (``wallet_empty`` /
       ``included_allowance_exhausted``, body or X-MindsHub-Reason header)
       → TokenLimitExceeded (ENG-1169). Code-exact: BYOK 402s stay generic.
+    - 404 → ModelUnavailableError or EndpointConfigurationError via the
+      shared ``classify_404`` (ENG-1139) — permanent, non-duplicated copy
+      instead of the generic "temporarily unavailable, try again".
     - overloaded/api_error (incl. the mid-stream HTTP-200 case), 5xx, plain 429
       → TransientProviderError (retryable — see ENG-673).
     - anything else → the generic "temporarily unavailable" ConnectionError.
@@ -86,6 +90,20 @@ def _raise_for_status_error(
         raise TokenLimitExceeded(
             f"Server returned {exc.status_code} — {what} Add credits at "
             "https://console.mindshub.ai/settings/organization/billing to continue."
+        ) from exc
+
+    # A 404 from the Anthropic Messages API means the model isn't recognized
+    # (there's no alternate route to misconfigure on this fixed endpoint) —
+    # ``error.type="not_found_error"`` is Anthropic's own signal. Shared
+    # classifier with the openai.py mapper (ENG-1139) so the wording — and
+    # the "permanent, switch models" framing instead of the misleading
+    # "temporarily unavailable, try again" — can't drift between providers.
+    if exc.status_code == 404:
+        envelope = body.get("error") if isinstance(body.get("error"), dict) else {}
+        raise classify_404(
+            model,
+            message=envelope.get("message") or body.get("message"),
+            error_type=envelope.get("type"),
         ) from exc
 
     transient = classify_transient(exc.status_code, body, provider=provider, model=model)

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -30,6 +30,7 @@ from .provider import (
     ToolCall,
     TransientProviderError,
     Usage,
+    classify_404,
     classify_transient,
     compute_context_pressure,
     wallet_denial_code,
@@ -169,52 +170,13 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
 
     # A 404 needs care: this mapper is shared by direct OpenAI, Gemini, MindsHub,
     # Azure, and arbitrary OpenAI-compatible endpoints, so a bare 404 does NOT by
-    # itself mean the model is missing — a wrong base URL, a missing ``/v1``, a
-    # reverse-proxy route, or an unsupported API path all 404 too, and there
-    # "switch models" is the wrong remedy. Only treat it as model-not-found when
-    # the structured body actually points at the model: OpenAI's
-    # ``code="model_not_found"``, or a model-oriented message (Gemini's
-    # ``status="NOT_FOUND"`` with "models/<id> is not found / no longer
-    # available"). Everything else is surfaced as an endpoint/configuration
-    # failure carrying the provider's own words. (ENG-1145 review)
+    # itself mean the model is missing. `classify_404` (shared with the Anthropic
+    # mapper, ENG-1139) decides model-not-found vs. endpoint-misconfiguration.
     if exc.status_code == 404:
         provider_msg = envelope.get("message") or body.get("message")
-        msg_l = provider_msg.lower() if isinstance(provider_msg, str) else ""
-        status_str = str(body.get("status") or envelope.get("status") or "").upper()
-        model_specific = code == "model_not_found" or (
-            "model" in msg_l
-            and (
-                status_str == "NOT_FOUND"
-                or "not found" in msg_l
-                or "not available" in msg_l
-                or "no longer available" in msg_l
-                or "does not exist" in msg_l
-            )
-        )
-        # Provider message as a leading-space fragment with a normalized
-        # terminator, so the appended copy reads cleanly whether or not the
-        # provider punctuated its own message (Gemini's ends in a period; a raw
-        # proxy/FastAPI detail may not). Named `suffix`, not `detail`: the `detail`
-        # bound above is the FastAPI 429 detail, and reusing the name would leak
-        # this 404-local value into any branch added after this block.
-        clean = provider_msg.strip() if isinstance(provider_msg, str) else ""
-        if clean and clean[-1] not in ".!?":
-            clean += "."
-        suffix = f" {clean}" if clean else ""
-        if model_specific:
-            reason = f":{suffix}" if suffix else "."
-            raise ModelUnavailableError(
-                f"The model '{model}' isn't available{reason} Switch models in Settings.",
-                code="model_not_found", model=model,
-            ) from exc
-        # Not model-specific → almost always a misrouted/misconfigured endpoint
-        # (bad base URL, missing /v1, proxy route). Permanent for this request,
-        # but the remedy is the endpoint config, not the model — a distinct type
-        # so the CLI defaults it to `setup` (fix provider/endpoint), not `retry`,
-        # and never to "switch models" (ENG-1145 review).
-        raise EndpointConfigurationError(
-            f"The model endpoint returned 404 — check the endpoint URL and model "
-            f"configuration.{suffix}"
+        status_str = str(body.get("status") or envelope.get("status") or "")
+        raise classify_404(
+            model, message=provider_msg, code=code, status=status_str,
         ) from exc
 
     # Retryable provider/infra failures — overload/api_error (incl. the mid-stream

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -550,6 +550,70 @@ class ModelUnavailableError(ConnectionError):
         self.model = model
 
 
+def classify_404(
+    model: str,
+    *,
+    message: str | None,
+    code: str | None = None,
+    status: str | None = None,
+    error_type: str | None = None,
+) -> "ModelUnavailableError | EndpointConfigurationError":
+    """Classify a bare 404 as model-not-found vs. endpoint-misconfiguration.
+
+    Shared by the OpenAI-compatible and Anthropic status-error mappers
+    (ENG-1139) so the heuristic — and the exact non-duplicated wording —
+    can't drift between them. A bare 404 does NOT by itself mean the model
+    is missing: a wrong base URL, a missing ``/v1``, a reverse-proxy route,
+    or an unsupported API path all 404 too, and there "switch models" is
+    the wrong remedy (ENG-1145). Only treat it as model-not-found when the
+    structured body actually points at the model: OpenAI's
+    ``code="model_not_found"``, Anthropic's ``error.type="not_found_error"``,
+    or a model-oriented message (Gemini's ``status="NOT_FOUND"`` with
+    "models/<id> is not found / no longer available"). Everything else is
+    surfaced as an endpoint/configuration failure carrying the provider's
+    own words.
+    """
+    msg_l = message.lower() if isinstance(message, str) else ""
+    status_str = (status or "").upper()
+    model_specific = (
+        code == "model_not_found"
+        or error_type == "not_found_error"
+        or (
+            "model" in msg_l
+            and (
+                status_str == "NOT_FOUND"
+                or "not found" in msg_l
+                or "not available" in msg_l
+                or "no longer available" in msg_l
+                or "does not exist" in msg_l
+            )
+        )
+    )
+    # Provider message as a leading-space fragment with a normalized
+    # terminator, so the appended copy reads cleanly whether or not the
+    # provider punctuated its own message (Gemini's ends in a period; a raw
+    # proxy/FastAPI detail may not).
+    clean = message.strip() if isinstance(message, str) else ""
+    if clean and clean[-1] not in ".!?":
+        clean += "."
+    suffix = f" {clean}" if clean else ""
+    if model_specific:
+        reason = f":{suffix}" if suffix else "."
+        return ModelUnavailableError(
+            f"The model '{model}' isn't available{reason} Switch models in Settings.",
+            code="model_not_found", model=model,
+        )
+    # Not model-specific → almost always a misrouted/misconfigured endpoint
+    # (bad base URL, missing /v1, proxy route). Permanent for this request,
+    # but the remedy is the endpoint config, not the model — a distinct type
+    # so the CLI defaults it to `setup` (fix provider/endpoint), not `retry`,
+    # and never to "switch models" (ENG-1145 review).
+    return EndpointConfigurationError(
+        f"The model endpoint returned 404 — check the endpoint URL and model "
+        f"configuration.{suffix}"
+    )
+
+
 class EndpointConfigurationError(ConnectionError):
     """Raised when a request fails in a way that points at the endpoint
     configuration — a wrong base URL, a missing ``/v1``, a reverse-proxy route,

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -31,6 +31,7 @@ from anton.core.llm.prompts import (
 )
 from anton.core.llm.provider import (
     ContextOverflowError,
+    EndpointConfigurationError,
     LLMResponse,
     ModelUnavailableError,
     ProviderOverloadedError,
@@ -2365,12 +2366,15 @@ class ChatSession:
                         yield event
                     break  # completed successfully
                 except Exception as _agent_exc:
-                    # Token/billing limits and model-gate 403s are
-                    # deterministic — the auto-retry below would just re-send
-                    # the same doomed request (and burn its budget) before
-                    # failing anyway. Don't retry; let the chat loop / server
-                    # map them to their cards.
-                    if isinstance(_agent_exc, (TokenLimitExceeded, ModelUnavailableError)):
+                    # Token/billing limits, model-gate 403s, and endpoint/model
+                    # 404s (ENG-1139) are deterministic — the auto-retry below
+                    # would just re-send the same doomed request (and burn its
+                    # budget) before failing anyway. Don't retry; let the chat
+                    # loop / server map them to their cards.
+                    if isinstance(
+                        _agent_exc,
+                        (TokenLimitExceeded, ModelUnavailableError, EndpointConfigurationError),
+                    ):
                         raise
 
                     # ENG-673: a mid-stream transient failure that had NO prior

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -557,6 +557,23 @@ def test_anthropic_byok_402_stays_generic():
     assert not isinstance(err.value, TokenLimitExceeded)
 
 
+def test_anthropic_404_not_found_error_maps_to_model_unavailable():
+    # ENG-1139: a bare Anthropic 404 for an unknown model must become a
+    # ModelUnavailableError with the provider's own reason folded in once,
+    # not the generic "temporarily unavailable, try again" ConnectionError
+    # (which then got double-wrapped by session.py's fallback prose).
+    exc = _anthropic_sdk_error(404, json_body={"type": "error", "error": {
+        "type": "not_found_error",
+        "message": "model: nonexistent-model-xyz",
+    }})
+    with pytest.raises(ModelUnavailableError) as err:
+        _raise_anthropic(exc, model="nonexistent-model-xyz")
+    assert err.value.code == "model_not_found"
+    assert str(err.value).count("nonexistent-model-xyz") == 2  # template + provider detail, not 3+
+    assert "temporarily unavailable" not in str(err.value)
+    assert "Switch models in Settings" in str(err.value)
+
+
 def test_429_wallet_code_never_transient():
     # Defense for direct classify_transient callers (the mid-stream paths):
     # the M3 allowance 429 has no `detail`, so without the code-exact guard


### PR DESCRIPTION
## Summary

- 404 responses from the raw Anthropic provider previously had no dedicated classification and fell through to a generic `ConnectionError("Server returned 404 — the LLM endpoint may be temporarily unavailable. Try again in a moment.")`. Because this exception is not one of the "curated" types the session loop fails fast on, it exhausted the auto-retry budget and then got wrapped a second time by the turn loop's generic fallback (`"An unexpected error occurred: {e}. Please try again or rephrase your request."`), producing a doubled, confusing message with a stray double period and two redundant "try again" instructions.
- Extracted the existing OpenAI-compatible 404 classification logic (model-not-found vs. endpoint-misconfiguration) out of `openai.py` into a shared `classify_404()` helper in `provider.py`, extended it to recognize Anthropic's own `error.type == "not_found_error"` signal, and wired it into `anthropic.py`'s status-error mapper.
- A 404 is now consistently raised as `ModelUnavailableError` (permanent, "switch models" remedy) or `EndpointConfigurationError` (permanent, "check endpoint config" remedy) across both providers, instead of being misclassified as a transient, retryable failure.
- Added `EndpointConfigurationError` to the session turn loop's fail-fast exception tuple, alongside `ModelUnavailableError`: without this, an endpoint-misconfiguration 404 (the sibling outcome of `classify_404()`, not model-specific) would still get auto-retried against the same doomed endpoint and double-wrapped by the generic fallback prose — reproducing the exact bug this PR fixes, just for that branch (caught in review).
- Added regression tests pinning the new Anthropic 404 behavior and asserting the model name/reason isn't duplicated in the final message.

## Why

ENG-1139 reported that a 404 from the LLM endpoint surfaced as a confusing, duplicated error message to the user. Root cause: the Anthropic provider had no 404-specific handling, so the error was treated as transient/retryable and got double-wrapped by the turn loop's catch-all error text before reaching the user, instead of being classified as the permanent, actionable error it actually is. The same double-wrap risk existed for the endpoint-misconfiguration outcome of the shared classifier, since the session loop's fail-fast list didn't know about `EndpointConfigurationError` either.

## Changes

- `anton/core/llm/provider.py`: add `classify_404()` — shared model-vs-endpoint 404 classifier.
- `anton/core/llm/openai.py`: replace inline 404 classification with a call to `classify_404()` (behavior-preserving).
- `anton/core/llm/anthropic.py`: add a 404 branch (previously missing) that calls `classify_404()` before falling through to the generic transient/unavailable mapping.
- `anton/core/session.py`: add `EndpointConfigurationError` to the turn loop's fail-fast tuple (alongside `TokenLimitExceeded`, `ModelUnavailableError`) so both `classify_404()` outcomes skip auto-retry and the generic error-wrap, consistent with how `chat.py` already treats both types as "permanent, use `setup`" rather than "retry".
- `tests/test_status_error_mapper.py`: new test covering the Anthropic 404 → `ModelUnavailableError` mapping.

## Test plan

- [x] `pytest tests/test_status_error_mapper.py -q` — 38 passed
- [x] `pytest tests/ -q` — 1500 passed, 28 skipped (full suite)
- [x] Manually reproduced via `anton chat` with `ANTON_PLANNING_PROVIDER=anthropic` + a nonexistent model — confirmed the old doubled/misleading message is gone and the new message is a single, permanent, actionable `ModelUnavailableError`
