### PR TITLE
ENG-1286: bound a turn's token spend and ask the user before continuing

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2211,7 +2211,8 @@ class ChatSession:
         fire after real work had happened, on the reasoning that every call site
         sits inside the tool loop; that is true of LLM calls and false of tool
         dispatches, which happen later in the same iteration. The per-round call
-        site carries the progress condition explicitly — see `_spend_ceiling_ok`.
+        site carries the progress condition explicitly — see
+        `_spend_ceiling_stops_the_tool_loop`.
         """
         if self._max_turn_tokens <= 0 or self._turn_cost is None:
             return False
@@ -2788,7 +2789,14 @@ class ChatSession:
             # the cap mark above: public API, and the books are wired here too.
             # This path runs no completion verifier, so there is no continuation
             # gate to also check — the per-round check is the whole gate here.
-            if self._spend_ceiling_reached():
+            #
+            # Uses the same `_spend_ceiling_stops_the_tool_loop` as the streaming
+            # loop, NOT the bare predicate: the "never end a turn that dispatched
+            # no tools" guarantee is stated unconditionally ("at any ceiling"),
+            # and CLI/host callers have no lower bound on `max_turn_tokens` at
+            # all, so this path is exactly where a tiny ceiling would break the
+            # loop on round 1 having run nothing (#344 review).
+            if self._spend_ceiling_stops_the_tool_loop():
                 if self._turn_cost is not None:
                     self._turn_cost.ended_by = "spend_ceiling"
                 logger.info(

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -292,6 +292,21 @@ _TRANSIENT_VERDICT_ERRORS: tuple[type[BaseException], ...] = (
 # verdict" can never fire, since a latched session makes no verdict calls.
 _VERIFIER_LATCH_REPROBE_TURNS = 10
 
+# Floor for the tokens held back from the spend ceiling (ENG-1286).
+#
+# TWO calls land after the last check that passed, not one: the call that
+# carried the total over the gate (the gate is only read between calls, so the
+# crossing is never observed mid-flight), and then the hand-back diagnosis,
+# which is a full-history planning call. So the reserve has to cover both or the
+# turn overshoots the ceiling it promised — the actual per-call cost on these
+# turns is ~200k, which a flat 200k reserve under-covers by half.
+#
+# The live reserve is therefore `max(this, 2 x peak_context_tokens)`: the
+# turn's own largest call is the best available estimate of what the next two
+# will cost, and ENG-1288 already tracks it. This floor only applies before any
+# call has reported usage.
+_SPEND_CEILING_RESERVE = 200_000
+
 # Appended to the verifier system prompt. Shortens the preamble on narrating
 # models but is not sufficient alone (0/3 at 256 with it), so it pairs with the
 # budgets above. Tool name comes off the schema class so it can't go stale.
@@ -669,6 +684,10 @@ class ChatSession:
         self._max_tool_rounds = s.max_tool_rounds
         self._max_continuations = s.max_continuations
         self._verify_min_tool_rounds = s.verify_min_tool_rounds
+        # Per-turn raw-token ceiling (ENG-1286). getattr so a host passing an
+        # older settings object doesn't break — absent means "no ceiling",
+        # matching the pre-ENG-1286 behaviour rather than silently applying one.
+        self._max_turn_tokens = getattr(s, "max_turn_tokens", 0)
         # Latch for a verifier that fails the same hard way every turn — e.g.
         # kimi-K3 rejecting forced `tool_choice` with a 400 (ENG-1095), which
         # fails on every verdict call until the gateway fix lands. Without the
@@ -2175,6 +2194,71 @@ class ChatSession:
             # Reporting must never affect the turn that just ran.
             pass
 
+    def _spend_ceiling_reached(self) -> bool:
+        """True when this turn has spent enough that it must stop and ask.
+
+        Reads `TurnCost.total_tokens` — raw tokens, the unit the user's included
+        allowance drains in (see `CoreSettings.max_turn_tokens` for why cache
+        reads are NOT discounted here). Gated at `ceiling - reserve` so the
+        hand-back's own call fits inside the promised ceiling.
+
+        Returns False when the ceiling is disabled (0) or the books are closed,
+        so a host on older settings, or any path that runs outside a turn, keeps
+        exactly its pre-ENG-1286 behaviour.
+
+        Note this can only ever be consulted AFTER at least one LLM call has been
+        made — every call site sits inside the tool loop, which is only entered
+        once a planning response exists. So the gate cannot produce a turn that
+        made no call and said nothing.
+        """
+        if self._max_turn_tokens <= 0 or self._turn_cost is None:
+            return False
+        return self._turn_cost.total_tokens >= self._spend_ceiling_gate()
+
+    def _spend_ceiling_gate(self) -> int:
+        """The token total at which the turn must stop starting new work.
+
+        Sits a reserve below the ceiling because two more calls are still coming
+        after the last check that passed — the one that crosses the gate, and
+        the hand-back. Sized from this turn's own `peak_context_tokens` rather
+        than a constant: a turn carrying 190k of context per call overshoots a
+        flat 200k reserve by roughly a full call, which is precisely the bound
+        the ceiling exists to make true.
+
+        Floored at 1 so a pathological ceiling smaller than the reserve still
+        gates on something positive instead of tripping before any work.
+        """
+        peak = self._turn_cost.peak_context_tokens if self._turn_cost else 0
+        reserve = max(_SPEND_CEILING_RESERVE, 2 * peak)
+        return max(self._max_turn_tokens - reserve, 1)
+
+    def _spend_ceiling_notice(self) -> str:
+        """The SYSTEM injection for a ceiling stop.
+
+        Mirrors the 25-round cap's pause-and-ask wording deliberately: the user
+        already meets that shape when a long turn stops, and two different
+        "I stopped, shall I go on?" behaviours would read as two different
+        products. `Do NOT retry automatically` is what keeps this a question
+        rather than a speed bump the model drives straight through.
+
+        Deliberately does NOT quote a share of the user's allowance. The turn
+        knows its token count but not the plan behind it — BYOK users have no
+        MindsHub allowance at all — and inventing "you've used a quarter of your
+        month" for them would be a confident lie. The model is told what it
+        spent and asked to be honest that it was a lot.
+        """
+        spent = self._turn_cost.total_tokens if self._turn_cost is not None else 0
+        return (
+            f"SYSTEM: This turn has used {spent:,} tokens, which is a large amount "
+            "of work for a single request and counts against the user's plan. "
+            "Pause here. Summarize what you have accomplished so far and what "
+            "remains. Be straightforward that this has already taken a lot of "
+            "work, so the user can decide whether it is worth continuing. "
+            "If you are on a good track and can finish, say so and ask if they'd "
+            "like you to continue. "
+            "Do NOT retry automatically — wait for the user's response."
+        )
+
     async def _stream_handback_diagnosis(self, *, system: str, label: str):
         """Stream a hand-back diagnosis and persist exactly what the user read.
 
