### PR TITLE
[ENG-578] Scratchpad discovery on startup

### DIFF
--- a/anton/core/backends/manager.py
+++ b/anton/core/backends/manager.py
@@ -59,6 +59,32 @@ class ScratchpadManager:
         """Read-only view of the active scratchpad runtimes."""
         return self._pads
 
+    @property
+    def workspace_path(self) -> Path | None:
+        """Project root this manager serves — discovery needs it for listings."""
+        return self._workspace_path
+
+    def pad_snapshot_mtime(self, name: str) -> float | None:
+        """Epoch mtime of `name`'s ENG-1124 snapshot, or None when unknowable.
+
+        None covers every non-answer (unscoped session, no snapshot dir,
+        never persisted): discovery renders those pads without an age rather
+        than failing the block.
+        """
+        if not self._session_id or not name:
+            return None
+        try:
+            from anton.core.backends.local import default_venvs_base, snapshot_file
+
+            path = snapshot_file(
+                default_venvs_base(self._workspace_path), self._session_id, name
+            )
+            return path.stat().st_mtime if path is not None else None
+        except OSError:
+            return None
+        except Exception:
+            return None
+
     def _agent_pads_file(self):
         """Where this conversation's agent-chosen pad names are recorded, or None.
 

--- a/anton/core/llm/prompt_builder.py
+++ b/anton/core/llm/prompt_builder.py
@@ -138,6 +138,7 @@ class ChatSystemPromptBuilder:
         self_awareness_context: str = "",
         datasource_context: str = "",
         skill_store: "SkillStore | None" = None,
+        workspace_context: str = "",
     ) -> str:
         visualizations_section = self._build_visualizations_section(
             proactive_dashboards=proactive_dashboards,
@@ -199,6 +200,10 @@ class ChatSystemPromptBuilder:
         )
         if memory_context:
             prompt += memory_context
+        # Workspace discovery (ENG-578) is volatile too — pads and files
+        # change between turns, so it must never sit in the cached prefix.
+        if workspace_context:
+            prompt += workspace_context
 
         return prompt
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -74,6 +74,7 @@ from anton.core.tools.tool_defs import (
 )
 from anton.core.interaction.selection import SelectionElicitor
 from anton.core.utils.scratchpad import (
+    build_workspace_discovery_context,
     prepare_scratchpad_exec,
     format_cell_result,
     observe_scratchpad_cell,
@@ -1127,6 +1128,16 @@ class ChatSession:
         # Inject connected datasource context without credentials
         ds_ctx = build_datasource_context(self._data_vault, active_only=self._active_datasource)
 
+        # Turn-start workspace discovery (ENG-578): volatile, so it rides the
+        # tail — never the cache-stable prefix. Best-effort; a failure here
+        # must not break the turn.
+        workspace_ctx = ""
+        if self._scratchpads is not None:
+            try:
+                workspace_ctx = build_workspace_discovery_context(self._scratchpads)
+            except Exception:
+                workspace_ctx = ""
+
         # Ensure the registry is populated before we extract tool prompts.
         self._build_tools()
 
@@ -1144,6 +1155,7 @@ class ChatSession:
             self_awareness_context=sa_section,
             datasource_context=ds_ctx,
             skill_store=self._skill_store,
+            workspace_context=workspace_ctx,
         )
 
         return prompt

--- a/anton/core/utils/scratchpad.py
+++ b/anton/core/utils/scratchpad.py
@@ -14,6 +14,86 @@ def _acc_observe(session, kind: str, detail: dict, *, severity: int = 1) -> None
         fn(kind, detail, severity=severity)
 
 
+_DISCOVERY_MAX_PADS = 10
+_DISCOVERY_MAX_ROOT_ENTRIES = 30
+
+
+def _age_label(mtime: float | None) -> str:
+    if mtime is None:
+        return ""
+    import time
+
+    mins = max(0, int((time.time() - mtime) / 60))
+    if mins < 60:
+        return f" (snapshot {mins}m old)"
+    if mins < 60 * 48:
+        return f" (snapshot {mins // 60}h old)"
+    return f" (snapshot {mins // (60 * 24)}d old)"
+
+
+def build_workspace_discovery_context(manager) -> str:
+    """Compact turn-start block: known pads + project-root names (ENG-578).
+
+    Cold-start blindness made the agent invent pad names and rebuild state it
+    already had on disk. Source of truth is agent_pads() — live pads only add
+    the "active" label, so system-created pads never leak in. Best-effort by
+    construction: any failure degrades to omitting that part or the whole
+    block, never to breaking the turn.
+    """
+    pads_line = ""
+    try:
+        known = sorted(manager.agent_pads())
+        if known:
+            shown = known[:_DISCOVERY_MAX_PADS]
+            live = set(manager.pads)
+            parts = []
+            for name in shown:
+                label = (
+                    " (active)"
+                    if name in live
+                    else _age_label(manager.pad_snapshot_mtime(name))
+                )
+                parts.append(f"{name}{label}")
+            more = (
+                f" … and {len(known) - len(shown)} more"
+                if len(known) > len(shown)
+                else ""
+            )
+            pads_line = (
+                "\nScratchpads for this conversation: "
+                + ", ".join(parts)
+                + more
+                + " — reuse via scratchpad exec with the same name; each name is a "
+                "separate environment."
+            )
+    except Exception:
+        pads_line = ""
+
+    root_line = ""
+    try:
+        root = manager.workspace_path
+        if root is not None:
+            entries = sorted(
+                p.name + ("/" if p.is_dir() else "")
+                for p in root.iterdir()
+                if not p.name.startswith(".")
+            )
+            if entries:
+                shown_entries = entries[:_DISCOVERY_MAX_ROOT_ENTRIES]
+                more = (
+                    f" … and {len(entries) - len(shown_entries)} more"
+                    if len(entries) > len(shown_entries)
+                    else ""
+                )
+                root_line = "\nProject root: " + ", ".join(shown_entries) + more
+    except Exception:
+        root_line = ""
+
+    if not pads_line and not root_line:
+        return ""
+    return "\n\nWorkspace state:" + pads_line + root_line
+
+
 def observe_scratchpad_cell(session, name: str, cell) -> None:
     """Emit the post-execute ACC event for a finished cell.
 

