### PR TITLE
ENG-1453: Stop the anton test suite from opening real browser windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,24 @@ def make_llm_response():
 
 
 @pytest.fixture(autouse=True)
+def _no_browser_windows(monkeypatch):
+    """No test may pop a real browser window.
+
+    Every /publish, /share and `anton setup` path ends in ``webbrowser.open``,
+    and a stubbed prompt is all it takes to reach one: three tests in
+    test_openai_setup.py answer ``Confirm.ask`` with a blanket ``False``, which
+    the first prompt in ``_setup_minds`` reads as "no, I don't have an API key"
+    and so opens the MindsHub signup page — three windows on every local run.
+    Same posture as the analytics kill above: the suite never touches the
+    desktop. Tests that assert on the call still patch it themselves.
+    """
+    import webbrowser
+
+    for name in ("open", "open_new", "open_new_tab"):
+        monkeypatch.setattr(webbrowser, name, lambda *a, **kw: True)
+
+
+@pytest.fixture(autouse=True)
 def _no_builtin_skills(tmp_path_factory, monkeypatch):
     """Point the built-in skills root at an empty dir for all tests.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,8 +83,18 @@ def _no_browser_windows(monkeypatch):
     test_openai_setup.py answer ``Confirm.ask`` with a blanket ``False``, which
     the first prompt in ``_setup_minds`` reads as "no, I don't have an API key"
     and so opens the MindsHub signup page — three windows on every local run.
-    Same posture as the analytics kill above: the suite never touches the
-    desktop. Tests that assert on the call still patch it themselves.
+
+    Same *intent* as the analytics kill above — the suite never touches the
+    world outside the process — but not the same mechanism, which matters for
+    what it reaches: that one is a module-level env var, so it is live during
+    collection and inherited by subprocesses, while this is per-test and
+    parent-process only. Hence the one call site it cannot cover, the
+    module-level ``webbrowser.open`` in demo_data/nvda_btc_scratchpad_backup.py
+    that ``_agent_zero`` runs in a scratchpad subprocess (ENG-1453). No test
+    goes near it today.
+
+    Tests that assert on the call still patch it themselves. Deleting this
+    fixture is caught by tests/test_suite_guards.py.
     """
     import webbrowser
 

--- a/tests/test_suite_guards.py
+++ b/tests/test_suite_guards.py
@@ -1,0 +1,36 @@
+"""The suite's own guards must stay armed.
+
+conftest.py disarms things the suite is never allowed to do, and a disarmed
+side effect is invisible when it works — which is exactly how it rots. Delete
+the browser guard and three real `webbrowser.open` calls come back on every
+local run while CI stays green, because no assertion anywhere depends on it
+(ENG-1453). These tests are the thing that fails instead.
+"""
+from __future__ import annotations
+
+import webbrowser
+
+import pytest
+
+
+@pytest.mark.parametrize("name", ["open", "open_new", "open_new_tab"])
+def test_browser_guard_is_installed(name):
+    """`_no_browser_windows` must have replaced the stdlib entry point.
+
+    Checked by provenance rather than behaviour: actually calling the real
+    function is the failure mode under test, so the assertion has to hold
+    before any call happens.
+    """
+    fn = getattr(webbrowser, name)
+    assert fn.__module__ != "webbrowser", (
+        f"the _no_browser_windows guard in tests/conftest.py is not covering "
+        f"webbrowser.{name} — a local run will open real browser windows"
+    )
+    assert callable(fn)
+
+
+# Deliberately NOT asserted by calling it: `webbrowser.open(...) is True` holds
+# whether the guard is installed or not — the real function also returns True,
+# after opening a window. Mutation-verified: with the guard neutered that
+# assertion passes *and* opens a browser, making it both a blind test and an
+# instance of the very problem this file exists to catch.


### PR DESCRIPTION
## What

Adds one autouse fixture to `tests/conftest.py` so no test in the anton suite can open a real browser window, plus a regression test that fails if that guard is ever removed. Test-only — no shipped code path changes.

Closes ENG-1453.

