### PR TITLE
feat(analytics): report to collect.mindshub.ai and send an identifying agent (ENG-1355)

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -8,16 +8,29 @@ an anonymous machine fingerprint, and whatever the caller passes as
 Where these events actually land
 ================================
 
-The collector lambda RELAYS into PostHog — verified 2026-08-06 against
-project 355390 ("Anton"), where anton's events appear tagged
-``source = mindsdb-zoominfo-lambda``.  Two consequences worth knowing before
-adding a caller:
+The collector relays into PostHog project 355390 ("Anton"), where these events
+appear tagged ``source = mindshub-analytics-collector``.  Rows written before
+2026-08-11 carry ``source = mindsdb-zoominfo-lambda`` instead: that was a
+different collector, in a different AWS account, and installs old enough to
+still hold the previous ``analytics_url`` keep reporting to it.  A query
+covering both needs to accept either value.
 
-* **Every ``extra`` kwarg becomes a queryable PostHog event property.**  Not
-  an allowlist — ``ds_connect_success`` carries its ``engine=postgres``
-  through, and ``turn_completed`` carries its full token breakdown.  So the
-  parameter names here ARE the analytics schema; renaming one silently breaks
-  whatever queries or dashboards read it.
+Consequences worth knowing before adding a caller:
+
+* **Every ``extra`` kwarg becomes a queryable PostHog event property**, apart
+  from a small denylist of credential- and address-shaped names, and any value
+  that looks like an email address.  ``ds_connect_success`` carries its
+  ``engine=postgres`` through and ``turn_completed`` carries its full token
+  breakdown, with no collector change needed for either.  So the parameter
+  names here ARE the analytics schema; renaming one silently breaks whatever
+  queries or dashboards read it.
+* **This was not true until 2026-08-11.**  The previous collector copied a
+  fixed list of five property names and relayed only actions starting with
+  a lowercase ``anton_`` or ``ds_connect_``, discarding everything else and
+  answering HTTP 200 regardless.  ``turn_completed`` and its 27 properties
+  therefore went nowhere at all from the day they shipped.  If a property
+  seems to be missing, check what the collector accepts before assuming the
+  caller is at fault.
 * **``distinct_id`` is the ``aid`` fingerprint, so these events are
   per-INSTALL, not per-user.**  They do not join to the Keycloak ``sub`` that
   the console, the desktop renderer's PostHog client, and the billing mirror
@@ -81,6 +94,14 @@ if TYPE_CHECKING:
     from anton.config.settings import AntonSettings
 
 _TIMEOUT = 3  # seconds
+
+# Sent instead of urllib's default ``Python-urllib/3.x``, which Cloudflare's bot
+# protection answers with 403 on the mindshub.ai zone.  The collector host is
+# deliberately not proxied, so this is belt and braces rather than the only
+# guard, but ``_fire`` discards its response either way: anything that blocks
+# this request disappears without a trace, so it is worth not looking like a
+# script.
+_USER_AGENT = "anton-analytics/1.0"
 
 # Cached after first computation — the fingerprint never changes within
 # a process, so computing it once is sufficient.
@@ -194,6 +215,7 @@ def send_event(settings: "AntonSettings", action: str, **extra: str) -> None:
 def _fire(url: str) -> None:
     """Perform the actual HTTP GET.  Runs inside a daemon thread."""
     try:
-        urllib.request.urlopen(url, timeout=_TIMEOUT)
+        req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+        urllib.request.urlopen(req, timeout=_TIMEOUT)
     except Exception:
         pass

--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -136,7 +136,9 @@ class AntonSettings(CoreSettings):
 
     # Analytics — anonymous usage events (set ANTON_ANALYTICS_ENABLED=false to opt out)
     analytics_enabled: bool = True
-    analytics_url: str = "https://x6nik28qi6.execute-api.us-east-2.amazonaws.com/default/zoomInfoCollector"
+    # A hostname we own rather than an API Gateway id, so the collector can move
+    # without a release to follow it. Override with ANTON_ANALYTICS_URL.
+    analytics_url: str = "https://collect.mindshub.ai/collect"
 
     # Minds datasource integration
     minds_enabled: bool = True  # use Minds server as LLM provider

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -103,3 +103,37 @@ def test_send_event_sends_when_not_ci(monkeypatch):
     assert params["action"] == "anton_query"
     assert params["llm_provider"] == "openai"
     assert "is_ci" not in params  # flag removed; CI events aren't sent at all
+
+
+def test_fire_sends_an_identifying_user_agent(monkeypatch):
+    """urllib's default ``Python-urllib/3.x`` agent is answered with 403 by the
+    bot rules on the mindshub.ai zone, and ``_fire`` throws its response away,
+    so an event blocked for looking like a script would vanish with no trace.
+    """
+    seen: list[object] = []
+
+    def _fake_urlopen(request, timeout=None):
+        seen.append(request)
+        return None
+
+    monkeypatch.setattr(analytics.urllib.request, "urlopen", _fake_urlopen)
+
+    analytics._fire("https://example.test/collect?action=anton_query")
+
+    assert len(seen) == 1
+    agent = seen[0].get_header("User-agent")
+    assert agent == analytics._USER_AGENT
+    assert "python-urllib" not in agent.lower()
+
+
+def test_default_collector_url_is_a_host_we_control():
+    """Guards the regression this replaced: the previous default was a raw
+    ``*.execute-api.amazonaws.com`` id in an account nobody could deploy to, so
+    the endpoint could not be changed without shipping a new release to every
+    install.
+    """
+    from anton.config.settings import AntonSettings
+
+    url = AntonSettings.model_fields["analytics_url"].default
+    assert url.startswith("https://collect.")
+    assert "execute-api" not in url