@@ -2652,6 +2736,28 @@ class ChatSession:
                             "Do NOT retry automatically — wait for the user's response."
                         ),
                     }
+                )
+                response = await self.plan_with_recovery(system=system)
+                break
+
+            # Spend ceiling (ENG-1286), mirroring turn_stream. Same reasoning as
+            # the cap mark above: public API, and the books are wired here too.
+            # This path runs no completion verifier, so there is no continuation
+            # gate to also check — the per-round check is the whole gate here.
+            if self._spend_ceiling_reached():
+                if self._turn_cost is not None:
+                    self._turn_cost.ended_by = "spend_ceiling"
+                logger.info(
+                    "spend ceiling reached (turn): tokens=%d ceiling=%d "
+                    "tool_round=%d — pausing to ask the user",
+                    self._turn_cost.total_tokens if self._turn_cost else 0,
+                    self._max_turn_tokens, tool_round,
+                )
+                self._append_history(
+                    {"role": "assistant", "content": response.content or ""}
+                )
+                self._append_history(
+                    {"role": "user", "content": self._spend_ceiling_notice()}
                 )
                 response = await self.plan_with_recovery(system=system)
                 break
@@ -3412,6 +3518,12 @@ class ChatSession:
         # task isn't actually done yet.
         continuation = 0
         _max_rounds_hit = False
+        # Set when the per-turn spend ceiling stopped the turn (ENG-1286). Like
+        # `_max_rounds_hit` it also suppresses verification: the turn is already
+        # ending on an honest "I stopped, shall I continue?", and a verdict call
+        # would both cost more of the budget we just declared spent and risk
+        # forcing a continuation past it.
+        _spend_ceiling_hit = False
         # Set per verification-loop iteration (see below): tells the post-loop
         # fallback the current reply is already in history, so it must not append
         # it a second time (ENG-1155 double-append).
@@ -3476,6 +3588,41 @@ class ChatSession:
                     _reply_persisted = True
                     async for event in self._stream_handback_diagnosis(
                         system=system, label="max-tool-rounds"
+                    ):
+                        yield event
+                    break
+
+                # Spend ceiling (ENG-1286). Checked per round rather than only at
+                # the continuation gate: the measured runaway shape is 13-26
+                # CONSECUTIVE scratchpad calls inside one tool loop, which reaches
+                # the round cap having triggered no continuation at all — a
+                # continuation-gate-only check never sees it. Ordered after the
+                # round cap so a turn that breaches both still reports
+                # `round_cap`, leaving that path's behaviour untouched.
+                if self._spend_ceiling_reached():
+                    _spend_ceiling_hit = True
+                    if self._turn_cost is not None:
+                        self._turn_cost.ended_by = "spend_ceiling"
+                    logger.info(
+                        "spend ceiling reached: tokens=%d ceiling=%d reserve=%d "
+                        "tool_round=%d continuation=%d — pausing to ask the user",
+                        self._turn_cost.total_tokens if self._turn_cost else 0,
+                        self._max_turn_tokens, _SPEND_CEILING_RESERVE,
+                        tool_round, continuation,
+                    )
+                    self._append_history(
+                        {"role": "assistant", "content": llm_response.content or ""}
+                    )
+                    self._append_history(
+                        {"role": "user", "content": self._spend_ceiling_notice()}
+                    )
+                    # Same ENG-1155 capture the other four hand-back sites need:
+                    # the reply above is already in history, so without this the
+                    # post-loop fallback appends it again and the message the user
+                    # actually read is lost.
+                    _reply_persisted = True
+                    async for event in self._stream_handback_diagnosis(
+                        system=system, label="spend-ceiling"
                     ):
                         yield event
                     break
@@ -3960,7 +4107,7 @@ class ChatSession:
             # Skip when too few tool rounds were used (pure Q&A always skips at
             # tool_round==0; raising verify_min_tool_rounds also skips trivial
             # single-round turns) or when we hit the max-rounds hard stop.
-            if tool_round < self._verify_min_tool_rounds or _max_rounds_hit:
+            if tool_round < self._verify_min_tool_rounds or _max_rounds_hit or _spend_ceiling_hit:
                 break
 
             # Append the assistant's final text so the verifier can see it.
@@ -4236,7 +4383,35 @@ class ChatSession:
                     yield event
                 break
 
-            # INCOMPLETE — continue working
+            # INCOMPLETE — continue working, unless the budget for this turn is
+            # already gone. Checked here as well as per-round because a
+            # continuation re-enters the tool loop with a full history: the round
+            # counter resets to 0, so without this gate a turn can spend the
+            # ceiling several times over across continuations and each pass looks
+            # cheap to the per-round check (ENG-1286).
+            if self._spend_ceiling_reached():
+                _spend_ceiling_hit = True
+                if self._turn_cost is not None:
+                    self._turn_cost.ended_by = "spend_ceiling"
+                logger.info(
+                    "spend ceiling reached at the continuation gate: tokens=%d "
+                    "ceiling=%d continuation=%d — pausing to ask the user",
+                    self._turn_cost.total_tokens if self._turn_cost else 0,
+                    self._max_turn_tokens, continuation,
+                )
+                self._append_history(
+                    {"role": "user", "content": self._spend_ceiling_notice()}
+                )
+                # `_reply_persisted` is already True here — the verification block
+                # appends the assistant reply before requesting a verdict — so the
+                # post-loop fallback is already suppressed and only the diagnosis
+                # needs capturing.
+                async for event in self._stream_handback_diagnosis(
+                    system=system, label="spend-ceiling"
+                ):
+                    yield event
+                break
+
             continuation += 1
             if self._turn_cost is not None:
                 self._turn_cost.continuations = continuation

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2206,30 +2206,74 @@ class ChatSession:
         so a host on older settings, or any path that runs outside a turn, keeps
         exactly its pre-ENG-1286 behaviour.
 
