### PR TITLE
ENG-1140: resolve MindsHub setup models from the live catalogue, surface probe errors

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -274,10 +274,8 @@ async def _handle_connect(
 
     # --- Test if the Minds server also supports LLM endpoints ---
     # (silenced: was printing "Testing LLM endpoints..." and "not available" messages)
-    planning_model, coding_model = resolve_minds_models(
-        minds_url, api_key, verify=ssl_verify
-    )
-    llm_result = test_llm(minds_url, api_key, verify=ssl_verify, model=coding_model)
+    models = resolve_minds_models(minds_url, api_key, verify=ssl_verify)
+    llm_result = test_llm(minds_url, api_key, verify=ssl_verify, model=models.probe)
 
     if not llm_result.ok and llm_result.error:
         console.print(
@@ -291,15 +289,15 @@ async def _handle_connect(
         )
         settings.planning_provider = "openai-compatible"
         settings.coding_provider = "openai-compatible"
-        settings.planning_model = planning_model
-        settings.coding_model = coding_model
+        settings.planning_model = models.planning
+        settings.coding_model = models.coding
         # openai_api_key and openai_base_url are derived at runtime from
         # minds_api_key and minds_url via model_post_init — no need to persist them.
         settings.model_post_init(None)
         global_ws.set_secret("ANTON_PLANNING_PROVIDER", "openai-compatible")
         global_ws.set_secret("ANTON_CODING_PROVIDER", "openai-compatible")
-        global_ws.set_secret("ANTON_PLANNING_MODEL", planning_model)
-        global_ws.set_secret("ANTON_CODING_MODEL", coding_model)
+        global_ws.set_secret("ANTON_PLANNING_MODEL", models.planning)
+        global_ws.set_secret("ANTON_CODING_MODEL", models.coding)
     else:
         # Check if Anthropic key is already configured
         has_anthropic = settings.anthropic_api_key or os.environ.get(

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -95,6 +95,7 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.styles import Style as PTStyle
+from rich.markup import escape
 from rich.prompt import Prompt
 from anton.memory.manage import MemoryManage, MEMORY_COMMANDS
 from anton.commands.goal import parse_goal_args, run_goal_loop
@@ -277,13 +278,24 @@ async def _handle_connect(
     models = resolve_minds_models(minds_url, api_key, verify=ssl_verify)
     llm_result = test_llm(minds_url, api_key, verify=ssl_verify, model=models.probe)
 
-    if not llm_result.ok and llm_result.error:
+    # A 429 proves the endpoint is THERE — it answered, it just throttled this
+    # probe. Treating it as unavailable dropped a throttled-but-valid MindsHub
+    # endpoint and fell through to the BYOK prompt (#317 review); the previous
+    # truthy "rate_limited" string had adopted it.
+    llm_available = llm_result.ok or llm_result.rate_limited
+
+    if not llm_available and llm_result.error:
         console.print(
-            f"[anton.muted]Minds LLM endpoints unavailable ({llm_result.error}) — "
-            "keeping the current LLM provider.[/]"
+            f"[anton.muted]Minds LLM endpoints unavailable "
+            f"({escape(llm_result.error)}) — keeping the current LLM provider.[/]"
+        )
+    elif llm_result.rate_limited:
+        console.print(
+            "[anton.muted]Minds LLM endpoints are rate-limited right now — "
+            "using them anyway; limits clear on their own.[/]"
         )
 
-    if llm_result.ok:
+    if llm_available:
         console.print(
             "[anton.success]LLM endpoints available — using Minds server as LLM provider.[/]"
         )

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -80,6 +80,7 @@ from anton.minds_client import (
     describe_minds_connection_error,
     list_minds,
     list_datasources,
+    resolve_minds_models,
     test_llm,
 )
 from anton.core.datasources.data_vault import LocalDataVault
@@ -273,23 +274,26 @@ async def _handle_connect(
 
     # --- Test if the Minds server also supports LLM endpoints ---
     # (silenced: was printing "Testing LLM endpoints..." and "not available" messages)
-    llm_ok = test_llm(minds_url, api_key, verify=ssl_verify)
+    planning_model, coding_model = resolve_minds_models(
+        minds_url, api_key, verify=ssl_verify
+    )
+    llm_result = test_llm(minds_url, api_key, verify=ssl_verify, model=coding_model)
 
-    if llm_ok:
+    if llm_result.ok:
         console.print(
             "[anton.success]LLM endpoints available — using Minds server as LLM provider.[/]"
         )
         settings.planning_provider = "openai-compatible"
         settings.coding_provider = "openai-compatible"
-        settings.planning_model = "_reason_"
-        settings.coding_model = "_code_"
+        settings.planning_model = planning_model
+        settings.coding_model = coding_model
         # openai_api_key and openai_base_url are derived at runtime from
         # minds_api_key and minds_url via model_post_init — no need to persist them.
         settings.model_post_init(None)
         global_ws.set_secret("ANTON_PLANNING_PROVIDER", "openai-compatible")
         global_ws.set_secret("ANTON_CODING_PROVIDER", "openai-compatible")
-        global_ws.set_secret("ANTON_PLANNING_MODEL", "_reason_")
-        global_ws.set_secret("ANTON_CODING_MODEL", "_code_")
+        global_ws.set_secret("ANTON_PLANNING_MODEL", planning_model)
+        global_ws.set_secret("ANTON_CODING_MODEL", coding_model)
     else:
         # Check if Anthropic key is already configured
         has_anthropic = settings.anthropic_api_key or os.environ.get(
@@ -378,7 +382,7 @@ async def _handle_remote(
         console.print("  [anton.muted]To use remote scratchpad you need a free Minds account.[/]")
         console.print()
         has_key = await prompt_or_cancel(
-            "  Do you have an mdb.ai API key?",
+            "  Do you have a MindsHub API key?",
             choices=["y", "n"],
             choices_display="y/n",
             default="y",
@@ -441,7 +445,7 @@ async def _handle_publish(
         console.print("  [anton.muted]To publish dashboards you need a free Minds account.[/]")
         console.print()
         has_key = await prompt_or_cancel(
-            "  Do you have an mdb.ai API key?",
+            "  Do you have a MindsHub API key?",
             choices=["y", "n"],
             choices_display="y/n",
             default="y",
@@ -1917,7 +1921,7 @@ async def _chat_loop(
                     console.print(
                         f"[anton.warning]Approaching token limit: {last_token_status.used:,} / "
                         f"{last_token_status.limit:,} tokens used ({pct}%). "
-                        "Visit mdb.ai to upgrade your plan or top up your tokens.[/]"
+                        "Visit console.mindshub.ai to upgrade your plan or top up your tokens.[/]"
                     )
                     console.print()
                 if _query_count == 1:

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -80,7 +80,7 @@ from anton.minds_client import (
     describe_minds_connection_error,
     list_minds,
     list_datasources,
-    resolve_minds_models,
+    resolve_and_probe,
     test_llm,
 )
 from anton.core.datasources.data_vault import LocalDataVault
@@ -275,8 +275,7 @@ async def _handle_connect(
 
     # --- Test if the Minds server also supports LLM endpoints ---
     # (silenced: was printing "Testing LLM endpoints..." and "not available" messages)
-    models = resolve_minds_models(minds_url, api_key, verify=ssl_verify)
-    llm_result = test_llm(minds_url, api_key, verify=ssl_verify, model=models.probe)
+    models, llm_result = resolve_and_probe(minds_url, api_key, verify=ssl_verify)
 
     # A 429 proves the endpoint is THERE — it answered, it just throttled this
     # probe. Treating it as unavailable dropped a throttled-but-valid MindsHub

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -279,6 +279,12 @@ async def _handle_connect(
     )
     llm_result = test_llm(minds_url, api_key, verify=ssl_verify, model=coding_model)
 
+    if not llm_result.ok and llm_result.error:
+        console.print(
+            f"[anton.muted]Minds LLM endpoints unavailable ({llm_result.error}) — "
+            "keeping the current LLM provider.[/]"
+        )
+
     if llm_result.ok:
         console.print(
             "[anton.success]LLM endpoints available — using Minds server as LLM provider.[/]"

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -36,7 +36,7 @@ from anton.commands.datasource import (
     handle_list_data_sources,
     handle_test_datasource
 )
-from anton.minds_client import resolve_minds_models, test_llm
+from anton.minds_client import minds_v1_base, resolve_minds_models, test_llm
 
 
 def _build_scratchpad_manager(
@@ -735,16 +735,13 @@ def _setup_minds(settings, ws) -> None:
     llm_ok = False
     rate_limited = False
     error_detail: str | None = None
-    planning_model = coding_model = None
 
     with Live(Spinner("dots", text="  Connecting...", style="anton.cyan"), console=console, transient=True):
         # Resolve the models from the live catalogue first, then probe with
         # the model we're about to configure — a passing probe validates the
         # actual configuration, not a hardcoded alias (ENG-1140).
-        planning_model, coding_model = resolve_minds_models(
-            minds_url, api_key, verify=True
-        )
-        result = test_llm(minds_url, api_key, verify=True, model=coding_model)
+        models = resolve_minds_models(minds_url, api_key, verify=True)
+        result = test_llm(minds_url, api_key, verify=True, model=models.probe)
         if result.rate_limited:
             rate_limited = True
             error_detail = result.error
@@ -756,11 +753,9 @@ def _setup_minds(settings, ws) -> None:
             error_detail = result.error
         else:
             error_detail = result.error
-            planning_model, coding_model = resolve_minds_models(
-                minds_url, api_key, verify=False
-            )
+            models = resolve_minds_models(minds_url, api_key, verify=False)
             result_no_ssl = test_llm(
-                minds_url, api_key, verify=False, model=coding_model
+                minds_url, api_key, verify=False, model=models.probe
             )
             if result_no_ssl.rate_limited:
                 rate_limited = True
@@ -785,16 +780,19 @@ def _setup_minds(settings, ws) -> None:
         console.print("  [anton.success]Connected[/]")
         settings.planning_provider = "openai-compatible"
         settings.coding_provider = "openai-compatible"
-        settings.planning_model = planning_model
-        settings.coding_model = coding_model
+        settings.planning_model = models.planning
+        settings.coding_model = models.coding
         settings.minds_ssl_verify = ssl_verify
-        derived_base_url = f"{minds_url}/v1"
+        # Same host rule as the probe (test_llm) — the persisted base must be
+        # the URL the probe validated, or "Connected" lies about the config
+        # that gets saved (e.g. a /v1-suffixed ANTON_MINDS_URL would double).
+        derived_base_url = minds_v1_base(minds_url)
         settings.openai_api_key = api_key
         settings.openai_base_url = derived_base_url
         ws.set_secret("ANTON_PLANNING_PROVIDER", "openai-compatible")
         ws.set_secret("ANTON_CODING_PROVIDER", "openai-compatible")
-        ws.set_secret("ANTON_PLANNING_MODEL", planning_model)
-        ws.set_secret("ANTON_CODING_MODEL", coding_model)
+        ws.set_secret("ANTON_PLANNING_MODEL", models.planning)
+        ws.set_secret("ANTON_CODING_MODEL", models.coding)
         ws.set_secret("ANTON_MINDS_SSL_VERIFY", "true" if ssl_verify else "false")
         ws.set_secret("ANTON_OPENAI_API_KEY", api_key)
         ws.set_secret("ANTON_OPENAI_BASE_URL", derived_base_url)

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import typer
 from rich.console import Console
 from rich.live import Live
+from rich.markup import escape
 from rich.panel import Panel
 from rich.prompt import Confirm
 from rich.spinner import Spinner
@@ -800,8 +801,13 @@ def _setup_minds(settings, ws) -> None:
         # A 429 here is usually the TPM/RPM limiter, not an exhausted
         # allowance (wallet-empty is a 402) — so lead with the provider's own
         # message and keep the top-up advice secondary.
+        # escape(): the provider's text is interpolated into Rich markup, and
+        # a message containing [...] that Rich reads as a bad style tag raises
+        # MarkupError — crashing setup instead of reporting the error it was
+        # added to surface (#317 review).
         console.print(
-            f"  [anton.error]{error_detail or 'Rate limit or token limit exceeded.'}[/]"
+            f"  [anton.error]"
+            f"{escape(error_detail) if error_detail else 'Rate limit or token limit exceeded.'}[/]"
         )
         console.print(
             "  [anton.muted]Rate limits clear on their own — try again in a moment. "
@@ -810,7 +816,9 @@ def _setup_minds(settings, ws) -> None:
         raise _SetupRetry()
     else:
         if error_detail:
-            console.print(f"  [anton.error]Could not connect: {error_detail}[/]")
+            console.print(
+                f"  [anton.error]Could not connect: {escape(error_detail)}[/]"
+            )
         else:
             console.print(
                 "  [anton.error]Could not connect. Check your API key and URL.[/]"

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -36,7 +36,7 @@ from anton.commands.datasource import (
     handle_list_data_sources,
     handle_test_datasource
 )
-from anton.minds_client import test_llm
+from anton.minds_client import resolve_minds_models, test_llm
 
 
 def _build_scratchpad_manager(
@@ -443,9 +443,9 @@ def _onboard(settings) -> None:
     _INTRO_LINES = [
         "Hi Boss! I'm Anton, your AI coworker.",
         "",
-        "For the best experience, I recommend Minds-Enterprise-Cloud as your LLM Provider:",
+        "For the best experience, I recommend MindsHub as your LLM Provider:",
         "",
-        "  \u2713 Smart model routing",
+        "  \u2713 Latest frontier models",
         "  \u2713 Faster responses",
         "  \u2713 Cost optimized",
         "  \u2713 Secure data connectors",
@@ -555,21 +555,12 @@ async def _animate_onboard(
     console.print()
     console.print(f"[anton.glow] {'━' * 40}[/]")
     console.print()
-    console.print(
-        "  [bold]1[/]  [link=https://mdb.ai][anton.cyan]Minds-Enterprise-Cloud[/][/link] [anton.success](recommended)[/]"
-    )
-    console.print(
-        "  [bold]2[/]  [anton.cyan]Minds-Enterprise-Server[/] [anton.muted]self-hosted[/]"
-    )
-    console.print(
-        "  [bold]3[/]  [anton.cyan]Bring your own key[/] [anton.muted]Anthropic / OpenAI / Gemini[/]"
-    )
-    console.print()
+    _print_provider_choices()
 
     while True:
         choice = await prompt_or_cancel(
             "(anton) Choose LLM Provider",
-            choices=["1", "2", "3"],
+            choices=["1", "2"],
             default="1",
             allow_cancel=False,
         )
@@ -578,22 +569,11 @@ async def _animate_onboard(
             if choice == "1":
                 _setup_minds(settings, ws)
             elif choice == "2":
-                _setup_minds(settings, ws, default_url=None)
-            elif choice == "3":
                 _setup_other_provider(settings, ws)
             break  # success
         except _SetupRetry:
             console.print()
-            console.print(
-                "  [bold]1[/]  [link=https://mdb.ai][anton.cyan]Minds-Enterprise-Cloud[/][/link] [anton.success](recommended)[/]"
-            )
-            console.print(
-                "  [bold]2[/]  [anton.cyan]Minds-Enterprise-Server[/] [anton.muted]self-hosted[/]"
-            )
-            console.print(
-                "  [bold]3[/]  [anton.cyan]Bring your own key[/] [anton.muted]Anthropic / OpenAI / Gemini[/]"
-            )
-            console.print()
+            _print_provider_choices()
             continue
 
     # Reload env vars so the scratchpad subprocess inherits them
@@ -607,9 +587,10 @@ async def _animate_onboard(
     model_label = settings.planning_model
     if provider_label == "openai-compatible":
         base = settings.openai_base_url or ""
-        if settings.minds_url and "mdb.ai" in settings.minds_url:
-            provider_label = "Minds-Enterprise-Cloud"
-            model_label = "smart_router"
+        if settings.minds_url and (
+            "mindshub.ai" in settings.minds_url or "mdb.ai" in settings.minds_url
+        ):
+            provider_label = "MindsHub"
         elif url_hostname(base) == "generativelanguage.googleapis.com":
             provider_label = "Google Gemini"
         elif base:
@@ -695,8 +676,19 @@ def _setup_prompt(
     return result
 
 
+def _print_provider_choices() -> None:
+    """Print the LLM-provider menu (shared by first-run onboarding and retry)."""
+    console.print(
+        "  [bold]1[/]  [link=https://mindshub.ai][anton.cyan]MindsHub[/][/link] [anton.success](recommended)[/]"
+    )
+    console.print(
+        "  [bold]2[/]  [anton.cyan]Bring your own key[/] [anton.muted]Anthropic / OpenAI / Gemini[/]"
+    )
+    console.print()
+
+
 def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshub.ai") -> None:
-    """Set up Minds as the LLM provider (cloud or enterprise)."""
+    """Set up MindsHub as the LLM provider."""
     console.print()
 
     is_cloud = default_url and default_url.endswith(("mindshub.ai", "mdb.ai"))
@@ -717,7 +709,7 @@ def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshu
         )
         console.print()
         has_key = Confirm.ask(
-            "  Do you have an mdb.ai API key?",
+            "  Do you have a MindsHub API key?",
             default=True,
             console=console,
         )
@@ -745,20 +737,36 @@ def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshu
     ssl_verify = True
     llm_ok = False
     rate_limited = False
+    error_detail: str | None = None
+    planning_model = coding_model = None
 
     with Live(Spinner("dots", text="  Connecting...", style="anton.cyan"), console=console, transient=True):
-        result = test_llm(minds_url, api_key, verify=True)
-        if result == "rate_limited":
+        # Resolve the models from the live catalogue first, then probe with
+        # the model we're about to configure — a passing probe validates the
+        # actual configuration, not a hardcoded alias (ENG-1140).
+        planning_model, coding_model = resolve_minds_models(
+            minds_url, api_key, verify=True
+        )
+        result = test_llm(minds_url, api_key, verify=True, model=coding_model)
+        if result.rate_limited:
             rate_limited = True
-        elif not result:
-            result_no_ssl = test_llm(minds_url, api_key, verify=False)
-            if result_no_ssl == "rate_limited":
+        elif result.ok:
+            llm_ok = True
+        else:
+            error_detail = result.error
+            planning_model, coding_model = resolve_minds_models(
+                minds_url, api_key, verify=False
+            )
+            result_no_ssl = test_llm(
+                minds_url, api_key, verify=False, model=coding_model
+            )
+            if result_no_ssl.rate_limited:
                 rate_limited = True
-            elif result_no_ssl:
+            elif result_no_ssl.ok:
                 ssl_verify = False
                 llm_ok = True
-        else:
-            llm_ok = True
+            else:
+                error_detail = result_no_ssl.error or error_detail
 
     if llm_ok and not ssl_verify:
         console.print("  [anton.warning]SSL certificate verification failed.[/]")
@@ -774,28 +782,31 @@ def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshu
         console.print("  [anton.success]Connected[/]")
         settings.planning_provider = "openai-compatible"
         settings.coding_provider = "openai-compatible"
-        settings.planning_model = "_reason_"
-        settings.coding_model = "_code_"
+        settings.planning_model = planning_model
+        settings.coding_model = coding_model
         settings.minds_ssl_verify = ssl_verify
         derived_base_url = f"{minds_url}/v1"
         settings.openai_api_key = api_key
         settings.openai_base_url = derived_base_url
         ws.set_secret("ANTON_PLANNING_PROVIDER", "openai-compatible")
         ws.set_secret("ANTON_CODING_PROVIDER", "openai-compatible")
-        ws.set_secret("ANTON_PLANNING_MODEL", "_reason_")
-        ws.set_secret("ANTON_CODING_MODEL", "_code_")
+        ws.set_secret("ANTON_PLANNING_MODEL", planning_model)
+        ws.set_secret("ANTON_CODING_MODEL", coding_model)
         ws.set_secret("ANTON_MINDS_SSL_VERIFY", "true" if ssl_verify else "false")
         ws.set_secret("ANTON_OPENAI_API_KEY", api_key)
         ws.set_secret("ANTON_OPENAI_BASE_URL", derived_base_url)
     elif rate_limited:
         console.print(
-            "[anton.error]Token limit exceeded. Visit https://mdb.ai to upgrade or to top up your tokens.[/]"
+            "[anton.error]Token limit exceeded. Visit https://console.mindshub.ai to upgrade or to top up your tokens.[/]"
         )
         raise _SetupRetry()
     else:
-        console.print(
-            "  [anton.error]Could not connect. Check your API key and URL.[/]"
-        )
+        if error_detail:
+            console.print(f"  [anton.error]Could not connect: {error_detail}[/]")
+        else:
+            console.print(
+                "  [anton.error]Could not connect. Check your API key and URL.[/]"
+            )
         retry = Confirm.ask("  Try again?", default=True, console=console)
         if retry:
             _setup_minds(settings, ws, default_url=default_url)

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -752,6 +752,10 @@ def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshu
             rate_limited = True
         elif result.ok:
             llm_ok = True
+        elif result.http_status is not None:
+            # The server answered — TLS worked, so retrying without SSL
+            # verification cannot change the outcome.
+            error_detail = result.error
         else:
             error_detail = result.error
             planning_model, coding_model = resolve_minds_models(

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -37,7 +37,7 @@ from anton.commands.datasource import (
     handle_list_data_sources,
     handle_test_datasource
 )
-from anton.minds_client import minds_v1_base, resolve_minds_models, test_llm
+from anton.minds_client import minds_v1_base, resolve_and_probe, test_llm
 
 
 def _build_scratchpad_manager(
@@ -741,8 +741,7 @@ def _setup_minds(settings, ws) -> None:
         # Resolve the models from the live catalogue first, then probe with
         # the model we're about to configure — a passing probe validates the
         # actual configuration, not a hardcoded alias (ENG-1140).
-        models = resolve_minds_models(minds_url, api_key, verify=True)
-        result = test_llm(minds_url, api_key, verify=True, model=models.probe)
+        models, result = resolve_and_probe(minds_url, api_key, verify=True)
         if result.rate_limited:
             rate_limited = True
             error_detail = result.error
@@ -754,9 +753,8 @@ def _setup_minds(settings, ws) -> None:
             error_detail = result.error
         else:
             error_detail = result.error
-            models = resolve_minds_models(minds_url, api_key, verify=False)
-            result_no_ssl = test_llm(
-                minds_url, api_key, verify=False, model=models.probe
+            models, result_no_ssl = resolve_and_probe(
+                minds_url, api_key, verify=False
             )
             if result_no_ssl.rate_limited:
                 rate_limited = True

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -687,37 +687,34 @@ def _print_provider_choices() -> None:
     console.print()
 
 
-def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshub.ai") -> None:
-    """Set up MindsHub as the LLM provider."""
+def _setup_minds(settings, ws) -> None:
+    """Set up MindsHub as the LLM provider.
+
+    The host is not user-editable — same as the Electron onboarding, where
+    MINDS_API_BASE is baked per build. Operators/QA point anton at staging or
+    a self-hosted server via the ANTON_MINDS_URL env var (honored here so
+    setup doesn't clobber it back to prod); there is no prompt for it.
+    """
     console.print()
 
-    is_cloud = default_url and default_url.endswith(("mindshub.ai", "mdb.ai"))
+    minds_url = (
+        os.environ.get("ANTON_MINDS_URL", "").strip() or "https://api.mindshub.ai"
+    ).rstrip("/")
 
-    if is_cloud:
-        minds_url = default_url
-    else:
-        minds_url = _setup_prompt("Server URL", default=default_url).strip()
-        if not minds_url.startswith(("http://", "https://")):
-            minds_url = "https://" + minds_url
-
-    # Normalize: ensure no trailing slash
-    minds_url = minds_url.rstrip("/")
-
-    if is_cloud:
-        console.print(
-            "  [anton.muted]If you don't have an API key yet, we'll help you create one — it takes a few seconds.[/]"
+    console.print(
+        "  [anton.muted]If you don't have an API key yet, we'll help you create one — it takes a few seconds.[/]"
+    )
+    console.print()
+    has_key = Confirm.ask(
+        "  Do you have a MindsHub API key?",
+        default=True,
+        console=console,
+    )
+    if not has_key:
+        webbrowser.open(
+            "https://auth.mindshub.ai/auth/realms/mindsdb/protocol/openid-connect/registrations?client_id=public-client&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fconsole.mindshub.ai"
         )
         console.print()
-        has_key = Confirm.ask(
-            "  Do you have a MindsHub API key?",
-            default=True,
-            console=console,
-        )
-        if not has_key:
-            webbrowser.open(
-                "https://auth.mindshub.ai/auth/realms/mindsdb/protocol/openid-connect/registrations?client_id=public-client&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fconsole.mindshub.ai"
-            )
-            console.print()
 
     while True:
         api_key = _setup_prompt("API key", is_password=True)
@@ -750,6 +747,7 @@ def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshu
         result = test_llm(minds_url, api_key, verify=True, model=coding_model)
         if result.rate_limited:
             rate_limited = True
+            error_detail = result.error
         elif result.ok:
             llm_ok = True
         elif result.http_status is not None:
@@ -766,6 +764,7 @@ def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshu
             )
             if result_no_ssl.rate_limited:
                 rate_limited = True
+                error_detail = result_no_ssl.error
             elif result_no_ssl.ok:
                 ssl_verify = False
                 llm_ok = True
@@ -800,8 +799,15 @@ def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshu
         ws.set_secret("ANTON_OPENAI_API_KEY", api_key)
         ws.set_secret("ANTON_OPENAI_BASE_URL", derived_base_url)
     elif rate_limited:
+        # A 429 here is usually the TPM/RPM limiter, not an exhausted
+        # allowance (wallet-empty is a 402) — so lead with the provider's own
+        # message and keep the top-up advice secondary.
         console.print(
-            "[anton.error]Token limit exceeded. Visit https://console.mindshub.ai to upgrade or to top up your tokens.[/]"
+            f"  [anton.error]{error_detail or 'Rate limit or token limit exceeded.'}[/]"
+        )
+        console.print(
+            "  [anton.muted]Rate limits clear on their own — try again in a moment. "
+            "If you're out of tokens, visit https://console.mindshub.ai to upgrade or top up.[/]"
         )
         raise _SetupRetry()
     else:
@@ -813,7 +819,7 @@ def _setup_minds(settings, ws, *, default_url: str | None = "https://api.mindshu
             )
         retry = Confirm.ask("  Try again?", default=True, console=console)
         if retry:
-            _setup_minds(settings, ws, default_url=default_url)
+            _setup_minds(settings, ws)
         else:
             raise _SetupRetry()
 

--- a/anton/commands/setup.py
+++ b/anton/commands/setup.py
@@ -42,8 +42,10 @@ async def handle_setup_models(
     def _provider_label(provider: str) -> str:
         if provider == "openai-compatible":
             base = settings.openai_base_url or ""
-            if settings.minds_url and "mdb.ai" in settings.minds_url:
-                return "Minds-Enterprise-Cloud"
+            if settings.minds_url and (
+                "mindshub.ai" in settings.minds_url or "mdb.ai" in settings.minds_url
+            ):
+                return "MindsHub"
             else:
                 hostname = None
                 if base:
@@ -59,14 +61,9 @@ async def handle_setup_models(
             return "OpenAI-compatible"
         return provider.capitalize()
 
-    def _model_label(model: str, role: str) -> str:
-        if model in ("_reason_", "_code_"):
-            return f"smart_router({role})"
-        return model
-
     provider_display = _provider_label(settings.planning_provider)
-    planning_display = _model_label(settings.planning_model, "planning")
-    coding_display = _model_label(settings.coding_model, "coding")
+    planning_display = settings.planning_model
+    coding_display = settings.coding_model
 
     console.print()
     console.print("[anton.cyan]Current configuration:[/]")
@@ -79,9 +76,8 @@ async def handle_setup_models(
     console.print()
 
     def _print_choices():
-        console.print("  [bold]1[/]  [link=https://mdb.ai][anton.cyan]Minds-Enterprise-Cloud[/][/link] [anton.success](recommended)[/]")
-        console.print("  [bold]2[/]  [anton.cyan]Minds-Enterprise-Server[/] [anton.muted]self-hosted[/]")
-        console.print("  [bold]3[/]  [anton.cyan]Bring your own key[/] [anton.muted]Anthropic / OpenAI / Gemini[/]")
+        console.print("  [bold]1[/]  [link=https://mindshub.ai][anton.cyan]MindsHub[/][/link] [anton.success](recommended)[/]")
+        console.print("  [bold]2[/]  [anton.cyan]Bring your own key[/] [anton.muted]Anthropic / OpenAI / Gemini[/]")
         console.print("  [bold]q[/]  [anton.muted]Back[/]")
         console.print()
 
@@ -90,7 +86,7 @@ async def handle_setup_models(
     while True:
         choice = await prompt_or_cancel(
             "(anton) Choose LLM Provider",
-            choices=["1", "2", "3", "q"],
+            choices=["1", "2", "q"],
             default="1",
         )
         if choice is None or choice == "q":
@@ -100,8 +96,6 @@ async def handle_setup_models(
             if choice == "1":
                 _setup_minds(settings, global_ws)
             elif choice == "2":
-                _setup_minds(settings, global_ws, default_url=None)
-            elif choice == "3":
                 _setup_other_provider(settings, global_ws)
             break
         except _SetupRetry:

--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -10,15 +10,24 @@ if TYPE_CHECKING:
 
 
 def _resolve_openai_compatible_flavor(settings: AntonSettings) -> str:
-    """Distinguish mdb.ai passthrough from a generic openai-compatible endpoint.
+    """Distinguish MindsHub/mdb.ai passthrough from a generic openai-compatible
+    endpoint.
 
-    The MindsHub setup path writes ``openai_base_url =
-    f"{minds_url.rstrip('/')}/api/v1"`` and ``openai_api_key = minds_api_key``
-    (see ``AntonSettings.model_post_init``). When that exact pairing matches
-    the user's current settings, the OpenAI provider is talking to mdb.ai and
-    can therefore use the chat.completions native web tool passthrough. Any
-    other base URL is a generic third-party endpoint that needs the
-    handler-dispatched fallback at the session layer.
+    ``AntonSettings.model_post_init`` derives ``openai_base_url`` from
+    ``minds_url`` host-awarely: ``api.mindshub.ai`` serves the
+    OpenAI-compatible API at ``/v1``, the legacy ``mdb.ai`` host at
+    ``/api/v1`` (ENG-436). Both derivations, plus a ``minds_url`` that already
+    carries its own suffix, mean the provider is talking to our gateway and
+    can use the chat.completions native web-tool passthrough — it accepts
+    ``{"type": "web_search"}`` / ``{"type": "fetch"}`` directly (matching the
+    gateway's own ``GenericToolType``). Any other base URL is a generic
+    third-party endpoint that needs the handler-dispatched fallback at the
+    session layer.
+
+    The ``/v1`` case was missing, so **every MindsHub install fell through to
+    generic** and silently lost native web search — the session's fallback
+    needs an Exa/Brave key that MindsHub users don't have (#317 review).
+    Pinned by ``tests/test_openai_setup.py``.
 
     No new env var is introduced — we infer flavor purely from the existing
     config the setup flow already produces.
@@ -27,7 +36,7 @@ def _resolve_openai_compatible_flavor(settings: AntonSettings) -> str:
 
     base = (getattr(settings, "openai_base_url", None) or "").rstrip("/").lower()
     minds = (getattr(settings, "minds_url", None) or "").rstrip("/").lower()
-    if minds and (base == minds or base == f"{minds}/api/v1"):
+    if minds and base in (minds, f"{minds}/v1", f"{minds}/api/v1"):
         return OpenAIProvider.FLAVOR_MINDS_PASSTHROUGH
     return OpenAIProvider.FLAVOR_OPENAI_COMPATIBLE_GENERIC
 

--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 def _resolve_openai_compatible_flavor(settings: AntonSettings) -> str:
     """Distinguish mdb.ai passthrough from a generic openai-compatible endpoint.
 
-    The "Minds-Enterprise-Cloud" setup path writes ``openai_base_url =
+    The MindsHub setup path writes ``openai_base_url =
     f"{minds_url.rstrip('/')}/api/v1"`` and ``openai_api_key = minds_api_key``
     (see ``AntonSettings.model_post_init``). When that exact pairing matches
     the user's current settings, the OpenAI provider is talking to mdb.ai and

--- a/anton/minds_client.py
+++ b/anton/minds_client.py
@@ -249,10 +249,26 @@ def list_models(base_url: str, api_key: str, verify: bool = True) -> list[str]:
     return ids
 
 
+@dataclass
+class MindsModels:
+    """Resolved (planning, coding) pair plus the model to probe with.
+
+    When the pair came from the live catalogue, probing the coding model
+    validates the actual configuration. With no catalogue to trust, the pair
+    is the tier defaults but the probe uses the free-bucket model — a paid
+    default would 403 for free-tier keys on exactly the hosts that don't
+    serve the listing route (the ENG-576 shape).
+    """
+
+    planning: str
+    coding: str
+    probe: str
+
+
 def resolve_minds_models(
     base_url: str, api_key: str, verify: bool = True
-) -> tuple[str, str]:
-    """Pick the (planning, coding) model pair from the live catalogue.
+) -> MindsModels:
+    """Pick the setup models from the live catalogue.
 
     Falls back to the tier defaults when /v1/models is unreachable — listing
     routes are not deployed on every MindsHub host and can 404 even for valid
@@ -263,7 +279,11 @@ def resolve_minds_models(
     except Exception:
         ids = []
     if not ids:
-        return (MINDS_DEFAULT_PLANNING_MODEL, MINDS_DEFAULT_CODING_MODEL)
+        return MindsModels(
+            planning=MINDS_DEFAULT_PLANNING_MODEL,
+            coding=MINDS_DEFAULT_CODING_MODEL,
+            probe=MINDS_FREE_TIER_MODEL,
+        )
 
     def pick(preferred: tuple[str, ...], fallback: str) -> str:
         for name in preferred:
@@ -279,7 +299,7 @@ def resolve_minds_models(
         ids[0],
     )
     coding = pick((MINDS_DEFAULT_CODING_MODEL, MINDS_FREE_TIER_MODEL), planning)
-    return (planning, coding)
+    return MindsModels(planning=planning, coding=coding, probe=coding)
 
 
 @dataclass

--- a/anton/minds_client.py
+++ b/anton/minds_client.py
@@ -27,6 +27,32 @@ if TYPE_CHECKING:
 MINDS_DEFAULT_PLANNING_MODEL = "sonnet"
 MINDS_DEFAULT_CODING_MODEL = "haiku"
 
+# The free-bucket model present in every tier (auth's model_policy.json sets
+# free_bucket only for it) — the last resort when the catalogue says the key
+# cannot use the tier defaults, and cowork-server's probe model (ENG-576).
+MINDS_FREE_TIER_MODEL = "mindshub_air"
+
+# Dead mdb.ai smart-router aliases — never usable, whatever a server claims
+# to serve (ENG-1140).
+LEGACY_SMART_ROUTER_ALIASES = frozenset({"_reason_", "_code_"})
+
+
+def minds_v1_base(base_url: str) -> str:
+    """Host-aware OpenAI-compatible base URL.
+
+    api.mindshub.ai serves the OpenAI-compatible API at /v1, the legacy
+    mdb.ai host at /api/v1. Same rule as AntonSettings.model_post_init
+    (ENG-436) and cowork-server's minds_chat_base_url; a shell twin lives in
+    anton_services snapshots/cowork/setup.sh (mh_fetch_model_catalog) — keep
+    them aligned.
+    """
+    base = base_url.rstrip("/")
+    if base.endswith("/v1"):
+        return base
+    if "mdb.ai" in base:
+        return f"{base}/api/v1"
+    return f"{base}/v1"
+
 
 def minds_request(
     url: str,
@@ -193,15 +219,33 @@ def list_datasources(
 
 
 def list_models(base_url: str, api_key: str, verify: bool = True) -> list[str]:
-    """List model ids from the server's OpenAI-compatible /v1/models catalogue."""
-    url = f"{base_url}/v1/models"
-    raw = minds_request(url, api_key, verify=verify)
+    """List the chat-model ids this key can actually use.
+
+    Filters the catalogue on the fields that say whether a model is usable,
+    not just listed: ``embedding`` models can't chat, and ``enabled`` is
+    auth's wallet/allowance-aware access decision — a free-tier or
+    wallet-empty key sees paid models with ``enabled: false`` (clients must
+    not recompute access themselves; ENG-576). Entries without the flag are
+    kept, so older hosts that don't send it still work. The dead smart-router
+    aliases are dropped defensively.
+
+    Short timeout: the catalogue is advisory (callers fall back to defaults),
+    so it must not double the worst-case spinner hang of the probe itself.
+    """
+    url = f"{minds_v1_base(base_url)}/models"
+    raw = minds_request(url, api_key, verify=verify, timeout=10)
     data = _json.loads(raw.decode())
     entries = data.get("data") if isinstance(data, dict) else data
     ids: list[str] = []
     for entry in entries or []:
-        if isinstance(entry, dict) and entry.get("id"):
-            ids.append(str(entry["id"]))
+        if not isinstance(entry, dict) or not entry.get("id"):
+            continue
+        if entry.get("embedding") or entry.get("enabled") is False:
+            continue
+        model_id = str(entry["id"])
+        if model_id in LEGACY_SMART_ROUTER_ALIASES:
+            continue
+        ids.append(model_id)
     return ids
 
 
@@ -227,8 +271,14 @@ def resolve_minds_models(
                 return name
         return fallback
 
-    planning = pick((MINDS_DEFAULT_PLANNING_MODEL, "opus", "fable"), ids[0])
-    coding = pick((MINDS_DEFAULT_CODING_MODEL,), planning)
+    # The free-bucket model sits last in each chain: when the catalogue says
+    # the key can't use the paid defaults (free tier / empty wallet), land on
+    # the model it is entitled to instead of one that will 403 (ENG-576).
+    planning = pick(
+        (MINDS_DEFAULT_PLANNING_MODEL, "opus", "fable", MINDS_FREE_TIER_MODEL),
+        ids[0],
+    )
+    coding = pick((MINDS_DEFAULT_CODING_MODEL, MINDS_FREE_TIER_MODEL), planning)
     return (planning, coding)
 
 
@@ -275,25 +325,34 @@ def test_llm(
     verify: bool = True,
     model: str = MINDS_DEFAULT_CODING_MODEL,
 ) -> LLMTestResult:
-    """Probe the server's chat-completions endpoint with a 1-token request.
+    """Probe the server's chat-completions endpoint with a tiny request.
 
     Probes with the model setup is about to configure (resolved from the live
     catalogue by the caller), so a passing probe validates the actual config.
-    Uses the new /v1/ format (legacy /api/v1/ is still supported by the server).
+
+    max_tokens must be >= 16: the OpenAI-backed catalogue entries (gpt-*,
+    mindshub_air) reject smaller values with integer_below_min_value, so a
+    1-token probe was a deterministic false negative on those models. 20
+    matches cowork-server's validate_minds.
     """
     payload = _json.dumps(build_chat_completion_kwargs(
         model=model,
         messages=[{"role": "user", "content": "ping"}],
-        max_tokens=1,
+        max_tokens=20,
     )).encode()
 
-    url = f"{base_url}/v1/chat/completions"
+    url = f"{minds_v1_base(base_url)}/chat/completions"
     try:
         minds_request(url, api_key, method="POST", payload=payload, verify=verify)
         return LLMTestResult(ok=True)
     except urllib.error.HTTPError as e:
         if e.code == 429:
-            return LLMTestResult(ok=False, rate_limited=True, http_status=429)
+            return LLMTestResult(
+                ok=False,
+                rate_limited=True,
+                error=_http_error_detail(e),
+                http_status=429,
+            )
         return LLMTestResult(ok=False, error=_http_error_detail(e), http_status=e.code)
     except Exception as e:
         headline, _advice = describe_minds_connection_error(e)

--- a/anton/minds_client.py
+++ b/anton/minds_client.py
@@ -234,11 +234,17 @@ def resolve_minds_models(
 
 @dataclass
 class LLMTestResult:
-    """Outcome of an LLM connectivity probe, with the provider's own error."""
+    """Outcome of an LLM connectivity probe, with the provider's own error.
+
+    ``http_status`` is set when the server answered with an HTTP error — which
+    proves the transport (TLS included) worked, so callers can skip
+    no-SSL-verification retries that cannot change the outcome.
+    """
 
     ok: bool
     rate_limited: bool = False
     error: str | None = None
+    http_status: int | None = None
 
 
 def _http_error_detail(e: urllib.error.HTTPError) -> str:
@@ -287,8 +293,8 @@ def test_llm(
         return LLMTestResult(ok=True)
     except urllib.error.HTTPError as e:
         if e.code == 429:
-            return LLMTestResult(ok=False, rate_limited=True)
-        return LLMTestResult(ok=False, error=_http_error_detail(e))
+            return LLMTestResult(ok=False, rate_limited=True, http_status=429)
+        return LLMTestResult(ok=False, error=_http_error_detail(e), http_status=e.code)
     except Exception as e:
         headline, _advice = describe_minds_connection_error(e)
         return LLMTestResult(ok=False, error=headline)

--- a/anton/minds_client.py
+++ b/anton/minds_client.py
@@ -13,12 +13,19 @@ import json as _json
 import ssl
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from anton.core.llm.openai import build_chat_completion_kwargs
 
 if TYPE_CHECKING:
     from anton.config.settings import AntonSettings
+
+# Tier-default models on MindsHub Cloud — bare catalogue ids, the same pair
+# cowork-server's apply_model_defaults seeds. Used when /v1/models is not
+# deployed on the target host (not every MindsHub host serves listing routes).
+MINDS_DEFAULT_PLANNING_MODEL = "sonnet"
+MINDS_DEFAULT_CODING_MODEL = "haiku"
 
 
 def minds_request(
@@ -185,13 +192,91 @@ def list_datasources(
     return data.get("datasources", data if isinstance(data, list) else [])
 
 
-def test_llm(base_url: str, api_key: str, verify: bool = True) -> bool:
-    """Test if the Minds server supports LLM endpoints (_code_/_reason_ models).
+def list_models(base_url: str, api_key: str, verify: bool = True) -> list[str]:
+    """List model ids from the server's OpenAI-compatible /v1/models catalogue."""
+    url = f"{base_url}/v1/models"
+    raw = minds_request(url, api_key, verify=verify)
+    data = _json.loads(raw.decode())
+    entries = data.get("data") if isinstance(data, dict) else data
+    ids: list[str] = []
+    for entry in entries or []:
+        if isinstance(entry, dict) and entry.get("id"):
+            ids.append(str(entry["id"]))
+    return ids
 
+
+def resolve_minds_models(
+    base_url: str, api_key: str, verify: bool = True
+) -> tuple[str, str]:
+    """Pick the (planning, coding) model pair from the live catalogue.
+
+    Falls back to the tier defaults when /v1/models is unreachable — listing
+    routes are not deployed on every MindsHub host and can 404 even for valid
+    keys — so setup never blocks on the catalogue being available.
+    """
+    try:
+        ids = list_models(base_url, api_key, verify=verify)
+    except Exception:
+        ids = []
+    if not ids:
+        return (MINDS_DEFAULT_PLANNING_MODEL, MINDS_DEFAULT_CODING_MODEL)
+
+    def pick(preferred: tuple[str, ...], fallback: str) -> str:
+        for name in preferred:
+            if name in ids:
+                return name
+        return fallback
+
+    planning = pick((MINDS_DEFAULT_PLANNING_MODEL, "opus", "fable"), ids[0])
+    coding = pick((MINDS_DEFAULT_CODING_MODEL,), planning)
+    return (planning, coding)
+
+
+@dataclass
+class LLMTestResult:
+    """Outcome of an LLM connectivity probe, with the provider's own error."""
+
+    ok: bool
+    rate_limited: bool = False
+    error: str | None = None
+
+
+def _http_error_detail(e: urllib.error.HTTPError) -> str:
+    """Extract the provider's error message from an HTTP error body.
+
+    MindsHub returns OpenAI-shaped error envelopes ({"error": {"code":
+    "model_not_found", "message": ...}}); surface that instead of a bare
+    status so setup can tell the user what actually failed.
+    """
+    try:
+        body = _json.loads(e.read().decode())
+        err = body.get("error", body) if isinstance(body, dict) else None
+        if isinstance(err, dict):
+            message = err.get("message")
+            code = err.get("code")
+            if message:
+                return f"{code}: {message}" if code else str(message)
+        elif isinstance(err, str) and err:
+            return err
+    except Exception:
+        pass
+    return f"HTTP {e.code}: {e.reason or 'error'}"
+
+
+def test_llm(
+    base_url: str,
+    api_key: str,
+    verify: bool = True,
+    model: str = MINDS_DEFAULT_CODING_MODEL,
+) -> LLMTestResult:
+    """Probe the server's chat-completions endpoint with a 1-token request.
+
+    Probes with the model setup is about to configure (resolved from the live
+    catalogue by the caller), so a passing probe validates the actual config.
     Uses the new /v1/ format (legacy /api/v1/ is still supported by the server).
     """
     payload = _json.dumps(build_chat_completion_kwargs(
-        model="_code_",
+        model=model,
         messages=[{"role": "user", "content": "ping"}],
         max_tokens=1,
     )).encode()
@@ -199,10 +284,11 @@ def test_llm(base_url: str, api_key: str, verify: bool = True) -> bool:
     url = f"{base_url}/v1/chat/completions"
     try:
         minds_request(url, api_key, method="POST", payload=payload, verify=verify)
-        return True
+        return LLMTestResult(ok=True)
     except urllib.error.HTTPError as e:
         if e.code == 429:
-            return "rate_limited"
-        return False
-    except Exception:
-        return False
+            return LLMTestResult(ok=False, rate_limited=True)
+        return LLMTestResult(ok=False, error=_http_error_detail(e))
+    except Exception as e:
+        headline, _advice = describe_minds_connection_error(e)
+        return LLMTestResult(ok=False, error=headline)

--- a/anton/minds_client.py
+++ b/anton/minds_client.py
@@ -253,16 +253,26 @@ def list_models(base_url: str, api_key: str, verify: bool = True) -> list[str]:
 class MindsModels:
     """Resolved (planning, coding) pair plus the model to probe with.
 
-    When the pair came from the live catalogue, probing the coding model
-    validates the actual configuration. With no catalogue to trust, the pair
-    is the tier defaults but the probe uses the free-bucket model — a paid
-    default would 403 for free-tier keys on exactly the hosts that don't
-    serve the listing route (the ENG-576 shape).
+    ``probe`` is always one of the pair, so a passing probe validates the
+    configuration that gets persisted — that invariant is the point of
+    ENG-1140 and must hold on every branch.
+
+    With no catalogue to trust, the pair is the tier defaults and
+    ``free_fallback`` names the free-bucket model to *escalate down to* if the
+    paid probe is denied. Probing the free model directly instead would pass
+    for a free-tier key and then persist an unvalidated paid pair that 403s on
+    the first real request — "Connected" masking a broken install, which is
+    the exact class this ticket exists to remove (#317 re-review). Probing the
+    paid default alone would wrongly block free-tier keys (ENG-576), so
+    neither single probe is correct: the escalation is.
     """
 
     planning: str
     coding: str
     probe: str
+    # None when the pair came from the live catalogue (already access-aware —
+    # /v1/models only lists what the key may use, so no escalation exists).
+    free_fallback: str | None = None
 
 
 def resolve_minds_models(
@@ -279,10 +289,13 @@ def resolve_minds_models(
     except Exception:
         ids = []
     if not ids:
+        # Probe the model we would actually configure, and let the caller
+        # escalate down to the free bucket if that probe is denied.
         return MindsModels(
             planning=MINDS_DEFAULT_PLANNING_MODEL,
             coding=MINDS_DEFAULT_CODING_MODEL,
-            probe=MINDS_FREE_TIER_MODEL,
+            probe=MINDS_DEFAULT_CODING_MODEL,
+            free_fallback=MINDS_FREE_TIER_MODEL,
         )
 
     def pick(preferred: tuple[str, ...], fallback: str) -> str:
@@ -377,3 +390,40 @@ def test_llm(
     except Exception as e:
         headline, _advice = describe_minds_connection_error(e)
         return LLMTestResult(ok=False, error=headline)
+
+
+def resolve_and_probe(
+    base_url: str, api_key: str, verify: bool = True
+) -> tuple[MindsModels, LLMTestResult]:
+    """Resolve the setup models and validate them with one probe.
+
+    Returns the pair that should be PERSISTED together with the probe result
+    for it — so callers never persist a configuration no probe covered
+    (ENG-1140's invariant).
+
+    On the no-catalogue branch, a paid-default probe denied for model-access
+    reasons escalates once to the free bucket and, on success, returns the
+    free pair. Only access denials escalate: a 401 is a bad key, a 429 is
+    throttling, and a transport failure says nothing about entitlement — all
+    of those must surface as themselves rather than be retried as if the model
+    were the problem (#317 re-review).
+    """
+    models = resolve_minds_models(base_url, api_key, verify=verify)
+    result = test_llm(base_url, api_key, verify=verify, model=models.probe)
+    if (
+        result.ok
+        or models.free_fallback is None
+        or models.free_fallback == models.probe
+        # 403 = model_access_denied/model_disabled, 404 = model_not_found.
+        # Anything else is not an entitlement signal.
+        or result.http_status not in (403, 404)
+    ):
+        return models, result
+
+    free = models.free_fallback
+    free_result = test_llm(base_url, api_key, verify=verify, model=free)
+    if not free_result.ok:
+        # Report the ORIGINAL denial: it names the model the user actually
+        # asked to be set up with, which is the more useful message.
+        return models, result
+    return MindsModels(planning=free, coding=free, probe=free), free_result

--- a/docs/docs/connect/web-fetch.md
+++ b/docs/docs/connect/web-fetch.md
@@ -13,7 +13,7 @@ your LLM provider:
 | --- | --- |
 | Anthropic BYOK | Anthropic native server tool |
 | OpenAI BYOK | covered by `web_search` |
-| Minds-Enterprise-Cloud (mdb.ai) | mdb.ai passthrough |
+| MindsHub | MindsHub passthrough |
 | Generic OpenAI-compatible | built-in HTTP GET fallback (no key needed) |
 
 The fallback needs no API key at all: Anton performs a plain HTTP GET,

--- a/docs/docs/connect/web-search.md
+++ b/docs/docs/connect/web-search.md
@@ -12,7 +12,7 @@ default. How it executes depends on your LLM provider:
 | --- | --- | --- |
 | Anthropic BYOK | Anthropic native server tool | None — billed on your Anthropic key |
 | OpenAI BYOK | OpenAI Responses API native | None — billed on your OpenAI key |
-| Minds-Enterprise-Cloud (mdb.ai) | mdb.ai passthrough | None — billed on your Minds key |
+| MindsHub | MindsHub passthrough | None — billed on your MindsHub key |
 | Generic OpenAI-compatible (Together, Groq, Ollama, vLLM, …) | Exa.ai or Brave (you choose) | Run `anton setup-search` once |
 
 For the first three rows there is nothing to configure — the LLM provider

--- a/docs/docs/start/pick-a-provider.md
+++ b/docs/docs/start/pick-a-provider.md
@@ -5,7 +5,7 @@ description: Compare the LLM providers Anton supports and how to set each one up
 
 # Pick a provider
 
-Anton works with any of five provider options. You choose one during
+Anton works with any of these provider options. You choose one during
 onboarding (the first time you run `anton`), and you can switch at any time
 with `/llm` in chat or by running `anton setup`. All keys are persisted to
 `~/.anton/.env`, so they carry across sessions and workspaces.
@@ -14,36 +14,33 @@ with `/llm` in chat or by running `anton setup`. All keys are persisted to
 
 | Option | Default model | Web search / fetch | Best for |
 | --- | --- | --- | --- |
-| Minds-Enterprise-Cloud (mdb.ai) — recommended | `_reason_` / `_code_` smart routing | Native passthrough, zero setup | Best overall experience |
-| Minds-Enterprise-Server | Smart routing on your server | Depends on server | Self-hosted deployments |
+| MindsHub — recommended | Resolved from the live catalogue (`sonnet` / `haiku` tier defaults) | Native passthrough, zero setup | Best overall experience |
 | Anthropic (bring your own key) | `claude-sonnet-4-6` | Native server tools | Anthropic accounts |
 | OpenAI (bring your own key) | `gpt-5.4` | Native via Responses API | OpenAI accounts |
 | Google Gemini (bring your own key) | `gemini-3-flash-preview` | Needs `anton setup-search` | Gemini accounts |
 | Custom OpenAI-compatible | You choose | Needs `anton setup-search` | Ollama, vLLM, Together, Groq, LM Studio, Azure, … |
 
-## Option 1 — Minds-Enterprise-Cloud (recommended)
+## Option 1 — MindsHub (recommended)
 
-[mdb.ai](https://mdb.ai) is the default and recommended choice. Anton uses
-two virtual models — `_reason_` for planning and `_code_` for coding — and
-Minds routes each request to the best underlying model:
+[MindsHub](https://mindshub.ai) is the default and recommended choice. During
+setup Anton resolves the planning and coding models from the server's live
+model catalogue — picking the models your key is actually entitled to use —
+and validates the connection with a real request against that configuration:
 
-- Smart model routing
+- Latest frontier models
 - Faster responses
 - Cost optimized
 - Secure data connectors
 - Native web search and fetch passthrough — no extra setup
 
-During onboarding, if you don't have an mdb.ai API key yet, Anton opens the
+During onboarding, if you don't have a MindsHub API key yet, Anton opens the
 signup page for you — it takes a few seconds.
 
-## Option 2 — Minds-Enterprise-Server (self-hosted)
+The MindsHub host itself is not prompted for. To point Anton at a non-default
+host (staging, self-hosted), set `ANTON_MINDS_URL` in your environment or in
+`~/.anton/.env` before running setup — setup honors it.
 
-The same Minds experience against your own server. Onboarding asks for your
-server URL and API key, tests the connection, and (with your explicit
-confirmation) can proceed without SSL verification for servers with
-self-signed certificates.
-
-## Option 3 — Bring your own key
+## Option 2 — Bring your own key
 
 Choosing "Bring your own key" presents four sub-options. In each case Anton
 validates the key with a quick probe call before saving it.
@@ -92,7 +89,7 @@ both on by default. How they execute depends on your provider:
 | --- | --- | --- | --- |
 | Anthropic BYOK | Anthropic native server tool | Anthropic native server tool | None — billed on your Anthropic key |
 | OpenAI BYOK | OpenAI Responses API native | covered by `web_search` | None — billed on your OpenAI key |
-| Minds-Enterprise-Cloud (mdb.ai) | mdb.ai passthrough | mdb.ai passthrough | None — billed on your Minds key |
+| MindsHub | MindsHub passthrough | MindsHub passthrough | None — billed on your MindsHub key |
 | Generic OpenAI-compatible (Together, Groq, Ollama, vLLM, …) | Exa.ai or Brave (you choose at setup) | stdlib HTTP GET (no key) | Run `anton setup-search` once |
 
 To opt out, set `ANTON_WEB_SEARCH_ENABLED=false` and/or

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -351,12 +351,11 @@ class TestMindsSetupRecovery:
 
         monkeypatch.setattr("anton.chat.list_minds", fake_list_minds)
         monkeypatch.setattr(
-            "anton.chat.test_llm",
-            lambda *args, **kwargs: LLMTestResult(ok=True),
-        )
-        monkeypatch.setattr(
-            "anton.chat.resolve_minds_models",
-            lambda *args, **kwargs: MindsModels("sonnet", "haiku", "haiku"),
+            "anton.chat.resolve_and_probe",
+            lambda *args, **kwargs: (
+                MindsModels("sonnet", "haiku", "haiku"),
+                LLMTestResult(ok=True),
+            ),
         )
         rebuilt = object()
         monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: rebuilt)
@@ -417,14 +416,16 @@ class TestMindsSetupRecovery:
             lambda *a, **k: [{"name": "warehouse", "datasources": []}],
         )
         monkeypatch.setattr(
-            "anton.chat.test_llm",
-            lambda *a, **k: LLMTestResult(
-                ok=False, rate_limited=True, error="Rate limit exceeded", http_status=429
+            "anton.chat.resolve_and_probe",
+            lambda *a, **k: (
+                MindsModels("sonnet", "haiku", "haiku"),
+                LLMTestResult(
+                    ok=False,
+                    rate_limited=True,
+                    error="Rate limit exceeded",
+                    http_status=429,
+                ),
             ),
-        )
-        monkeypatch.setattr(
-            "anton.chat.resolve_minds_models",
-            lambda *a, **k: MindsModels("sonnet", "haiku", "haiku"),
         )
         monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: object())
 
@@ -477,12 +478,11 @@ class TestMindsSetupRecovery:
 
         monkeypatch.setattr("anton.chat.list_minds", fake_list_minds)
         monkeypatch.setattr(
-            "anton.chat.test_llm",
-            lambda *args, **kwargs: LLMTestResult(ok=True),
-        )
-        monkeypatch.setattr(
-            "anton.chat.resolve_minds_models",
-            lambda *args, **kwargs: MindsModels("sonnet", "haiku", "haiku"),
+            "anton.chat.resolve_and_probe",
+            lambda *args, **kwargs: (
+                MindsModels("sonnet", "haiku", "haiku"),
+                LLMTestResult(ok=True),
+            ),
         )
         rebuilt = object()
         monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: rebuilt)

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -391,6 +391,65 @@ class TestMindsSetupRecovery:
         assert "Recovery options:" in printed
         assert "certificate issue" not in printed
 
+    async def test_connect_adopts_a_rate_limited_minds_endpoint(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A 429 proves the endpoint is THERE — it answered and throttled the
+        probe. Treating it as unavailable dropped a throttled-but-valid MindsHub
+        endpoint and fell through to the BYOK prompt (#317 review); the earlier
+        truthy ``"rate_limited"`` string had adopted it.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        prompts = iter(["https://api.mindshub.ai", "", "1"])
+
+        async def fake_prompt(*args, **kwargs):
+            return next(prompts)
+
+        monkeypatch.setattr("anton.chat.prompt_or_cancel", fake_prompt)
+        monkeypatch.setattr("anton.utils.prompt.prompt_or_cancel", fake_prompt)
+        monkeypatch.setattr(
+            "anton.chat.list_minds",
+            lambda *a, **k: [{"name": "warehouse", "datasources": []}],
+        )
+        monkeypatch.setattr(
+            "anton.chat.test_llm",
+            lambda *a, **k: LLMTestResult(
+                ok=False, rate_limited=True, error="Rate limit exceeded", http_status=429
+            ),
+        )
+        monkeypatch.setattr(
+            "anton.chat.resolve_minds_models",
+            lambda *a, **k: MindsModels("sonnet", "haiku", "haiku"),
+        )
+        monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: object())
+
+        workspace_base = tmp_path / "workspace"
+        workspace_base.mkdir()
+        workspace = Workspace(workspace_base)
+        workspace.initialize()
+        settings = AntonSettings(minds_api_key="minds-key", _env_file=None)
+
+        await _handle_connect(
+            MagicMock(),
+            settings,
+            workspace,
+            state={},
+            self_awareness=None,
+            cortex=None,
+            session=object(),
+        )
+
+        # The throttled endpoint is adopted, with the catalogue-resolved models.
+        assert settings.planning_provider == "openai-compatible"
+        assert settings.coding_provider == "openai-compatible"
+        assert settings.planning_model == "sonnet"
+        assert settings.coding_model == "haiku"
+
     async def test_connect_can_retry_without_ssl_verification_after_timeout(
         self,
         tmp_path,

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -10,7 +10,7 @@ from tests.conftest import make_mock_llm
 import pytest
 
 from anton.chat import ChatSession, _handle_connect
-from anton.minds_client import LLMTestResult
+from anton.minds_client import LLMTestResult, MindsModels
 from anton.core.session import ChatSessionConfig
 from anton.core.llm.prompt_builder import SystemPromptContext
 from anton.minds_client import describe_minds_connection_error
@@ -356,7 +356,7 @@ class TestMindsSetupRecovery:
         )
         monkeypatch.setattr(
             "anton.chat.resolve_minds_models",
-            lambda *args, **kwargs: ("sonnet", "haiku"),
+            lambda *args, **kwargs: MindsModels("sonnet", "haiku", "haiku"),
         )
         rebuilt = object()
         monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: rebuilt)
@@ -423,7 +423,7 @@ class TestMindsSetupRecovery:
         )
         monkeypatch.setattr(
             "anton.chat.resolve_minds_models",
-            lambda *args, **kwargs: ("sonnet", "haiku"),
+            lambda *args, **kwargs: MindsModels("sonnet", "haiku", "haiku"),
         )
         rebuilt = object()
         monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: rebuilt)

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -10,6 +10,7 @@ from tests.conftest import make_mock_llm
 import pytest
 
 from anton.chat import ChatSession, _handle_connect
+from anton.minds_client import LLMTestResult
 from anton.core.session import ChatSessionConfig
 from anton.core.llm.prompt_builder import SystemPromptContext
 from anton.minds_client import describe_minds_connection_error
@@ -349,7 +350,14 @@ class TestMindsSetupRecovery:
             return [{"name": "warehouse", "datasources": []}]
 
         monkeypatch.setattr("anton.chat.list_minds", fake_list_minds)
-        monkeypatch.setattr("anton.chat.test_llm", lambda *args, **kwargs: True)
+        monkeypatch.setattr(
+            "anton.chat.test_llm",
+            lambda *args, **kwargs: LLMTestResult(ok=True),
+        )
+        monkeypatch.setattr(
+            "anton.chat.resolve_minds_models",
+            lambda *args, **kwargs: ("sonnet", "haiku"),
+        )
         rebuilt = object()
         monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: rebuilt)
 
@@ -409,7 +417,14 @@ class TestMindsSetupRecovery:
             return [{"name": "warehouse", "datasources": []}]
 
         monkeypatch.setattr("anton.chat.list_minds", fake_list_minds)
-        monkeypatch.setattr("anton.chat.test_llm", lambda *args, **kwargs: True)
+        monkeypatch.setattr(
+            "anton.chat.test_llm",
+            lambda *args, **kwargs: LLMTestResult(ok=True),
+        )
+        monkeypatch.setattr(
+            "anton.chat.resolve_minds_models",
+            lambda *args, **kwargs: ("sonnet", "haiku"),
+        )
         rebuilt = object()
         monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: rebuilt)
 

--- a/tests/test_openai_setup.py
+++ b/tests/test_openai_setup.py
@@ -225,6 +225,131 @@ class TestMindsV1Base:
         assert minds_client.minds_v1_base("https://host.example/v1") == "https://host.example/v1"
 
 
+class TestMindsPassthroughFlavorDetection:
+    """The gateway must be detected as passthrough for every base URL
+    ``model_post_init`` can derive (#317 review).
+
+    Getting this wrong is silent: the provider falls back to
+    ``FLAVOR_OPENAI_COMPATIBLE_GENERIC``, whose ``native_web_tools()`` returns
+    an empty set, so the session routes web_search to a handler ToolDef needing
+    an Exa/Brave key that MindsHub users don't have. Web search just stops
+    working, with no error anywhere.
+    """
+
+    def _flavor(self, minds_url: str) -> str:
+        from anton.core.llm.client import _resolve_openai_compatible_flavor
+
+        settings = AntonSettings(
+            planning_provider="openai-compatible",
+            coding_provider="openai-compatible",
+            minds_api_key="k",
+            minds_url=minds_url,
+            openai_base_url=None,
+            openai_api_key=None,
+        )
+        return _resolve_openai_compatible_flavor(settings)
+
+    def _passthrough(self) -> str:
+        from anton.core.llm.openai import OpenAIProvider
+
+        return OpenAIProvider.FLAVOR_MINDS_PASSTHROUGH
+
+    def test_mindshub_host_is_passthrough(self):
+        # The canonical value setup writes. This is the case that was broken:
+        # minds_url has no suffix, model_post_init derives .../v1, and the
+        # detection only knew about the bare host and /api/v1.
+        assert self._flavor("https://api.mindshub.ai") == self._passthrough()
+
+    def test_legacy_mdb_host_is_passthrough(self):
+        assert self._flavor("https://mdb.ai") == self._passthrough()
+
+    def test_explicit_v1_suffix_is_passthrough(self):
+        assert self._flavor("https://api.mindshub.ai/v1") == self._passthrough()
+
+    def test_third_party_endpoint_stays_generic(self):
+        # The guard against over-matching: a generic endpoint must NOT get the
+        # passthrough, or anton sends web-tool types it can't understand.
+        from anton.core.llm.openai import OpenAIProvider
+
+        settings = AntonSettings(
+            planning_provider="openai-compatible",
+            coding_provider="openai-compatible",
+            minds_api_key="k",
+            minds_url="https://api.mindshub.ai",
+            openai_base_url="https://some-proxy.example/v1",
+            openai_api_key="k",
+        )
+        from anton.core.llm.client import _resolve_openai_compatible_flavor
+
+        assert (
+            _resolve_openai_compatible_flavor(settings)
+            == OpenAIProvider.FLAVOR_OPENAI_COMPATIBLE_GENERIC
+        )
+
+    def test_passthrough_actually_enables_native_web_tools(self):
+        # The property that matters downstream — the flavor is only a means.
+        from anton.core.llm.openai import OpenAIProvider
+
+        provider = OpenAIProvider(
+            api_key="k",
+            base_url="https://api.mindshub.ai/v1",
+            flavor=self._passthrough(),
+        )
+        assert provider.native_web_tools() == {"web_search", "web_fetch"}
+
+
+class TestSetupErrorTextIsMarkupSafe:
+    """Provider error text is interpolated into Rich markup; an unescaped
+    ``[...]`` that Rich reads as a style tag raises MarkupError and crashes
+    setup — the opposite of the error-surfacing this PR adds (#317 review).
+    """
+
+    def _run_setup_with_error(self, monkeypatch, detail: str):
+        import anton.cli as cli
+
+        monkeypatch.setattr(
+            cli, "resolve_minds_models",
+            lambda *a, **k: minds_client.MindsModels(
+                planning="sonnet", coding="haiku", probe="haiku"
+            ),
+        )
+        monkeypatch.setattr(
+            cli, "test_llm",
+            lambda *a, **k: minds_client.LLMTestResult(
+                ok=False, error=detail, http_status=404
+            ),
+        )
+        monkeypatch.setattr(cli, "_setup_prompt", lambda *a, **k: "key")
+        monkeypatch.setattr(cli.Confirm, "ask", staticmethod(lambda *a, **k: False))
+        settings = AntonSettings(minds_url="https://api.mindshub.ai")
+        ws = MagicMock()
+        # Declining the retry exits via _SetupRetry — that's the normal control
+        # flow and not what this test is about. The assertion is narrow on
+        # purpose: MarkupError must never escape, whatever the provider said.
+        from rich.errors import MarkupError
+
+        try:
+            cli._setup_minds(settings, ws)
+        except MarkupError:
+            raise
+        except Exception:
+            pass
+
+    # Fixture choice matters: Rich TOLERATES an unmatched OPENING tag
+    # ("[sonnet-4-6]" prints fine), so those strings prove nothing. Only a
+    # CLOSING tag ("[/...]") raises — verified against rich directly. A route
+    # or JSON-pointer echoed in a gateway error is exactly that shape.
+    def test_route_in_error_text_does_not_crash_setup(self, monkeypatch):
+        self._run_setup_with_error(
+            monkeypatch, "model_not_found: unknown route [/v1/chat/completions]"
+        )
+
+    def test_json_pointer_in_error_text_does_not_crash_setup(self, monkeypatch):
+        self._run_setup_with_error(
+            monkeypatch, "validation error at [/model] — field required"
+        )
+
+
 def test_setup_minds_skips_no_ssl_retry_on_http_error(monkeypatch):
     """An HTTP-level failure (server answered → TLS worked) must not trigger
     the verify=False retry — it can only repeat the same error."""

--- a/tests/test_openai_setup.py
+++ b/tests/test_openai_setup.py
@@ -28,7 +28,10 @@ def test_minds_test_llm_uses_modern_openai_token_parameter(monkeypatch):
 
     payload = json.loads(captured["payload"].decode())
     assert payload["model"] == minds_client.MINDS_DEFAULT_CODING_MODEL
-    assert payload["max_completion_tokens"] == 1
+    # >= 16: the OpenAI-backed catalogue models (gpt-*, mindshub_air) reject
+    # smaller values with integer_below_min_value — a 1-token probe was a
+    # deterministic false negative on them.
+    assert payload["max_completion_tokens"] == 20
     assert "max_tokens" not in payload
 
 
@@ -75,15 +78,22 @@ def test_minds_test_llm_propagates_provider_error_message(monkeypatch):
     assert "_code_" in result.error
 
 
-def test_minds_test_llm_flags_rate_limit(monkeypatch):
+def test_minds_test_llm_flags_rate_limit_and_keeps_detail(monkeypatch):
+    """A 429 is usually the TPM/RPM limiter, not an empty wallet — the
+    provider's own message must survive so the caller doesn't hardcode
+    'buy tokens' advice at a user who has tokens."""
+
     def fake_minds_request(*args, **kwargs):
-        raise _http_error(429, {"error": {"message": "limit"}})
+        raise _http_error(
+            429, {"error": {"code": "rate_limit", "message": "Rate limit exceeded for model 'sonnet'"}}
+        )
 
     monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
 
     result = minds_client.test_llm("https://example.com", "test-key")
     assert result.ok is False
     assert result.rate_limited is True
+    assert "Rate limit exceeded" in result.error
 
 
 def test_minds_test_llm_falls_back_to_status_when_body_unparseable(monkeypatch):
@@ -104,7 +114,12 @@ def test_minds_test_llm_falls_back_to_status_when_body_unparseable(monkeypatch):
 
 class TestResolveMindsModels:
     def _catalog(self, ids):
+        """Entries deliberately omit enabled/embedding — older hosts don't
+        send the flags, and absent flags must mean 'usable'."""
         return json.dumps({"data": [{"id": i} for i in ids]}).encode()
+
+    def _rich_catalog(self, entries):
+        return json.dumps({"data": entries}).encode()
 
     def test_prefers_tier_defaults_from_catalog(self, monkeypatch):
         monkeypatch.setattr(
@@ -122,7 +137,16 @@ class TestResolveMindsModels:
         )
         planning, coding = minds_client.resolve_minds_models("https://x", "k")
         assert planning == "fable"
-        assert coding == "fable"  # no haiku → coding follows planning
+        assert coding == "mindshub_air"  # no haiku → the free-bucket model
+
+    def test_coding_follows_planning_when_no_cheap_model_exists(self, monkeypatch):
+        monkeypatch.setattr(
+            "anton.minds_client.minds_request",
+            lambda *a, **kw: self._catalog(["fable", "grok"]),
+        )
+        planning, coding = minds_client.resolve_minds_models("https://x", "k")
+        assert planning == "fable"
+        assert coding == "fable"
 
     def test_falls_back_to_defaults_when_models_route_missing(self, monkeypatch):
         """/v1/models is not deployed on every MindsHub host — a 404 there
@@ -139,13 +163,60 @@ class TestResolveMindsModels:
         )
 
     def test_never_returns_dead_smart_router_aliases(self, monkeypatch):
-        """The legacy mdb.ai aliases must never be picked, whatever the server says."""
+        """The legacy mdb.ai aliases must never be picked, whatever the server
+        says — even a catalogue consisting only of them falls back to defaults."""
         monkeypatch.setattr(
             "anton.minds_client.minds_request",
-            lambda *a, **kw: self._catalog(["sonnet", "haiku"]),
+            lambda *a, **kw: self._catalog(["_reason_", "_code_"]),
         )
-        pair = minds_client.resolve_minds_models("https://x", "k")
-        assert "_reason_" not in pair and "_code_" not in pair
+        assert minds_client.resolve_minds_models("https://x", "k") == (
+            minds_client.MINDS_DEFAULT_PLANNING_MODEL,
+            minds_client.MINDS_DEFAULT_CODING_MODEL,
+        )
+
+    def test_free_tier_key_lands_on_the_free_bucket_model(self, monkeypatch):
+        """enabled=false is auth's wallet/allowance-aware access decision: a
+        free-tier key sees paid models disabled and must land on mindshub_air,
+        not on a model that will 403 (the ENG-576 shape)."""
+        monkeypatch.setattr(
+            "anton.minds_client.minds_request",
+            lambda *a, **kw: self._rich_catalog([
+                {"id": "sonnet", "enabled": False, "embedding": False},
+                {"id": "haiku", "enabled": False, "embedding": False},
+                {"id": "opus", "enabled": False, "embedding": False},
+                {"id": "mindshub_air", "enabled": True, "embedding": False},
+            ]),
+        )
+        assert minds_client.resolve_minds_models("https://x", "k") == (
+            "mindshub_air",
+            "mindshub_air",
+        )
+
+    def test_embedding_models_are_never_picked(self, monkeypatch):
+        """The ids[0] fallback must not land on an embeddings model configured
+        as planning/coding."""
+        monkeypatch.setattr(
+            "anton.minds_client.minds_request",
+            lambda *a, **kw: self._rich_catalog([
+                {"id": "embed-small", "enabled": True, "embedding": True},
+                {"id": "grok", "enabled": True, "embedding": False},
+            ]),
+        )
+        assert minds_client.resolve_minds_models("https://x", "k") == ("grok", "grok")
+
+
+class TestMindsV1Base:
+    """Host-aware base rule — same as AntonSettings.model_post_init (ENG-436)
+    and cowork-server's minds_chat_base_url."""
+
+    def test_mindshub_host_uses_v1(self):
+        assert minds_client.minds_v1_base("https://api.mindshub.ai") == "https://api.mindshub.ai/v1"
+
+    def test_legacy_mdb_host_uses_api_v1(self):
+        assert minds_client.minds_v1_base("https://mdb.ai") == "https://mdb.ai/api/v1"
+
+    def test_explicit_v1_suffix_kept_as_is(self):
+        assert minds_client.minds_v1_base("https://host.example/v1") == "https://host.example/v1"
 
 
 def test_setup_minds_skips_no_ssl_retry_on_http_error(monkeypatch):
@@ -203,6 +274,32 @@ def test_setup_minds_writes_catalog_resolved_models(monkeypatch):
     assert settings.coding_model == "haiku"
     workspace.set_secret.assert_any_call("ANTON_PLANNING_MODEL", "sonnet")
     workspace.set_secret.assert_any_call("ANTON_CODING_MODEL", "haiku")
+
+
+def test_setup_minds_honors_env_url_override(monkeypatch):
+    """ANTON_MINDS_URL is the only path to a non-default host (staging,
+    self-hosted) — setup must use it, not clobber it back to prod."""
+    import anton.cli as cli
+
+    settings = AntonSettings(_env_file=None)
+    workspace = MagicMock()
+
+    monkeypatch.setenv("ANTON_MINDS_URL", "https://api.staging.mindshub.ai/")
+    monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
+    monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "anton.cli.resolve_minds_models", lambda *a, **kw: ("sonnet", "haiku")
+    )
+    monkeypatch.setattr(
+        "anton.cli.test_llm", lambda *a, **kw: minds_client.LLMTestResult(ok=True)
+    )
+
+    cli._setup_minds(settings, workspace)
+
+    assert settings.minds_url == "https://api.staging.mindshub.ai"
+    workspace.set_secret.assert_any_call(
+        "ANTON_MINDS_URL", "https://api.staging.mindshub.ai"
+    )
 
 
 def test_setup_openai_uses_modern_openai_token_parameter(monkeypatch):

--- a/tests/test_openai_setup.py
+++ b/tests/test_openai_setup.py
@@ -23,12 +23,155 @@ def test_minds_test_llm_uses_modern_openai_token_parameter(monkeypatch):
 
     monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
 
-    assert minds_client.test_llm("https://example.com", "test-key") is True
+    result = minds_client.test_llm("https://example.com", "test-key")
+    assert result.ok is True
 
     payload = json.loads(captured["payload"].decode())
-    assert payload["model"] == "_code_"
+    assert payload["model"] == minds_client.MINDS_DEFAULT_CODING_MODEL
     assert payload["max_completion_tokens"] == 1
     assert "max_tokens" not in payload
+
+
+def _http_error(code: int, body: dict | None = None, reason: str = "err"):
+    import io
+    import urllib.error
+
+    raw = json.dumps(body).encode() if body is not None else b""
+    return urllib.error.HTTPError(
+        "https://example.com/v1/chat/completions", code, reason, {}, io.BytesIO(raw)
+    )
+
+
+def test_minds_test_llm_probes_with_given_model(monkeypatch):
+    captured: dict = {}
+
+    def fake_minds_request(url, api_key, method="GET", payload=None, verify=True, **kwargs):
+        captured["payload"] = payload
+        return b"{}"
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
+
+    assert minds_client.test_llm("https://example.com", "k", model="sonnet").ok
+    assert json.loads(captured["payload"].decode())["model"] == "sonnet"
+
+
+def test_minds_test_llm_propagates_provider_error_message(monkeypatch):
+    """Regression for ENG-1140: a 404 model_not_found must surface the
+    provider's message, not collapse into a bare False that gets rendered as
+    'Check your API key and URL'."""
+
+    err = _http_error(404, {"error": {"code": "model_not_found",
+                                      "message": "The model '_code_' does not exist"}})
+
+    def fake_minds_request(*args, **kwargs):
+        raise err
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
+
+    result = minds_client.test_llm("https://example.com", "test-key")
+    assert result.ok is False
+    assert result.rate_limited is False
+    assert "model_not_found" in result.error
+    assert "_code_" in result.error
+
+
+def test_minds_test_llm_flags_rate_limit(monkeypatch):
+    def fake_minds_request(*args, **kwargs):
+        raise _http_error(429, {"error": {"message": "limit"}})
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
+
+    result = minds_client.test_llm("https://example.com", "test-key")
+    assert result.ok is False
+    assert result.rate_limited is True
+
+
+def test_minds_test_llm_falls_back_to_status_when_body_unparseable(monkeypatch):
+    def fake_minds_request(*args, **kwargs):
+        import io
+        import urllib.error
+
+        raise urllib.error.HTTPError(
+            "https://example.com", 502, "Bad Gateway", {}, io.BytesIO(b"<html>")
+        )
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
+
+    result = minds_client.test_llm("https://example.com", "test-key")
+    assert result.ok is False
+    assert "502" in result.error
+
+
+class TestResolveMindsModels:
+    def _catalog(self, ids):
+        return json.dumps({"data": [{"id": i} for i in ids]}).encode()
+
+    def test_prefers_tier_defaults_from_catalog(self, monkeypatch):
+        monkeypatch.setattr(
+            "anton.minds_client.minds_request",
+            lambda *a, **kw: self._catalog(
+                ["mindshub_air", "haiku", "sonnet", "opus", "fable"]
+            ),
+        )
+        assert minds_client.resolve_minds_models("https://x", "k") == ("sonnet", "haiku")
+
+    def test_falls_back_within_catalog_when_defaults_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            "anton.minds_client.minds_request",
+            lambda *a, **kw: self._catalog(["fable", "mindshub_air"]),
+        )
+        planning, coding = minds_client.resolve_minds_models("https://x", "k")
+        assert planning == "fable"
+        assert coding == "fable"  # no haiku → coding follows planning
+
+    def test_falls_back_to_defaults_when_models_route_missing(self, monkeypatch):
+        """/v1/models is not deployed on every MindsHub host — a 404 there
+        must not block setup (same caution as cowork-server's validate_minds)."""
+
+        def fake_minds_request(*args, **kwargs):
+            raise _http_error(404)
+
+        monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
+
+        assert minds_client.resolve_minds_models("https://x", "k") == (
+            minds_client.MINDS_DEFAULT_PLANNING_MODEL,
+            minds_client.MINDS_DEFAULT_CODING_MODEL,
+        )
+
+    def test_never_returns_dead_smart_router_aliases(self, monkeypatch):
+        """The legacy mdb.ai aliases must never be picked, whatever the server says."""
+        monkeypatch.setattr(
+            "anton.minds_client.minds_request",
+            lambda *a, **kw: self._catalog(["sonnet", "haiku"]),
+        )
+        pair = minds_client.resolve_minds_models("https://x", "k")
+        assert "_reason_" not in pair and "_code_" not in pair
+
+
+def test_setup_minds_writes_catalog_resolved_models(monkeypatch):
+    """End-to-end through _setup_minds: on a passing probe the resolved pair —
+    not the dead _reason_/_code_ aliases — is persisted (ENG-1140)."""
+    import anton.cli as cli
+
+    settings = AntonSettings(_env_file=None)
+    workspace = MagicMock()
+
+    monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
+    monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "anton.cli.resolve_minds_models", lambda *a, **kw: ("sonnet", "haiku")
+    )
+    monkeypatch.setattr(
+        "anton.cli.test_llm",
+        lambda *a, **kw: minds_client.LLMTestResult(ok=True),
+    )
+
+    cli._setup_minds(settings, workspace)
+
+    assert settings.planning_model == "sonnet"
+    assert settings.coding_model == "haiku"
+    workspace.set_secret.assert_any_call("ANTON_PLANNING_MODEL", "sonnet")
+    workspace.set_secret.assert_any_call("ANTON_CODING_MODEL", "haiku")
 
 
 def test_setup_openai_uses_modern_openai_token_parameter(monkeypatch):

--- a/tests/test_openai_setup.py
+++ b/tests/test_openai_setup.py
@@ -128,25 +128,25 @@ class TestResolveMindsModels:
                 ["mindshub_air", "haiku", "sonnet", "opus", "fable"]
             ),
         )
-        assert minds_client.resolve_minds_models("https://x", "k") == ("sonnet", "haiku")
+        r = minds_client.resolve_minds_models("https://x", "k")
+        assert (r.planning, r.coding) == ("sonnet", "haiku")
+        assert r.probe == r.coding  # catalogue-backed probe validates the config
 
     def test_falls_back_within_catalog_when_defaults_missing(self, monkeypatch):
         monkeypatch.setattr(
             "anton.minds_client.minds_request",
             lambda *a, **kw: self._catalog(["fable", "mindshub_air"]),
         )
-        planning, coding = minds_client.resolve_minds_models("https://x", "k")
-        assert planning == "fable"
-        assert coding == "mindshub_air"  # no haiku → the free-bucket model
+        r = minds_client.resolve_minds_models("https://x", "k")
+        assert (r.planning, r.coding) == ("fable", "mindshub_air")
 
     def test_coding_follows_planning_when_no_cheap_model_exists(self, monkeypatch):
         monkeypatch.setattr(
             "anton.minds_client.minds_request",
             lambda *a, **kw: self._catalog(["fable", "grok"]),
         )
-        planning, coding = minds_client.resolve_minds_models("https://x", "k")
-        assert planning == "fable"
-        assert coding == "fable"
+        r = minds_client.resolve_minds_models("https://x", "k")
+        assert (r.planning, r.coding) == ("fable", "fable")
 
     def test_falls_back_to_defaults_when_models_route_missing(self, monkeypatch):
         """/v1/models is not deployed on every MindsHub host — a 404 there
@@ -157,10 +157,14 @@ class TestResolveMindsModels:
 
         monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
 
-        assert minds_client.resolve_minds_models("https://x", "k") == (
+        r = minds_client.resolve_minds_models("https://x", "k")
+        assert (r.planning, r.coding) == (
             minds_client.MINDS_DEFAULT_PLANNING_MODEL,
             minds_client.MINDS_DEFAULT_CODING_MODEL,
         )
+        # No catalogue to trust → probe with the universal free-bucket model,
+        # not a paid default that 403s on free-tier keys (ENG-576).
+        assert r.probe == minds_client.MINDS_FREE_TIER_MODEL
 
     def test_never_returns_dead_smart_router_aliases(self, monkeypatch):
         """The legacy mdb.ai aliases must never be picked, whatever the server
@@ -169,7 +173,8 @@ class TestResolveMindsModels:
             "anton.minds_client.minds_request",
             lambda *a, **kw: self._catalog(["_reason_", "_code_"]),
         )
-        assert minds_client.resolve_minds_models("https://x", "k") == (
+        r = minds_client.resolve_minds_models("https://x", "k")
+        assert (r.planning, r.coding) == (
             minds_client.MINDS_DEFAULT_PLANNING_MODEL,
             minds_client.MINDS_DEFAULT_CODING_MODEL,
         )
@@ -187,9 +192,9 @@ class TestResolveMindsModels:
                 {"id": "mindshub_air", "enabled": True, "embedding": False},
             ]),
         )
-        assert minds_client.resolve_minds_models("https://x", "k") == (
-            "mindshub_air",
-            "mindshub_air",
+        r = minds_client.resolve_minds_models("https://x", "k")
+        assert (r.planning, r.coding, r.probe) == (
+            "mindshub_air", "mindshub_air", "mindshub_air",
         )
 
     def test_embedding_models_are_never_picked(self, monkeypatch):
@@ -202,7 +207,8 @@ class TestResolveMindsModels:
                 {"id": "grok", "enabled": True, "embedding": False},
             ]),
         )
-        assert minds_client.resolve_minds_models("https://x", "k") == ("grok", "grok")
+        r = minds_client.resolve_minds_models("https://x", "k")
+        assert (r.planning, r.coding) == ("grok", "grok")
 
 
 class TestMindsV1Base:
@@ -231,7 +237,8 @@ def test_setup_minds_skips_no_ssl_retry_on_http_error(monkeypatch):
     monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
     monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: False)  # no retry
     monkeypatch.setattr(
-        "anton.cli.resolve_minds_models", lambda *a, **kw: ("sonnet", "haiku")
+        "anton.cli.resolve_minds_models",
+        lambda *a, **kw: minds_client.MindsModels("sonnet", "haiku", "haiku"),
     )
 
     def fake_test_llm(*a, **kw):
@@ -261,7 +268,8 @@ def test_setup_minds_writes_catalog_resolved_models(monkeypatch):
     monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
     monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: True)
     monkeypatch.setattr(
-        "anton.cli.resolve_minds_models", lambda *a, **kw: ("sonnet", "haiku")
+        "anton.cli.resolve_minds_models",
+        lambda *a, **kw: minds_client.MindsModels("sonnet", "haiku", "haiku"),
     )
     monkeypatch.setattr(
         "anton.cli.test_llm",
@@ -288,7 +296,8 @@ def test_setup_minds_honors_env_url_override(monkeypatch):
     monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
     monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: True)
     monkeypatch.setattr(
-        "anton.cli.resolve_minds_models", lambda *a, **kw: ("sonnet", "haiku")
+        "anton.cli.resolve_minds_models",
+        lambda *a, **kw: minds_client.MindsModels("sonnet", "haiku", "haiku"),
     )
     monkeypatch.setattr(
         "anton.cli.test_llm", lambda *a, **kw: minds_client.LLMTestResult(ok=True)
@@ -300,6 +309,38 @@ def test_setup_minds_honors_env_url_override(monkeypatch):
     workspace.set_secret.assert_any_call(
         "ANTON_MINDS_URL", "https://api.staging.mindshub.ai"
     )
+
+
+def test_setup_minds_persists_the_base_url_the_probe_validated(monkeypatch):
+    """Invariant: the persisted ANTON_OPENAI_BASE_URL must be the base the
+    probe hit. With a /v1-suffixed ANTON_MINDS_URL the probe absorbs the
+    suffix (minds_v1_base) — persisting f"{url}/v1" would double it and save
+    a runtime config the probe never validated ('Connected', then 404s)."""
+    import anton.cli as cli
+
+    settings = AntonSettings(_env_file=None)
+    workspace = MagicMock()
+    probed: dict = {}
+
+    monkeypatch.setenv("ANTON_MINDS_URL", "https://api.staging.mindshub.ai/v1")
+    monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
+    monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "anton.cli.resolve_minds_models",
+        lambda *a, **kw: minds_client.MindsModels("sonnet", "haiku", "haiku"),
+    )
+
+    def fake_test_llm(base_url, api_key, verify=True, model=None):
+        probed["base"] = minds_client.minds_v1_base(base_url)
+        return minds_client.LLMTestResult(ok=True)
+
+    monkeypatch.setattr("anton.cli.test_llm", fake_test_llm)
+
+    cli._setup_minds(settings, workspace)
+
+    assert probed["base"] == "https://api.staging.mindshub.ai/v1"
+    assert settings.openai_base_url == probed["base"]
+    workspace.set_secret.assert_any_call("ANTON_OPENAI_BASE_URL", probed["base"])
 
 
 def test_setup_openai_uses_modern_openai_token_parameter(monkeypatch):

--- a/tests/test_openai_setup.py
+++ b/tests/test_openai_setup.py
@@ -162,9 +162,24 @@ class TestResolveMindsModels:
             minds_client.MINDS_DEFAULT_PLANNING_MODEL,
             minds_client.MINDS_DEFAULT_CODING_MODEL,
         )
-        # No catalogue to trust → probe with the universal free-bucket model,
-        # not a paid default that 403s on free-tier keys (ENG-576).
-        assert r.probe == minds_client.MINDS_FREE_TIER_MODEL
+        # No catalogue to trust → probe the model we would actually CONFIGURE,
+        # and expose the free bucket as the escalation target. Probing the free
+        # model directly (the old behaviour) passed for free-tier keys and then
+        # persisted an unvalidated paid pair that 403s on first real use —
+        # "Connected" masking a broken install (#317 re-review). Escalation is
+        # what keeps free-tier keys unblocked; see resolve_and_probe.
+        assert r.probe == r.coding
+        assert r.free_fallback == minds_client.MINDS_FREE_TIER_MODEL
+
+    def test_catalogue_resolved_pair_has_no_escalation_target(self, monkeypatch):
+        """A catalogue-derived pair is already access-aware — /v1/models only
+        lists what the key may use — so there is nothing to escalate to."""
+        monkeypatch.setattr(
+            "anton.minds_client.list_models", lambda *a, **k: ["sonnet", "haiku"]
+        )
+        r = minds_client.resolve_minds_models("https://x", "k")
+        assert (r.planning, r.coding, r.probe) == ("sonnet", "haiku", "haiku")
+        assert r.free_fallback is None
 
     def test_never_returns_dead_smart_router_aliases(self, monkeypatch):
         """The legacy mdb.ai aliases must never be picked, whatever the server
@@ -308,15 +323,12 @@ class TestSetupErrorTextIsMarkupSafe:
         import anton.cli as cli
 
         monkeypatch.setattr(
-            cli, "resolve_minds_models",
-            lambda *a, **k: minds_client.MindsModels(
-                planning="sonnet", coding="haiku", probe="haiku"
-            ),
-        )
-        monkeypatch.setattr(
-            cli, "test_llm",
-            lambda *a, **k: minds_client.LLMTestResult(
-                ok=False, error=detail, http_status=404
+            cli, "resolve_and_probe",
+            lambda *a, **k: (
+                minds_client.MindsModels(
+                    planning="sonnet", coding="haiku", probe="haiku"
+                ),
+                minds_client.LLMTestResult(ok=False, error=detail, http_status=404),
             ),
         )
         monkeypatch.setattr(cli, "_setup_prompt", lambda *a, **k: "key")
@@ -350,6 +362,123 @@ class TestSetupErrorTextIsMarkupSafe:
         )
 
 
+class TestResolveAndProbeEscalation:
+    """The invariant: never persist a pair no probe covered (#317 re-review).
+
+    On the no-catalogue branch the paid default is probed first. A model-access
+    denial escalates ONCE to the free bucket and returns the free pair — so a
+    free-tier key is neither blocked (ENG-576) nor handed an unvalidated paid
+    pair that 403s on the first real request.
+    """
+
+    def _probes(self, monkeypatch, results: dict):
+        """Stub the catalogue away (no-catalogue branch) and script the probes."""
+        monkeypatch.setattr("anton.minds_client.list_models", lambda *a, **k: [])
+        seen: list[str] = []
+
+        def fake_test_llm(base_url, api_key, verify=True, model=None):
+            seen.append(model)
+            return results[model]
+
+        monkeypatch.setattr("anton.minds_client.test_llm", fake_test_llm)
+        return seen
+
+    def test_paid_probe_passing_persists_the_paid_pair(self, monkeypatch):
+        seen = self._probes(
+            monkeypatch, {"haiku": minds_client.LLMTestResult(ok=True)}
+        )
+        models, result = minds_client.resolve_and_probe("https://x", "k")
+        assert result.ok
+        assert (models.planning, models.coding) == ("sonnet", "haiku")
+        assert seen == ["haiku"], "no needless second probe"
+
+    def test_denied_paid_probe_escalates_and_persists_the_free_pair(self, monkeypatch):
+        seen = self._probes(monkeypatch, {
+            "haiku": minds_client.LLMTestResult(
+                ok=False, error="model_access_denied", http_status=403
+            ),
+            "mindshub_air": minds_client.LLMTestResult(ok=True),
+        })
+        models, result = minds_client.resolve_and_probe("https://x", "k")
+        assert result.ok
+        # The pair PERSISTED is the one that was validated — the whole point.
+        assert models.planning == models.coding == minds_client.MINDS_FREE_TIER_MODEL
+        assert models.probe == minds_client.MINDS_FREE_TIER_MODEL
+        assert seen == ["haiku", "mindshub_air"]
+
+    def test_model_not_found_also_escalates(self, monkeypatch):
+        self._probes(monkeypatch, {
+            "haiku": minds_client.LLMTestResult(
+                ok=False, error="model_not_found", http_status=404
+            ),
+            "mindshub_air": minds_client.LLMTestResult(ok=True),
+        })
+        models, result = minds_client.resolve_and_probe("https://x", "k")
+        assert result.ok and models.coding == minds_client.MINDS_FREE_TIER_MODEL
+
+    def test_bad_key_does_not_escalate(self, monkeypatch):
+        # A 401 is not an entitlement signal — escalating would burn a second
+        # call and could report the wrong cause.
+        seen = self._probes(monkeypatch, {
+            "haiku": minds_client.LLMTestResult(
+                ok=False, error="Invalid API key", http_status=401
+            ),
+        })
+        models, result = minds_client.resolve_and_probe("https://x", "k")
+        assert not result.ok and result.http_status == 401
+        assert seen == ["haiku"]
+
+    def test_rate_limit_does_not_escalate(self, monkeypatch):
+        seen = self._probes(monkeypatch, {
+            "haiku": minds_client.LLMTestResult(
+                ok=False, rate_limited=True, error="Rate limit", http_status=429
+            ),
+        })
+        _, result = minds_client.resolve_and_probe("https://x", "k")
+        assert result.rate_limited
+        assert seen == ["haiku"]
+
+    def test_transport_failure_does_not_escalate(self, monkeypatch):
+        # http_status None = never reached the server; says nothing about models.
+        seen = self._probes(monkeypatch, {
+            "haiku": minds_client.LLMTestResult(ok=False, error="timed out"),
+        })
+        _, result = minds_client.resolve_and_probe("https://x", "k")
+        assert not result.ok and result.http_status is None
+        assert seen == ["haiku"]
+
+    def test_both_denied_reports_the_original_denial(self, monkeypatch):
+        # The first error names the model the user asked to be set up with.
+        self._probes(monkeypatch, {
+            "haiku": minds_client.LLMTestResult(
+                ok=False, error="paid model denied", http_status=403
+            ),
+            "mindshub_air": minds_client.LLMTestResult(
+                ok=False, error="free model denied too", http_status=403
+            ),
+        })
+        models, result = minds_client.resolve_and_probe("https://x", "k")
+        assert result.error == "paid model denied"
+        assert models.coding == "haiku"
+
+    def test_catalogue_pair_never_escalates(self, monkeypatch):
+        monkeypatch.setattr(
+            "anton.minds_client.list_models", lambda *a, **k: ["sonnet", "haiku"]
+        )
+        seen: list[str] = []
+
+        def fake_test_llm(base_url, api_key, verify=True, model=None):
+            seen.append(model)
+            return minds_client.LLMTestResult(
+                ok=False, error="denied", http_status=403
+            )
+
+        monkeypatch.setattr("anton.minds_client.test_llm", fake_test_llm)
+        _, result = minds_client.resolve_and_probe("https://x", "k")
+        assert not result.ok
+        assert seen == ["haiku"], "catalogue pair is already access-aware"
+
+
 def test_setup_minds_skips_no_ssl_retry_on_http_error(monkeypatch):
     """An HTTP-level failure (server answered → TLS worked) must not trigger
     the verify=False retry — it can only repeat the same error."""
@@ -361,18 +490,16 @@ def test_setup_minds_skips_no_ssl_retry_on_http_error(monkeypatch):
 
     monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
     monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: False)  # no retry
-    monkeypatch.setattr(
-        "anton.cli.resolve_minds_models",
-        lambda *a, **kw: minds_client.MindsModels("sonnet", "haiku", "haiku"),
-    )
-
-    def fake_test_llm(*a, **kw):
+    def fake_resolve_and_probe(*a, **kw):
         probe_calls.append(kw)
-        return minds_client.LLMTestResult(
-            ok=False, error="model_not_found: nope", http_status=404
+        return (
+            minds_client.MindsModels("sonnet", "haiku", "haiku"),
+            minds_client.LLMTestResult(
+                ok=False, error="model_not_found: nope", http_status=404
+            ),
         )
 
-    monkeypatch.setattr("anton.cli.test_llm", fake_test_llm)
+    monkeypatch.setattr("anton.cli.resolve_and_probe", fake_resolve_and_probe)
 
     import pytest
 
@@ -393,12 +520,11 @@ def test_setup_minds_writes_catalog_resolved_models(monkeypatch):
     monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
     monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: True)
     monkeypatch.setattr(
-        "anton.cli.resolve_minds_models",
-        lambda *a, **kw: minds_client.MindsModels("sonnet", "haiku", "haiku"),
-    )
-    monkeypatch.setattr(
-        "anton.cli.test_llm",
-        lambda *a, **kw: minds_client.LLMTestResult(ok=True),
+        "anton.cli.resolve_and_probe",
+        lambda *a, **kw: (
+            minds_client.MindsModels("sonnet", "haiku", "haiku"),
+            minds_client.LLMTestResult(ok=True),
+        ),
     )
 
     cli._setup_minds(settings, workspace)
@@ -421,11 +547,11 @@ def test_setup_minds_honors_env_url_override(monkeypatch):
     monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
     monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: True)
     monkeypatch.setattr(
-        "anton.cli.resolve_minds_models",
-        lambda *a, **kw: minds_client.MindsModels("sonnet", "haiku", "haiku"),
-    )
-    monkeypatch.setattr(
-        "anton.cli.test_llm", lambda *a, **kw: minds_client.LLMTestResult(ok=True)
+        "anton.cli.resolve_and_probe",
+        lambda *a, **kw: (
+            minds_client.MindsModels("sonnet", "haiku", "haiku"),
+            minds_client.LLMTestResult(ok=True),
+        ),
     )
 
     cli._setup_minds(settings, workspace)
@@ -450,16 +576,14 @@ def test_setup_minds_persists_the_base_url_the_probe_validated(monkeypatch):
     monkeypatch.setenv("ANTON_MINDS_URL", "https://api.staging.mindshub.ai/v1")
     monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
     monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: True)
-    monkeypatch.setattr(
-        "anton.cli.resolve_minds_models",
-        lambda *a, **kw: minds_client.MindsModels("sonnet", "haiku", "haiku"),
-    )
-
-    def fake_test_llm(base_url, api_key, verify=True, model=None):
+    def fake_resolve_and_probe(base_url, api_key, verify=True):
         probed["base"] = minds_client.minds_v1_base(base_url)
-        return minds_client.LLMTestResult(ok=True)
+        return (
+            minds_client.MindsModels("sonnet", "haiku", "haiku"),
+            minds_client.LLMTestResult(ok=True),
+        )
 
-    monkeypatch.setattr("anton.cli.test_llm", fake_test_llm)
+    monkeypatch.setattr("anton.cli.resolve_and_probe", fake_resolve_and_probe)
 
     cli._setup_minds(settings, workspace)
 

--- a/tests/test_openai_setup.py
+++ b/tests/test_openai_setup.py
@@ -148,6 +148,37 @@ class TestResolveMindsModels:
         assert "_reason_" not in pair and "_code_" not in pair
 
 
+def test_setup_minds_skips_no_ssl_retry_on_http_error(monkeypatch):
+    """An HTTP-level failure (server answered → TLS worked) must not trigger
+    the verify=False retry — it can only repeat the same error."""
+    import anton.cli as cli
+
+    settings = AntonSettings(_env_file=None)
+    workspace = MagicMock()
+    probe_calls = []
+
+    monkeypatch.setattr("anton.cli._setup_prompt", lambda *a, **kw: "mdb_test-key")
+    monkeypatch.setattr("anton.cli.Confirm.ask", lambda *a, **kw: False)  # no retry
+    monkeypatch.setattr(
+        "anton.cli.resolve_minds_models", lambda *a, **kw: ("sonnet", "haiku")
+    )
+
+    def fake_test_llm(*a, **kw):
+        probe_calls.append(kw)
+        return minds_client.LLMTestResult(
+            ok=False, error="model_not_found: nope", http_status=404
+        )
+
+    monkeypatch.setattr("anton.cli.test_llm", fake_test_llm)
+
+    import pytest
+
+    with pytest.raises(cli._SetupRetry):
+        cli._setup_minds(settings, workspace)
+
+    assert len(probe_calls) == 1
+
+
 def test_setup_minds_writes_catalog_resolved_models(monkeypatch):
     """End-to-end through _setup_minds: on a passing probe the resolved pair —
     not the dead _reason_/_code_ aliases — is persisted (ENG-1140)."""


### PR DESCRIPTION
Fixes [ENG-1140](https://linear.app/mindsdb/issue/ENG-1140/antons-cloud-setup-hardcodes-a-non-existent-model-alias-fails-with-a).

## Problem

Anton's Minds setup flow hardcoded the legacy mdb.ai smart-router aliases `_reason_`/`_code_`, which don't exist in the MindsHub catalogue. Setup therefore **always failed with a valid key**, and `test_llm()` collapsed the server's precise `404 model_not_found` into a bare `False`, rendered as *"Could not connect. Check your API key and URL."* — pointing the user at the one thing that was fine.

## What changed

**Durable fix, not just the string** (per the ticket):

- **`minds_client.resolve_minds_models()`** picks the (planning, coding) pair from the live `/v1/models` catalogue, preferring the tier defaults `sonnet`/`haiku`, with `opus`/`fable`/first-listed as fallbacks. When the listing route isn't deployed it falls back to the defaults instead of blocking — same caution cowork-server's `validate_minds` documents (listing routes 404 on some hosts even for valid keys).
- **`test_llm()`** now probes with the model setup is about to configure (so a passing probe validates the actual config) and returns a structured `LLMTestResult` carrying the provider's own error message — the local instance of the ENG-1283 pattern. The setup flow prints that message (`Could not connect: model_not_found: ...`) instead of the generic advice; the generic line remains only when no detail is available.
- **Provider menu now matches the Electron onboarding**: `MindsHub` + `Bring your own key`. The `Minds-Enterprise-Cloud` / `Minds-Enterprise-Server` split is gone (the product no longer exists); mdb.ai links/copy → MindsHub (`console.mindshub.ai` for upgrade messages). Applied in first-run onboarding, `/setup`, and the `/minds` connect flow in `chat.py` (the third hardcoded-alias write site the ticket didn't mention).
- The router role (`router_model`, history summarization) intentionally stays unset — it falls back to the coding model by design, which now resolves to the cheap tier default.

## Verification

- Live against prod `api.mindshub.ai`: catalogue resolves `('sonnet', 'haiku')`; probe with `haiku` passes; probing the old alias reports `model_not_found: The model '_code_' does not exist or you do not have access to it.` — the exact message that was being masked.
- New regression tests: error-message propagation, 429 → rate-limited, unparseable body fallback, catalogue resolution (defaults present / missing / route 404), never-returns-dead-aliases, and an end-to-end `_setup_minds` test asserting the resolved pair is persisted instead of `_reason_`/`_code_`.
- Full suite: 1521 passed; the 2 `test_chat_scratchpad` failures are pre-existing on `origin/staging` (verified by stashing).

## Security pass

Reviewed the changed surface: the propagated error text comes from the provider's response body and is printed only to the local user's own console (no keys echoed, nothing logged); API-key handling paths are unchanged; no new endpoints or deserialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)