## Why

Running the suite locally pops **three browser windows** on the MindsHub signup page. Nothing user-facing is broken; it's a papercut on every local `pytest` run, plus a moment of "did I just trigger something real?"

### Root cause

`_setup_minds` (`anton/cli.py`) asks three yes/no questions through the same `Confirm.ask`:

| Line | Question | What "no" does |
|---|---|---|
| `cli.py:709` | "Do you have a MindsHub API key?" | **opens the signup page in a browser** |
| `cli.py:770` | "Continue without SSL verification?" | skips the insecure retry |
| `cli.py:824` | "Try again?" | gives up, raises `_SetupRetry` |

Three tests in `tests/test_openai_setup.py` want to answer **no** to "Try again?" so setup terminates instead of looping, and do it by replacing `Confirm.ask` wholesale:

```python
monkeypatch.setattr(cli.Confirm, "ask", lambda *a, **kw: False)   # "# no retry"
```

The stub is prompt-blind, so it also answers "no, I don't have an API key" to the *first* prompt — which is exactly the branch that helpfully opens the signup page. Correct product behaviour, wrong context.

The three: `TestSetupErrorTextIsMarkupSafe::test_route_in_error_text_does_not_crash_setup`, `TestSetupErrorTextIsMarkupSafe::test_json_pointer_in_error_text_does_not_crash_setup`, `test_setup_minds_skips_no_ssl_retry_on_http_error`.

## How

```python
@pytest.fixture(autouse=True)
def _no_browser_windows(monkeypatch):
    import webbrowser
    for name in ("open", "open_new", "open_new_tab"):
        monkeypatch.setattr(webbrowser, name, lambda *a, **kw: True)
```

Setup still *decides* to open a browser; the function it calls does nothing. Same *intent* as the suite-wide analytics kill directly above it in that file (ENG-1288) — the suite is not allowed to touch the world outside the process — but deliberately **not** the same mechanism, and the difference is worth stating: the analytics kill is a module-level `os.environ.setdefault(...)`, so it is in force during collection and is inherited by subprocesses; an autouse `monkeypatch` fixture is per-test and parent-process only. That weaker reach is exactly why the seventh call site below is out of scope.

Plus a regression test for the guard itself (`tests/test_suite_guards.py`). Without it the guard is deletable in silence: neuter the fixture and three real browser calls return while CI stays green, because nothing asserts on it — the same rot the guard exists to prevent.

**Why the guard and not the three stubs.** Fixing the stubs fixes today. `webbrowser.open` is reachable from six in-process places — `/publish` and artifact preview (`tools.py:472`, `:613`), `/publish` and `/share` in chat (`chat.py:412`, `:473`, `:780`), and setup (`cli.py:715`) — and any blunt prompt stub can fall into one. Three tests already do; nothing stops the fourth.

**Known limit — there is a seventh call site this guard structurally cannot cover.** `anton/demo_data/nvda_btc_scratchpad_backup.py:497` calls `webbrowser.open` at **module level** (its step 12, "OPEN IN BROWSER"), and `_agent_zero` (`chat.py:937`) runs that file in a real scratchpad cell — i.e. a **subprocess**. An autouse fixture patches this process only, so nothing in `conftest.py` can reach it. Harmless today: nothing imports the module (it is referenced by path), pytest does not collect it, and no test exercises `_agent_zero`. Recorded here and on the ticket rather than papered over, because "fix the class, not the instance" is this PR's whole framing and this is where the class ends. Covering it would mean an env-var guard the subprocess inherits — out of scope, and not worth it until a test actually goes near that path.

**It masks no assertion.** The three `tests/test_publish_*.py` files that already `patch("webbrowser.open")` use it purely to suppress the side effect — checked each: none binds the mock or asserts it was called. Their local patches are now redundant but harmless, and still take precedence for any future test that *does* want to assert.

## Evidence

Measured, not reasoned. Ran the suite with a plugin that swapped `webbrowser.open`/`open_new`/`open_new_tab` for a stack-recorder, so calls were counted instead of executed.

