### PR TITLE
ENG-1390: make the hidden rule-retrieval LLM call countable and its outcomes separable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,6 @@ __marimo__/
 # Anton
 .anton/
 .DS_Store
+
+# Eval run artifacts — output, not source (accidentally swept into #330).
+evals/results/

--- a/anton/core/llm/tracing.py
+++ b/anton/core/llm/tracing.py
@@ -85,4 +85,13 @@ def tagged_trace(*tags: str):
     try:
         yield
     finally:
-        _trace_ctx.reset(token)
+        try:
+            _trace_ctx.reset(token)
+        except ValueError:
+            # Cross-context teardown: when an abandoned async generator is
+            # finalized, the cleanup can run in a COPIED context, where resetting
+            # a token created elsewhere raises. `ChatSession.turn_stream` already
+            # carries this exact guard (#309 review), where an unguarded reset
+            # aborted a `finally` and dropped the whole turn's books. The copy
+            # dies with the context, so there is nothing to restore.
+            pass

--- a/anton/core/llm/tracing.py
+++ b/anton/core/llm/tracing.py
@@ -18,8 +18,9 @@ Gemini) ignore the context entirely.
 
 from __future__ import annotations
 
+import contextlib
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 
 @dataclass(frozen=True)
@@ -57,3 +58,31 @@ def set_trace_context(ctx: TraceContext | None) -> Token:
 def reset_trace_context(token: Token) -> None:
     """Restore the previous trace context. Pass the token returned by `set_trace_context`."""
     _trace_ctx.reset(token)
+
+
+@contextlib.contextmanager
+def tagged_trace(*tags: str):
+    """Append `tags` to the active trace for the duration of the block (ENG-1390).
+
+    For isolating ONE call site among the many that share an `LLMClient` entry
+    point. Tags ride the ``Langfuse-Tags`` header, and tags are one of the few
+    dimensions the Langfuse metrics API can group by — so a tagged call stays
+    countable without reading trace payloads, which matters while ENG-1392 is
+    redacting them.
+
+    Deliberately a no-op rather than an error when there is nothing to annotate:
+    no turn in flight (the CLI `turn()` path never installs a context), or a
+    provider that ignores trace context entirely (anything but the
+    MindsHub-routed OpenAI provider — a BYOK user on direct Anthropic has no
+    gateway trace to tag in the first place). Callers can therefore annotate
+    unconditionally without branching on either condition.
+    """
+    ctx = _trace_ctx.get()
+    if ctx is None or not tags:
+        yield
+        return
+    token = _trace_ctx.set(replace(ctx, tags=ctx.tags + tuple(tags)))
+    try:
+        yield
+    finally:
+        _trace_ctx.reset(token)

