### PR TITLE
 ENG-1359: don't register a web_search fallback with no usable credential

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1389,9 +1389,18 @@ class ChatSession:
         # appear in the registry; the model uses the provider's server-side
         # web tools instead and Anton's dispatch loop never sees a ``tool_use``
         # for them. See ``anton/core/tools/web_tools.py`` for the handlers.
+        #
+        # ``web_search`` additionally needs a usable Exa/Brave credential — a
+        # model offered a tool that can only fail will call it anyway, so skip
+        # registration outright rather than let it dispatch to a guaranteed
+        # error (ENG-1359).
         if "web_search" in self._fallback_web_tools:
-            from anton.core.tools.web_tools import WEB_SEARCH_FALLBACK_TOOL
-            self.tool_registry.register_tool(WEB_SEARCH_FALLBACK_TOOL)
+            from anton.core.tools.web_tools import (
+                WEB_SEARCH_FALLBACK_TOOL,
+                has_search_credential,
+            )
+            if has_search_credential(self._settings):
+                self.tool_registry.register_tool(WEB_SEARCH_FALLBACK_TOOL)
         if "web_fetch" in self._fallback_web_tools:
             from anton.core.tools.web_tools import WEB_FETCH_FALLBACK_TOOL
             self.tool_registry.register_tool(WEB_FETCH_FALLBACK_TOOL)

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1458,7 +1458,7 @@ class ChatSession:
         # ``web_search`` additionally needs a usable Exa/Brave credential — a
         # model offered a tool that can only fail will call it anyway, so skip
         # registration outright rather than let it dispatch to a guaranteed
