### PR TITLE
[ENG-1275] Scratchpad auto install is killed by the watchdog it runs

### DIFF
--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -17,6 +17,8 @@ from anton.core.backends.base import Cell, ScratchpadRuntime
 from anton.core.backends.wire import (
     CELL_DELIM,
     HEARTBEAT_MARKER,
+    INSTALL_END_MARKER,
+    INSTALL_START_MARKER,
     PROGRESS_MARKER,
     RESULT_END,
     RESULT_START,
@@ -31,6 +33,12 @@ _BOOT_SCRIPT_PATH = Path(__file__).parent / "scratchpad_boot.py"
 # _MAX_OUTPUT so a killed cell can never report more stdout than a successful
 # one would have.
 _SALVAGE_MAX = 10_000
+
+# Extra headroom on top of cell_install_timeout while an in-cell auto-install
+# runs: the worker enforces the budget itself and reports a named install
+# error, so the parent's windows must outlast the worker's timer for that
+# error to win the race against a generic kill (ENG-1275).
+_INSTALL_GRACE = 30.0
 
 
 def _read_boot_script() -> str:
@@ -582,6 +590,12 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         if uv:
             env["ANTON_UV_PATH"] = uv
 
+        # The in-cell auto-installer (scratchpad_boot) runs pip/uv under this
+        # budget. Pass the resolved setting so the worker's timer and the
+        # parent's kill windows in _read_result run off one number — they
+        # used to be independent constants that drifted apart (ENG-1275).
+        env["ANTON_CELL_INSTALL_TIMEOUT"] = str(CoreSettings().cell_install_timeout)
+
         # Namespace snapshot path (ENG-1124). The boot script reads
         # ANTON_SCRATCHPAD_SESSION_PATH and nothing ever set it, so it fell back to a
         # hardcoded "/anton_scratchpad_session.pkl" — the filesystem root, which no
@@ -842,12 +856,30 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         start = _time.monotonic()
         current_inactivity = inactivity_timeout
 
+        # In-cell auto-install span (ENG-1275). While the worker's installer
+        # runs, both kill windows defer to the install budget — the same
+        # cell_install_timeout the worker was handed at spawn — plus a grace
+        # margin, so the worker's own named install error wins the race
+        # against a parent kill. The cell's budget resumes, install time
+        # excluded, when the end marker arrives.
+        install_budget = float(s.cell_install_timeout)
+        installing: str | None = None
+        install_started = 0.0
+        pre_install_total = total_timeout
+        pre_install_inactivity = current_inactivity
+
         # A budget kill with zero salvaged output is ambiguous: a stuck call
         # and silent heavy work look identical from outside, so the message
         # says so instead of implying "too heavy" (the confident wrong guess
         # that taught the ENG-578 per-item pattern). The phrase routes to its
         # own nudge — lockstep constraint, see the silence-kill raise below.
         def _total_timeout_message() -> str:
+            if installing:
+                return (
+                    f"Cell killed during auto-install of '{installing}' — the "
+                    f"install ran past its {install_budget:.0f}s budget and "
+                    "grace window without reporting a result"
+                )
             base = f"Cell timed out after {total_timeout:.0f}s total"
             if not self._salvage:
                 return base + (
@@ -873,13 +905,19 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 if elapsed_now >= total_timeout - 0.5:
                     raise asyncio.TimeoutError(_total_timeout_message()) from None
                 # Wording is load-bearing in THREE places (ENG-578 lockstep):
-                # _select_resilience_nudge routes on "liveness"/"timed out"/
-                # "without producing any output", the ACC kill-loop detector
-                # classifies on the same phrases, and observe_scratchpad_cell
-                # records only the FIRST 120 chars as the ACC reason — the
-                # routing keywords must stay inside that slice. Change all of
-                # them together.
-                #
+                # _select_resilience_nudge routes on "auto-install"/
+                # "liveness"/"timed out"/"without producing any output", the
+                # ACC kill-loop detector classifies on the same phrases, and
+                # observe_scratchpad_cell records only the FIRST 120 chars as
+                # the ACC reason — the routing keywords must stay inside that
+                # slice. Change all of them together.
+                if installing:
+                    raise asyncio.TimeoutError(
+                        f"Cell killed during auto-install of '{installing}' — "
+                        f"no liveness signal for {current_inactivity:.0f}s: "
+                        "the worker process died or the installer is wedged; "
+                        "the package is likely not installed"
+                    ) from None
                 # Only two things actually reach this timer now: a dead worker
                 # (EOF follows shortly) or one pinned below Python by a native
                 # call holding the GIL — a userland deadlock or spin keeps
@@ -899,7 +937,12 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 yield {
                     "stdout": "".join(self._salvage),
                     "stderr": "",
-                    "error": "Process exited unexpectedly.",
+                    "error": (
+                        f"Process exited unexpectedly while auto-installing "
+                        f"'{installing}'."
+                        if installing
+                        else "Process exited unexpectedly."
+                    ),
                 }
                 return
 
@@ -932,6 +975,32 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 )
                 message = line[len(PROGRESS_MARKER) :].strip()
                 yield message
+                continue
+
+            if line.startswith(INSTALL_START_MARKER):
+                # `elapsed` is stale by up to the readline wait — recompute,
+                # or the install loses that much of its budget.
+                now = _time.monotonic() - start
+                installing = line[len(INSTALL_START_MARKER) :].strip()
+                install_started = now
+                pre_install_total = total_timeout
+                pre_install_inactivity = current_inactivity
+                total_timeout = max(
+                    total_timeout, now + install_budget + _INSTALL_GRACE
+                )
+                current_inactivity = max(
+                    current_inactivity, install_budget + _INSTALL_GRACE
+                )
+                yield f"Installing {installing}..."
+                continue
+
+            if line.startswith(INSTALL_END_MARKER):
+                if installing is not None:
+                    # Install time doesn't count against the cell's budget.
+                    now = _time.monotonic() - start
+                    total_timeout = pre_install_total + (now - install_started)
+                    current_inactivity = pre_install_inactivity
+                    installing = None
                 continue
 
             if line == RESULT_START:

--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -809,6 +809,8 @@ import threading
 
 from anton.core.backends.wire import (
     HEARTBEAT_MARKER,
+    INSTALL_END_MARKER,
+    INSTALL_START_MARKER,
     PROGRESS_MARKER,
     STDOUT_CHUNK_MARKER,
 )
@@ -827,6 +829,19 @@ try:
     )
 except ValueError:
     _HEARTBEAT_INTERVAL = 10.0