**Before** (1945 passed, 28 skipped, `-m "not slow"`):

```
============================== BROWSER OPEN TRAP ===============================
>>> test_openai_setup.py::TestSetupErrorTextIsMarkupSafe::test_route_in_error_text_does_not_crash_setup
    -> webbrowser.open('https://auth.mindshub.ai/auth/realms/mindsdb/protocol/openid-connect/registrations?...')
       anton/cli.py, line 715, in _setup_minds
>>> test_openai_setup.py::TestSetupErrorTextIsMarkupSafe::test_json_pointer_in_error_text_does_not_crash_setup
>>> test_openai_setup.py::test_setup_minds_skips_no_ssl_retry_on_http_error

TOTAL webbrowser calls: 3
```

Exactly three — one per window, all from `_setup_minds`. No other test reaches any of the other in-process call sites.

Re-measured on the **full** suite including slow tests (`1997 passed / 28 skipped`): still **0** calls with the guard. Nothing hides behind the `slow` marker.

**After**, on this branch off `origin/staging`, same trap still installed:

```
============================== BROWSER OPEN TRAP ===============================
no webbrowser.open* calls
56 passed in 2.29s
```

That's the mutation check: same tests, 3 calls before the guard, 0 after, all still green.

**The guard's own regression test, mutation-verified both directions** (interpreter pinned to 3.11.14, no trap plugin loaded — the trap patches `webbrowser.open` itself and would fool a provenance assertion):

```
fixture neutered  -> 3 failed   tests/test_suite_guards.py
fixture restored  -> 3 passed
full suite        -> 1999 passed, 28 skipped
```

## Security pass

Reviewed per convention 8. The change is a test-only fixture that *removes* an outbound side effect; it adds no input handling, no logging, no new endpoint, no deserialization. Two things checked specifically:

- **Does it weaken a security-relevant assertion?** No — nothing in the suite asserts on `webbrowser.open`, so no test's meaning changes.
- **Does it hide a real problem?** The signup URL being opened is a hardcoded public Keycloak registration endpoint with no secrets in it, and it is correct behaviour for a real user. Nothing is being suppressed except the window.

## Scope

Deliberately **not** in this PR:

- Any change to `anton/cli.py`. A real user answering "no" should still get the signup page.
- **`os.environ.setdefault("BROWSER", "/usr/bin/true")` beside the analytics kill**, which would extend coverage to subprocesses and collection time. Declined, on two grounds. It buys nothing measurable today — the only subprocess call site is the demo-data script, which pytest does not collect and no test exercises, so there is no path it closes. And it is not portable: `/usr/bin/true` is POSIX-only, this repo ships `install.ps1`, and `BROWSER` leaks into *every* subprocess the suite spawns, including scratchpad cells. If a test ever does reach `_agent_zero`, the right form is that line guarded by `os.name == "posix"` — noted on ENG-1453 so the option isn't lost.
- The prompt-aware stub (`lambda prompt, *a, **kw: "API key" in str(prompt)`) that would fix the three tests' *intent* — they currently traverse a branch unrelated to what they assert. Tidiness, not a defect; worth doing next time that file is touched.
- ~~Three pre-existing failures seen during the investigation~~ — **withdrawn, they were never this PR's neighbours.** The original full-suite run happened in a clone sitting on an unrelated feature branch (`alejandrocantu/eng-1390-…`), and I attributed its failures to "the suite" rather than to that branch. Isolated since, with the interpreter held constant at 3.11.14: on clean `origin/staging` all three **pass**; on eng-1390 two of them still fail (`test_scratchpad_exec_via_chat` and `test_scratchpad_in_streaming_path`, both `Process exited unexpectedly`), and the third only fails in a full run, so it is order-dependent. Branch-local, not staging, and nothing to do with this PR. Flagged to the eng-1390 author separately.

## How to verify

```bash
uv run pytest -q tests/test_openai_setup.py
```

Before this change, three browser tabs open on the MindsHub signup page. After, none — and the tests pass either way, which is why this went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