--- a/anton/core/memory/cortex.py
+++ b/anton/core/memory/cortex.py
@@ -20,11 +20,13 @@ like how the PFC coordinates retrieval from multiple brain memory systems.
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
+from anton.core.llm.tracing import tagged_trace
 from anton.core.llm.structured import (
     generate_with_truncation_retry,
     no_preamble_instruction,
@@ -38,6 +40,58 @@ if TYPE_CHECKING:
     from anton.core.memory.episodes import EpisodicMemory
 
 logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rule-retrieval observability (ENG-1390)
+# ─────────────────────────────────────────────────────────────────────────────
+# `_retrieve_relevant_rules` makes an LLM call during PROMPT ASSEMBLY, through
+# the same `llm.code` entry point as the completion verifier and every other
+# coding call — so it was indistinguishable from them in a trace, and its
+# frequency was unknown. Measured retroactively before this shipped (ENG-1390):
+# 1.77% of all LLM calls, 4 users, median 4.3k input tokens, p90 latency 23.9s
+# added BEFORE the turn starts.
+#
+# Two sinks, because neither alone is sufficient:
+#   * the trace tag isolates the call in Langfuse, but only for MindsHub-routed
+#     traffic with a turn in flight;
+#   * the analytics event works for every user and every provider, and is the
+#     only way to observe the EXCEPTION outcome at all (a failed call leaves no
+#     observation to count).
+_RULE_RETRIEVAL_TAG = "rule-retrieval"
+_RULE_RETRIEVAL_MAX_TOKENS = 4096
+
+# Built once: `AntonSettings()` reads the environment, and while this call site
+# is rare it sits on the latency-critical prompt-assembly path.
+_analytics_settings = None
+
+
+def _emit_rule_retrieval(**shape) -> None:
+    """Report one rule-retrieval call's SHAPE to analytics.
+
+    Counts, sizes and enums ONLY — never rule text and never the user message,
+    both of which are user content (ENG-1390's security note, and the standing
+    rule for this sink: numbers, names and IDs only).
+
+    Every `extra` kwarg becomes a queryable PostHog property, so these parameter
+    names are a published schema — renaming one breaks whatever reads it.
+    Silent on failure: observability must never break prompt assembly.
+    """
+    global _analytics_settings
+    try:
+        if _analytics_settings is None:
+            from anton.config.settings import AntonSettings
+
+            _analytics_settings = AntonSettings()
+        from anton.analytics import send_event
+
+        send_event(
+            _analytics_settings,
+            "rule_retrieval",
+            **{key: str(value) for key, value in shape.items()},
+        )
+    except Exception:
+        logger.debug("rule_retrieval analytics event failed", exc_info=True)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -282,30 +336,75 @@ Do NOT add, modify, or summarize rules — return them verbatim.
         if len(when_text) < 1000:
             return engrams
 
+        # ENG-1390 instrumentation. Purely observational — every branch below
+        # produces exactly the value it produced before. What is new is that the
+        # branches are now DISTINGUISHABLE: `filtered_when = when_engrams` is
+        # reached three different ways (no exact match, empty response, exception)
+        # and all three are byte-identical in their effect on the prompt, so a
+        # count of invocations could never tell a working filter from a broken one.
+        # Measured shares before this shipped: 55.7% filtered, 30.2% dropped_all,
+        # 14.2% kept_all_no_match, plus an exception rate that was unobservable.
+        outcome = "error"
+        kept = len(when_engrams)
+        stop_reason = ""
+        usage = None
+        early: list[Engram] | None = None
+        started = time.monotonic()
         try:
-            response = await self._llm.code(
-                system=self._RULES_RETRIEVAL_PROMPT,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": f"User message: {user_message}\n\nRules:\n{when_text}",
-                    }
-                ],
-                max_tokens=4096,
-            )
+            # Isolate this call from every other `llm.code` caller in the trace.
+            with tagged_trace(_RULE_RETRIEVAL_TAG):
+                response = await self._llm.code(
+                    system=self._RULES_RETRIEVAL_PROMPT,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": f"User message: {user_message}\n\nRules:\n{when_text}",
+                        }
+                    ],
+                    max_tokens=_RULE_RETRIEVAL_MAX_TOKENS,
+                )
+            usage = getattr(response, "usage", None)
+            stop_reason = getattr(response, "stop_reason", None) or ""
             result = response.content.strip()
             if result.upper() == "NONE":
-                return mandatory
-            if result:
+                # A fourth outcome the ticket did not name: EVERY conditional rule
+                # is discarded. The opposite of the permissive fallback, and ~30%
+                # of calls.
+                outcome, kept, early = "dropped_all", 0, mandatory
+            elif result:
                 returned = {line.lstrip("- ").strip() for line in result.splitlines() if line.strip()}
                 filtered_when = [e for e in when_engrams if e.text in returned]
                 if not filtered_when:
-                    filtered_when = when_engrams
+                    # Exact string equality against the model's echo. Any rewrap,
+                    # added punctuation, or a response truncated at the ceiling
+                    # yields zero matches — and then we silently keep everything.
+                    outcome, filtered_when = "kept_all_no_match", when_engrams
+                else:
+                    outcome, kept = "filtered", len(filtered_when)
             else:
-                filtered_when = when_engrams
+                outcome, filtered_when = "kept_all_empty", when_engrams
         except Exception:
             filtered_when = when_engrams
