### PR TITLE
docs(readme): point the desktop download links at downloads.mindshub.ai (ENG-1437)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Anton is the default agent in **MindsHub Cowork**, the unified workspace with da
 ### MindsHub Cowork app
 
 - **Web** — nothing to install: open **[console.mindshub.ai](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=anton-readme)**.
-- **macOS** — [download the desktop app](https://downloads.mindsdb.com/mindshub-cowork/mac/mindshub-cowork-latest.pkg) (`.pkg`).
-- **Windows** — [download the desktop app](https://downloads.mindsdb.com/mindshub-cowork/windows/mindshub-cowork-latest.exe) (`.exe`).
+- **macOS** — [download the desktop app](https://downloads.mindshub.ai/mindshub-cowork/mac/mindshub-cowork-latest.pkg) (`.pkg`).
+- **Windows** — [download the desktop app](https://downloads.mindshub.ai/mindshub-cowork/windows/mindshub-cowork-latest.exe) (`.exe`).
 
 ### Anton CLI (standalone)
 


### PR DESCRIPTION
## Story

**As a** developer landing on this README for the first time
**I want** the install links to name the canonical download host
**So that** the first host I learn is the one every other surface uses

## Context

ENG-437 migrated download URLs from `downloads.mindsdb.com` to `downloads.mindshub.ai` and closed as Done, but a handful of consumers were never repointed. This README's **MindsHub Cowork app** section is one of them.

Nothing was broken: both names are aliases on the same CloudFront distribution, so the old links have always served the same bytes. The problem is pedagogical rather than functional. The README is the first thing a new reader sees, and it was teaching the legacy host to everyone who arrived through it.

## Acceptance criteria

- [x] No file in this repo references `downloads.mindsdb.com`.
- [x] Both install links resolve to a live installer on `downloads.mindshub.ai`.

## How to test

1. `grep -rn "downloads.mindsdb.com" .` — expect no hits.
2. Click both links in the rendered README; each downloads its installer.
3. Or check without downloading 220 MB:
   ```
   curl -sSI https://downloads.mindshub.ai/mindshub-cowork/mac/mindshub-cowork-latest.pkg | head -1
   curl -sSI https://downloads.mindshub.ai/mindshub-cowork/windows/mindshub-cowork-latest.exe | head -1
   ```
   Both answered `200` when this was written.

## Notes

**The legacy alias stays live** and is not being retired. Links already published against it keep working.

This README is also vendored into `mindsdb/minds` as the `backend/core_agent` submodule, so that copy corrects itself at the next pin bump rather than needing its own edit.

Cross-repo: part of ENG-1437, alongside open PRs on `mindsdb/website` (#104), `mindsdb/mindshub_frontend` (#1418), `mindsdb/auth` (#270), `mindsdb/minds`, and `mindsdb/terraform`. Independent; merge order does not matter.

Refs: ENG-1437
