### PR TITLE
docs(truncation): gateway reports "length" at the cap, not "stop"

### DIFF
--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -153,8 +153,10 @@ class LLMClient:
 
         Exposed so the session's truncation recovery can compare a
         response's ``output_tokens`` against the budget the call actually
-        ran with (ENG-1042) — the gateway's ``finish_reason`` can't be
-        trusted at the cap (ENG-1082).
+        ran with (ENG-1042). This gate was added because the gateway once
+        reported a normal stop at the cap (ENG-1082, fixed 2026-08-03); it is
+        kept because a token count needs no dialect mapping and no provider
+        can get it wrong.
         """
         return self._max_tokens
 

--- a/anton/core/llm/structured.py
+++ b/anton/core/llm/structured.py
@@ -131,10 +131,13 @@ async def generate_with_truncation_retry(
 def looks_truncated(response, budget: int) -> bool:
     """True if `response` was cut off by the `max_tokens` budget.
 
-    Token count first, because the MindsHub gateway reports
-    ``finish_reason: "stop"`` at the cap for most aliases (ENG-1082) — the
-    standard ``"length"`` check can't be relied on there. Both dialects are
-    honoured when reported: OpenAI says ``"length"``, Anthropic ``"max_tokens"``.
+    Token count first: it is provider-agnostic and needs no dialect mapping.
+    The clause exists because the MindsHub gateway once reported
+    ``finish_reason: "stop"`` at the cap for most aliases (ENG-1082) — measured
+    2026-08-11, it now reports ``"length"`` on all 19 chat aliases, streaming
+    and non-streaming, so both gates fire. Keep both: the token count is the
+    one that cannot silently regress. Both dialects are honoured when
+    reported: OpenAI says ``"length"``, Anthropic ``"max_tokens"``.
     No usage information → ``False``; without evidence we don't buy a retry.
     """
     usage = getattr(response, "usage", None)

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3191,10 +3191,11 @@ class ChatSession:
         """Retry a response that burned its output budget without finishing.
 
         ``llm_response`` hit ``max_tokens`` before producing a tool call —