+            outcome = "error"
+        finally:
+            _emit_rule_retrieval(
+                outcome=outcome,
+                when_rules=len(when_engrams),
+                kept_rules=kept,
+                rules_chars=len(when_text),
+                # `stop_reason`, not output_tokens == max_tokens: a truncated
+                # verbatim echo is silently accepted as "the relevant rules", so
+                # this is the difference between a real filter and one that just
+                # ran out of room. The provider reason is authoritative where the
+                # exact-cap heuristic gives false positives.
+                stop_reason=stop_reason,
+                input_tokens=getattr(usage, "input_tokens", 0) or 0,
+                output_tokens=getattr(usage, "output_tokens", 0) or 0,
+                duration_ms=int((time.monotonic() - started) * 1000),
+            )
 
+        if early is not None:
+            return early
         return mandatory + filtered_when
 
     def get_scratchpad_context(self) -> str:

--- a/anton/core/memory/cortex.py
+++ b/anton/core/memory/cortex.py
@@ -19,6 +19,7 @@ like how the PFC coordinates retrieval from multiple brain memory systems.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from pathlib import Path
@@ -383,6 +384,17 @@ Do NOT add, modify, or summarize rules — return them verbatim.
                     outcome, kept = "filtered", len(filtered_when)
             else:
                 outcome, filtered_when = "kept_all_empty", when_engrams