### PR DESCRIPTION
## User story

**As a** harness engineer who shipped per-turn cost accounting last week
**I want** anton's `turn_completed` event to reach a collector that keeps its properties
**So that** ENG-1286's spend ceiling can be set from real turn costs instead of guessed at

## Why this matters

`turn_completed` has never arrived in PostHog. The collector it was pointed at matched a lowercase `anton_` / `ds_connect_` prefix on the action name and copied five known property names, discarding everything else and answering HTTP 200 either way. `send_event` is fire-and-forget behind a bare `except`, so nothing reported it. The `turn_cost` log line worked the whole time, which is what made it look healthy.

This is the client half of the fix. The collector half is mindsdb/mindshub_services#186.

## What happens today

```mermaid
sequenceDiagram
    participant S as anton session
    participant A as anton/analytics.py
    participant L as zoomInfoCollector
    participant P as PostHog 355390

    S->>A: send_event("turn_completed", 28 props)
    A->>L: GET ?action=turn_completed&...
    L--xP: action fails the prefix filter, nothing relayed
    L-->>A: HTTP 200
    A->>A: response discarded, no error raised
    Note over S,P: The log line is complete.<br/>The sink is empty. Nothing says so.
```

## What should happen

```mermaid
sequenceDiagram
    participant S as anton session
    participant A as anton/analytics.py
    participant L as collect.mindshub.ai
    participant P as PostHog 355390

    S->>A: send_event("turn_completed", 28 props)
    A->>L: GET ?action=turn_completed&... (User-Agent set)
    L->>P: capture, all properties minus a denylist
    L-->>A: HTTP 200, relayed true
    A->>A: response discarded, as before
    Note over L,P: A drop or a relay failure now<br/>increments a counter and alarms.
```

## What changed

| File | Change |
|---|---|
| `anton/config/settings.py` | `analytics_url` default is now `https://collect.mindshub.ai/collect`. Still overridable with `ANTON_ANALYTICS_URL`. |
| `anton/analytics.py` | `_fire` sends `User-Agent: anton-analytics/1.0` instead of urllib's default. |
| `anton/analytics.py` | Module docstring corrected. It claimed every `extra` kwarg became a queryable property and that this was not an allowlist. Both halves were false. |
| `tests/test_analytics.py` | Two tests: the user agent is sent and is not urllib's default; the baked default is not an `execute-api` id. |

**On the docstring.** It is worth reading the diff on it rather than skimming. The old text told any author that no collector work was needed to add a property, which is a plausible reason this defect reached Passed QA. The new text says what the collector actually does, notes that it was different before 2026-08-11, and tells a reader to check the collector before assuming a missing property is the caller's fault.

**On the user agent.** Cloudflare's bot protection answers `Python-urllib/3.x` with 403 on the mindshub.ai zone. The collector host is deliberately not proxied, so this is a second line rather than the only one, but `_fire` discards its response either way and a blocked event would disappear with nothing reporting it.

## Acceptance criteria

- [ ] A real turn produces exactly one `turn_completed` row in project 355390 whose properties match that turn's `turn_cost` log line, with the per-role token sums reconciling to `tokens_total` and `unknown_tokens` at 0.
- [ ] `ANTON_ANALYTICS_URL` still overrides the default.
- [ ] `ANTON_ANALYTICS_ENABLED=false` still suppresses the event entirely.
- [ ] CI traffic is still dropped rather than sent.
- [ ] Still true afterwards: `send_event` raises nothing when the endpoint is unreachable, refuses the request, or returns a non-200.

## How to test

1. **Merge order matters.** mindsdb/mindshub_services#186 and mindsdb/terraform#162 must be deployed first, so `collect.mindshub.ai` answers. Confirm with `curl -s "https://collect.mindshub.ai/collect?action=anton_probe&aid=qaprobe1355"` returning `relayed: true`.
2. Install this branch and run one turn with analytics on, no `ANTON_ANALYTICS_ENABLED=false`.
3. Read the `turn_cost` line for that turn from `~/Library/Logs/anton/cowork-server.log`.
4. Wait 60 seconds, then in project 355390: `select * from events where event = 'turn_completed' and properties.conversation_id = '<the session id from step 3>'`. Expect exactly one row.
5. Diff its properties against the log line. `planning_tokens + coding_tokens + router_tokens + unknown_tokens` must equal `tokens_total`.
6. Confirm the override: `ANTON_ANALYTICS_URL=https://example.test/collect` and check the request goes there instead.
7. Confirm the opt-out: `ANTON_ANALYTICS_ENABLED=false` and check nothing is sent.
8. Exclude probe rows from any validation query: `where properties.aid not like '%probe1288%' and properties.aid not like '%probe1355%'`.

## Verified locally

| Check | Result |
|---|---|
| `pytest tests/` (full suite) | 1680 passed, 28 skipped |
| `pytest tests/test_analytics.py tests/test_settings.py` after rebase onto current `staging` | 34 passed |

## Note on rollout

The endpoint reaches the fleet through a normal release plus the sidecar auto-updater, so no flag day. Installs older than that release keep reporting to the previous collector, which stays running and relays into the same PostHog project, so there is no gap in the event stream while the tail drains. Rows are told apart by their `source` property.

## Ships with

- mindsdb/mindshub_services#186, the collector.
- mindsdb/terraform#162, the host and the alarms.
- mindsdb/cowork, the same repoint for the desktop app's four install events.

Refs ENG-1355
