### PR TITLE
ENG-1366: load scratchpad snapshots that hold agent-authored modules

### DIFF
--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -596,6 +596,27 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
             # persist, rather than silently pretending it does.
             env.pop("ANTON_SCRATCHPAD_SESSION_PATH", None)
 
+        # The workspace root, for resolving agent-authored modules when the snapshot
+        # is loaded (ENG-1366). Python puts the *script's* directory on `sys.path`,
+        # never the cwd, so a helper the agent wrote into the workspace and imported
+        # on turn 1 (via its own `sys.path.insert`) is unimportable in the fresh
+        # process that loads the snapshot — and dill stores those objects by
+        # reference to their defining module, so the import failure discarded the
+        # whole namespace.
+        #
+        # Set ONLY from the explicit workspace arg, never from `os.getcwd()`: with no
+        # workspace bound the cwd is whatever launched the parent server (cowork's own
+        # install directory), which must never go on the scratchpad's `sys.path`.
+        # Persistence is process-global (`ANTON_SCRATCHPAD_PERSIST_SESSION`), so the
+        # loader is reachable from contexts that never opted in — the credential probe
+        # among them — and this keeps it inert for all of them.
+        if self._explicit_workspace_path is not None:
+            env["ANTON_SCRATCHPAD_WORKSPACE_PATH"] = str(
+                Path(self._explicit_workspace_path).resolve()
+            )
+        else:
+            env.pop("ANTON_SCRATCHPAD_WORKSPACE_PATH", None)
+
         _anton_root = str(Path(__file__).resolve().parent.parent.parent.parent)
         python_path = env.get("PYTHONPATH", "")
         if _anton_root not in python_path:

--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import json
 import os
@@ -26,6 +27,11 @@ PERSIST_SESSION = os.environ.get("ANTON_SCRATCHPAD_PERSIST_SESSION", "false").lo
 # aiming writes at somewhere unwritable. The caller owns the path: `local.py` composes
 # a per-pad, per-conversation one under the workspace and creates the directory.
 SESSION_PATH = os.environ.get("ANTON_SCRATCHPAD_SESSION_PATH", "")
+
+# The agent's workspace root, set by `local.py` ONLY when a real workspace is bound
+# (ENG-1366). Used to resolve agent-authored modules while the snapshot is loaded —
+# see `_workspace_on_syspath`. Empty means "no workspace", and every use is inert.
+WORKSPACE_PATH = os.environ.get("ANTON_SCRATCHPAD_WORKSPACE_PATH", "")
 
 # Snapshot size ceiling. Persisting after every cell costs nothing while it always
 # fails; once it works, a namespace holding large frames would be rewritten on each
@@ -91,6 +97,103 @@ _UNPICKLABLE: dict = {}
 _session_notes: list[str] = []
 
 