+
+# Budget for the in-cell auto-installer. The parent resolves
+# CoreSettings.cell_install_timeout and passes it through at spawn (see
+# LocalScratchpadRuntime.start), so the installer and the parent's kill
+# windows run off one number instead of two constants that can drift apart
+# (ENG-1275); the fallback mirrors that setting's default. Same
+# malformed-override guard as the heartbeat interval above.
+try:
+    _INSTALL_TIMEOUT = float(os.environ.get("ANTON_CELL_INSTALL_TIMEOUT", "120"))
+except ValueError:
+    _INSTALL_TIMEOUT = 120.0
+if _INSTALL_TIMEOUT <= 0:
+    _INSTALL_TIMEOUT = 120.0
 
 # Per-tick cap on salvage chunk size: bounds a single wire line even when a
 # cell floods stdout between ticks; the remainder ships on later ticks.
@@ -1178,26 +1193,54 @@ while True:
                 sys.stdout = _real_stdout
                 sys.stderr = sys.__stderr__
                 _cell_log_handler.buf = None
+                # The parent turns this marker into the visible "Installing
+                # X..." progress line and defers its kill windows to the
+                # install budget while the install runs (ENG-1275).
                 with _wire_lock:
-                    _real_stdout.write(
-                        PROGRESS_MARKER + " " + f"Installing {_missing}..." + "\n"
-                    )
+                    _real_stdout.write(INSTALL_START_MARKER + " " + _missing + "\n")
                     _real_stdout.flush()
                 import subprocess as _sp
 
                 _uv_path = os.environ.get("ANTON_UV_PATH", "")