-        Note this can only ever be consulted AFTER at least one LLM call has been
-        made — every call site sits inside the tool loop, which is only entered
-        once a planning response exists. So the gate cannot produce a turn that
-        made no call and said nothing.
+        This is pure arithmetic and says nothing about whether the turn has done
+        any WORK yet. An earlier version of this docstring claimed it could only
+        fire after real work had happened, on the reasoning that every call site
+        sits inside the tool loop; that is true of LLM calls and false of tool
+        dispatches, which happen later in the same iteration. The per-round call
+        site carries the progress condition explicitly — see `_spend_ceiling_ok`.
         """
         if self._max_turn_tokens <= 0 or self._turn_cost is None:
             return False
         return self._turn_cost.total_tokens >= self._spend_ceiling_gate()
 
+    def _spend_ceiling_stops_the_tool_loop(self) -> bool:
+        """Should the tool loop stop here on the spend ceiling?
+
+        The ceiling, plus the one thing it must never do: end a turn that has
+        dispatched no tools at all. The gate is checked at the TOP of a round,
+        before dispatch, so on the first round a small ceiling would break the
+        loop having run nothing — the user gets a "this used a lot of tokens"
+        message for a task that never started.
+
+        `TurnCost.rounds` is turn-wide (it accumulates across verifier-forced
+        continuations rather than resetting with the loop-local counter), so
+        `> 1` means at least one round has completed its dispatch — including
+        rounds from an earlier continuation, which is why a continuation cannot
+        hand out a fresh free round.
+
+        Belt and braces with the reserve cap in `_spend_ceiling_gate`: that cap
+        keeps the gate proportional to the ceiling, this keeps the guarantee true
+        even for a ceiling smaller than a single call — a shape the settings
+        floor is supposed to prevent, but which anton's own `max_turn_tokens`
+        has no bounds on for CLI and host callers.
+        """
+        if not self._spend_ceiling_reached():
+            return False
+        rounds = self._turn_cost.rounds if self._turn_cost is not None else 0
+        return rounds > 1
+
     def _spend_ceiling_gate(self) -> int:
         """The token total at which the turn must stop starting new work.
 
         Sits a reserve below the ceiling because two more calls are still coming
-        after the last check that passed — the one that crosses the gate, and
-        the hand-back. Sized from this turn's own `peak_context_tokens` rather
-        than a constant: a turn carrying 190k of context per call overshoots a
-        flat 200k reserve by roughly a full call, which is precisely the bound
-        the ceiling exists to make true.
+        after the last check that passed — the one that crosses the gate (the
+        total is only read *between* calls, so the crossing is never observed
+        mid-flight), and the hand-back. Sized from this turn's own
+        `peak_context_tokens` rather than a constant: a turn carrying 190k of
+        context per call overshoots a flat 200k reserve by roughly a full call.
 
-        Floored at 1 so a pathological ceiling smaller than the reserve still
-        gates on something positive instead of tripping before any work.
+        **The reserve is capped at half the ceiling**, and that cap is the whole
+        reason small ceilings are usable. Without it the reserve bears no
+        relation to the ceiling's size, so any ceiling at or below the reserve
+        drove this to the `max(..., 1)` floor — the gate then tripped on the
+        first check, before any tool had been dispatched, and the turn still
+        paid for two calls. Measured at a 100k ceiling with 190k contexts: zero
+        tools run, 400k spent, 300% over the number the user asked for. The cap
+        binds only below ~2x the reserve; at the 1.25M default it changes
+        nothing.
+
+        The bound this produces is close, not exact: the reserve is derived from
+        `peak_context_tokens` (input + cache_read + cache_creation) but compared
+        against `total_tokens`, which also counts output, so a turn can land
+        over the ceiling by roughly two output budgets. See
+        `test_total_is_bounded_by_the_ceiling` for the asserted form.
         """
         peak = self._turn_cost.peak_context_tokens if self._turn_cost else 0
-        reserve = max(_SPEND_CEILING_RESERVE, 2 * peak)
+        reserve = min(
+            max(_SPEND_CEILING_RESERVE, 2 * peak),
+            max(self._max_turn_tokens // 2, 1),
+        )
         return max(self._max_turn_tokens - reserve, 1)
 
     def _spend_ceiling_notice(self) -> str:
@@ -3599,15 +3643,15 @@ class ChatSession:
                 # continuation-gate-only check never sees it. Ordered after the
                 # round cap so a turn that breaches both still reports
                 # `round_cap`, leaving that path's behaviour untouched.
-                if self._spend_ceiling_reached():
+                if self._spend_ceiling_stops_the_tool_loop():
                     _spend_ceiling_hit = True
                     if self._turn_cost is not None:
                         self._turn_cost.ended_by = "spend_ceiling"
                     logger.info(
-                        "spend ceiling reached: tokens=%d ceiling=%d reserve=%d "
+                        "spend ceiling reached: tokens=%d ceiling=%d gate=%d "
                         "tool_round=%d continuation=%d — pausing to ask the user",
                         self._turn_cost.total_tokens if self._turn_cost else 0,
-                        self._max_turn_tokens, _SPEND_CEILING_RESERVE,
+                        self._max_turn_tokens, self._spend_ceiling_gate(),
                         tool_round, continuation,
                     )
                     self._append_history(
@@ -4388,11 +4432,19 @@ class ChatSession:
                 break
 
             # INCOMPLETE — continue working, unless the budget for this turn is
-            # already gone. Checked here as well as per-round because a
-            # continuation re-enters the tool loop with a full history: the round
-            # counter resets to 0, so without this gate a turn can spend the
-            # ceiling several times over across continuations and each pass looks
-            # cheap to the per-round check (ENG-1286).
+            # already gone.
+            #
+            # NOT because the per-round check misses continuation spend: an
+            # earlier version of this comment said the round counter resets so
+            # each pass "looks cheap", which is wrong — `TurnCost` is built once
+            # per turn and `add()` accumulates, so the per-round check always
+            # sees the turn's full running total. Deleting this gate on the
+            # strength of disproving that rationale would still be a regression.
+            #
+            # The real reason: a continuation whose planning call returns a TEXT
+            # reply never enters the tool loop, so the per-round check is never
+            # reached and the turn would end `completed` with no hand-back at
+            # all, however much it had spent (ENG-1286).
             if self._spend_ceiling_reached():
                 _spend_ceiling_hit = True
                 if self._turn_cost is not None:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3621,6 +3621,10 @@ class ChatSession:
                     # post-loop fallback appends it again and the message the user
                     # actually read is lost.
                     _reply_persisted = True
+                    yield StreamTaskProgress(
+                        phase="analyzing",
+                        message="Reached this task's token budget — checking in with you...",
+                    )
                     async for event in self._stream_handback_diagnosis(
                         system=system, label="spend-ceiling"
                     ):
@@ -4406,6 +4410,10 @@ class ChatSession:
                 # appends the assistant reply before requesting a verdict — so the
                 # post-loop fallback is already suppressed and only the diagnosis
                 # needs capturing.
+                yield StreamTaskProgress(
+                    phase="analyzing",
+                    message="Reached this task's token budget — checking in with you...",
+                )
                 async for event in self._stream_handback_diagnosis(
                     system=system, label="spend-ceiling"
                 ):

--- a/anton/core/settings.py
+++ b/anton/core/settings.py
@@ -34,6 +34,22 @@ class CoreSettings(BaseSettings):
     # is skipped). Raise to 2 to also skip trivial single-tool-round turns once
     # verdict logs confirm they're rarely INCOMPLETE (ENG-716).
     verify_min_tool_rounds: int = 1
+    # Per-turn spend ceiling in RAW tokens — input + output + cache_read +
+    # cache_creation, i.e. `TurnCost.total_tokens` (ENG-1286). 0 disables it.
+    #
+    # RAW is deliberate, and the instinct to discount cache reads here is wrong:
+    # they bill at ~a tenth, but they draw the user's included-token allowance at
+    # full 1:1 weight (`auth/entitlements/services/included_usage.py` sums
+    # input + output + cached_input). This ceiling protects the user's allowance,
+    # so it counts the unit that allowance drains in. The TPM limiter's identical
+    # weighting IS a defect (ENG-1132) because it guards money — same arithmetic,
+    # opposite verdict, because they protect different things.
+    #
+    # 1.25M measured against 30 days of production (2026-08-12): trips ~15% of
+    # external turns at a median of 16 LLM calls in. Set above Kiranam's worst
+    # turn (1,480,766) and you stop catching the case this exists for — 1.5M
+    # misses it by 20k tokens.
+    max_turn_tokens: int = 1_250_000
     context_pressure_threshold: float = 0.7
     max_consecutive_errors: int = 5
     resilience_nudge_at: int = 2

--- a/tests/test_spend_ceiling.py
+++ b/tests/test_spend_ceiling.py
@@ -393,18 +393,28 @@ async def test_ceiling_trips_at_the_continuation_gate(workspace):
     assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
 
 
-async def test_ceiling_applies_to_the_non_streaming_turn(workspace):
+@pytest.mark.parametrize("ceiling", [CEILING, 100_000, 1])
+async def test_ceiling_applies_to_the_non_streaming_turn(workspace, ceiling):
     """`turn()` runs no verifier, so its per-round check is the whole gate.
 
     Public API with no in-tree caller, but its cost books are wired, so a
     silently unbounded path here would under-report every host that uses it.