+# Snapshot envelope (ENG-1366). The payload is a dict of name -> individually-pickled
+# bytes rather than one pickle of the whole namespace, so ONE value that cannot be
+# rebuilt no longer discards every other variable: a pickle stream is a sequential
+# program, and an exception part-way through it kills the remainder. The envelope holds
+# nothing but str/int/bytes, so opening it can never fail on something the agent made.
+_SNAPSHOT_MAGIC = "__anton_snapshot__"
+_SNAPSHOT_VERSION = 2
+_SNAPSHOT_VALUES = "values"
+
+
+def _resolved_workspace() -> str | None:
+    """The workspace root to make importable during a load, or None.
+
+    Host-supplied (`conversation.project.path` -> `local.py`), never model-influenced:
+    the pad NAME reaches the snapshot filename, but nothing the model chooses reaches
+    this path. Re-resolved and required to be a real directory here anyway, so a
+    malformed value is inert rather than trusted.
+    """
+    if not WORKSPACE_PATH:
+        return None
+    try:
+        path = os.path.realpath(WORKSPACE_PATH)
+    except OSError:
+        return None
+    return path if os.path.isdir(path) else None
+
+
+@contextlib.contextmanager
+def _workspace_on_syspath():
+    """Make agent-authored modules importable for the duration of a snapshot load.
+
+    Python puts the *script's* directory on `sys.path`, never the cwd — so a helper the
+    agent wrote into the workspace and imported on turn 1 (having added the path itself)
+    is unimportable in the fresh process that loads the snapshot. dill stores such
+    objects by reference to their defining module, so that import failure is what
+    discarded the whole namespace.
+
+    APPENDED, never inserted at the front: the workspace is the agent's own directory
+    and may contain files named after stdlib modules (`types.py`, `logging.py`). At the
+    front those would shadow the real ones for the rest of the process; at the back they
+    resolve only when nothing else claims the name. Verified both ways.
+
+    Scoped to the load and removed afterwards, so the agent's own cell imports resolve
+    exactly as they did before this change.
+    """
+    path = _resolved_workspace()
+    if path is None or path in sys.path:
+        yield
+        return
+    sys.path.append(path)
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(path)
+        except ValueError:  # a cell rearranged sys.path mid-load
+            pass
+
+
+def _decode_values(blobs: dict) -> tuple[dict, dict]:
+    """Unpickle each value independently. Returns (namespace, {name: reason})."""
+    ns: dict = {}
+    dropped: dict = {}
+    for name, blob in blobs.items():
+        try:
+            ns[name] = dill.loads(blob)
+        except Exception as exc:
+            # Per-value, so an unresolvable reference costs one variable, not all of
+            # them. Most common cause: an object whose defining module is a .py file
+            # the agent wrote and has since renamed or deleted.
+            dropped[name] = f"{type(exc).__name__}: {exc}"
+    return ns, dropped
+
+
+# How many per-name failure reasons to spell out. Every dropped NAME is always listed
+# — the agent needs those to know what to rebuild — but the reasons are tracebacks-worth
+# of text and this note lands on `logs`, i.e. straight into the model's context on the
+# next turn. A namespace that drops fifty names would otherwise spend more context
+# explaining the loss than the loss cost.
+_MAX_DROP_REASONS = 5
+
+
+def _dropped_load_note(dropped: dict) -> str:
+    names = sorted(dropped)
+    shown = names[:_MAX_DROP_REASONS]
+    detail = "; ".join(f"{name} ({dropped[name]})" for name in shown)
+    if len(names) > len(shown):
+        detail += f"; … and {len(names) - len(shown)} more"
+    return (
+        "Scratchpad session restored, but these variables could not be rebuilt and are "
+        "now undefined: " + ", ".join(names) + ". Everything else was restored. This "
+        "usually means an object whose class or function lives in a .py file this "
+        "scratchpad wrote, which has since been renamed, moved or deleted — recreate "
+        "those objects rather than relying on them persisting. Details: " + detail
+    )
+
+
 def _load_namespace() -> tuple[dict, str | None]:
     if not PERSIST_SESSION:
         return {"__builtins__": __builtins__}, None
@@ -102,19 +205,31 @@ def _load_namespace() -> tuple[dict, str | None]:
             "process. Variables and imports are lost when this scratchpad restarts.",
         )
     try:
-        with open(SESSION_PATH, "rb") as f:
-            ns = dill.load(f)
-        if not isinstance(ns, dict):
-            raise TypeError("Session file did not contain a namespace dict")
+        # The workspace covers BOTH reads: the per-value decode below, and a legacy
+        # single-stream snapshot, which resolves its module references during
+        # `dill.load` itself.
+        with _workspace_on_syspath():
+            with open(SESSION_PATH, "rb") as f:
+                raw = dill.load(f)
+            if not isinstance(raw, dict):
+                raise TypeError("Session file did not contain a namespace dict")
+            if raw.get(_SNAPSHOT_MAGIC) == _SNAPSHOT_VERSION:
+                ns, dropped = _decode_values(raw.get(_SNAPSHOT_VALUES) or {})
+            else:
+                # A snapshot written before this format existed: one stream holding the
+                # real objects. Still readable, so a conversation in flight across the
+                # upgrade keeps its state instead of paying a cold turn. It is
+                # all-or-nothing by construction; the next dump rewrites it as v2.
+                ns, dropped = raw, {}
         ns.setdefault("__builtins__", __builtins__)
-        return ns, None
+        return ns, (_dropped_load_note(dropped) if dropped else None)
     except FileNotFoundError:
         # First cell of a brand-new pad — expected, not a problem.
         return {"__builtins__": __builtins__}, None
     except Exception:
-        # Includes unpickling failures from package-version skew between turns (e.g. a
-        # later cell installed a newer pandas). Degrading to a fresh namespace is the
-        # old behaviour; the difference is that now it is reported.
+        # Now reachable only for a torn/unreadable file or a legacy snapshot that still
+        # will not load. Degrading to a fresh namespace is the old behaviour; the
+        # difference is that now it is reported.
         return (
             {"__builtins__": __builtins__},
             "Failed to load scratchpad session; starting fresh.\n" + traceback.format_exc(),
@@ -163,10 +278,45 @@ def _snapshot_payload(ns: dict) -> dict:
     }
 
 
-def _write_snapshot(payload: dict, tmp_path: str) -> None:
-    """Serialise `payload` to `tmp_path`, aborting past the size cap."""
+def _encode_values(payload: dict) -> tuple[dict, list]:
+    """Pickle each value on its own. Returns (blobs, dropped names).
+
+    Isolating values at WRITE time is what lets the load be partial, and it also makes
+    an unpicklable value ordinary rather than exceptional: the old code discovered the
+    offender by re-walking the whole namespace after a failed bulk dump. Raises
+    `_TooBig` as soon as the accumulated size passes the cap, so an oversized namespace
+    stops costing a full serialise before being thrown away.
+    """
+    blobs: dict = {}
+    dropped: list = []
+    total = 0
+    for key, value in payload.items():
+        try:
+            blob = dill.dumps(value)
+        except Exception:
+            # Live resources — DB connections, sockets, generators. Remembered by id()
+            # so the retry is skipped next cell but a rebind to something picklable is
+            # not excluded forever.
+            _UNPICKLABLE[key] = id(value)
+            dropped.append(key)
+            continue
+        total += len(blob)
+        if total > SESSION_MAX_BYTES:
+            raise _TooBig()
+        blobs[key] = blob
+    return blobs, dropped
+
+
+def _write_snapshot(blobs: dict, tmp_path: str) -> None:
+    """Serialise the snapshot envelope to `tmp_path`, aborting past the size cap."""
+    envelope = {
+        _SNAPSHOT_MAGIC: _SNAPSHOT_VERSION,
+        _SNAPSHOT_VALUES: blobs,
+    }
     with open(tmp_path, "wb") as f:
-        dill.dump(payload, _CappedWriter(f, SESSION_MAX_BYTES))
+        # _CappedWriter still guards the envelope overhead on top of the value bytes
+        # already counted in `_encode_values`.
+        dill.dump(envelope, _CappedWriter(f, SESSION_MAX_BYTES))
 
 
 def _dump_namespace(ns: dict) -> str | None:
@@ -176,19 +326,23 @@ def _dump_namespace(ns: dict) -> str | None:
     # Include the pid: a pad can briefly overlap with its own replacement, and two
     # writers sharing one .tmp would corrupt each other's snapshot.
     tmp_path = f"{SESSION_PATH}.{os.getpid()}.tmp"
-    try:
-        # Write-then-replace. This process is killed abruptly at the end of a turn (and
-        # by the inactivity watchdog mid-cell), so writing straight to SESSION_PATH
-        # would eventually leave a torn pickle that the next process fails to load.
-        # os.replace is atomic within a filesystem.
-        _write_snapshot(payload, tmp_path)
-        os.replace(tmp_path, SESSION_PATH)
-        return None
-    except _TooBig:
+
+    def _discard_tmp() -> None:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
+
+    try:
+        blobs, dropped = _encode_values(payload)
+        # Write-then-replace. This process is killed abruptly at the end of a turn (and
+        # by the inactivity watchdog mid-cell), so writing straight to SESSION_PATH
+        # would eventually leave a torn pickle that the next process fails to load.
+        # os.replace is atomic within a filesystem.
+        _write_snapshot(blobs, tmp_path)
+        os.replace(tmp_path, SESSION_PATH)
+    except _TooBig:
+        _discard_tmp()
         return (
             f"Scratchpad session NOT saved: the namespace exceeds the "
             f"{SESSION_MAX_BYTES:,}-byte snapshot cap. Variables will not survive a "
@@ -196,32 +350,9 @@ def _dump_namespace(ns: dict) -> str | None:
             "instead of holding them in memory."
         )
     except Exception:
-        first_failure = traceback.format_exc()
-        # Save what we can instead of losing everything to one bad object. Only reached
-        # the first time a given object fails; after that it is pre-excluded above.
-        dropped = []
-        for key in list(payload):
-            try:
-                dill.dumps(payload[key])
-            except Exception:
-                _UNPICKLABLE[key] = id(payload[key])
-                dropped.append(key)
-                payload.pop(key)
-        if not dropped:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            return "Failed to dump scratchpad session.\n" + first_failure
-        try:
-            _write_snapshot(payload, tmp_path)
-            os.replace(tmp_path, SESSION_PATH)
-        except Exception:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            return "Failed to dump scratchpad session.\n" + first_failure
+        _discard_tmp()
+        return "Failed to dump scratchpad session.\n" + traceback.format_exc()
+    if dropped:
         return (
             "Scratchpad session saved, but these variables could not be preserved and "
             "will be undefined if this scratchpad restarts: "
@@ -230,6 +361,7 @@ def _dump_namespace(ns: dict) -> str | None:
             "generators) cannot be saved — recreate them rather than relying on them "
             "persisting."
         )
+    return None
 
 
 # Persistent namespace across cells. Keep the load note — discarding it is how the

--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -97,14 +97,22 @@ _UNPICKLABLE: dict = {}
 _session_notes: list[str] = []
 
 
-# Snapshot envelope (ENG-1366). The payload is a dict of name -> individually-pickled
-# bytes rather than one pickle of the whole namespace, so ONE value that cannot be
-# rebuilt no longer discards every other variable: a pickle stream is a sequential
-# program, and an exception part-way through it kills the remainder. The envelope holds
-# nothing but str/int/bytes, so opening it can never fail on something the agent made.
+# Snapshot envelope (ENG-1366). The payload is name -> individually-pickled bytes
+# rather than one pickle of the whole namespace, so ONE value that cannot be rebuilt no
+# longer discards every other variable: a pickle stream is a sequential program, and an
+# exception part-way through it kills the remainder. The envelope holds nothing but
+# str/int/bytes, so opening it can never fail on something the agent made.
+#
+# A TUPLE, deliberately not a dict. An anton predating this format loads the file and
+# accepts ANY dict as the namespace itself — so a dict envelope would hand it a
+# namespace containing `values` and `__anton_snapshot__` and nothing else, with the
+# agent's real variables silently gone and NOTHING reported. That is precisely the
+# silent no-op ENG-1124 was filed to end, and a rollback or an older desktop build
+# resuming the conversation is enough to reach it. A non-dict trips that older loader's
+# `isinstance(ns, dict)` guard instead, so it starts fresh AND says so. Verified against
+# the real staging loader, both ways.
 _SNAPSHOT_MAGIC = "__anton_snapshot__"
 _SNAPSHOT_VERSION = 2
-_SNAPSHOT_VALUES = "values"
 
 
 def _resolved_workspace() -> str | None:
@@ -211,10 +219,17 @@ def _load_namespace() -> tuple[dict, str | None]:
         with _workspace_on_syspath():
             with open(SESSION_PATH, "rb") as f:
                 raw = dill.load(f)
-            if not isinstance(raw, dict):
+            if isinstance(raw, tuple) and raw and raw[0] == _SNAPSHOT_MAGIC:
+                if len(raw) != 3 or raw[1] != _SNAPSHOT_VERSION:
+                    # A snapshot from a NEWER anton than this one. Refuse it rather
+                    # than guess at its shape; the except below reports and starts
+                    # fresh, which is the honest degradation.
+                    raise TypeError(
+                        f"Unsupported scratchpad snapshot version: {raw[1:2]}"
+                    )
+                ns, dropped = _decode_values(raw[2] or {})
+            elif not isinstance(raw, dict):
                 raise TypeError("Session file did not contain a namespace dict")
-            if raw.get(_SNAPSHOT_MAGIC) == _SNAPSHOT_VERSION:
-                ns, dropped = _decode_values(raw.get(_SNAPSHOT_VALUES) or {})
             else:
                 # A snapshot written before this format existed: one stream holding the
                 # real objects. Still readable, so a conversation in flight across the
@@ -309,10 +324,7 @@ def _encode_values(payload: dict) -> tuple[dict, list]:
 
 def _write_snapshot(blobs: dict, tmp_path: str) -> None:
     """Serialise the snapshot envelope to `tmp_path`, aborting past the size cap."""