-        # error (ENG-1359).
+        # error.
         if "web_search" in self._fallback_web_tools:
             from anton.core.tools.web_tools import (
                 WEB_SEARCH_FALLBACK_TOOL,

--- a/anton/core/tools/web_tools.py
+++ b/anton/core/tools/web_tools.py
@@ -446,6 +446,21 @@ _NO_PROVIDER_MSG = (
 )
 
 
+def has_search_credential(settings: object) -> bool:
+    """Whether ``settings`` has a usable Exa/Brave key for the fallback handler.
+
+    Shared by the registration gate (``ChatSession.__init__`` skips
+    registering ``WEB_SEARCH_FALLBACK_TOOL`` when this is False, ENG-1359) and
+    the handler itself, so the two can't drift out of sync.
+    """
+    provider = (getattr(settings, "external_search_provider", None) or "").lower()
+    if provider == "exa":
+        return bool(getattr(settings, "exa_api_key", None))
+    if provider == "brave":
+        return bool(getattr(settings, "brave_api_key", None))
+    return False
+
+
 async def handle_web_search_fallback(session: "ChatSession", tc_input: dict) -> str:
     query = (tc_input.get("query") or "").strip()
     if not query:
@@ -454,20 +469,13 @@ async def handle_web_search_fallback(session: "ChatSession", tc_input: dict) -> 
     max_results = max(1, min(max_results, 20))
 
     settings = session._settings
+    if not has_search_credential(settings):
+        return _NO_PROVIDER_MSG
+
     provider = (getattr(settings, "external_search_provider", None) or "").lower()
-
     if provider == "exa":
-        key = getattr(settings, "exa_api_key", None)
-        if not key:
-            return _NO_PROVIDER_MSG
-        return await _search_exa(query, key, max_results)
-    if provider == "brave":
-        key = getattr(settings, "brave_api_key", None)
-        if not key:
-            return _NO_PROVIDER_MSG
-        return await _search_brave(query, key, max_results)
-
-    return _NO_PROVIDER_MSG
+        return await _search_exa(query, getattr(settings, "exa_api_key"), max_results)
+    return await _search_brave(query, getattr(settings, "brave_api_key"), max_results)
 
 
 async def handle_web_fetch_fallback(session: "ChatSession", tc_input: dict) -> str:

--- a/anton/core/tools/web_tools.py
+++ b/anton/core/tools/web_tools.py
@@ -440,8 +440,9 @@ async def _fetch_url(url: str, max_chars: int) -> str:
 
 
 _NO_PROVIDER_MSG = (
-    "No search provider configured for this LLM endpoint. "
-    "Run `anton setup search` to configure Exa.ai or Brave Search."
+    "No search provider configured for this LLM endpoint. Web search is "
+    "unavailable in this session; if you're running the anton CLI standalone, "
+    "run `anton setup search` to configure Exa.ai or Brave Search."
 )
 
 

--- a/anton/core/tools/web_tools.py
+++ b/anton/core/tools/web_tools.py
@@ -449,9 +449,9 @@ _NO_PROVIDER_MSG = (
 def has_search_credential(settings: object) -> bool:
     """Whether ``settings`` has a usable Exa/Brave key for the fallback handler.
 
-    Shared by the registration gate (``ChatSession.__init__`` skips
-    registering ``WEB_SEARCH_FALLBACK_TOOL`` when this is False, ENG-1359) and
-    the handler itself, so the two can't drift out of sync.
+    Shared by the registration gate (``ChatSession.__init__`` skips registering
+    ``WEB_SEARCH_FALLBACK_TOOL`` when this is False) and the handler itself, so
+    the two can't drift out of sync.
     """
     provider = (getattr(settings, "external_search_provider", None) or "").lower()
     if provider == "exa":
@@ -474,8 +474,10 @@ async def handle_web_search_fallback(session: "ChatSession", tc_input: dict) -> 
 
     provider = (getattr(settings, "external_search_provider", None) or "").lower()
     if provider == "exa":
-        return await _search_exa(query, getattr(settings, "exa_api_key"), max_results)
-    return await _search_brave(query, getattr(settings, "brave_api_key"), max_results)
+        return await _search_exa(query, settings.exa_api_key, max_results)
+    if provider == "brave":
+        return await _search_brave(query, settings.brave_api_key, max_results)
+    return _NO_PROVIDER_MSG
 
 
 async def handle_web_fetch_fallback(session: "ChatSession", tc_input: dict) -> str:

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -576,8 +576,8 @@ class TestSessionWebToolResolution:
         assert "web_fetch" in names
 
     def test_fallback_web_search_not_registered_without_credential(self):
-        # ENG-1359: a model offered a tool that can only fail (no Exa/Brave
-        # key configured) will call it anyway — don't register it at all.
+        # A model offered a tool that can only fail (no Exa/Brave key
+        # configured) will call it anyway — don't register it at all.
         session = self._build_session(provider_native=set())
         tools = session._build_tools()
         names = {t["name"] for t in tools}

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -539,6 +539,11 @@ class TestSessionWebToolResolution:
         cfg = ChatSessionConfig(llm_client=mock_llm, **(cfg_kwargs or {}))
         return ChatSession(cfg)
 
+    def _settings_with_credential(self):
+        from anton.config.settings import AntonSettings
+
+        return AntonSettings(external_search_provider="exa", exa_api_key="k")
+
     def test_anthropic_style_native_provider_uses_no_fallback(self):
         session = self._build_session(provider_native={"web_search", "web_fetch"})
         assert session._native_web_tools == {"web_search", "web_fetch"}
@@ -559,11 +564,25 @@ class TestSessionWebToolResolution:
         assert "web_fetch" in session._native_web_tools
 
     def test_fallback_toolDefs_registered_when_provider_lacks_native(self):
-        session = self._build_session(provider_native=set())
-        # Trigger lazy build of the registry.
+        # web_search additionally needs a usable Exa/Brave credential; without
+        # one it must not be registered even though the provider isn't native.
+        session = self._build_session(
+            provider_native=set(),
+            cfg_kwargs={"settings": self._settings_with_credential()},
+        )
         tools = session._build_tools()
         names = {t["name"] for t in tools}
         assert "web_search" in names
+        assert "web_fetch" in names
+
+    def test_fallback_web_search_not_registered_without_credential(self):
+        # ENG-1359: a model offered a tool that can only fail (no Exa/Brave
+        # key configured) will call it anyway — don't register it at all.
+        session = self._build_session(provider_native=set())
+        tools = session._build_tools()
+        names = {t["name"] for t in tools}
+        assert "web_search" not in names
+        # web_fetch needs no credential, so it's unaffected.
         assert "web_fetch" in names
 
     def test_fallback_toolDefs_not_registered_when_provider_is_native(self):


### PR DESCRIPTION
## Problem
When a provider has no native web search, anton registers `WEB_SEARCH_FALLBACK_TOOL` unconditionally — even when the session has no Exa/Brave key configured. The model calls the tool anyway and gets a guaranteed error every time, with copy telling the user to run `anton setup search`, a CLI command a Cowork desktop or web user does not have. Observed in production: the agent frequently reacts to the dead tool by fabricating the data it could not retrieve and shipping it as research.

This is the anton half of ENG-1359. The cowork-server half (mindsdb/cowork-server#294) stops constructing the MindsHub provider with a flavor that reports no native web tools; this half stops offering a tool that cannot succeed regardless of flavor.

## Fix
- `anton/core/tools/web_tools.py`: extracted `has_search_credential(settings)`, shared by the registration gate and the handler so the two can't drift.
- `anton/core/session.py`: `WEB_SEARCH_FALLBACK_TOOL` is registered only when `has_search_credential` is true. `web_fetch` is unaffected — its fallback is credential-free stdlib HTTP.
- Reworded `_NO_PROVIDER_MSG` so it no longer presents the CLI command as the only route. Still correct for standalone anton CLI users; no longer misleading for a host-app user who can't run it (and who, after this change, won't reach the tool at all).

## Tests
`tests/test_web_tools.py`:
- `test_fallback_web_search_not_registered_without_credential` (new) — with no credential, `web_search` is absent from the built tool list while `web_fetch` is still present.
- `test_fallback_toolDefs_registered_when_provider_lacks_native` (updated) — now configures a credential, since one is required for registration.

Mutation-checked: the new test kills a `has_search_credential` → `return True` mutant, the updated sibling kills `return False`. Full run: 155 passed, 17 skipped across the web-tools, session and provider suites.

Fixes https://linear.app/mindsdb/issue/ENG-1359/web-search-is-broken-for-every-cowork-user-the-provider-flavor-is