+
+    Parametrised down to a ceiling of 1 because this path is where the
+    never-zero-tools guarantee is easiest to lose: it gated on the bare
+    predicate rather than `_spend_ceiling_stops_the_tool_loop`, so a small
+    ceiling broke the loop on round 1 having dispatched nothing (#344 review).
+    CLI and host callers have no lower bound on `max_turn_tokens`, so the
+    product floor does not protect them.
     """
-    session = _session(workspace, per_call=190_000,
+    session = _session(workspace, ceiling=ceiling, per_call=190_000,
                        responses=[_tool_call(i) for i in range(1, 40)])
     with patch("anton.analytics.send_event") as send:
         await session.turn("do the thing")
     assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
-    assert session.tool_registry.dispatch_tool.call_count > 0
+    assert session.tool_registry.dispatch_tool.call_count > 0, (
+        f"ceiling={ceiling:,} ended turn() having dispatched no tools"
+    )
 
 
 async def test_empty_diagnosis_does_not_double_append_the_reply(workspace):

--- a/tests/test_spend_ceiling.py
+++ b/tests/test_spend_ceiling.py
@@ -196,6 +196,28 @@ async def test_verification_is_skipped_after_a_ceiling_trip(workspace):
     )
 
 
+async def test_ceiling_stop_announces_itself_to_the_host(workspace):
+    """The stop emits a progress marker, like the other hand-back paths.
+
+    Without it a ceiling stop is indistinguishable, at the host boundary, from
+    the agent simply choosing to ask a question — and the ceiling is expected to
+    fire on roughly 1 in 5 external turns, so "the agent gave up" is the reading
+    a user would otherwise land on. The marker is ephemeral in today's renderer;
+    a persistent paused-state affordance is tracked separately.
+    """
+    from anton.core.llm.provider import StreamTaskProgress
+
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 12)])
+    seen = []
+    with patch("anton.analytics.send_event"):
+        async for ev in session.turn_stream("do the thing"):
+            if isinstance(ev, StreamTaskProgress):
+                seen.append(ev.message or "")
+    assert any("token budget" in m for m in seen), (
+        f"no ceiling marker among progress events: {seen}"
+    )
+
+
 async def test_turn_under_the_ceiling_is_untouched(workspace):
     """No behaviour change for a turn that never reaches the gate."""
     session = _session(workspace, responses=[_tool_call(1), _text("all done")],

--- a/tests/test_spend_ceiling.py
+++ b/tests/test_spend_ceiling.py
@@ -28,9 +28,17 @@ from anton.core.llm.provider import (
 from anton.core.session import ChatSession, ChatSessionConfig, _SPEND_CEILING_RESERVE
 
 CEILING = 1_000_000
-# Per call: enough that two calls clear (CEILING - reserve) and one does not,
-# so the tests can place the trip at a known round.
-PER_CALL = 500_000
+# Sized so the trip needs SEVERAL rounds. The first version used 500_000, which
+# breached the gate on the very first call — that made `rounds`/`continuations`
+# assertions structurally unfalsifiable, so the placement guard below passed
+# even with the per-round gate disabled. At 100_000 (context 75_000, reserve
+# 200_000, gate 800_000) the trip lands around round 8.
+PER_CALL = 100_000
+# The product floor for the user-settable ceiling (cowork-server
+# `UserSettings.max_turn_tokens` ge=750_000). Below one call's cost no ceiling
+# can avoid overshooting, so the floor is what keeps the setting honest — these
+# tests pin that the floor itself still does real work.
+PRODUCT_FLOOR = 750_000
 
 
 @pytest.fixture()
@@ -128,16 +136,25 @@ async def test_ceiling_stops_the_turn_and_marks_the_exit(workspace):
 
 
 async def test_total_is_bounded_by_the_ceiling(workspace):
-    """The turn's spend lands at or under the ceiling.
+    """The turn's spend lands at the ceiling, give or take two output budgets.
 
-    The reserve is what makes this hold: the hand-back diagnosis is itself an
-    LLM call, so gating AT the ceiling would overshoot it by that call's cost.
+    The reserve is what makes this hold at all: the hand-back diagnosis is
+    itself an LLM call, so gating AT the ceiling would overshoot by that call.
+
+    The slack is not slop — it is the exact residual of the design. The reserve
+    is derived from `peak_context_tokens` (input + cache_read + cache_creation)
+    but compared against `total_tokens`, which also counts output, so the two
+    calls that land after the last passing check contribute their output on top.
+    Asserting `<= CEILING` exactly passed only because the old fixture happened
+    to land on 1,000,000 with zero margin; it reddened as soon as `per_call`
+    moved. State the real bound instead of a knife-edge one.
     """
-    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 20)])
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 40)])
     with patch("anton.analytics.send_event") as send:
         await _run(session)