+        except asyncio.CancelledError:
+            # A user pressing STOP, or an abandoned SSE stream, cancels the turn
+            # mid-call. `CancelledError` is a BaseException, so `except Exception`
+            # below does NOT catch it — but the `finally` still fires, and without
+            # this branch every user abort was reported as `error`, inflating the
+            # filter-failure rate in the one metric this instrumentation exists to
+            # produce. Reported distinctly and re-raised: cancellation is not ours
+            # to swallow. (`kept_rules` is meaningless here — no decision was
+            # reached — which is why consumers must key on `outcome` first.)
+            outcome = "cancelled"
+            raise
         except Exception:
             filtered_when = when_engrams
             outcome = "error"

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -240,3 +240,213 @@ class TestMaybeUpdateIdentity:
         await cortex.maybe_update_identity("Hi, I'm Jorge")
         assert (g / "profile.md").exists()
         assert "Name: Jorge" in (g / "profile.md").read_text()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ENG-1390 — the hidden LLM call in prompt assembly
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _when_engrams(n: int, filler: int = 500) -> list[Engram]:
+    """Enough conditional rules to clear every gate.
+
+    Four must all hold before the call happens: a user message + an attached LLM,
+    formatted rules over `_RULES_BUDGET_CHARS` (6000), at least one `when` rule,
+    and a conditional block of at least 1000 chars. 12 x ~545 chars clears the
+    6000 budget; `filler=5` deliberately does not (see the short-circuit test).
+    """
+    return [
+        Engram(
+            text=f"When condition {i:03d} applies, do the thing {'x' * filler}",
+            kind="when",
+            scope="global",
+            confidence="high",
+        )
+        for i in range(n)
+    ]
+
+
+class _FakeLLM:
+    """Stands in for LLMClient.code, recording the trace tags it was called under."""
+
+    def __init__(self, content: str = "", raises: bool = False, stop_reason: str | None = None):
+        self._content = content
+        self._raises = raises
+        self._stop_reason = stop_reason
+        self.calls = 0
+        self.tags_seen: tuple[str, ...] = ()
+
+    async def code(self, **kwargs):
+        from anton.core.llm.provider import LLMResponse, Usage
+        from anton.core.llm.tracing import get_trace_context
+
+        self.calls += 1
+        ctx = get_trace_context()
+        self.tags_seen = ctx.tags if ctx else ()
+        if self._raises:
+            raise RuntimeError("provider exploded")
+        return LLMResponse(
+            content=self._content,
+            usage=Usage(input_tokens=4258, output_tokens=252),
+            stop_reason=self._stop_reason,
+        )
+
+
+@pytest.fixture()
+def captured_events(monkeypatch):
+    """Capture the analytics events the rule-retrieval path emits."""
+    events: list[dict] = []
+    import anton.core.memory.cortex as cortex_mod
+
+    # raising=False on purpose: on code without the instrumentation the hook does
+    # not exist, and we want these tests to FAIL with "no event was emitted"
+    # rather than ERROR on a missing attribute. An error says the fixture broke;
+    # a failure says the property under test is absent, which is the point.
+    monkeypatch.setattr(
+        cortex_mod, "_emit_rule_retrieval", lambda **shape: events.append(shape), raising=False
+    )
+    return events
+
+
+def _one_event(events: list[dict]) -> dict:
+    """The single rule-retrieval event, with a failure message worth reading.
+
+    Indexing `events[0]` directly fails as a bare IndexError, which tells a
+    future reader nothing about what broke.
+    """
+    assert len(events) == 1, (
+        f"expected exactly one rule_retrieval event, got {len(events)}: {events}. "
+        "Zero means the call is not reporting its outcome at all — which is the "
+        "defect ENG-1390 exists to close."
+    )
+    return events[0]
+
+
+class TestRuleRetrievalObservability:
+    """ENG-1390 — the call must be countable, and its outcomes distinguishable.
+
+    Before this, `filtered_when = when_engrams` was reached three different ways
+    (no exact match, empty response, exception) and all three were byte-identical
+    in their effect on the prompt — so a count of invocations could never
+    separate a working filter from a broken one. Measured in production at 1.77%
+    of all LLM calls before any of this existed.
+    """
+
+    async def _run(self, cortex, llm, rules):
+        cortex._llm = llm
+        return await cortex._retrieve_relevant_rules(rules, "please do the august campaign")
+
+    async def test_filtered_outcome_is_reported(self, cortex, captured_events):
+        rules = _when_engrams(12)
+        # Echo back exactly two rules, verbatim, as the prompt demands.
+        echo = "\n".join(f"- {rules[i].text}" for i in (0, 1))
+        llm = _FakeLLM(content=echo)
+        out = await self._run(cortex, llm, rules)
+
+        assert llm.calls == 1
+        assert len(out) == 2, "behaviour must be unchanged: only the echoed rules survive"
+        ev = _one_event(captured_events)
+        assert ev["outcome"] == "filtered"
+        assert ev["when_rules"] == 12 and ev["kept_rules"] == 2
+
+    async def test_dropped_all_is_its_own_outcome(self, cortex, captured_events):
+        """`NONE` discards every conditional rule — measured at 30% and absent
+        from the ticket's original three-outcome taxonomy."""
+        rules = _when_engrams(12)
+        out = await self._run(cortex, _FakeLLM(content="NONE"), rules)
+        assert out == [], "no mandatory rules present, so nothing should remain"
+        ev = _one_event(captured_events)
+        assert ev["outcome"] == "dropped_all"
+        assert ev["kept_rules"] == 0
+
+    async def test_no_exact_match_is_distinguishable_from_keeping_everything(
+        self, cortex, captured_events
+    ):
+        """The silent fallback. The model answered, but nothing matched verbatim —
+        so every rule is kept, which is indistinguishable in the PROMPT from the
+        filter deciding all rules were relevant. Only the event separates them."""
+        rules = _when_engrams(12)
+        # Plausible model output that fails exact string equality.
+        llm = _FakeLLM(content="- When condition 001 applies, do the thing (reworded)")
+        out = await self._run(cortex, llm, rules)
+
+        assert len(out) == 12, "behaviour must be unchanged: everything is kept"
+        ev = _one_event(captured_events)
+        assert ev["outcome"] == "kept_all_no_match"
+        assert ev["kept_rules"] == 12
+
+    async def test_empty_response_is_distinguishable(self, cortex, captured_events):
+        rules = _when_engrams(12)
+        out = await self._run(cortex, _FakeLLM(content="   "), rules)
+        assert len(out) == 12
+        assert _one_event(captured_events)["outcome"] == "kept_all_empty"
+
+    async def test_exception_is_reported_at_all(self, cortex, captured_events):
+        """The one outcome no trace could ever show: a failed call leaves no
+        observation to count, so retroactive measurement is blind to it."""
+        rules = _when_engrams(12)
+        out = await self._run(cortex, _FakeLLM(raises=True), rules)
+        assert len(out) == 12, "the permissive fallback must still apply"
+        assert _one_event(captured_events)["outcome"] == "error"
+
+    async def test_truncation_is_reported_via_stop_reason(self, cortex, captured_events):
+        """A verbatim echo cut at the ceiling is accepted as 'the relevant rules',
+        so truncation masquerades as a successful filter — 8 of 9 truncated calls
+        in production were classified that way. `stop_reason` is what separates
+        them; output_tokens == max_tokens is a heuristic with false positives."""
+        rules = _when_engrams(12)
+        echo = "\n".join(f"- {rules[i].text}" for i in (0, 1))
+        llm = _FakeLLM(content=echo, stop_reason="max_tokens")
+        await self._run(cortex, llm, rules)
+        ev = _one_event(captured_events)
+        assert ev["outcome"] == "filtered"
+        assert ev["stop_reason"] == "max_tokens", "a truncated filter must be separable"
+
+    async def test_the_call_is_tagged_so_it_is_isolatable_in_a_trace(self, cortex):
+        """Done-when #1: distinguishable from every other `llm.code` call."""
+        from anton.core.llm.tracing import (
+            TraceContext,
+            reset_trace_context,
+            set_trace_context,
+        )
+
+        rules = _when_engrams(12)
+        llm = _FakeLLM(content="NONE")
+        token = set_trace_context(TraceContext(session_id="conv-1", turn_id=3, harness="anton"))
+        try:
+            await self._run(cortex, llm, rules)
+        finally:
+            reset_trace_context(token)
+
+        assert "rule-retrieval" in llm.tags_seen, llm.tags_seen
+        # …and the tag must not leak past the call it annotates.
+        from anton.core.llm.tracing import get_trace_context
+
+        assert get_trace_context() is None
+
+    async def test_no_rule_text_or_user_message_reaches_analytics(self, cortex, captured_events):
+        """The ticket's security note: shape only — counts, sizes, enums."""
+        rules = _when_engrams(12)
+        await self._run(cortex, _FakeLLM(content="NONE"), rules)
+        ev = _one_event(captured_events)
+        blob = repr(ev)
+        assert "august campaign" not in blob, "user message must never be sent"
+        assert "do the thing" not in blob, "rule text must never be sent"
+        assert set(ev) == {
+            "outcome",
+            "when_rules",
+            "kept_rules",
+            "rules_chars",
+            "stop_reason",
+            "input_tokens",
+            "output_tokens",
+            "duration_ms",
+        }
+
+    async def test_gates_still_short_circuit_without_an_llm_call(self, cortex, captured_events):
+        """Below the budget the call must not happen — and must not be reported."""
+        llm = _FakeLLM(content="NONE")
+        small = _when_engrams(1, filler=5)
+        out = await self._run(cortex, llm, small)
+        assert llm.calls == 0 and captured_events == []
+        assert out == small

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -424,6 +424,61 @@ class TestRuleRetrievalObservability:
 
         assert get_trace_context() is None
 
