### PR TITLE
Check uv.lock against pyproject.toml and move dev deps to a group

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,16 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Check uv.lock matches pyproject.toml
+        # Snyk scans the lockfile, so a lockfile behind pyproject.toml means
+        # Snyk is reporting on dependencies we no longer install.
+        run: uv lock --check
+
       - name: Run unit tests
-        run: uv run --extra dev pytest tests/ -v --ignore=tests/e2e
+        run: uv run --group dev pytest tests/ -v --ignore=tests/e2e
 
       - name: Run E2E tests (stub)
-        run: uv run --extra dev pytest tests/e2e/ -v
+        run: uv run --group dev pytest tests/e2e/ -v
 
   notify:
     # Alert the eng channel if CI fails on a direct push to main/staging. PR runs

--- a/.github/workflows/tests_e2e_release.yml
+++ b/.github/workflows/tests_e2e_release.yml
@@ -30,4 +30,4 @@ jobs:
           ANTON_CODING_PROVIDER: openai
           ANTON_PLANNING_MODEL: gpt-4.1-mini
           ANTON_CODING_MODEL: gpt-4.1-mini
-        run: uv run --extra dev pytest tests/e2e/ --live -v
+        run: uv run --group dev pytest tests/e2e/ --live -v

--- a/docs/docs/developer/contributing.md
+++ b/docs/docs/developer/contributing.md
@@ -52,15 +52,15 @@ The test suite uses pytest with `asyncio_mode = "auto"` (configured in
 `pyproject.toml`, under `[tool.pytest.ini_options]`). From a clone:
 
 ```bash
-pip install -e ".[dev]"     # installs pytest + pytest-asyncio
-pytest tests/
+uv sync --group dev     # installs pytest + pytest-asyncio
+uv run pytest tests/
 ```
 
 Useful subsets while developing:
 
 ```bash
-pytest tests/test_acc.py            # one module
-pytest -k cerebellum                # by keyword
+uv run pytest tests/test_acc.py     # one module
+uv run pytest -k cerebellum         # by keyword
 ```
 
 Some tests are marked `stub_only` (they require the stub server and are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+clipboard = [
+    "Pillow>=12.3.0",
+]
+
+[dependency-groups]
 dev = [
     "pytest>=9.0.0",
     "pytest-asyncio>=0.24",
-]
-clipboard = [
-    "Pillow>=12.3.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -184,6 +184,8 @@ dependencies = [
 clipboard = [
     { name = "pillow" },
 ]
+
+[package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -200,13 +202,17 @@ requires-dist = [
     { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0,<15" },
     { name = "typer", specifier = ">=0.12.4" },
 ]
-provides-extras = ["clipboard", "dev"]
+provides-extras = ["clipboard"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+]
 
 [[package]]
 name = "anyio"


### PR DESCRIPTION
Same change as [#301](https://github.com/mindsdb/anton/pull/301), targeting `main` instead of `staging`. The content is byte-identical to what is already on `staging`: this branch was cut from `main` and the five files were taken from `origin/staging`, so merging it makes `main` match `staging` on exactly these files and nothing else.

## Changed

| File | Change |
|---|---|
| `.github/workflows/tests.yml` | adds a `uv lock --check` step; `--extra dev` becomes `--group dev` |
| `.github/workflows/tests_e2e_release.yml` | `--extra dev` becomes `--group dev` |
| `pyproject.toml` | `dev` moves from `[project.optional-dependencies]` to `[dependency-groups]`; `clipboard` stays an extra |
| `uv.lock` | relocked for the group move |
| `docs/docs/developer/contributing.md` | `pip install -e ".[dev]"` becomes `uv sync --group dev` |

Snyk scans `uv.lock`, so a lockfile behind `pyproject.toml` means Snyk reports on dependencies we no longer install. `uv lock --check` fails the build when they drift.

Dev dependencies are tooling that is never installed with the package, which is what PEP 735 dependency-groups are for. `clipboard` remains an extra because it is an optional feature of the installed package.

Note: `main` takes `staging` through the weekly release PR (`weekly-merge-staging.yml`, most recently #316), so this change would reach `main` on the next release without this PR. This is the direct-promotion path instead.

Part of [ENG-875](https://linear.app/mindsdb/issue/ENG-875/setup-snyk-security-scanning-for-repositories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)