--- a/anton/core/utils/scratchpad.py
+++ b/anton/core/utils/scratchpad.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import os
 from typing import TYPE_CHECKING
 
 from anton.core.tools.registry import ToolOutcome
@@ -73,11 +75,18 @@ def build_workspace_discovery_context(manager) -> str:
     try:
         root = manager.workspace_path
         if root is not None:
-            entries = sorted(
-                p.name + ("/" if p.is_dir() else "")
-                for p in root.iterdir()
-                if not p.name.startswith(".")
-            )
+            # Hidden entries are excluded deliberately: this block ships to
+            # the model, and filenames hinting at secret locations (.env,
+            # .aws) don't belong in LLM-visible context — even names-only.
+            # scandir rather than iterdir+is_dir: dir-ness comes from the
+            # dirent for free instead of a stat per entry, and this runs
+            # every turn. Full iteration is inherent to a sorted first-30.
+            with os.scandir(root) as it:
+                entries = sorted(
+                    entry.name + ("/" if entry.is_dir() else "")
+                    for entry in it
+                    if not entry.name.startswith(".")
+                )
             if entries:
                 shown_entries = entries[:_DISCOVERY_MAX_ROOT_ENTRIES]
                 more = (

--- a/tests/test_workspace_discovery.py
+++ b/tests/test_workspace_discovery.py
@@ -110,3 +110,42 @@ class TestDiscoveryBlock:
         block = build_workspace_discovery_context(mgr)
         assert "catanah" in block
         assert "Project root" not in block
+
+
+class TestVolatileTailPlacement:
+    def test_workspace_context_lands_after_datetime_marker(self):
+        # Cache-stability contract (ENG-1122): the block is volatile and must
+        # sit after the volatile-tail marker so it never busts the cached
+        # prefix.
+        from anton.core.llm.prompt_builder import (
+            ChatSystemPromptBuilder,
+            SystemPromptContext,
+        )
+
+        builder = ChatSystemPromptBuilder()
+        prompt = builder.build(
+            conversation_started="Monday, January 05, 2026",
+            current_datetime="Monday, January 05, 2026 at 09:00 AM",
+            system_prompt_context=SystemPromptContext(),
+            proactive_dashboards=False,
+            output_dir="/tmp/out",
+            workspace_context="\n\nWorkspace state:\nScratchpads for this conversation: catanah",
+        )
+        assert "Workspace state:" in prompt
+        assert prompt.index("Workspace state:") > prompt.index("Current date and time")
+
+    def test_empty_workspace_context_adds_nothing(self):
+        from anton.core.llm.prompt_builder import (
+            ChatSystemPromptBuilder,
+            SystemPromptContext,
+        )
+
+        builder = ChatSystemPromptBuilder()
+        prompt = builder.build(
+            conversation_started="Monday, January 05, 2026",
+            current_datetime="Monday, January 05, 2026 at 09:00 AM",
+            system_prompt_context=SystemPromptContext(),
+            proactive_dashboards=False,
+            output_dir="/tmp/out",
+        )
+        assert "Workspace state:" not in prompt

--- a/tests/test_workspace_discovery.py
+++ b/tests/test_workspace_discovery.py
@@ -51,3 +51,62 @@ class TestManagerAccessors:
         path.write_bytes(b"stub")
         got = mgr.pad_snapshot_mtime("campaign")
         assert got is not None and abs(got - time.time()) < 60
+
+
+from anton.core.utils.scratchpad import build_workspace_discovery_context
+
+
+def seed_agent_pads(mgr: ScratchpadManager, names: list[str]) -> None:
+    for n in names:
+        mgr.record_agent_pad(n)
+
+
+class TestDiscoveryBlock:
+    def test_empty_everything_renders_nothing(self, tmp_path):
+        empty_root = tmp_path / "root"
+        empty_root.mkdir()
+        mgr = make_manager(empty_root)
+        assert build_workspace_discovery_context(mgr) == ""
+
+    def test_pads_and_root_listing(self, tmp_path):
+        (tmp_path / "campaign_engine.py").write_text("x")
+        (tmp_path / "BRIEFING.md").write_text("x")
+        (tmp_path / "campaigns").mkdir()
+        (tmp_path / ".env").write_text("PLACEHOLDER=1")  # hidden: excluded
+        mgr = make_manager(tmp_path)
+        seed_agent_pads(mgr, ["catanah"])
+        block = build_workspace_discovery_context(mgr)
+        assert "Workspace state:" in block
+        assert "catanah" in block
+        assert "campaign_engine.py" in block
+        assert "campaigns/" in block
+        assert ".env" not in block
+
+    def test_live_pad_labeled_active_system_pads_hidden(self, tmp_path):
+        mgr = make_manager(tmp_path)
+        seed_agent_pads(mgr, ["catanah"])
+        # Simulate live pads: one agent-recorded, one system-created.
+        mgr._pads["catanah"] = object()
+        mgr._pads["artifact-slug-pad"] = object()
+        block = build_workspace_discovery_context(mgr)
+        assert "catanah (active)" in block
+        assert "artifact-slug-pad" not in block
+
+    def test_caps_and_remainders(self, tmp_path):
+        for i in range(35):
+            (tmp_path / f"file{i:02d}.txt").write_text("x")
+        mgr = make_manager(tmp_path)
+        seed_agent_pads(mgr, [f"pad{i:02d}" for i in range(12)])
+        block = build_workspace_discovery_context(mgr)
+        assert "… and 2 more" in block   # 12 pads, cap 10
+        assert "… and 5 more" in block   # 35 files, cap 30
+
+    def test_listing_failure_renders_without_root(self, tmp_path, monkeypatch):
+        mgr = make_manager(tmp_path)
+        seed_agent_pads(mgr, ["catanah"])
+        monkeypatch.setattr(
+            Path, "iterdir", lambda self: (_ for _ in ()).throw(PermissionError())
+        )
+        block = build_workspace_discovery_context(mgr)
+        assert "catanah" in block
+        assert "Project root" not in block

--- a/tests/test_workspace_discovery.py
+++ b/tests/test_workspace_discovery.py
@@ -102,10 +102,14 @@ class TestDiscoveryBlock:
         assert "… and 5 more" in block   # 35 files, cap 30
 
     def test_listing_failure_renders_without_root(self, tmp_path, monkeypatch):
+        import anton.core.utils.scratchpad as scratchpad_utils
+
         mgr = make_manager(tmp_path)
         seed_agent_pads(mgr, ["catanah"])
         monkeypatch.setattr(
-            Path, "iterdir", lambda self: (_ for _ in ()).throw(PermissionError())
+            scratchpad_utils.os,
+            "scandir",
+            lambda path: (_ for _ in ()).throw(PermissionError()),
         )
         block = build_workspace_discovery_context(mgr)
         assert "catanah" in block

--- a/tests/test_workspace_discovery.py
+++ b/tests/test_workspace_discovery.py
@@ -1,0 +1,53 @@
+"""ENG-578 slice 2: cold-start discovery — manager accessors + context block."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from anton.core.backends.local import (
+    LocalScratchpadRuntime,
+    local_scratchpad_runtime_factory,
+    snapshot_file,
+)
+from anton.core.backends.manager import ScratchpadManager
+
+_MANAGER_DEFAULTS = dict(
+    runtime_factory=local_scratchpad_runtime_factory,
+    coding_provider="anthropic",
+    coding_model="",
+    coding_api_key="",
+    coding_base_url="",
+)
+
+
+def make_manager(tmp_path: Path | None = None, session_id: str | None = "conv1") -> ScratchpadManager:
+    return ScratchpadManager(
+        **_MANAGER_DEFAULTS,
+        workspace_path=tmp_path,
+        session_id=session_id,
+    )
+
+
+class TestManagerAccessors:
+    def test_workspace_path_exposed(self, tmp_path):
+        assert make_manager(tmp_path).workspace_path == tmp_path
+
+    def test_snapshot_mtime_none_when_unscoped(self, tmp_path):
+        mgr = make_manager(tmp_path, session_id=None)
+        assert mgr.pad_snapshot_mtime("anything") is None
+
+    def test_snapshot_mtime_none_when_missing(self, tmp_path):
+        assert make_manager(tmp_path).pad_snapshot_mtime("ghost") is None
+
+    def test_snapshot_mtime_reads_existing_snapshot(self, tmp_path):
+        # Compose the snapshot path exactly the way the runtime does, write a
+        # stub snapshot, and confirm the mtime comes back.
+        from anton.core.backends.local import default_venvs_base
+
+        mgr = make_manager(tmp_path)
+        path = snapshot_file(default_venvs_base(tmp_path), "conv1", "campaign")
+        assert path is not None
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"stub")
+        got = mgr.pad_snapshot_mtime("campaign")
+        assert got is not None and abs(got - time.time()) < 60


### PR DESCRIPTION
[ENG-578:](https://linear.app/mindsdb/issue/ENG-578/anton-inactivity-watchdog-kills-throttled-batch-loops-forces-per-item) scratchpad discovery at turn start |


- Added a small "Workspace state" block the agent sees at the start of each turn
- It lists the scratchpads that already exist for this conversation (with "active" or snapshot age) and the files in the project root
- Fixes the blind cold start: the agent stops inventing new scratchpad names and rebuilding data it already has (measured ~$30 of wasted rebuilding in one session; 12+ pad names including typos)
- Only agent-created scratchpads are shown — system pads never appear
- Small by design: max 10 pads and 30 files, hidden files excluded, a few hundred tokens
- Placed after the prompt's cached prefix, so it never breaks prompt caching (pinned by a test)
- If anything fails while building the block, it's simply skipped — a turn can never break because of it