+    async def test_a_user_abort_is_not_reported_as_a_filter_failure(self, cortex, captured_events):
+        """`CancelledError` is a BaseException, so `except Exception` misses it —
+        but the `finally` still fires. Without a distinct branch every user
+        pressing STOP (or an abandoned SSE stream) was counted as `error`,
+        inflating the failure rate in the one metric this instrumentation exists
+        to produce. Found by adversarial self-review, reproduced before fixing."""
+        import asyncio
+
+        class _Hanging:
+            async def code(self, **kwargs):
+                await asyncio.sleep(30)
+
+        cortex._llm = _Hanging()
+        task = asyncio.create_task(
+            cortex._retrieve_relevant_rules(_when_engrams(12), "do the august campaign")
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert _one_event(captured_events)["outcome"] == "cancelled", (
+            "a cancelled turn must be distinguishable from a filter that failed"
+        )
+
+    async def test_the_tag_reaches_the_actual_langfuse_header(self, cortex):
+        """Done-when #1 is about a TRACE, so asserting the ContextVar is not enough.
+
+        The tag has to survive `_build_trace_headers` and its sanitiser (which
+        drops commas and control chars) to reach the wire. Without this, an
+        allowlist or a rename in that builder would break the ticket's
+        requirement with every other test still green.
+        """
+        from anton.core.llm.openai import OpenAIProvider
+        from anton.core.llm.tracing import (
+            TraceContext,
+            reset_trace_context,
+            set_trace_context,
+            tagged_trace,
+        )
+
+        provider = OpenAIProvider(api_key="x", base_url="https://api.mindshub.ai/v1")
+        token = set_trace_context(TraceContext(session_id="c", turn_id=1, harness="anton"))
+        try:
+            with tagged_trace("rule-retrieval"):
+                tagged = (provider._build_trace_headers() or {}).get("Langfuse-Tags", "")
+            after = (provider._build_trace_headers() or {}).get("Langfuse-Tags", "")
+        finally:
+            reset_trace_context(token)
+
+        assert "rule-retrieval" in tagged.split(","), tagged
+        assert "rule-retrieval" not in after.split(","), (
+            "the tag must not outlive the call it annotates"
+        )
+
     async def test_no_rule_text_or_user_message_reaches_analytics(self, cortex, captured_events):
         """The ticket's security note: shape only — counts, sizes, enums."""
         rules = _when_engrams(12)

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -332,6 +332,23 @@ class TestRuleRetrievalObservability:
     of all LLM calls before any of this existed.
     """
 
+    @pytest.fixture(autouse=True)
+    def _stub_the_analytics_emit(self, captured_events):
+        """Route the emit through the capture for EVERY test in this class.
+
+        Autouse rather than per-test opt-in, so a test added here without asking
+        for `captured_events` still cannot reach the real `_emit_rule_retrieval`.
+
+        This is defence in depth, NOT a live-leak fix: `tests/conftest.py`
+        already disables analytics for the whole suite, precisely because the
+        default `analytics_url` is the real collector and turn-cost tests began
+        reaching that sink. So an unguarded test here does real work (builds
+        `AntonSettings`, calls `send_event`) but sends nothing. Keeping the stub
+        local means hermeticity does not depend on that global staying in place.
+        Caught in review by @pnewsam.
+        """
+        return captured_events
+
     async def _run(self, cortex, llm, rules):
         cortex._llm = llm
         return await cortex._retrieve_relevant_rules(rules, "please do the august campaign")


### PR DESCRIPTION
Closes Done-when 1 and 2 of [ENG-1390](https://linear.app/mindsdb/issue/ENG-1390). Done-when 3 and 4 were answered by measurement — [posted on the ticket](https://linear.app/mindsdb/issue/ENG-1390).

## The problem

`Cortex._retrieve_relevant_rules` (`cortex.py`) makes an **LLM call during prompt assembly** through the same `llm.code` entry point as the completion verifier and every other coding call. Two things were true and neither was knowable:

1. **It couldn't be counted** — no marker distinguished it in a trace.
2. **Its failure was indistinguishable from success** — `filtered_when = when_engrams` is reached three different ways (no exact match, empty response, exception), and all three are byte-identical in their effect on the prompt. A count of invocations could never separate a working filter from a broken one.

## Measured first, and the ticket's step order turned out to be backwards

The ticket assumed we had to instrument before we could count. We didn't: `_RULES_RETRIEVAL_PROMPT` is its own fingerprint, so the call was countable **retroactively from existing payloads** — no code change, no release, no week of waiting.

6,000 sampled GENERATIONs, 2026-07-16 → 08-06, zero redacted in-window, probe validity confirmed by a control:

| | |
|---|---|
| Rule-retrieval calls | **106 / 6,000 = 1.77% of all LLM calls** |
| Distinct users | 4 |
| Input tokens | median **4,258**, max 14,759 |
| **Latency added before the turn starts** | median **5.5s**, p90 **23.9s** |
| Recorded cost | $1.47 / 106 calls (5 unpriced, $0) |

So the answer is **"it fires"**, not the "rarely" the gates suggested. And the heaviest user is the same one as ENG-1366 — their "slow and expensive" profile has two mechanisms behind it, not one.

**The ticket's three-outcome taxonomy was incomplete.** Measured shares: 55.7% filtered, **30.2% dropped-all** (model returns `NONE`, every conditional rule discarded — a fourth outcome the ticket never named), 14.2% kept-all via no-exact-match. Plus **8% of calls ended at exactly 4,096 output tokens**, and cross-tabbing shows **8 of those 9 were classified as successful filters** — truncation masquerading as a working filter, a third silent-failure path.

## What this PR does

**A `rule-retrieval` trace tag**, via a new `tagged_trace()` context manager on the existing `TraceContext` — whose docstring already invites caller-supplied annotations, so this is the intended extension point rather than a new mechanism. Tags ride `Langfuse-Tags` and are one of the few dimensions the Langfuse metrics API can **group by**, so the call stays countable *without reading payloads* — which matters while ENG-1392 is redacting ~66% of them.

Deliberately a no-op rather than an error when there's nothing to annotate: no turn in flight (the CLI `turn()` path never installs a context — it's the only `set_trace_context` in the codebase), or a provider that ignores trace context (a BYOK user on direct Anthropic has no gateway trace to tag). Callers annotate unconditionally without branching.

**A `rule_retrieval` analytics event** carrying the call's shape: outcome, rule counts, block size, `stop_reason`, tokens, duration. Works for every user and provider, and is **the only way to observe the exception outcome at all** — a failed call leaves no observation, so the retroactive method is blind to it.

Both sinks, because neither alone is sufficient — the tag covers "distinguishable in a trace" (Done-when 1), the event covers "outcomes separable" (Done-when 2) and reaches non-MindsHub users.

**`stop_reason`, not `output_tokens == max_tokens`.** The exact-cap heuristic has known false positives, and the provider reason is authoritative. This is the field that separates a real filter from one that ran out of room.

## Deliberately not done

Per the ticket's out-of-scope list: **no change** to the filtering behaviour, the 6000/1000 thresholds, the silent fallback, or the exact-string-equality comparison that appears to cause it. Every branch returns exactly what it returned before; the only difference is that the branches are now distinguishable.

Also **not** added: a `rules` role in `TurnCost`/`EVENT_ROLES`. It would give per-turn token attribution and follows the precedent `router` sets, but the analytics event already carries the tokens, and per-turn cost attribution belongs with the cost question — which is the follow-up ticket's subject, not this one's.

## Security

Counts, sizes and enums only — never rule text, never the user message, both of which are user content. A test asserts neither can reach the sink and **pins the exact property set**, so a future field addition has to be deliberate. Every `extra` kwarg becomes a queryable PostHog property, so these names are a published schema; that's stated in the code comment.

Analytics failures are swallowed to `logger.debug` — observability must never break prompt assembly, which sits on the latency-critical path.

## Tests

11 new, in `TestRuleRetrievalObservability` (9 in the original commit, 2 added by the self-review), covering all five outcomes (filtered / dropped-all / kept-all-no-match / kept-all-empty / error), the trace tag plus that it does not leak past the call it annotates, the security property, and that the gates still short-circuit without a call.

**Each was watched failing on uninstrumented code.** The capture fixture uses `raising=False` deliberately, so code without the instrumentation fails with *"expected exactly one rule_retrieval event, got 0 — zero means the call is not reporting its outcome at all"* rather than erroring on a missing attribute: an error says the fixture broke, a failure says the property is absent.

Two of the eleven (`test_gates_still_short_circuit_without_an_llm_call` and `test_the_tag_reaches_the_actual_langfuse_header`) pass on uninstrumented code by construction — they are a behaviour-preservation guard and a coverage-gap closer respectively, not regression tests.

Worth noting: `_retrieve_relevant_rules` had **no test coverage at all** before this, which is ENG-1384's theme.

## Suite state

`1907 passed, 28 skipped`. `tests/test_datasource.py` has **2 failures that reproduce on clean `origin/staging`** (verified by checking out the base) — unrelated to this change, but staging is currently red on them and someone should look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