-    envelope = {
-        _SNAPSHOT_MAGIC: _SNAPSHOT_VERSION,
-        _SNAPSHOT_VALUES: blobs,
-    }
+    envelope = (_SNAPSHOT_MAGIC, _SNAPSHOT_VERSION, blobs)
     with open(tmp_path, "wb") as f:
         # _CappedWriter still guards the envelope overhead on top of the value bytes
         # already counted in `_encode_values`.

--- a/tests/test_scratchpad.py
+++ b/tests/test_scratchpad.py
@@ -1556,8 +1556,17 @@ class TestAgentAuthoredModuleSnapshots:
             assert cell.stdout.strip() == "0.458 False", cell.stdout
             # …and the loss is NAMED, on `logs` and never on `error` (a snapshot
             # problem must not feed the consecutive-error circuit breaker).
-            assert "could not be rebuilt" in (cell.logs or ""), cell.logs
-            assert "c" in (cell.logs or "")
+            logs = cell.logs or ""
+            assert "could not be rebuilt" in logs, logs
+            # Match the rendered name list, not a bare "c" — the letter appears in
+            # the prose of the note itself, so a substring check would pass even if
+            # nothing were named at all.
+            named = logs.split("now undefined: ", 1)[1].split(".", 1)[0]
+            assert sorted(n.strip() for n in named.split(",")) == [
+                "c",
+                "campaign_engine",
+            ], named
+            assert "ModuleNotFoundError" in logs, logs
             assert cell.error is None
         finally:
             await pad2.cleanup()
@@ -1604,6 +1613,37 @@ class TestAgentAuthoredModuleSnapshots:
             assert cell.stdout.strip() == "sent august False", cell.stdout
         finally:
             await pad2.cleanup()
