### PR TITLE
ENG-1390: prefix the rule-retrieval analytics action so the collector relays it

### DIFF
--- a/anton/core/memory/cortex.py
+++ b/anton/core/memory/cortex.py
@@ -62,6 +62,20 @@ logger = logging.getLogger(__name__)
 _RULE_RETRIEVAL_TAG = "rule-retrieval"
 _RULE_RETRIEVAL_MAX_TOKENS = 4096
 
+# The analytics ACTION NAME, and the `anton_` prefix is load-bearing, not style.
+# The collector lambda relays an event only if its action starts with `anton_` or
+# `ds_connect` — a prefix rule, not a list — and drops everything else while still
+# returning HTTP 200, so the client cannot tell. Measured 2026-08-10:
+#
+#     action=rule_retrieval        -> posthogResult: false   (silently dropped)
+#     action=anton_rule_retrieval  -> posthogResult: true
+#
+# The unprefixed name is why this event produced nothing in project 355390 after
+# shipping. Any new action added here must carry the prefix, or it disappears.
+# (Separately, the lambda also allowlists property NAMES, so the properties below
+# still do not arrive until ENG-1355 lands — the prefix fixes one of two gates.)
+_RULE_RETRIEVAL_ACTION = "anton_rule_retrieval"
+
 # Built once: `AntonSettings()` reads the environment, and while this call site
 # is rare it sits on the latency-critical prompt-assembly path.
 _analytics_settings = None
@@ -88,11 +102,11 @@ def _emit_rule_retrieval(**shape) -> None:
 
         send_event(
             _analytics_settings,
-            "rule_retrieval",
+            _RULE_RETRIEVAL_ACTION,
             **{key: str(value) for key, value in shape.items()},
         )
     except Exception:
-        logger.debug("rule_retrieval analytics event failed", exc_info=True)
+        logger.debug("%s analytics event failed", _RULE_RETRIEVAL_ACTION, exc_info=True)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -522,3 +522,42 @@ class TestRuleRetrievalObservability:
         out = await self._run(cortex, llm, small)
         assert llm.calls == 0 and captured_events == []
         assert out == small
+
+class TestRuleRetrievalActionName:
+    """ENG-1390 — the analytics ACTION NAME, kept out of the class above on purpose.
+
+    `TestRuleRetrievalObservability` autouse-stubs `_emit_rule_retrieval`, which is
+    exactly what these tests must NOT have stubbed: they assert what reaches
+    `send_event`.
+    """
+
+    async def test_the_action_name_carries_the_prefix_the_collector_requires(self):
+        """The collector lambda relays only `anton_`/`ds_connect`-prefixed actions.
+
+        It drops anything else while still returning HTTP 200, and `send_event` is
+        fire-and-forget behind a bare `except`, so a wrong name is invisible from
+        the client — this event shipped as `rule_retrieval` and produced nothing.
+        Pinning the literal here because the constraint lives in a lambda whose
+        code is in no repo, so nothing else in this codebase can enforce it.
+        """
+        from anton.core.memory.cortex import _RULE_RETRIEVAL_ACTION
+
+        assert _RULE_RETRIEVAL_ACTION.startswith("anton_"), (
+            f"{_RULE_RETRIEVAL_ACTION!r} would be silently dropped by the collector"
+        )
+
+    async def test_the_emitted_action_is_the_prefixed_one(self, cortex, monkeypatch):
+        """End to end: the name that actually reaches `send_event`, not just the
+        constant. A refactor could reintroduce a literal and this would catch it."""
+        import anton.core.memory.cortex as cortex_mod
+
+        sent = {}
+        monkeypatch.setattr(cortex_mod, "_analytics_settings", object())
+        monkeypatch.setattr(
+            "anton.analytics.send_event",
+            lambda settings, action, **props: sent.update(action=action, props=props),
+        )
+        cortex_mod._emit_rule_retrieval(outcome="filtered", when_rules=3)
+
+        assert sent["action"] == "anton_rule_retrieval", sent
+        assert sent["props"]["outcome"] == "filtered"


### PR DESCRIPTION
Follow-up to [ENG-1390](https://linear.app/mindsdb/issue/ENG-1390) (merged in #330). Two-line behaviour change plus two tests.

## The bug

`rule_retrieval` shipped and produced **nothing** in PostHog project 355390. The collector lambda relays an action only if it starts with `anton_` or `ds_connect` — a **prefix rule, not a list** — and drops everything else **while still returning HTTP 200**. `send_event` is fire-and-forget behind a bare `except`, so there is no client-side signal whatsoever.

Measured against the live collector:

```
action=rule_retrieval        -> posthogResult: false   (silently dropped)
action=anton_rule_retrieval  -> posthogResult: true
```

Renamed to `anton_rule_retrieval`. It also matches every other action on this channel — `anton_started`, `anton_query`, `anton_first_query`, `ds_connect_*` — so the unprefixed name was off-convention as well as broken.

## Scope: this fixes ONE of two gates

The lambda **also** allowlists property *names*: `action`, `aid`, `engine`, `llm_provider`, `has_mdb_key`. So after this, the event arrives but carries **none of its data** until [ENG-1355](https://linear.app/mindsdb/issue/ENG-1355) lands.

Verified by probing a *passing* action name with the real payload:

| Sent | Arrived |
|---|---|
| `outcome`, `when_rules`, `kept_rules`, `stop_reason`, `duration_ms` | **all dropped** |
| `llm_provider` | ✅ (pre-allowlisted) |

So this PR is **necessary, not sufficient**. Merging it does not make ENG-1390's Done-when #2 pass — that needs ENG-1355, and specifically the *generic pass-through* option rather than adding `turn_completed`'s 28 names, since `rule_retrieval`'s properties aren't among those either.

## Tests

Two, deliberately in their **own class**. `TestRuleRetrievalObservability` autouse-stubs `_emit_rule_retrieval` — which is exactly what these must not have stubbed, since they assert what reaches `send_event`. I hit that while writing them: the first version silently exercised the stub and failed with `KeyError: 'action'`.

- `test_the_action_name_carries_the_prefix_the_collector_requires` — pins the constant.
- `test_the_emitted_action_is_the_prefixed_one` — pins the name that actually goes out, so a refactor reintroducing a literal is caught.

Both **mutation-verified** against the old name:

```
AssertionError: 'rule_retrieval' would be silently dropped by the collector
AssertionError: {'action': 'rule_retrieval', 'props': {...}}
```

Suite: `1745 passed, 28 skipped`.

## Why a test rather than just a fixed string

The constraint lives in a lambda whose code is **in no repo in the workspace** — ENG-1355 documents that. So nothing in this codebase can enforce it structurally, and a test with the measured `posthogResult` values in its docstring is the only place the constraint can be recorded where the next person will trip over it.

## Note on `turn_completed`

`turn_completed` fails the same gate (`posthogResult: false`) and would be fixed the same cheap way. **Deliberately not touched here:** ENG-1355 is in progress and its Done-when queries name the literal string `turn_completed`, so renaming it unilaterally would invalidate acceptance criteria someone is actively working against. Worth a conversation rather than a surprise — flagged on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)