-                if _uv_path:
-                    _pip = _sp.run(
-                        [_uv_path, "pip", "install", "--python", sys.executable, _missing],
-                        capture_output=True,
-                        timeout=120,
+                _pip = None
+                _install_error = None
+                try:
+                    if _uv_path:
+                        _pip = _sp.run(
+                            [_uv_path, "pip", "install", "--python", sys.executable, _missing],
+                            capture_output=True,
+                            timeout=_INSTALL_TIMEOUT,
+                        )
+                    else:
+                        _pip = _sp.run(
+                            [sys.executable, "-m", "pip", "install", _missing],
+                            capture_output=True,
+                            timeout=_INSTALL_TIMEOUT,
+                        )
+                except _sp.TimeoutExpired:
+                    # An uncaught raise here used to take down the whole
+                    # worker, and the parent reported a generic process death
+                    # with no mention of the install (ENG-1275).
+                    _install_error = (
+                        f"ModuleNotFoundError: No module named '{_missing}'\n"
+                        f"Auto-install of '{_missing}' was killed after "
+                        f"{_INSTALL_TIMEOUT:.0f}s (cell_install_timeout) without "
+                        "finishing — the package is not installed. Retrying may "
+                        "complete it (downloads are cached); for a large package, "
+                        "run the scratchpad's install action first."
                     )
-                else:
-                    _pip = _sp.run(
-                        [sys.executable, "-m", "pip", "install", _missing],
-                        capture_output=True,
-                        timeout=120,
+                except OSError as _exc:
+                    _install_error = (
+                        f"ModuleNotFoundError: No module named '{_missing}'\n"
+                        f"Auto-install of '{_missing}' could not run: {_exc}"
                     )
+                # Deliberately not in a finally: if the install failed in a
+                # way not handled above the worker is going down, and the
+                # missing end marker is what lets the parent name the install
+                # in the death report.
+                with _wire_lock:
+                    _real_stdout.write(INSTALL_END_MARKER + " " + _missing + "\n")
+                    _real_stdout.flush()
                 # Reset buffers and retry
                 out_buf = io.StringIO()
                 err_buf = io.StringIO()
@@ -1209,12 +1252,14 @@ while True:
                 _cell_log_handler.buf = log_buf
                 sys.stdout = out_buf
                 sys.stderr = err_buf
-                if _pip.returncode == 0:
+                if _pip is not None and _pip.returncode == 0:
                     _auto_installed.append(_missing)
                     try:
                         exec(compiled, namespace)
                     except Exception:
                         error = traceback.format_exc()
+                elif _install_error is not None:
+                    error = _install_error
                 else:
                     error = (
                         f"ModuleNotFoundError: No module named '{_missing}'\n"

--- a/anton/core/backends/wire.py
+++ b/anton/core/backends/wire.py
@@ -10,6 +10,11 @@ RESULT_END = "__ANTON_RESULT_END__"
 PROGRESS_MARKER = "__ANTON_PROGRESS__"
 HEARTBEAT_MARKER = "__ANTON_HEARTBEAT__"
 STDOUT_CHUNK_MARKER = "__ANTON_STDOUT_CHUNK__"
+# In-cell auto-install span (ENG-1275): the worker brackets its pip/uv run
+# with these so the parent can defer its kill windows to the install budget
+# and name the install if the cell dies anyway. Payload is the package name.
+INSTALL_START_MARKER = "__ANTON_INSTALL_START__"
+INSTALL_END_MARKER = "__ANTON_INSTALL_END__"
 
 
 def heal_surrogate_source(code: str) -> str:

--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -449,6 +449,18 @@ SCRATCHPAD_STUCK_NUDGE = (
     "native call may be hanging — give that call its own timeout. Reuse the "
     "SAME scratchpad; do not rename it."
 )
+# An install failure is neither a size nor a liveness problem — shrinking the
+# cell cannot make a package install, and a reset throws away a venv that may
+# already hold most of the download (ENG-1275). Routed on "auto-install" in
+# the error text, ahead of the other scratchpad branches.
+SCRATCHPAD_INSTALL_NUDGE = (
+    "\n\nSYSTEM: This scratchpad cell keeps failing on a package install, not "
+    "on its logic. Do not shrink or split the cell — that cannot make a "
+    "package install. Install the package explicitly with the scratchpad's "
+    "install action (double-check the PyPI name), then rerun the same cell. "
+    "If the explicit install also fails or times out, tell the user instead "
+    "of retrying."
+)
 # A budget kill with zero output is ambiguous — a stuck call and silent heavy
 # work look identical from outside. Say so, rather than confidently claiming
 # "too heavy" (the guess that taught the ENG-578 per-item pattern).

--- a/anton/core/memory/acc.py
+++ b/anton/core/memory/acc.py
@@ -470,6 +470,11 @@ def detect_kill_loop(events: Sequence[Event]) -> Lesson | None:
         # AMBIGUOUS and counts toward neither lesson: this rule is written
         # into durable memory, and no rule beats a wrong one.
         r = (e.detail.get("reason") or "").lower()
+        # Checked before "liveness": the mid-install kill wording contains
+        # both, and a kill during a package install says nothing about the
+        # cell's size or the worker's health (ENG-1275).
+        if "auto-install" in r:
+            return "ambiguous"
         if "liveness" in r or "inactivity" in r:
             return "liveness"
         if not r or "without producing any output" in r:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -28,6 +28,7 @@ from anton.core.tools.recall_skill import RECALL_SKILL_TOOL
 from anton.memory.history_store import is_user_turn
 from anton.core.llm.prompts import (
     RESILIENCE_NUDGE,
+    SCRATCHPAD_INSTALL_NUDGE,
     SCRATCHPAD_SIZE_NUDGE,
     SCRATCHPAD_SILENT_TIMEOUT_NUDGE,
     SCRATCHPAD_STUCK_NUDGE,
@@ -972,6 +973,12 @@ class ChatSession:
         if tool_name != "scratchpad":
             return RESILIENCE_NUDGE
         low = result_text.lower()
+        # An install failure/kill is neither a size nor a liveness problem —
+        # checked before both: the mid-install kill wording also contains
+        # "liveness", and the worker's install errors contain "killed"/
+        # "timed out"-adjacent words (ENG-1275).
+        if "auto-install" in low:
+            return SCRATCHPAD_INSTALL_NUDGE
         # A silence/liveness kill means the worker looked dead — "make the
         # cell smaller" is exactly the wrong advice there (ENG-578: it taught
         # per-item LLM round-trips). A budget kill that produced no output is

--- a/tests/test_scratchpad_watchdog_contracts.py
+++ b/tests/test_scratchpad_watchdog_contracts.py
@@ -169,6 +169,98 @@ class TestLivenessHeartbeat:
             await pad.close()
 
 
+class TestAutoInstallBudget:
+    """ENG-1275: the in-cell auto-installer must run under a budget derived
+    from CoreSettings.cell_install_timeout (one number, both sides), fail with
+    an error naming the install as the cause, and never take the pad down."""
+
+    async def test_install_past_install_timeout_fails_named_and_pad_survives(
+        self, monkeypatch, tmp_path
+    ):
+        """An install running past cell_install_timeout must produce a cell
+        error naming the auto-install and the module — and the worker must
+        survive it (no crash, next cell runs)."""
+        shrink_timers(monkeypatch)
+        monkeypatch.setenv("ANTON_CELL_INSTALL_TIMEOUT", "1")
+        stub = tmp_path / "hung_uv.sh"
+        stub.write_text("#!/bin/sh\nexec sleep 5\n")
+        stub.chmod(0o755)
+        monkeypatch.setenv("ANTON_UV_PATH", str(stub))
+        monkeypatch.setattr(
+            LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: None)
+        )
+        pad = make_pad()
+        await pad.start()
+        try:
+            cell = await pad.execute("import module_that_installs_slowly_eng1275")
+            assert cell.error is not None
+            low = cell.error.lower()
+            assert "auto-install" in low
+            assert "module_that_installs_slowly_eng1275" in cell.error
+            assert "liveness" not in low
+            follow_up = await pad.execute("print('pad-still-alive')")
+            assert follow_up.error is None
+            assert "pad-still-alive" in follow_up.stdout
+        finally:
+            await pad.close()
+
+    async def test_install_outlasting_total_budget_completes(
+        self, monkeypatch, tmp_path
+    ):
+        """The `import torch` shape: an install longer than the cell's total
+        budget must not be killed — the budget defers to the install's own
+        allowance while it runs, and the retried cell completes."""
+        monkeypatch.setenv("ANTON_CELL_INACTIVITY_TIMEOUT", "1")
+        monkeypatch.setenv("ANTON_CELL_INACTIVITY_MAX", "1")
+        monkeypatch.setenv("ANTON_CELL_INACTIVITY_AFTER_PROGRESS", "1")
+        monkeypatch.setenv("ANTON_CELL_TIMEOUT_DEFAULT", "2")
+        monkeypatch.setenv("ANTON_SCRATCHPAD_HEARTBEAT_INTERVAL", "0.2")
+        fake_mod = tmp_path / "eng1275_fake_mod.py"
+        stub = tmp_path / "slow_ok_uv.sh"
+        stub.write_text(
+            f"#!/bin/sh\nsleep 3\necho 'VALUE = 42' > '{fake_mod}'\nexit 0\n"
+        )
+        stub.chmod(0o755)
+        monkeypatch.setenv("ANTON_UV_PATH", str(stub))
+        monkeypatch.setattr(
+            LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: None)
+        )
+        pad = make_pad()
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                f"import sys\nsys.path.insert(0, {str(tmp_path)!r})\n"
+                "import eng1275_fake_mod\nprint(eng1275_fake_mod.VALUE)\n"
+            )
+            assert cell.error is None
+            assert "42" in cell.stdout
+        finally:
+            await pad.close()
+
+    async def test_worker_death_mid_install_names_install(
+        self, monkeypatch, tmp_path
+    ):
+        """A worker that dies while installing must not report the generic
+        'Process exited unexpectedly.' — the error names the install."""
+        shrink_timers(monkeypatch)
+        stub = tmp_path / "killer_uv.sh"
+        stub.write_text("#!/bin/sh\nkill -9 $PPID\n")
+        stub.chmod(0o755)
+        monkeypatch.setenv("ANTON_UV_PATH", str(stub))
+        monkeypatch.setattr(
+            LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: None)
+        )
+        pad = make_pad()
+        await pad.start()
+        try:
+            cell = await pad.execute("import module_whose_install_crashes_eng1275")
+            assert cell.error is not None
+            assert "auto-install" in cell.error.lower()
+            assert "module_whose_install_crashes_eng1275" in cell.error
+        finally:
+            await pad.close()
+
+
 class TestPartialStdoutSalvage:
     async def test_killed_cell_reports_partial_stdout(self, monkeypatch):
         """Prints from completed iterations survive a kill. Uses a

--- a/tests/test_scratchpad_watchdog_contracts.py
+++ b/tests/test_scratchpad_watchdog_contracts.py
@@ -524,6 +524,23 @@ class TestKillLoopLesson:
         ]
         assert detect_kill_loop(events) is None
 
+    def test_install_kills_write_no_rule(self):
+        """A kill during a package install says nothing about the cell's size
+        or the worker's health — no durable rule beats a wrong one (ENG-1275)."""
+        events = [
+            _kill_event(
+                "Cell killed during auto-install of 'torch' — the install ran "
+                "past its 120s budget and grace window without reporting a result",
+                round_idx=1,
+            ),
+            _kill_event(
+                "Cell killed during auto-install of 'torch' — no liveness signal "
+                "for 150s: the worker process died or the installer is wedged",
+                round_idx=2,
+            ),
+        ]
+        assert detect_kill_loop(events) is None
+
 
 class TestToolContractText:
     def test_description_does_not_claim_progress_is_survival_critical(self):