+
+    async def test_the_snapshot_is_not_a_bare_dict(self, tmp_path, monkeypatch):
+        """An anton predating this format must REPORT, not silently load junk.
+
+        The older loader accepts any dict in the session file as the namespace itself.
+        A dict envelope would therefore hand it `{'values': ..., '__anton_snapshot__':
+        2}` as the agent's variables — every real name gone, nothing said — which is
+        the exact silent no-op ENG-1124 exists to end, reachable by a rollback or an
+        older desktop build resuming the conversation. A non-dict trips that loader's
+        `isinstance(ns, dict)` guard so it starts fresh AND reports.
+
+        Verified against the real staging loader at review time; this pins it so the
+        envelope cannot drift back to a dict.
+        """
+        import dill
+
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PERSIST_SESSION", "true")
+        pad = make_scratchpad(
+            name="notadict", _venvs_base=tmp_path / "venvs", session_id="c"
+        )
+        await pad.start()
+        try:
+            assert (await pad.execute("kept = 1")).error is None
+            snapshot = pad._session_snapshot_path()
+            assert snapshot is not None and snapshot.exists()
+            written = dill.loads(snapshot.read_bytes())
+            assert not isinstance(written, dict), (
+                "a dict snapshot is silently mistaken for a namespace by older anton"
+            )
+        finally:
+            await pad.cleanup()
 
     async def test_a_snapshot_in_the_old_format_still_loads(self, tmp_path, monkeypatch):
         """A conversation in flight across the upgrade keeps its state.

--- a/tests/test_scratchpad.py
+++ b/tests/test_scratchpad.py
@@ -1440,3 +1440,192 @@ class TestSessionPersistence:
             cell = await pad.execute("print(repr(sample))")
             await pad.close()
             assert cell.stdout.strip() == "[1, 2, 3]", cell.stdout
+
+
+_HELPER_MODULE_SRC = (
+    "class Campaign:\n"
+    "    def __init__(self, name):\n"
+    "        self.name = name\n"
+    "    def send(self):\n"
+    "        return 'sent ' + self.name\n"
+)
+
+
+def _write_and_import_helper(module: str = "campaign_engine") -> str:
+    """Cell source that authors a local module, imports it, and binds an instance.
+
+    This is the shape ENG-1124's dill probe never covered: its agent-defined functions
+    were declared *inside* the exec namespace (pickled by value, always fine), never in
+    a .py file the agent wrote. dill stores objects from a real module by REFERENCE to
+    that module, which is the whole bug.
+    """
+    return (
+        "import sys, os\n"
+        f"open({module + '.py'!r}, 'w').write({_HELPER_MODULE_SRC!r})\n"
+        # The agent adds cwd itself — Python never does. This works for the rest of
+        # THIS process and is gone by the time the next one loads the snapshot.
+        "sys.path.insert(0, os.getcwd())\n"
+        f"import {module}\n"
+        f"c = {module}.Campaign('august')\n"
+        "rates = 0.458\n"
+    )
+
+
+class TestAgentAuthoredModuleSnapshots:
+    """ENG-1366 — a namespace holding objects from an agent-written .py file.
+
+    Measured at 8% of cells for one production user, costing a cache-cold reload each
+    time. It never surfaced as an error because the agent absorbs the loss by re-reading
+    from disk, which is why it survived the fix that was meant to end it.
+    """
+
+    async def test_namespace_survives_an_agent_written_local_module(
+        self, tmp_path, monkeypatch
+    ):
+        """The reported bug: one agent-authored helper discarded the whole namespace."""
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PERSIST_SESSION", "true")
+        venvs_base = tmp_path / "venvs"
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        pad = make_scratchpad(
+            name="helpermod",
+            _venvs_base=venvs_base,
+            session_id="c",
+            workspace_path=workspace,
+        )
+        await pad.start()
+        cell = await pad.execute(_write_and_import_helper())
+        assert cell.error is None, cell.error
+        await pad.close()
+        assert (workspace / "campaign_engine.py").exists()
+
+        pad2 = make_scratchpad(
+            name="helpermod",
+            _venvs_base=venvs_base,
+            session_id="c",
+            workspace_path=workspace,
+        )
+        await pad2.start()
+        try:
+            cell = await pad2.execute("print(c.send(), rates)")
+            # Before the fix: `logs` carried "Failed to load scratchpad session" with
+            # ModuleNotFoundError, and BOTH names were gone — not just the helper.
+            assert "Failed to load scratchpad session" not in (cell.logs or "")
+            assert cell.error is None, cell.error
+            assert cell.stdout.strip() == "sent august 0.458", cell.stdout
+        finally:
+            await pad2.cleanup()
+
+    async def test_an_unresolvable_value_drops_only_itself(self, tmp_path, monkeypatch):
+        """When a reference genuinely cannot be rebuilt, the rest must still load.
+
+        The helper file is deleted between turns, so no `sys.path` entry can save it.
+        This is the case the per-value snapshot format exists for: a pickle stream is a
+        sequential program, so a single unresolvable reference used to kill everything
+        after it too.
+        """
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PERSIST_SESSION", "true")
+        venvs_base = tmp_path / "venvs"
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        pad = make_scratchpad(
+            name="goneaway",
+            _venvs_base=venvs_base,
+            session_id="c",
+            workspace_path=workspace,
+        )
+        await pad.start()
+        cell = await pad.execute(_write_and_import_helper())
+        assert cell.error is None, cell.error
+        await pad.close()
+        (workspace / "campaign_engine.py").unlink()
+
+        pad2 = make_scratchpad(
+            name="goneaway",
+            _venvs_base=venvs_base,
+            session_id="c",
+            workspace_path=workspace,
+        )
+        await pad2.start()
+        try:
+            cell = await pad2.execute("print(rates, 'c' in dir())")
+            assert cell.error is None, cell.error
+            # The unrelated variable survived; only the helper-backed one is gone.
+            assert cell.stdout.strip() == "0.458 False", cell.stdout
+            # …and the loss is NAMED, on `logs` and never on `error` (a snapshot
+            # problem must not feed the consecutive-error circuit breaker).
+            assert "could not be rebuilt" in (cell.logs or ""), cell.logs
+            assert "c" in (cell.logs or "")
+            assert cell.error is None
+        finally:
+            await pad2.cleanup()
+
+    async def test_the_workspace_is_not_left_on_syspath(self, tmp_path, monkeypatch):
+        """The import path is widened for the load only, not for the agent's cells.
+
+        Guards the load-scoped design against drifting into a process-wide one: the
+        workspace is the agent's own directory and may hold files named after stdlib
+        modules, so leaving it on `sys.path` would change import resolution for every
+        subsequent cell.
+        """
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PERSIST_SESSION", "true")
+        venvs_base = tmp_path / "venvs"
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        pad = make_scratchpad(
+            name="scoped",
+            _venvs_base=venvs_base,
+            session_id="c",
+            workspace_path=workspace,
+        )
+        await pad.start()
+        assert (await pad.execute(_write_and_import_helper())).error is None
+        await pad.close()
+
+        pad2 = make_scratchpad(
+            name="scoped",
+            _venvs_base=venvs_base,
+            session_id="c",
+            workspace_path=workspace,
+        )
+        await pad2.start()
+        try:
+            cell = await pad2.execute(
+                "import sys, os\n"
+                "here = os.path.realpath(os.getcwd())\n"
+                "on_path = any(os.path.realpath(p) == here for p in sys.path)\n"
+                # Restored AND not left on the path — the pair is the point.
+                "print(c.send(), on_path)\n"
+            )
+            assert cell.error is None, cell.error
+            assert cell.stdout.strip() == "sent august False", cell.stdout
+        finally:
+            await pad2.cleanup()
+
+    async def test_a_snapshot_in_the_old_format_still_loads(self, tmp_path, monkeypatch):
+        """A conversation in flight across the upgrade keeps its state.
+
+        The pre-ENG-1366 snapshot is one stream holding real objects; the new one is an
+        envelope of individually-pickled values. The loader must read both, or the
+        release costs every open conversation a cold turn.
+        """
+        import dill
+
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PERSIST_SESSION", "true")
+        pad = make_scratchpad(
+            name="legacy", _venvs_base=tmp_path / "venvs", session_id="c"
+        )
+        snapshot = pad._session_snapshot_path(create=True)
+        assert snapshot is not None
+        snapshot.write_bytes(dill.dumps({"carried_over": [1, 2, 3]}))
+
+        await pad.start()
+        try:
+            cell = await pad.execute("print(carried_over)")
+            assert cell.error is None, cell.error
+            assert cell.stdout.strip() == "[1, 2, 3]", cell.stdout
+        finally:
+            await pad.cleanup()


### PR DESCRIPTION
Fixes [ENG-1366](https://linear.app/mindsdb/issue/ENG-1366/scratchpad-snapshots-fail-to-load-when-the-agent-writes-its-own-helper).

## The bug

ENG-1124 made the scratchpad namespace survive a turn boundary. The **write** side works. The **load** side discarded the entire namespace whenever it held an object whose defining module was a `.py` file the agent wrote into its own workspace.

Measured at **8% of cells** for one production user (22 of 29 failures naming the same helper, `campaign_engine`). It never surfaced as an error — the agent absorbs the loss by re-reading from disk — so the only symptom was a cache-cold reload costing ~$0.15–0.28 each time. That is why it survived the fix meant to end it.

## Root cause — two independent causes

**1. The module was unresolvable at load time.** `local.py` pins the subprocess cwd to the workspace, but Python puts the *script's* directory on `sys.path`, never the cwd. The agent adds cwd itself on turn 1 (`sys.path.insert(0, os.getcwd())`) and imports fine; that lives in memory and dies with the process. The next turn's loader runs before any cell, with a bare path — and dill stores those objects **by reference to their defining module**, so the import raises.

Broader than the ticket described: I verified all four reference shapes fail identically — the module object, an instance of an agent-defined class, the class, and a bare function. A namespace holding only `c = Campaign(...)`, never binding the module, is equally poisoned.

**2. The load was all-or-nothing.** A pickle stream is a sequential program; an exception part-way through kills everything after it. One bad reference destroyed every unrelated variable.

## The fix

**Cause 1 — `local.py` + `scratchpad_boot.py`.** `local.py` exports the resolved workspace root; the loader appends it to `sys.path` for the duration of the load.

- **Appended, never prepended.** The workspace is the agent's own directory and may hold files named after stdlib modules. I verified a workspace `types.py` shadows the stdlib when prepended and does not when appended.
- **Load-scoped** (`try/finally`), so the agent's own cell imports resolve exactly as before.
- **Set only from the explicit workspace arg, never `os.getcwd()`** — with no workspace bound, cwd is cowork-server's install directory. This matters because `ANTON_SCRATCHPAD_PERSIST_SESSION` is process-global, so the loader is reachable from contexts that never opted in (the credential probe among them); keying on the explicit arg keeps it inert there.

**Cause 2 — snapshot format.** The snapshot is now an envelope of individually-pickled values instead of one stream. A value that cannot be rebuilt is dropped and **named on the cell's `logs`** (never `error` — a snapshot problem must not feed the consecutive-error circuit breaker); everything else loads.

I tried to avoid the format change first, with an unpickler that substitutes a placeholder for any unresolvable reference. It got past all three bad references and died on the next instruction (`TypeError: Missing.__setstate__() missing 1 required positional argument`). No placeholder can satisfy every reconstruction protocol, so partial recovery genuinely requires the values to be independent on disk.

**Backwards compatible:** pre-existing snapshots still load, so a conversation in flight across the upgrade keeps its state instead of paying a cold turn.

**Simplification, not an added layer:** isolating values makes an unpicklable object ordinary rather than exceptional. This replaces the two-phase recovery that re-walked the whole namespace after a failed bulk dump. The size cap now aborts during encoding, before anything is written — strictly earlier than before.

## Why this format, measured first

The risk of per-value framing is snapshot inflation pushing a namespace past the 100 MB cap, whose failure mode is total (no snapshot at all). I measured both sides before committing:

| | Result |
|---|---|
| Snapshots that have ever hit the cap | **0** (399 turns, 12 users, 3 weeks) |
| Inflation, realistic mixed namespace | **1.03×** |
| Inflation, no sharing / slices / plain data | 1.00× |
| Inflation, worst realistic case (aliasing) | 2.00× |

So the tail this could push over does not exist. **Top-level alias de-duplication was considered and dropped**: measurement showed inflation comes from *nested* sharing, where top-level `id()` checks find nothing to dedupe — it would have added complexity for the cheapest case only.

**Known cost, stated plainly:** cross-key aliasing no longer survives a turn boundary (`df2 = df` restores as two objects), and peak memory during a dump is now ~snapshot-size higher, since values are encoded before writing. Both are bounded by the 100 MB cap and neither has cap pressure today.

## Tests

Three regression tests, **each watched failing on unfixed code** with the production traceback (`ModuleNotFoundError: No module named 'campaign_engine'` via dill's `_import_module`):

- `test_namespace_survives_an_agent_written_local_module` — the reported bug.
- `test_an_unresolvable_value_drops_only_itself` — helper deleted between turns, so no `sys.path` entry can save it; the rest of the namespace must survive and the loss must be named.
- `test_the_workspace_is_not_left_on_syspath` — restored *and* not left on the path; guards the load-scoped design against drifting process-wide.

Plus `test_a_snapshot_in_the_old_format_still_loads`, which passes on unfixed code by construction — it guards the new loader's backwards compatibility, not the bug.

`1899 passed, 28 skipped`. Two files fail identically with and without this change on clean `staging` (`test_chat_scratchpad.py`, `test_cloud_turn_process.py`) — pre-existing, verified by stashing.

## Security pass

Performed, covering:

- **Widening what the loader resolves.** Pickle load is already arbitrary code execution by design. The added path is the agent's own workspace, whose code already runs as the user, so no new execution surface. It is host-supplied (`conversation.project.path`), never model-influenced — the pad name reaches the snapshot *filename*, not this path — re-resolved with `realpath` and required to be a real directory.
- **Appending, not prepending**, so a workspace file cannot shadow the stdlib or site-packages.
- **The credential-probe path.** `ANTON_SCRATCHPAD_PERSIST_SESSION` is process-global, so the probe inherits persistence. It has no session id, so it gets no snapshot and the loader early-returns; the new env var is unused there.
- **No new secrets persisted.** The format change reframes the same values into the same per-conversation directory under the same retention.

## Delivery note

anton is vendored by cowork-server pinned to `branch = "main"`, so merging here ships nothing on its own — this needs a cowork-server bump and a desktop release to reach users.

**ENG-1366's Done-when #4** ("re-measure `aortiz`, load-failure rate drops to ~0") is currently **blocked by [ENG-1392](https://linear.app/mindsdb/issue/ENG-1392)** — since 2026-08-09, ~66% of production trace payloads are replaced by `[REDACTED:masking-error]`, and the cell `logs` carrying the failure text are exactly what is being redacted. Filed separately while measuring for this PR.

## Follow-up

ENG-1124's description states *"dill is not a second obstacle."* Its probe covered agent-defined functions declared **inside the exec namespace** (pickled by value, always fine) but never one whose home is an agent-written `.py` file. That sentence should be corrected on ENG-1124 so the next reader does not trust it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)