-        detected by token count (`looks_truncated`), NOT ``stop_reason``:
-        the MindsHub gateway reports a normal stop at the cap (ENG-1082),
-        which is what kept this recovery dead for every hosted user
-        (ENG-1042).
+        detected by token count (`looks_truncated`) rather than relying on
+        ``stop_reason``. The gateway *used to* report a normal stop at the cap
+        (ENG-1082), which is what kept this recovery dead for every hosted user
+        (ENG-1042); it was fixed 2026-08-03 and now reports ``"length"``. The
+        token gate stays: it is the half that cannot regress upstream.
 
         The retry always CHANGES the call — an identical re-issue dies
         identically (measured: three unchanged retries 14 minutes apart,
@@ -3291,9 +3292,10 @@ class ChatSession:
         llm_response = response.response
 
         # Detect max_tokens truncation — the LLM was cut off mid-response.
-        # By token count, not stop_reason: the gateway reports a normal stop
-        # at the cap (ENG-1082), which made a stop_reason gate dead code for
-        # every MindsHub-routed user (ENG-1042).
+        # By token count rather than stop_reason alone: the gateway used to
+        # report a normal stop at the cap (ENG-1082, fixed 2026-08-03), which
+        # made a stop_reason gate dead code for every MindsHub-routed user
+        # (ENG-1042). `looks_truncated` checks both.
         if not llm_response.tool_calls and looks_truncated(
             llm_response, self._turn_max_tokens()
         ):

--- a/tests/e2e/stub_server.py
+++ b/tests/e2e/stub_server.py
@@ -30,9 +30,14 @@ class _Response:
     # None = honour request's `stream` flag; True/False = override
     force_streaming: bool | None = None
     # Reported as `usage.completion_tokens`. Set it equal to the request's
-    # `max_tokens` to emulate a truncated response — which is how the real
-    # MindsHub gateway presents one, since it still says
-    # `finish_reason: "stop"` at the cap (ENG-1082).
+    # `max_tokens` to emulate a truncated response.
+    #
+    # This stub reports `finish_reason: "stop"` at the cap. That is NO LONGER
+    # what the gateway does — ENG-1082 was fixed 2026-08-03 and it now returns
+    # `"length"` on every alias. The stub keeps the old behaviour ON PURPOSE:
+    # it is the harder case, and a recovery that survives a gateway which lies
+    # also survives one that is honest. Do not "correct" this to `"length"` —
+    # that deletes the only coverage of the case ENG-1042 was built for.
     output_tokens: int = 10
 
 

--- a/tests/test_session_truncation_recovery.py
+++ b/tests/test_session_truncation_recovery.py
@@ -3,9 +3,12 @@
 A completion can burn its entire ``max_tokens`` on internal reasoning (or
 narration) and return nothing — no text, no tool call, no error. The session
 has had a recovery for this since early on, but it gated on
-``stop_reason in ("max_tokens", "length")`` and the MindsHub gateway reports
-``finish_reason: "stop"`` at the cap (ENG-1082), so the recovery was dead code
-for every hosted user: 38 fully-silent generations across 12 users in one week.
+``stop_reason in ("max_tokens", "length")`` and the MindsHub gateway then
+reported ``finish_reason: "stop"`` at the cap (ENG-1082), so the recovery was
+dead code for every hosted user: 38 fully-silent generations across 12 users in
+one week. ENG-1082 was fixed 2026-08-03; the token-count gate below is kept
+because it cannot regress upstream, and the e2e stub still emulates the old
+dishonest ``"stop"`` deliberately.
 
 What must hold now:
 

--- a/tests/test_verifier_truncation.py
+++ b/tests/test_verifier_truncation.py
@@ -11,7 +11,8 @@ Two behaviours are covered here:
 
 1. `_generate_object_with` reports *why* there was no tool call, distinguishing a
    blown budget (retryable) from a genuine failure — by token count, because the
-   MindsHub gateway reports `finish_reason: "stop"` at the cap (ENG-1082).
+   MindsHub gateway once reported `finish_reason: "stop"` at the cap (ENG-1082,
+   fixed 2026-08-03). The token check is kept as the provider-agnostic half.
 2. The verifier retries a truncated verdict once with a bigger budget, and does
    NOT spend a retry on a failure a bigger budget can't fix.
 """


### PR DESCRIPTION
Seven comments across six files assert that the MindsHub gateway returns `finish_reason: "stop"` when it truncates at `max_tokens`. That was true when they were written. **ENG-1082 was fixed on 2026-08-03** (mindshub_inference #367) and the gateway now returns `"length"`.

## Verification

Re-ran ENG-1082's own repro table against prod on 2026-08-11 — every chat alias, both modes:

| | result |
|---|---|
| Aliases tested | **19** (full `/v1/models` catalogue, minus embeddings) |
| Returning `"length"` at the cap, non-streaming | **19 / 19** |
| Returning `"length"` at the cap, streaming | **19 / 19** |
| Still returning `"stop"` | **none** |

That includes all nine ENG-1082 named as broken: `haiku`, `sonnet`, `opus`, `gpt`, `gpt-codex`, `gpt-nano`, `kimi`, `mindshub_air`, `deepseek`.

## No behaviour change

Verified mechanically, not by eye: each file was tokenized before and after with `COMMENT`/`STRING` tokens dropped, and the remaining token streams are byte-identical. **Comment and docstring text only.**

`looks_truncated` keeps **both** gates. The token-count clause stays checked first because it is provider-agnostic, needs no dialect mapping, and cannot regress upstream. Only the stated *reason* was stale.

`tests/test_session_truncation_recovery.py` and `tests/test_verifier_truncation.py` pass unchanged (31 tests).

## The stub keeps lying, on purpose

`tests/e2e/stub_server.py` still emits `finish_reason: "stop"` at the cap, and now says why in a comment. It is the harder case — a recovery that survives a gateway which lies also survives one that is honest. "Correcting" it to `"length"` would delete the only coverage of the scenario ENG-1042 was built for. That was the most likely accidental follow-on to this change, so it is called out explicitly.

## Why this drifted

ENG-1082's own `Done when` anticipated the cleanup — *"ENG-1081 can then simplify its truncation detection to the standard `finish_reason` check"* — but it lived as a sentence in a closing ticket rather than a tracked item, so it went with the close.

The deeper reason nothing caught it: these are **cross-repo behavioural claims**. anton's CI cannot test the gateway and the gateway's CI does not know anton exists, so a comment about the other system's behaviour is the one artifact with no way to fail. Each claim is now **dated**, so the next reader treats it as a point-in-time observation rather than a standing fact.

Found during the ENG-1384 Phase 1 verification pass.

## Security check

Comment-only; no endpoint, auth surface, input handling, or logging touched. Nothing added to output or history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)