--- a/tests/test_scratchpad_watchdog_contracts.py
+++ b/tests/test_scratchpad_watchdog_contracts.py
@@ -14,6 +14,7 @@ import pytest
 from anton.core.backends.local import LocalScratchpadRuntime
 from anton.core.llm.prompts import (
     RESILIENCE_NUDGE,
+    SCRATCHPAD_INSTALL_NUDGE,
     SCRATCHPAD_SILENT_TIMEOUT_NUDGE,
     SCRATCHPAD_STUCK_NUDGE,
     SCRATCHPAD_TIMEOUT_NUDGE,
@@ -405,6 +406,39 @@ class TestNudgeRouting:
             ChatSession._select_resilience_nudge("web_search", "timed out")
             == RESILIENCE_NUDGE
         )
+
+    def test_install_timeout_error_routes_to_install_nudge(self):
+        """An install that ran out of its budget is neither a size nor a
+        liveness problem — 'make the cell smaller' cannot make a package
+        install (ENG-1275)."""
+        nudge = ChatSession._select_resilience_nudge(
+            "scratchpad",
+            "ModuleNotFoundError: No module named 'torch'\n"
+            "Auto-install of 'torch' was killed after 120s (cell_install_timeout) "
+            "without finishing — the package is not installed.",
+        )
+        assert nudge == SCRATCHPAD_INSTALL_NUDGE
+        assert "too heavy" not in nudge
+        assert "smaller" not in nudge
+
+    def test_install_failure_routes_to_install_nudge(self):
+        nudge = ChatSession._select_resilience_nudge(
+            "scratchpad",
+            "ModuleNotFoundError: No module named 'torhc'\n"
+            "Auto-install failed:\nERROR: No matching distribution found for torhc",
+        )
+        assert nudge == SCRATCHPAD_INSTALL_NUDGE
+
+    def test_kill_during_install_routes_to_install_nudge(self):
+        """The kill wording also contains 'liveness' — the install cause must
+        win over the stuck diagnosis."""
+        nudge = ChatSession._select_resilience_nudge(
+            "scratchpad",
+            "Cell killed during auto-install of 'torch' — no liveness signal "
+            "for 150s: the worker process died or the installer is wedged; "
+            "the package is likely not installed",
+        )
+        assert nudge == SCRATCHPAD_INSTALL_NUDGE
 
 
 from anton.core.memory.acc import Event, detect_kill_loop


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-1275/scratchpad-auto-install-is-killed-by-the-watchdog-it-runs-under-a-120s

- The in-cell auto-installer's pip/uv timeout is no longer a hardcoded 120s
- An install exceeding that budget no longer takes down the whole worker 
- New wire markers INSTALL_START_MARKER/INSTALL_END_MARKER bracket the install so the parent knows one is in flight
- While the install runs, the parent defers its inactivity and total-budget kill windows to the install budget + a 30s grace,.
- A kill or worker death that still happens mid-install names the package
- Install failures route to a new install-specific nudge
- The ACC kill-loop detector classifies install kills as ambiguous