+    slack = 2 * (PER_CALL // 4)  # `_usage` puts a quarter of each call in output
     # Analytics properties go over the wire as strings.
-    assert int(send.call_args.kwargs["tokens_total"]) <= CEILING
+    assert int(send.call_args.kwargs["tokens_total"]) <= CEILING + slack
 
 
 async def test_trips_inside_one_tool_loop_with_no_continuation(workspace):
@@ -147,13 +164,17 @@ async def test_trips_inside_one_tool_loop_with_no_continuation(workspace):
     consecutive scratchpad calls that reach the round cap having triggered no
     continuation at all. This is the regression guard for that placement.
     """
-    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 12)])
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 40)])
     with patch("anton.analytics.send_event") as send:
         await _run(session)
     kwargs = send.call_args.kwargs
     assert kwargs["ended_by"] == "spend_ceiling"
     assert int(kwargs["continuations"]) == 0, "must trip without needing a continuation"
     assert int(kwargs["rounds"]) < 25, "must trip before the round cap, not because of it"
+    # Load-bearing: without this the whole test passes on a turn that tripped on
+    # its FIRST call, where "no continuation" and "under the round cap" are true
+    # by construction and say nothing about where the check lives.
+    assert int(kwargs["rounds"]) > 1, "must have run several rounds before tripping"
 
 
 async def test_handback_asks_the_user_and_is_persisted_as_streamed(workspace):
@@ -284,3 +305,129 @@ async def test_cache_reads_count_toward_the_ceiling(workspace):
         "a turn made almost entirely of cache reads still exhausts the "
         "user's included-token allowance"
     )
+
+
+# ── The guarantee: a ceiling stop never ends a turn that did nothing ────────
+
+
+@pytest.mark.parametrize("ceiling", [PRODUCT_FLOOR, 250_000, 100_000, 1])
+async def test_a_ceiling_stop_never_dispatches_zero_tools(workspace, ceiling):
+    """At ANY ceiling, the turn runs at least one tool before stopping.
+
+    The regression this pins was user-reachable: the reserve was
+    `max(200_000, 2 * peak)` with no relation to the ceiling, so any ceiling at
+    or below the reserve drove the gate to its `max(..., 1)` floor. The check
+    runs at the TOP of a round, before dispatch, so the loop broke having run
+    nothing — and still paid for two calls. Measured at a 100k ceiling with
+    190k contexts: 0 tools, 400k spent, 300% over what the user asked for.
+
+    The whole lower half of the range the Settings UI advertised sat in that
+    band. Parametrised down to `1` deliberately: anton's own `max_turn_tokens`
+    has no lower bound for CLI and host callers, so the guarantee cannot rest
+    on the product floor alone.
+    """
+    session = _session(workspace, ceiling=ceiling, per_call=190_000,
+                       responses=[_tool_call(i) for i in range(1, 40)])
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    assert session.tool_registry.dispatch_tool.call_count > 0, (
+        f"ceiling={ceiling:,} ended the turn having dispatched no tools"
+    )
+    assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
+
+
+async def test_gate_stays_proportional_to_the_ceiling(workspace):
+    """The reserve can never eat the whole ceiling.
+
+    Unit-level companion to the parametrised test above: it pins the arithmetic
+    rather than the behaviour, so a future change that keeps tools running by
+    some other means still can't reintroduce a gate of 1.
+    """
+    from anton.core.turn_cost import TurnCost
+
+    session = _session(workspace, ceiling=300_000)
+    session._turn_cost = TurnCost()
+    session._turn_cost.peak_context_tokens = 5_000_000  # absurd, on purpose
+    assert session._spend_ceiling_gate() >= 300_000 // 2
+    # …and the cap does not disturb the shipped default.
+    session._max_turn_tokens = 1_250_000
+    session._turn_cost.peak_context_tokens = 190_000
+    assert session._spend_ceiling_gate() == 1_250_000 - 380_000
+
+
+async def test_the_setting_actually_reaches_the_session(workspace):
+    """The wiring from settings to session, which nothing else covers.
+
+    `getattr(s, "max_turn_tokens", 0)` is deliberately fail-open, so a typo in
+    the key name silently disables the ceiling with no exception, no log and no
+    `ended_by` — and every other test in this file pokes `_max_turn_tokens`
+    directly after construction, so all of them would still pass.
+    """
+    from anton.core.settings import CoreSettings
+
+    session = ChatSession(ChatSessionConfig(llm_client=make_mock_llm(),
+                                            workspace=workspace))
+    assert session._max_turn_tokens == CoreSettings().max_turn_tokens == 1_250_000
+
+
+async def test_ceiling_trips_at_the_continuation_gate(workspace):
+    """A continuation whose planning call returns TEXT never enters the tool
+    loop, so only the continuation gate can stop it.
+
+    Both non-per-round call sites were previously uncovered: replacing either
+    with `if False:` left the entire 2,012-test suite green.
+    """
+    from anton.core.session import _VerifierVerdict
+
+    # One tool round, then text replies — so the tool loop exits and the
+    # verifier's INCOMPLETE drives a continuation that uses no tools at all.
+    session = _session(workspace, per_call=300_000,
+                       responses=[_tool_call(1), _text("partial"),
+                                  _text("still going"), _text("more")])
+    verdicts = [_VerifierVerdict(status="INCOMPLETE", reason="not done")]
+    session._llm.generate_object_code = AsyncMock(
+        side_effect=lambda *a, **k: verdicts.pop(0) if verdicts
+        else _VerifierVerdict(status="INCOMPLETE", reason="not done"))
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
+
+
+async def test_ceiling_applies_to_the_non_streaming_turn(workspace):
+    """`turn()` runs no verifier, so its per-round check is the whole gate.
+
+    Public API with no in-tree caller, but its cost books are wired, so a
+    silently unbounded path here would under-report every host that uses it.
+    """
+    session = _session(workspace, per_call=190_000,
+                       responses=[_tool_call(i) for i in range(1, 40)])
+    with patch("anton.analytics.send_event") as send:
+        await session.turn("do the thing")
+    assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
+    assert session.tool_registry.dispatch_tool.call_count > 0
+
+
+async def test_empty_diagnosis_does_not_double_append_the_reply(workspace):
+    """The ENG-1155 guard on this path is load-bearing and was untested.
+
+    `_reply_persisted = True` is the SOLE writer on the ceiling path — the
+    verification block's own assignment is unreachable because the verifier
+    skip breaks first. Deleting it survived the whole repo.
+    """
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 40)])
+    with patch("anton.analytics.send_event"), \
+         patch.object(ChatSession, "_stream_handback_diagnosis",
+                      lambda self, **kw: _empty_stream()):
+        await _run(session)
+    assistants = [i for i, m in enumerate(session._history)
+                  if m.get("role") == "assistant" and isinstance(m.get("content"), str)]
+    tails = [session._history[i]["content"] for i in assistants[-2:]]
+    assert len(tails) < 2 or tails[0] != tails[1], (
+        f"the pre-stop reply was appended twice: {tails!r}"
+    )
+
+
+async def _empty_stream():
+    """A hand-back that streams nothing — the guarded empty-diagnosis case."""
+    return
+    yield  # pragma: no cover - makes this an async generator

--- a/tests/test_spend_ceiling.py
+++ b/tests/test_spend_ceiling.py
@@ -93,17 +93,10 @@ def _session(workspace, *, ceiling: int = CEILING, responses=None,
     mock_llm.usage_listener = None
     mock_llm.plan_stream = _plan_stream
     mock_llm.plan = _plan
-    settings = MagicMock()
-    settings.max_tool_rounds = 25
-    settings.max_continuations = 3
-    settings.verify_min_tool_rounds = 1
-    settings.max_turn_tokens = ceiling
-    settings.max_consecutive_errors = 5
-    settings.resilience_nudge_at = 2
-    settings.context_pressure_threshold = 0.7
     session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
-    # Override post-construction: ChatSession reads a real CoreSettings in
-    # __init__, and only these two knobs matter here.
+    # Set post-construction rather than through a settings object: ChatSession
+    # resolves a real CoreSettings in __init__ (so every other knob keeps its
+    # production default), and this is the only one these tests vary.
     session._max_turn_tokens = ceiling
     from anton.core.tools.registry import ToolOutcome
     session.tool_registry.dispatch_tool = AsyncMock(
@@ -184,13 +177,23 @@ async def test_verification_is_skipped_after_a_ceiling_trip(workspace):
 
     Verification would spend more of the budget we just declared exhausted, and
     an INCOMPLETE verdict would force a continuation straight past the ceiling.
+
+    Asserts on CALL COUNT, not on a raising side-effect. The first version of
+    this test raised `AssertionError` from the verdict call — and passed with the
+    skip removed, because the verdict site catches bare `Exception` and converts
+    anything raised there into a "hard verdict failure" that continues down the
+    diagnosis path. A test whose failure mode is swallowed by the code under test
+    proves nothing.
     """
     session = _session(workspace, responses=[_tool_call(i) for i in range(1, 12)])
-    session._llm.generate_object_code = AsyncMock(
-        side_effect=AssertionError("verifier must not run after a ceiling trip")
-    )
+    verdict = AsyncMock()
+    session._llm.generate_object_code = verdict
     with patch("anton.analytics.send_event"):
         await _run(session)
+    assert verdict.call_count == 0, (
+        f"the completion verifier ran {verdict.call_count}x after the ceiling "
+        "stopped the turn"
+    )
 
 
 async def test_turn_under_the_ceiling_is_untouched(workspace):

--- a/tests/test_spend_ceiling.py
+++ b/tests/test_spend_ceiling.py
@@ -1,0 +1,261 @@
+"""Per-turn spend ceiling (ENG-1286).
+
+Drives the real ``turn_stream``/``turn`` rather than poking the predicate,
+because the ceiling's whole job is wiring: which loop it is checked in, what it
+does to the verifier, and whether the message the user read reaches history.
+
+The fake LLM calls ``usage_listener`` exactly as ``LLMClient`` does — the
+listener is the narrow waist ENG-1288 installs, so a stub that skips it would
+leave ``total_tokens`` at 0 and every one of these tests would pass by never
+reaching the gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_mock_llm
+
+from anton.core.llm.provider import (
+    LLMResponse,
+    StreamComplete,
+    ToolCall,
+    Usage,
+)
+from anton.core.session import ChatSession, ChatSessionConfig, _SPEND_CEILING_RESERVE
+
+CEILING = 1_000_000
+# Per call: enough that two calls clear (CEILING - reserve) and one does not,
+# so the tests can place the trip at a known round.
+PER_CALL = 500_000
+
+
+@pytest.fixture()
+def workspace():
+    base = Path(__file__).resolve().parents[1] / ".pytest-workspace"
+    base.mkdir(parents=True, exist_ok=True)
+    return MagicMock(base=base)
+
+
+def _usage(n: int = PER_CALL) -> Usage:
+    # Spread across the four components on purpose: the ceiling counts RAW
+    # tokens, so a cache-heavy call must count the same as a fresh one. A gate
+    # that read only `input_tokens` would pass every other test in this file.
+    q = n // 4
+    return Usage(
+        input_tokens=q, output_tokens=q,
+        cache_read_tokens=q, cache_creation_tokens=n - 3 * q,
+    )
+
+
+def _tool_call(i: int = 1) -> LLMResponse:
+    return LLMResponse(
+        content="working",
+        tool_calls=[ToolCall(id=f"tc_{i}", name="scratchpad",
+                             input={"action": "view", "name": "main"})],
+        usage=_usage(), stop_reason="tool_use",
+    )
+
+
+def _text(text: str = "done") -> LLMResponse:
+    return LLMResponse(content=text, tool_calls=[], usage=_usage(),
+                       stop_reason="end_turn")
+
+
+def _session(workspace, *, ceiling: int = CEILING, responses=None,
+             per_call: int = PER_CALL) -> ChatSession:
+    """Session whose LLM emits `responses` in order and reports usage per call.
+
+    Falls back to a text reply once the script runs out, so a test that fails to
+    trip the gate terminates instead of looping.
+    """
+    mock_llm = make_mock_llm()
+    script = list(responses or [])
+
+    def _plan_stream(**kwargs):
+        async def _gen():
+            resp = script.pop(0) if script else _text()
+            # Exactly what LLMClient does on every completion (ENG-1288).
+            if mock_llm.usage_listener is not None:
+                mock_llm.usage_listener("planning", "test-model", _usage(per_call))
+            yield StreamComplete(response=resp)
+        return _gen()
+
+    async def _plan(**kwargs):
+        resp = script.pop(0) if script else _text()
+        if mock_llm.usage_listener is not None:
+            mock_llm.usage_listener("planning", "test-model", _usage(per_call))
+        return resp
+
+    mock_llm.usage_listener = None
+    mock_llm.plan_stream = _plan_stream
+    mock_llm.plan = _plan
+    settings = MagicMock()
+    settings.max_tool_rounds = 25
+    settings.max_continuations = 3
+    settings.verify_min_tool_rounds = 1
+    settings.max_turn_tokens = ceiling
+    settings.max_consecutive_errors = 5
+    settings.resilience_nudge_at = 2
+    settings.context_pressure_threshold = 0.7
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    # Override post-construction: ChatSession reads a real CoreSettings in
+    # __init__, and only these two knobs matter here.
+    session._max_turn_tokens = ceiling
+    from anton.core.tools.registry import ToolOutcome
+    session.tool_registry.dispatch_tool = AsyncMock(
+        return_value=ToolOutcome(content="stubbed tool result", ok=True)
+    )
+    return session
+
+
+def _history_text(session) -> str:
+    out = []
+    for m in session._history:
+        c = m.get("content")
+        if isinstance(c, str):
+            out.append(c)
+    return "\n".join(out)
+
+
+async def _run(session, prompt="do the thing"):
+    async for _ in session.turn_stream(prompt):
+        pass
+
+
+async def test_ceiling_stops_the_turn_and_marks_the_exit(workspace):
+    """The turn stops on the ceiling and books `spend_ceiling`."""
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 12)])
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
+
+
+async def test_total_is_bounded_by_the_ceiling(workspace):
+    """The turn's spend lands at or under the ceiling.
+
+    The reserve is what makes this hold: the hand-back diagnosis is itself an
+    LLM call, so gating AT the ceiling would overshoot it by that call's cost.
+    """
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 20)])
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    # Analytics properties go over the wire as strings.
+    assert int(send.call_args.kwargs["tokens_total"]) <= CEILING
+
+
+async def test_trips_inside_one_tool_loop_with_no_continuation(workspace):
+    """The runaway shape is consecutive tool calls in ONE loop.
+
+    A continuation-gate-only check never sees it — the measured tail is 13-26
+    consecutive scratchpad calls that reach the round cap having triggered no
+    continuation at all. This is the regression guard for that placement.
+    """
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 12)])
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    kwargs = send.call_args.kwargs
+    assert kwargs["ended_by"] == "spend_ceiling"
+    assert int(kwargs["continuations"]) == 0, "must trip without needing a continuation"
+    assert int(kwargs["rounds"]) < 25, "must trip before the round cap, not because of it"
+
+
+async def test_handback_asks_the_user_and_is_persisted_as_streamed(workspace):
+    """ENG-1155 property: history holds what the user actually read.
+
+    Also asserts the message asks rather than merely announcing — a ceiling the
+    user cannot get past is worse than no ceiling.
+    """
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 12)])
+    with patch("anton.analytics.send_event"):
+        await _run(session)
+    text = _history_text(session)
+    assert "Do NOT retry automatically" in text
+    assert "ask if they'd like you to continue" in text
+    # The streamed diagnosis, not the pre-stop reply, is the tail of history.
+    assert session._history[-1]["role"] == "assistant"
+
+
+async def test_verification_is_skipped_after_a_ceiling_trip(workspace):
+    """No verdict call once the ceiling has stopped the turn.
+
+    Verification would spend more of the budget we just declared exhausted, and
+    an INCOMPLETE verdict would force a continuation straight past the ceiling.
+    """
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 12)])
+    session._llm.generate_object_code = AsyncMock(
+        side_effect=AssertionError("verifier must not run after a ceiling trip")
+    )
+    with patch("anton.analytics.send_event"):
+        await _run(session)
+
+
+async def test_turn_under_the_ceiling_is_untouched(workspace):
+    """No behaviour change for a turn that never reaches the gate."""
+    session = _session(workspace, responses=[_tool_call(1), _text("all done")],
+                       per_call=1_000)
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    kwargs = send.call_args.kwargs
+    assert kwargs["ended_by"] == "completed"
+    text = _history_text(session)
+    assert "Do NOT retry automatically" not in text
+
+
+async def test_ceiling_of_zero_disables_the_gate(workspace):
+    """0 means off — a host on older settings keeps pre-ENG-1286 behaviour.
+
+    Uses per-call usage far above any plausible ceiling, so a gate that ignored
+    the 0 would certainly trip.
+    """
+    session = _session(workspace, ceiling=0,
+                       responses=[_tool_call(i) for i in range(1, 6)] + [_text()],
+                       per_call=5_000_000)
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    assert send.call_args.kwargs["ended_by"] != "spend_ceiling"
+
+
+async def test_reserve_is_held_back_for_the_handback(workspace):
+    """The gate fires below the ceiling by the reserve, not at it."""
+    from anton.core.turn_cost import TurnCost
+    session = _session(workspace)
+    session._turn_cost = TurnCost()  # no calls yet -> reserve is the floor
+    session._turn_cost.input_tokens = CEILING - _SPEND_CEILING_RESERVE - 1
+    assert not session._spend_ceiling_reached()
+    session._turn_cost.input_tokens = CEILING - _SPEND_CEILING_RESERVE
+    assert session._spend_ceiling_reached()
+
+
+async def test_reserve_scales_with_the_turn_s_own_call_size(workspace):
+    """A big-context turn reserves more, because its remaining calls cost more.
+
+    Without this the bound is a promise the ceiling cannot keep: two calls land
+    after the last passing check, and at 190k+ of context per call they exceed
+    a flat 200k reserve on their own.
+    """
+    from anton.core.turn_cost import TurnCost
+    session = _session(workspace)
+    session._turn_cost = TurnCost()
+    session._turn_cost.peak_context_tokens = 190_000
+    assert session._spend_ceiling_gate() == CEILING - 380_000
+    # A small-context turn keeps the floor rather than shrinking below it.
+    session._turn_cost.peak_context_tokens = 1_000
+    assert session._spend_ceiling_gate() == CEILING - _SPEND_CEILING_RESERVE
+
+
+async def test_cache_reads_count_toward_the_ceiling(workspace):
+    """Raw tokens, not cost-weighted — cache reads draw the user's allowance
+    at full 1:1 weight, so a cache-heavy turn must trip like any other.
+    """
+    from anton.core.turn_cost import TurnCost
+    session = _session(workspace)
+    session._turn_cost = TurnCost()
+    session._turn_cost.cache_read_tokens = CEILING - _SPEND_CEILING_RESERVE
+    assert session._spend_ceiling_reached(), (
+        "a turn made almost entirely of cache reads still exhausts the "
+        "user's included-token allowance"
+    )


### PR DESCRIPTION
Closes the spend-ceiling half of [ENG-1286](https://linear.app/mindsdb/issue/ENG-1286). The thrash-breaker half is split to [ENG-1492](https://linear.app/mindsdb/issue/ENG-1492) (instrumentation first) and is **not** in this PR.

## What this does

A turn that spends **1,250,000 raw tokens** stops, tells the user what it accomplished and what remains, and asks whether to continue. Reads ENG-1288's `TurnCost.total_tokens`; no new plumbing.

Before this, nothing anywhere counted what a single task had spent. The Kiranam session (ENG-836) burned ~3.64M tokens in ~50 minutes for no working result — **73% of a 5M monthly allowance in one sitting** — and breached no existing bound: never 60 RPM, never 20 concurrent, TPM only intermittently.

## Three decisions worth reviewing, with the evidence

**1. Raw tokens, not cost-weighted.** The instinct is to discount cache reads since they bill at ~a tenth. That is wrong *for this control*: cache reads draw the user's included-token allowance at full 1:1 weight — `auth/entitlements/services/included_usage.py:88-92` sums `input + output + cached_input`, and its docstring says so deliberately (*"leaving them out would let a long cached prefix buy far more than the granted allowance"*). The cheap rate applies only to overage dollars. This ceiling protects the **user's allowance**, so it counts the unit that allowance drains in. The TPM limiter's identical weighting *is* a defect (ENG-1132) because it guards money — same arithmetic, opposite verdict, because they protect different things.

**2. 1.25M, not 1.5M.** Kiranam's worst single turn was **1,480,766** tokens. 1.5M is the number you reach for instinctively and it misses the motivating case by 20k.

**3. The reserve is adaptive — `ceiling - max(200k, 2 × peak_context_tokens)`.** Two calls land after the last passing check, not one: the call that carries the total over the gate (it is only read *between* calls) and then the hand-back. Simulated over the same 30 days of production:

| reserve | trips | turns still **exceeding** 1.25M | worst |
|---|---|---|---|
| flat 200k | 12.3% | **15.6%** of trips | 1,704,923 |
| adaptive (this PR) | 12.7% | **1.2%** of trips | 1,546,740 |

The flat reserve breaks the bound for 1 in 6 trips. The adaptive one costs 0.4pp more trips. Residual, stated rather than hidden: the reserve estimates from the peak seen *so far*, so a call suddenly exceeding twice the previous peak can still overshoot.

## Placement

Checked **per tool round** and at the continuation gate, not the continuation gate alone. The measured runaway shape is 13–26 *consecutive* `scratchpad` calls inside one tool loop, reaching the round cap with **zero** continuations — a continuation-gate-only check never sees it. `test_trips_inside_one_tool_loop_with_no_continuation` is the regression guard.

Verification is skipped after a trip (same as the round cap): a verdict call would spend more of the budget just declared exhausted, and an INCOMPLETE verdict would force a continuation straight past the ceiling.

## Measured impact — read this before approving

This is a **visible product behaviour**, not a silent backstop. Over 30 days: **19.4% of external turns** would trip (351/1,812), 7.1% of staff turns, **12.7% overall ≈ 17 turns/day**. It fires at a median of **16 LLM calls** into the turn (p10 6, p90 25) — comparable to where the 25-round cap already sits.

The position taken: a turn spending a quarter of someone's monthly allowance should say so. If you disagree, the number is one constant.

## The path to continue

- Continuing is already free — a new user message is a new turn with a fresh `TurnCost`. Consent renews per turn rather than latching; a permanent "yes" would restore the runaway.
- The message mirrors the round cap's wording (`Do NOT retry automatically — wait for the user's response`) so users meet one behaviour, not two.
- Persisted via `_stream_handback_diagnosis`, so history holds what the user actually read (ENG-1155 property).

**Deviations from the ticket, flagged deliberately.**

*Two, not one.* The second was raised in review and is declared here rather than left for QA to file as a miss:

**(a) No resume injection.** ENG-1286's *How* says the resume should carry the existing *"Do not repeat work already done"* wording, and *Done when* has *"resumes without redoing completed work"*. The **budget** half is implemented and correct — the next turn gets a fresh `TurnCost`. The **resume** half has no mechanism: that wording exists only inside the verifier-INCOMPLETE branch, which a ceiling exit never reaches. Left as-is because the same ticket bullet says to reuse the round cap's shape rather than invent a second one, and the round cap plus the other three hand-back paths have no resume injection either. Adding one here alone would make the ceiling behave differently from every other stop.

**(b) The message quotes tokens, not allowance.** The ticket says the message should express cost *in allowance terms*. It does not. The turn knows its token count but not the plan behind it, and BYOK users have no MindsHub allowance at all — quoting "a quarter of your month" to them would be a confident lie. Wiring `check_minds_token_limits()` into the session is a follow-up. Reject this call if you'd rather have the allowance framing gated on provider.

## Testing

`tests/test_spend_ceiling.py` — 10 tests driving the real `turn_stream`/`turn`. The fake LLM invokes `usage_listener` exactly as `LLMClient` does; a stub that skipped it would leave `total_tokens` at 0 and every test would pass by never reaching the gate.

**Mutation-verified** — each of these was applied and the intended test failed:
- disable the per-round gate → the no-continuation placement test fails *(**corrected 2026-08-13:** as originally written this claim was FALSE. That test passed under the mutation; two others failed instead, and I inferred which one from a ``1 failed`` count without checking. The fixture tripped on the very first call, so its ``rounds``/``continuations`` assertions were unfalsifiable. Fixture re-sized; the claim now holds and is re-verified.)*
- let the verifier run after a trip → the skip test fails
- flat reserve instead of adaptive → the bound and scaling tests fail
- count only `input_tokens` (discount cache) → the raw-unit tests fail

Full suite: **2,009 passed**, 2 failures in `test_datasource.py` that reproduce on unmodified `origin/staging` (verified by stashing this diff) — pre-existing, not from this change.

## Security

Reviewed per convention 8. No new input parsing, endpoints, or authz surface. The one new user-visible string interpolates an integer from our own accounting — no user input reaches it. New log lines carry token counts and config values only, never conversation content or the verifier's `reason` (matching the existing verifier-logging convention). No path handling, deserialization, or credential access added.

## Merge order

Independent and safe to merge alone — the ceiling works standalone at its default. The follow-up cowork-server PR exposing **"Max Tokens per Step"** as a per-user setting (beside "Max Steps per Task" and "Max Auto-Continues") should merge **after** this one, since it overlays a field that must exist in anton first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
