### PR TITLE
ENG-1495: send turn_completed and rule_retrieval straight to PostHog instead of through the collector

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -130,10 +130,7 @@ _POSTHOG_EVENTS = frozenset({"turn_completed", "rule_retrieval"})
 _LIB = "anton-library"
 
 # urllib's default ``Python-urllib/3.x`` is answered with 403 by some edges.
-# Named for its one consumer (``_fire_posthog``) rather than the module: ``_fire``
-# still sends urllib's default, and a bare ``_USER_AGENT`` here collides with the
-# identically-valued constant anton#333 adds for the collector path, dragging
-# ``_POSTHOG_EVENTS`` into a conflict region it has nothing to do with.
+# Only ``_fire_posthog`` sends this; ``_fire`` still sends urllib's default.
 _POSTHOG_USER_AGENT = "anton-posthog/1.0"
 
 # Transport noise, not analytics: appended as a cache buster for the GET path.
@@ -331,6 +328,21 @@ def send_event(settings: "AntonSettings", action: str, **extra: str) -> None:
         }
         params.update(extra)
 
+        # Blanking ``analytics_url`` has always stopped EVERY event, because the
+        # ``if not url: return`` below used to sit above this branch. Keep that
+        # true: it is a de-facto kill switch people rely on, and a routed event
+        # that ignored it would start shipping turn metadata to PostHog on
+        # upgrade for someone who had deliberately switched telemetry off, with
+        # nothing telling them.
+        #
+        # Re-pointing the URL at a private collector is NOT treated as
+        # suppression here — that is a live question about what the variable
+        # means, not something to settle silently. ``ANTON_POSTHOG_KEY=""``
+        # disables this sink specifically; both are documented in
+        # docs/configure/analytics.md.
+        if not settings.analytics_url:
+            return
+
         if action in _POSTHOG_EVENTS:
             # POST, not GET: a query string is copied into gateway, CDN and WAF
             # access logs, which is how the sibling endpoint ended up with real
@@ -346,8 +358,6 @@ def send_event(settings: "AntonSettings", action: str, **extra: str) -> None:
             )
         else:
             url = settings.analytics_url
-            if not url:
-                return
             t = threading.Thread(
                 target=_fire,
                 args=(f"{url}?{urllib.parse.urlencode(params)}",),

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -280,16 +280,21 @@ def _fire_posthog(url: str, body: bytes) -> None:
     status inside a ``with`` block that a rejection never reaches, and its test
     passed only because the stub returned where urllib raises.
     """
-    request = urllib.request.Request(
-        url,
-        data=body,
-        method="POST",
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": _POSTHOG_USER_AGENT,
-        },
-    )
     try:
+        # Inside the try on purpose: `Request()` raises ValueError on a malformed
+        # URL, and a bad `ANTON_POSTHOG_HOST` is a user-supplied value. This runs
+        # in a daemon thread, outside `send_event`'s guard, so anything escaping
+        # here reaches the user as a traceback mid-session — which would break
+        # this module's stated guarantee that it never raises.
+        request = urllib.request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": _POSTHOG_USER_AGENT,
+            },
+        )
         urllib.request.urlopen(request, timeout=_TIMEOUT)
     except urllib.error.HTTPError as exc:
         # The status is worth more than a traceback to whoever is reading logs

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -86,6 +86,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import threading
 import time
@@ -96,6 +97,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from anton.config.settings import AntonSettings
+
+logger = logging.getLogger(__name__)
 
 _TIMEOUT = 3  # seconds
 
@@ -126,7 +129,11 @@ _POSTHOG_EVENTS = frozenset({"turn_completed", "rule_retrieval"})
 _LIB = "anton-library"
 
 # urllib's default ``Python-urllib/3.x`` is answered with 403 by some edges.
-_USER_AGENT = "anton-analytics/1.0"
+# Named for its one consumer (``_fire_posthog``) rather than the module: ``_fire``
+# still sends urllib's default, and a bare ``_USER_AGENT`` here collides with the
+# identically-valued constant anton#333 adds for the collector path, dragging
+# ``_POSTHOG_EVENTS`` into a conflict region it has nothing to do with.
+_POSTHOG_USER_AGENT = "anton-posthog/1.0"
 
 # Transport noise, not analytics: appended as a cache buster for the GET path.
 # Carries no meaning as a property, so the PostHog payload drops it.
@@ -242,7 +249,26 @@ def _posthog_body(key: str, action: str, params: dict[str, str]) -> bytes:
 
 
 def _fire_posthog(url: str, body: bytes) -> None:
-    """POST one Capture payload.  Runs inside a daemon thread."""
+    """POST one Capture payload.  Runs inside a daemon thread.
+
+    Reads the status and logs a non-2xx at debug.  Still fire-and-forget — no
+    retry, no raise, no effect on the caller — but the failure leaves a trace on
+    the machine where it happened instead of only in an aggregate nobody has
+    built yet.
+
+    **What this does and does not catch.**  Measured against the live endpoint,
+    2026-08-13:
+
+        bogus api_key      -> HTTP 200  {"status":"Ok"}     <- NOT detectable
+        real api_key       -> HTTP 200  {"status":"Ok"}
+        malformed payload  -> HTTP 400  "failed to hydrate events..."
+
+    So this catches a malformed payload and any transport failure, and it
+    **cannot** catch a wrong, rotated or revoked project token: PostHog accepts
+    an invalid key with 200 and drops the event server-side.  A token problem is
+    therefore invisible from here by construction, which is exactly why the
+    zero-volume alert on ``turn_completed`` is not optional.
+    """
     try:
         request = urllib.request.Request(
             url,
@@ -250,12 +276,15 @@ def _fire_posthog(url: str, body: bytes) -> None:
             method="POST",
             headers={
                 "Content-Type": "application/json",
-                "User-Agent": _USER_AGENT,
+                "User-Agent": _POSTHOG_USER_AGENT,
             },
         )
-        urllib.request.urlopen(request, timeout=_TIMEOUT)
+        with urllib.request.urlopen(request, timeout=_TIMEOUT) as response:
+            status = getattr(response, "status", None)
+            if status is not None and not 200 <= status < 300:
+                logger.debug("posthog capture rejected: HTTP %s", status)
     except Exception:
-        pass
+        logger.debug("posthog capture failed", exc_info=True)
 
 
 def send_event(settings: "AntonSettings", action: str, **extra: str) -> None:

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -112,9 +112,13 @@ _TIMEOUT = 3  # seconds
 #                    unknown_{tokens,calls}, llm_provider, harness,
 #                    anton_version, conversation_id, turn_index
 #
+#   rule_retrieval   outcome, when_rules, kept_rules, rules_chars,
+#                    stop_reason, input_tokens, output_tokens, duration_ms
+#                    (anton/core/memory/cortex.py::_emit_rule_retrieval)
+#
 # An event NOT listed here keeps the collector path, so moving one is an
 # explicit decision rather than something that happens by default.
-_POSTHOG_EVENTS = frozenset({"turn_completed"})
+_POSTHOG_EVENTS = frozenset({"turn_completed", "rule_retrieval"})
 
 # `$lib` names the sender, matching the convention the other emitters follow
 # (`cowork-desktop`, `mindshub-site-beacon`), so a per-emitter breakdown in

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -90,6 +90,7 @@ import logging
 import os
 import threading
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
@@ -232,9 +233,10 @@ def _posthog_body(key: str, action: str, params: dict[str, str]) -> bytes:
     }
     properties["$lib"] = _LIB
     # Store the event without creating a Person for the install fingerprint.
-    # Without this every `aid` becomes a "person" in a project keyed on
-    # Keycloak subs — roughly 800 of them against ~1,098 real identified
-    # people — inflating every person-count metric and cohort there.
+    # Without this every `aid` becomes a "person" in project 424726, which is
+    # keyed on the Keycloak `sub` — so machine fingerprints would be counted
+    # alongside real identified users in every person metric and cohort there,
+    # and no later query can separate them again.
     properties["$process_person_profile"] = False
 
     return json.dumps(
@@ -262,27 +264,37 @@ def _fire_posthog(url: str, body: bytes) -> None:
         bogus api_key      -> HTTP 200  {"status":"Ok"}     <- NOT detectable
         real api_key       -> HTTP 200  {"status":"Ok"}
         malformed payload  -> HTTP 400  "failed to hydrate events..."
+        absent  api_key    -> HTTP 401  "event submitted without an api_key"
 
     So this catches a malformed payload and any transport failure, and it
     **cannot** catch a wrong, rotated or revoked project token: PostHog accepts
-    an invalid key with 200 and drops the event server-side.  A token problem is
-    therefore invisible from here by construction, which is exactly why the
+    an invalid key with 200 and drops the event server-side.  The 401 is
+    unreachable from here — ``send_event`` returns early when the key is empty,
+    so a request without one is never built.  A token problem is therefore
+    invisible from this side by construction, which is exactly why the
     zero-volume alert on ``turn_completed`` is not optional.
+
+    Note the rejection is caught as ``HTTPError``, not read off a response.
+    ``urlopen`` **raises** on 4xx/5xx rather than returning something with a
+    ``.status`` to inspect — an earlier version of this function checked the
+    status inside a ``with`` block that a rejection never reaches, and its test
+    passed only because the stub returned where urllib raises.
     """
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": _POSTHOG_USER_AGENT,
+        },
+    )
     try:
-        request = urllib.request.Request(
-            url,
-            data=body,
-            method="POST",
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": _POSTHOG_USER_AGENT,
-            },
-        )
-        with urllib.request.urlopen(request, timeout=_TIMEOUT) as response:
-            status = getattr(response, "status", None)
-            if status is not None and not 200 <= status < 300:
-                logger.debug("posthog capture rejected: HTTP %s", status)
+        urllib.request.urlopen(request, timeout=_TIMEOUT)
+    except urllib.error.HTTPError as exc:
+        # The status is worth more than a traceback to whoever is reading logs
+        # on a user's machine.
+        logger.debug("posthog capture rejected: HTTP %s", exc.code)
     except Exception:
         logger.debug("posthog capture failed", exc_info=True)
 

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -8,21 +8,37 @@ an anonymous machine fingerprint, and whatever the caller passes as
 Where these events actually land
 ================================
 
-The collector lambda RELAYS into PostHog — verified 2026-08-06 against
-project 355390 ("Anton"), where anton's events appear tagged
-``source = mindsdb-zoominfo-lambda``.  Two consequences worth knowing before
-adding a caller:
+Two sinks, chosen per event name — see ``_POSTHOG_EVENTS``.
 
-* **Every ``extra`` kwarg becomes a queryable PostHog event property.**  Not
-  an allowlist — ``ds_connect_success`` carries its ``engine=postgres``
-  through, and ``turn_completed`` carries its full token breakdown.  So the
-  parameter names here ARE the analytics schema; renaming one silently breaks
-  whatever queries or dashboards read it.
-* **``distinct_id`` is the ``aid`` fingerprint, so these events are
-  per-INSTALL, not per-user.**  They do not join to the Keycloak ``sub`` that
-  the console, the desktop renderer's PostHog client, and the billing mirror
-  all key on.  Per-user questions need either that identified client or the
-  ``conversation_id`` -> Langfuse -> user hop.
+**Direct to PostHog, project 424726 ("MindsHub main").**  Events named in
+``_POSTHOG_EVENTS`` POST straight to the Capture API.  Every property
+survives, because nothing sits in between to drop them.
+
+**Everything else goes to the collector lambda,** which relays into PostHog
+project 355390 ("Anton") — verified 2026-08-06, where those events appear
+tagged ``source = mindsdb-zoominfo-lambda``.  That path filters **twice**:
+it relays only actions beginning ``anton_`` or ``ds_connect`` (a prefix
+rule, case-sensitive), and of the properties only ``action``, ``aid``,
+``engine``, ``llm_provider`` and ``has_mdb_key`` survive.  It returns
+**HTTP 200 while dropping**, and ``_fire`` never reads the response, so a
+caller cannot tell (ENG-1355).
+
+This docstring asserted the opposite until ENG-1495 — it claimed every
+``extra`` kwarg became a queryable property, "not an allowlist".  That was
+false, and it is the likeliest reason ``turn_completed`` shipped with a sink
+that produced nothing at all: it told the author no collector work was
+needed.  Do not restore that claim for either path.
+
+Consequences worth knowing before adding a caller:
+
+* **Choose the sink deliberately.**  A new event left on the collector path
+  arrives with its properties stripped unless they are the five above, and
+  does not arrive at all unless its name carries one of the two prefixes.
+* **``distinct_id`` is the ``aid`` fingerprint on both paths, so these events
+  are per-INSTALL, not per-user.**  They do not join to the Keycloak ``sub``
+  that the console, the desktop renderer's PostHog client, and the billing
+  mirror all key on.  Per-user questions need either that identified client
+  or the ``conversation_id`` -> Langfuse -> user hop.
 * PostHog additionally enriches server-side with IP and GeoIP.
 
 Identifier policy
@@ -69,6 +85,7 @@ enough to be a readable query parameter.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import threading
 import time
@@ -81,6 +98,35 @@ if TYPE_CHECKING:
     from anton.config.settings import AntonSettings
 
 _TIMEOUT = 3  # seconds
+
+# ── The PostHog sink (ENG-1495) ─────────────────────────────────────
+# The register of events that bypass the collector and post straight to
+# PostHog, each with its own properties documented — the same shape as
+# cowork's renderer register (``src/renderer/cowork/lib/analytics.js``), so
+# both clients read the same way.
+#
+#   turn_completed   ended_by, tokens_total, input_tokens, output_tokens,
+#                    cache_read_tokens, cache_creation_tokens, llm_calls,
+#                    rounds, continuations, peak_context_tokens, duration_ms,
+#                    {planning,coding,router}_{model,tokens,calls},
+#                    unknown_{tokens,calls}, llm_provider, harness,
+#                    anton_version, conversation_id, turn_index
+#
+# An event NOT listed here keeps the collector path, so moving one is an
+# explicit decision rather than something that happens by default.
+_POSTHOG_EVENTS = frozenset({"turn_completed"})
+
+# `$lib` names the sender, matching the convention the other emitters follow
+# (`cowork-desktop`, `mindshub-site-beacon`), so a per-emitter breakdown in
+# project 424726 stays honest.
+_LIB = "anton-library"
+
+# urllib's default ``Python-urllib/3.x`` is answered with 403 by some edges.
+_USER_AGENT = "anton-analytics/1.0"
+
+# Transport noise, not analytics: appended as a cache buster for the GET path.
+# Carries no meaning as a property, so the PostHog payload drops it.
+_CACHE_BUSTER_KEY = "_"
 
 # Cached after first computation — the fingerprint never changes within
 # a process, so computing it once is sufficient.
@@ -153,6 +199,61 @@ def get_installation_id() -> str:
     return _cached_aid
 
 
+def _posthog_body(key: str, action: str, params: dict[str, str]) -> bytes:
+    """Build the PostHog Capture API payload for one event.
+
+    ``aid`` becomes ``distinct_id`` and is kept as a property too, so a query
+    can group on the install without touching person data.  ``timestamp`` is
+    promoted to PostHog's own field: it is the moment the turn ended, not the
+    moment a queued daemon thread got around to sending, and for a cost event
+    that difference is the one you would go on to plot.
+
+    Deliberately no ``$insert_id``.  The natural key would be
+    ``(conversation_id, turn_index)``, but an abandoned turn's books and a
+    later retry can legitimately share both, and dropping that row would lose
+    exactly the runaway a cancel was investigating (anton#309 review).
+    ``TurnCost.emitted`` already stops the same books emitting twice, so
+    dedupe here could only add a way to lose real events.
+    """
+    properties = {
+        k: v for k, v in params.items()
+        if k not in (_CACHE_BUSTER_KEY, "action", "timestamp")
+    }
+    properties["$lib"] = _LIB
+    # Store the event without creating a Person for the install fingerprint.
+    # Without this every `aid` becomes a "person" in a project keyed on
+    # Keycloak subs — roughly 800 of them against ~1,098 real identified
+    # people — inflating every person-count metric and cohort there.
+    properties["$process_person_profile"] = False
+
+    return json.dumps(
+        {
+            "api_key": key,
+            "event": action,
+            "distinct_id": params.get("aid") or "unknown",
+            "timestamp": params.get("timestamp"),
+            "properties": properties,
+        }
+    ).encode()
+
+
+def _fire_posthog(url: str, body: bytes) -> None:
+    """POST one Capture payload.  Runs inside a daemon thread."""
+    try:
+        request = urllib.request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": _USER_AGENT,
+            },
+        )
+        urllib.request.urlopen(request, timeout=_TIMEOUT)
+    except Exception:
+        pass
+
+
 def send_event(settings: "AntonSettings", action: str, **extra: str) -> None:
     """Send an analytics event in a background thread.
 
@@ -171,21 +272,37 @@ def send_event(settings: "AntonSettings", action: str, **extra: str) -> None:
         # from CI runs, and dropping avoids a per-query exclusion filter.
         if _is_ci():
             return
-        url = settings.analytics_url
-        if not url:
-            return
 
         params: dict[str, str] = {
             "action": action,
             "aid": get_installation_id(),
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            "_": str(int(time.time() * 1000)),
+            _CACHE_BUSTER_KEY: str(int(time.time() * 1000)),
         }
         params.update(extra)
 
-        full_url = f"{url}?{urllib.parse.urlencode(params)}"
-
-        t = threading.Thread(target=_fire, args=(full_url,), daemon=True)
+        if action in _POSTHOG_EVENTS:
+            # POST, not GET: a query string is copied into gateway, CDN and WAF
+            # access logs, which is how the sibling endpoint ended up with real
+            # email addresses in them (ENG-1355 §2). A body is not.
+            key = getattr(settings, "posthog_key", "") or ""
+            host = (getattr(settings, "posthog_host", "") or "").rstrip("/")
+            if not key or not host:
+                return
+            t = threading.Thread(
+                target=_fire_posthog,
+                args=(f"{host}/capture/", _posthog_body(key, action, params)),
+                daemon=True,
+            )
+        else:
+            url = settings.analytics_url
+            if not url:
+                return
+            t = threading.Thread(
+                target=_fire,
+                args=(f"{url}?{urllib.parse.urlencode(params)}",),
+                daemon=True,
+            )
         t.start()
     except Exception:
         pass

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -1393,6 +1393,9 @@ async def _chat_loop(
         console=console,
         history_store=history_store,
         session_id=current_session_id,
+        # ENG-1495: see the note on the same field in chat_session.py — an unset
+        # `harness` is indistinguishable from a host that forgot to set one.
+        harness="cli",
         proactive_dashboards=settings.proactive_dashboards,
         act_first=settings.act_first,
         output_dir=settings.artifacts_dir,

--- a/anton/chat_session.py
+++ b/anton/chat_session.py
@@ -116,6 +116,11 @@ def rebuild_session(
         console=console,
         history_store=history_store,
         session_id=session_id,
+        # ENG-1495: identify the host explicitly. Left unset, `harness` reached
+        # telemetry as "" — which meant BOTH "this is the CLI" and "the host
+        # didn't identify itself", so the two could never be told apart and the
+        # ambiguity got worse with every new host.
+        harness="cli",
         proactive_dashboards=settings.proactive_dashboards,
         act_first=settings.act_first,
         output_dir=settings.artifacts_dir,

--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -141,6 +141,24 @@ class AntonSettings(CoreSettings):
     analytics_enabled: bool = True
     analytics_url: str = "https://x6nik28qi6.execute-api.us-east-2.amazonaws.com/default/zoomInfoCollector"
 
+    # PostHog direct sink (ENG-1495). Events named in `analytics._POSTHOG_EVENTS`
+    # post here instead of through `analytics_url`, whose collector drops any
+    # action outside its `anton_`/`ds_connect` prefix filter while returning
+    # HTTP 200 — the reason `turn_completed` produced nothing at all.
+    #
+    # `posthog_key` is a PostHog *project* token, not a credential in the usual
+    # sense: it is write-only (it can send events and cannot read a single row)
+    # and is already served publicly in the console's JavaScript bundle, so
+    # carrying it here discloses nothing new.
+    #
+    # Baked rather than env-only on purpose. anton runs inside cowork-server on
+    # machines we do not configure, so requiring a host to supply the key would
+    # make the sink fail the exact way this change exists to prevent: silently,
+    # with nothing reporting it. Set `ANTON_POSTHOG_KEY` to re-point it, or to
+    # "" to disable the direct sink.
+    posthog_host: str = "https://us.i.posthog.com"
+    posthog_key: str = "phc_ypFMKbvAwRsLuDCToox2AkEg5wx6ReBfkyi3kX2zw6VK"
+
     # Minds datasource integration
     minds_enabled: bool = True  # use Minds server as LLM provider
     minds_api_key: str | None = None

--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -141,13 +141,11 @@ class AntonSettings(CoreSettings):
     analytics_enabled: bool = True
     analytics_url: str = "https://x6nik28qi6.execute-api.us-east-2.amazonaws.com/default/zoomInfoCollector"
 
-    # PostHog direct sink (ENG-1495). Events named in `analytics._POSTHOG_EVENTS`
-    # post here; everything else goes through `analytics_url`. The routing rule
-    # and each sink's behaviour are documented in one place — `anton/analytics.py`
-    # — deliberately not repeated here: `analytics_url` is expected to change
-    # collector (anton#333 repoints it at `collect.mindshub.ai`, which filters
-    # nothing), and a description of the old lambda's filters would survive that
-    # change as a silent falsehood. git raises no conflict on this file.
+    # PostHog direct sink. Events named in `analytics._POSTHOG_EVENTS` post here;
+    # everything else goes through `analytics_url`. The routing rule and each
+    # sink's behaviour are documented in one place — `anton/analytics.py` — and
+    # deliberately not repeated here, so a change of collector cannot leave a
+    # stale description of one behind in the settings file.
     #
     # `posthog_key` is a PostHog *project* token, not a credential in the usual
     # sense: it is write-only (it can send events and cannot read a single row)

--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -142,9 +142,12 @@ class AntonSettings(CoreSettings):
     analytics_url: str = "https://x6nik28qi6.execute-api.us-east-2.amazonaws.com/default/zoomInfoCollector"
 
     # PostHog direct sink (ENG-1495). Events named in `analytics._POSTHOG_EVENTS`
-    # post here instead of through `analytics_url`, whose collector drops any
-    # action outside its `anton_`/`ds_connect` prefix filter while returning
-    # HTTP 200 — the reason `turn_completed` produced nothing at all.
+    # post here; everything else goes through `analytics_url`. The routing rule
+    # and each sink's behaviour are documented in one place — `anton/analytics.py`
+    # — deliberately not repeated here: `analytics_url` is expected to change
+    # collector (anton#333 repoints it at `collect.mindshub.ai`, which filters
+    # nothing), and a description of the old lambda's filters would survive that
+    # change as a silent falsehood. git raises no conflict on this file.
     #
     # `posthog_key` is a PostHog *project* token, not a credential in the usual
     # sense: it is write-only (it can send events and cannot read a single row)

--- a/anton/core/runtime.py
+++ b/anton/core/runtime.py
@@ -85,7 +85,7 @@ async def build_chat_session(
         describe their UI affordances. None → no suffix.
     harness
         Identifier for the host driving this session, forwarded to telemetry and to
-        Langfuse tags/metadata (ENG-1495). Hosts should set it — leaving it None is
+        Langfuse tags/metadata. Hosts should set it — leaving it None is
         what made "which host produced this trace?" unanswerable, since an unset
         value could not be told apart from a host that simply never bothered. See
         `ChatSessionConfig.harness` for the values already in use.

--- a/anton/core/runtime.py
+++ b/anton/core/runtime.py
@@ -62,6 +62,7 @@ async def build_chat_session(
     model: Optional[str] = None,
     extra_tools: Optional[Sequence[Any]] = None,
     system_prompt_suffix: Optional[str] = None,
+    harness: Optional[str] = None,
 ):
     """Build a ChatSession scoped to one workspace.
 
@@ -82,6 +83,12 @@ async def build_chat_session(
     system_prompt_suffix
         Free-form text appended to the system prompt. Hosts use this to nudge tone or
         describe their UI affordances. None → no suffix.
+    harness
+        Identifier for the host driving this session, forwarded to telemetry and to
+        Langfuse tags/metadata (ENG-1495). Hosts should set it — leaving it None is
+        what made "which host produced this trace?" unanswerable, since an unset
+        value could not be told apart from a host that simply never bothered. See
+        `ChatSessionConfig.harness` for the values already in use.
 
     Returns
     -------
@@ -184,6 +191,7 @@ async def build_chat_session(
         initial_history=initial_history,
         history_store=history_store,
         session_id=session_id,
+        harness=harness,
         proactive_dashboards=settings.proactive_dashboards,
         act_first=settings.act_first,
         tools=list(extra_tools) if extra_tools else [],

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -605,10 +605,20 @@ class ChatSessionConfig:
     initial_history: list[dict] | None = None
     history_store: HistoryStore | None = None
     session_id: str | None = None
-    # Identifier for the host harness driving this session (e.g. "cowork",
-    # "cli"). Surfaced on telemetry / langfuse traces so the harness that
-    # produced a given trace is filterable in the dashboard. None means the
-    # host didn't identify itself.
+    # Identifier for the host driving this session. Surfaced on telemetry /
+    # langfuse traces so the host that produced a given trace is filterable.
+    #
+    # The values actually in use, which are NOT what this field's name suggests:
+    #   "cli"     — anton's own interactive chat (chat_session.py, chat.py)
+    #   "anton"   — cowork-server, which passes its *agent harness* id here;
+    #               desktop and hosted web are indistinguishable, both send
+    #               this (ENG-1459 is where that gets split)
+    #   "cloud"   — the one-turn-per-pod cloud path
+    #   None      — a host that did not identify itself
+    #
+    # None must stay reserved for that last case: until ENG-1495 the CLI left it
+    # unset, so "" meant both "CLI" and "unidentified" and nothing could tell
+    # them apart.
     harness: str | None = None
     proactive_dashboards: bool = False
     # When True (default), Anton acts on reasonable defaults and surfaces its

--- a/docs/docs/configure/analytics.md
+++ b/docs/docs/configure/analytics.md
@@ -34,11 +34,18 @@ Anton and a failure to send is never surfaced to you. Failures on the
 measurement events are recorded in Anton's own debug log; failures on the other
 events are discarded without a trace.
 
-Two transports are in use, depending on the event: most events are a single
-HTTP GET to the collector at `ANTON_ANALYTICS_URL`, while the measurement
-events are an HTTPS POST whose body carries the values —
-a body rather than a query string so the values do not end up in intermediate
-access logs.
+## Where it goes
+
+Two transports, depending on the event:
+
+- **Most events** are a single HTTP GET to a MindsDB-operated collector, at
+  `ANTON_ANALYTICS_URL`. That collector forwards them to PostHog.
+- **The measurement events** are an HTTPS POST directly to **PostHog Inc.**
+  (`us.i.posthog.com`), a US analytics processor. A body rather than a query
+  string, so the values do not end up in intermediate access logs.
+
+Either way the data ends up in PostHog; the difference is whether it passes
+through MindsDB's collector on the way.
 
 ## Opting out
 

--- a/docs/docs/configure/analytics.md
+++ b/docs/docs/configure/analytics.md
@@ -10,17 +10,29 @@ Anton collects anonymous usage events — for example "session started" or
 
 ## What is sent
 
-Each event is a single HTTP GET request carrying only:
+Every event carries:
 
 - the action name (e.g. `anton_started`),
 - a timestamp,
 - an anonymous installation ID.
 
-**No personal data or query content is ever sent** — no prompts, no file
-contents, no hostnames. The installation ID is a one-way SHA-256 hash of the
-machine's network adapter address, truncated to 16 hex characters; the raw
-address never leaves your device. Events are fire-and-forget: they never
-block Anton and failures are silently ignored.
+Some events also carry **anonymous measurements of that action** — for example
+a datasource event names the engine (`postgres`), and the per-turn accounting
+event carries token counts, model names, durations and an opaque conversation
+id. These are numbers, names and identifiers only.
+
+**No personal data or query content is ever sent** — no prompts, no message
+text, no tool output, no file contents, no file paths, no credentials, no
+hostnames, no email addresses. The installation ID is a one-way SHA-256 hash of
+the machine's network adapter address, truncated to 16 hex characters; the raw
+address never leaves your device. Events are fire-and-forget: they never block
+Anton, and failures are logged at debug level and otherwise ignored.
+
+Two transports are in use, depending on the event: most events are a single
+HTTP GET to the collector at `ANTON_ANALYTICS_URL`, while the per-turn
+accounting events are an HTTPS POST whose body carries the measurements —
+a body rather than a query string so the values do not end up in intermediate
+access logs.
 
 ## Opting out
 
@@ -36,7 +48,20 @@ Or add it to your workspace config (`.anton/.env`):
 ANTON_ANALYTICS_ENABLED=false
 ```
 
-To turn it off everywhere, put the same line in the global `~/.anton/.env`.
+That switch covers every event on every transport.
+
+### Turning off one transport only
+
+`ANTON_ANALYTICS_URL` re-points the collector, and governs **only** the events
+that use it — the per-turn accounting events are unaffected by it. To disable
+those specifically, set an empty key:
+
+```text
+ANTON_POSTHOG_KEY=
+```
+
+To turn everything off everywhere, put `ANTON_ANALYTICS_ENABLED=false` in the
+global `~/.anton/.env`.
 See [Environment variables](/configure/env-vars) for how the config files are
 loaded, and [Security model](/configure/security) for the full picture of
 what leaves your machine.

--- a/docs/docs/configure/analytics.md
+++ b/docs/docs/configure/analytics.md
@@ -65,9 +65,9 @@ That switch covers every event on every transport.
 
 ### Turning off one transport only
 
-`ANTON_ANALYTICS_URL` re-points the collector, and governs **only** the events
-that use it — the measurement events are unaffected by it. To disable those
-specifically, set an empty key:
+`ANTON_ANALYTICS_URL` set empty stops **every** event. Re-pointing it moves only
+the collector-path events; the measurement events still go to PostHog. To
+disable just those, set an empty key:
 
 ```text
 ANTON_POSTHOG_KEY=

--- a/docs/docs/configure/analytics.md
+++ b/docs/docs/configure/analytics.md
@@ -17,22 +17,26 @@ Every event carries:
 - an anonymous installation ID.
 
 Some events also carry **anonymous measurements of that action** — for example
-a datasource event names the engine (`postgres`), and the per-turn accounting
-event carries token counts, model names, durations and an opaque conversation
+a datasource event names the engine (`postgres`), and the **measurement
+events** carry token counts, model names, durations and an opaque conversation
 id. These are numbers, names and identifiers only.
+
+The measurement events are the two that report on Anton's own work rather than
+on something you did: what a turn cost, and how the memory-retrieval step
+behaved while assembling a prompt.
 
 **No personal data or query content is ever sent** — no prompts, no message
 text, no tool output, no file contents, no file paths, no credentials, no
 hostnames, no email addresses. The installation ID is a one-way SHA-256 hash of
 the machine's network adapter address, truncated to 16 hex characters; the raw
 address never leaves your device. Events are fire-and-forget: they never block
-Anton and a failure to send is never surfaced to you. Failures on the per-turn
-accounting events are recorded in Anton's own debug log; failures on the other
+Anton and a failure to send is never surfaced to you. Failures on the
+measurement events are recorded in Anton's own debug log; failures on the other
 events are discarded without a trace.
 
 Two transports are in use, depending on the event: most events are a single
-HTTP GET to the collector at `ANTON_ANALYTICS_URL`, while the per-turn
-accounting events are an HTTPS POST whose body carries the measurements —
+HTTP GET to the collector at `ANTON_ANALYTICS_URL`, while the measurement
+events are an HTTPS POST whose body carries the values —
 a body rather than a query string so the values do not end up in intermediate
 access logs.
 
@@ -55,8 +59,8 @@ That switch covers every event on every transport.
 ### Turning off one transport only
 
 `ANTON_ANALYTICS_URL` re-points the collector, and governs **only** the events
-that use it — the per-turn accounting events are unaffected by it. To disable
-those specifically, set an empty key:
+that use it — the measurement events are unaffected by it. To disable those
+specifically, set an empty key:
 
 ```text
 ANTON_POSTHOG_KEY=

--- a/docs/docs/configure/analytics.md
+++ b/docs/docs/configure/analytics.md
@@ -26,7 +26,9 @@ text, no tool output, no file contents, no file paths, no credentials, no
 hostnames, no email addresses. The installation ID is a one-way SHA-256 hash of
 the machine's network adapter address, truncated to 16 hex characters; the raw
 address never leaves your device. Events are fire-and-forget: they never block
-Anton, and failures are logged at debug level and otherwise ignored.
+Anton and a failure to send is never surfaced to you. Failures on the per-turn
+accounting events are recorded in Anton's own debug log; failures on the other
+events are discarded without a trace.
 
 Two transports are in use, depending on the event: most events are a single
 HTTP GET to the collector at `ANTON_ANALYTICS_URL`, while the per-turn

--- a/docs/docs/configure/env-vars.md
+++ b/docs/docs/configure/env-vars.md
@@ -70,8 +70,8 @@ see [Search providers](/configure/search-providers).
 | `ANTON_THEME` | `auto` | Terminal color theme |
 | `ANTON_DISABLE_AUTOUPDATES` | `false` | Skip automatic update checks — see [Updating](/start/updating) |
 | `ANTON_ANALYTICS_ENABLED` | `true` | Anonymous usage events, all transports — see [Analytics](/configure/analytics) |
-| `ANTON_ANALYTICS_URL` | collector endpoint | Re-points the collector. Governs **only** the events that use it, not the per-turn accounting events |
-| `ANTON_POSTHOG_KEY` | built-in | Destination for the per-turn accounting events. Set empty to disable just those |
+| `ANTON_ANALYTICS_URL` | collector endpoint | Re-points the collector. Governs **only** the events that use it, not the measurement events |
+| `ANTON_POSTHOG_KEY` | built-in | Destination for the measurement events. Set empty to disable just those |
 | `ANTON_LANGFUSE_HEADERS` | unset | Set to `1` to attach Langfuse trace headers on any OpenAI-compatible endpoint — see [Trace headers](/configure/trace-headers) |
 | `ANTON_PROACTIVE_DASHBOARDS` | `false` | When `true`, Anton builds HTML dashboards proactively; when `false`, CLI output only |
 | `ANTON_BACKEND` | `local` | Scratchpad backend: `local` or `remote` (remote requires Minds URL and API key) |

--- a/docs/docs/configure/env-vars.md
+++ b/docs/docs/configure/env-vars.md
@@ -70,8 +70,9 @@ see [Search providers](/configure/search-providers).
 | `ANTON_THEME` | `auto` | Terminal color theme |
 | `ANTON_DISABLE_AUTOUPDATES` | `false` | Skip automatic update checks — see [Updating](/start/updating) |
 | `ANTON_ANALYTICS_ENABLED` | `true` | Anonymous usage events, all transports — see [Analytics](/configure/analytics) |
-| `ANTON_ANALYTICS_URL` | collector endpoint | Re-points the collector. Governs **only** the events that use it, not the measurement events |
-| `ANTON_POSTHOG_KEY` | built-in | Destination for the measurement events. Set empty to disable just those |
+| `ANTON_ANALYTICS_URL` | MindsDB collector | The collector endpoint. Set empty to stop **every** event; re-point it to send the collector-path events elsewhere (the measurement events are unaffected by re-pointing) |
+| `ANTON_POSTHOG_HOST` | `https://us.i.posthog.com` | Where the measurement events are POSTed |
+| `ANTON_POSTHOG_KEY` | built-in | PostHog project key the measurement events are written with. Set empty to disable just those |
 | `ANTON_LANGFUSE_HEADERS` | unset | Set to `1` to attach Langfuse trace headers on any OpenAI-compatible endpoint — see [Trace headers](/configure/trace-headers) |
 | `ANTON_PROACTIVE_DASHBOARDS` | `false` | When `true`, Anton builds HTML dashboards proactively; when `false`, CLI output only |
 | `ANTON_BACKEND` | `local` | Scratchpad backend: `local` or `remote` (remote requires Minds URL and API key) |

--- a/docs/docs/configure/env-vars.md
+++ b/docs/docs/configure/env-vars.md
@@ -69,7 +69,9 @@ see [Search providers](/configure/search-providers).
 | --- | --- | --- |
 | `ANTON_THEME` | `auto` | Terminal color theme |
 | `ANTON_DISABLE_AUTOUPDATES` | `false` | Skip automatic update checks — see [Updating](/start/updating) |
-| `ANTON_ANALYTICS_ENABLED` | `true` | Anonymous usage events — see [Analytics](/configure/analytics) |
+| `ANTON_ANALYTICS_ENABLED` | `true` | Anonymous usage events, all transports — see [Analytics](/configure/analytics) |
+| `ANTON_ANALYTICS_URL` | collector endpoint | Re-points the collector. Governs **only** the events that use it, not the per-turn accounting events |
+| `ANTON_POSTHOG_KEY` | built-in | Destination for the per-turn accounting events. Set empty to disable just those |
 | `ANTON_LANGFUSE_HEADERS` | unset | Set to `1` to attach Langfuse trace headers on any OpenAI-compatible endpoint — see [Trace headers](/configure/trace-headers) |
 | `ANTON_PROACTIVE_DASHBOARDS` | `false` | When `true`, Anton builds HTML dashboards proactively; when `false`, CLI output only |
 | `ANTON_BACKEND` | `local` | Scratchpad backend: `local` or `remote` (remote requires Minds URL and API key) |

--- a/docs/docs/configure/security.md
+++ b/docs/docs/configure/security.md
@@ -46,9 +46,10 @@ Three things, and only three:
 1. **Prompts to your LLM provider.** Whatever you type, plus the context
    Anton assembles, goes to the provider you configured (Anthropic, OpenAI,
    Minds, or your own endpoint) and is governed by that provider's terms.
-2. **Anonymous analytics.** Event names and timestamps only — no query
-   content, no personal data. Opt out any time: see
-   [Analytics](/configure/analytics).
+2. **Anonymous analytics.** Event names, timestamps, and for some events
+   anonymous measurements of the action — token counts, model names, durations,
+   opaque ids. Never query content and never personal data. Opt out any time:
+   see [Analytics](/configure/analytics).
 3. **Whatever you ask Anton to send.** Emails, API calls, published
    dashboards — actions you request.
 

--- a/docs/docs/configure/security.md
+++ b/docs/docs/configure/security.md
@@ -46,10 +46,11 @@ Three things, and only three:
 1. **Prompts to your LLM provider.** Whatever you type, plus the context
    Anton assembles, goes to the provider you configured (Anthropic, OpenAI,
    Minds, or your own endpoint) and is governed by that provider's terms.
-2. **Anonymous analytics.** Event names, timestamps, and for some events
-   anonymous measurements of the action — token counts, model names, durations,
-   opaque ids. Never query content and never personal data. Opt out any time:
-   see [Analytics](/configure/analytics).
+2. **Anonymous analytics**, to MindsDB and to PostHog Inc. (a US analytics
+   processor). Event names, timestamps, and for some events anonymous
+   measurements of the action — token counts, model names, durations, opaque
+   ids. Never query content and never personal data. Opt out any time: see
+   [Analytics](/configure/analytics).
 3. **Whatever you ask Anton to send.** Emails, API calls, published
    dashboards — actions you request.
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -306,14 +306,36 @@ def test_turn_completed_respects_the_opt_out(monkeypatch):
     assert captured == []
 
 
+class _FakeResponse:
+    """Minimal stand-in for urlopen's context manager, so the status-reading
+    path in `_fire_posthog` is actually exercised rather than skipped."""
+
+    def __init__(self, status=200):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _capture_posthog_request(monkeypatch, status=200) -> list:
+    seen: list[urllib.request.Request] = []
+
+    def _urlopen(req, timeout=None):
+        seen.append(req)
+        return _FakeResponse(status)
+
+    monkeypatch.setattr(analytics.urllib.request, "urlopen", _urlopen)
+    return seen
+
+
 def test_posthog_request_is_a_post_with_json(monkeypatch):
     """Exercises the real `_fire_posthog` rather than a stub: a GET would land
     the whole payload in gateway and CDN access logs, which is exactly how the
     sibling endpoint ended up logging email addresses."""
-    seen: list[urllib.request.Request] = []
-    monkeypatch.setattr(
-        analytics.urllib.request, "urlopen", lambda req, timeout=None: seen.append(req)
-    )
+    seen = _capture_posthog_request(monkeypatch)
 
     analytics._fire_posthog("https://ph.example.test/capture/", b'{"a":1}')
 
@@ -321,6 +343,36 @@ def test_posthog_request_is_a_post_with_json(monkeypatch):
     assert seen[0].method == "POST"
     assert seen[0].get_header("Content-type") == "application/json"
     assert "python-urllib" not in seen[0].get_header("User-agent", "").lower()
+
+
+def test_posthog_rejection_is_logged_and_swallowed(monkeypatch, caplog):
+    """A non-2xx must leave a trace locally and still not raise.
+
+    Note what this can and cannot buy, measured against the live endpoint on
+    2026-08-13: a **bogus api_key returns HTTP 200** `{"status":"Ok"}`, so a
+    wrong/rotated/revoked token is NOT detectable here. Only a malformed payload
+    (400) and transport failures are. The zero-volume alert remains the only
+    defence against a token problem — this test exists so that the errors which
+    *are* visible stop being silent, not to suggest all of them are.
+    """
+    seen = _capture_posthog_request(monkeypatch, status=400)
+
+    with caplog.at_level("DEBUG", logger=analytics.logger.name):
+        analytics._fire_posthog("https://ph.example.test/capture/", b'{"bad":1}')
+
+    assert len(seen) == 1  # still sent; never raises
+    assert any("400" in r.getMessage() for r in caplog.records), caplog.text
+
+
+def test_posthog_transport_failure_never_raises(monkeypatch):
+    """Analytics must never break a turn — the guarantee the module docstring
+    makes. A raising urlopen has to be swallowed."""
+    def _boom(req, timeout=None):
+        raise OSError("network down")
+
+    monkeypatch.setattr(analytics.urllib.request, "urlopen", _boom)
+
+    analytics._fire_posthog("https://ph.example.test/capture/", b'{"a":1}')  # no raise
 
 
 def test_rule_retrieval_goes_to_posthog(monkeypatch):

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -189,10 +189,11 @@ def test_unregistered_events_still_use_the_collector(monkeypatch):
 
 def test_person_profile_is_disabled(monkeypatch):
     """Load-bearing: without this flag every install fingerprint becomes a
-    PostHog *Person* in a project keyed on Keycloak subs — roughly 800 of them
-    against ~1,098 real identified people — silently inflating every
-    person-count metric and cohort in it. Not cosmetic, and not recoverable by
-    a later query."""
+    PostHog *Person* in project 424726, which is keyed on the Keycloak `sub`.
+    Machine fingerprints would then be counted alongside real identified users
+    in every person metric and cohort there, and no later query can separate
+    them again. Deliberately unquantified — the ratio this docstring used to
+    give could not be reproduced from the description it carried."""
     _clear_ci(monkeypatch)
     captured = _capture_posthog(monkeypatch)
 
@@ -306,26 +307,23 @@ def test_turn_completed_respects_the_opt_out(monkeypatch):
     assert captured == []
 
 
-class _FakeResponse:
-    """Minimal stand-in for urlopen's context manager, so the status-reading
-    path in `_fire_posthog` is actually exercised rather than skipped."""
+def _capture_posthog_request(monkeypatch, status=None) -> list:
+    """Record the Request `_fire_posthog` builds.
 
-    def __init__(self, status=200):
-        self.status = status
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        return False
-
-
-def _capture_posthog_request(monkeypatch, status=200) -> list:
+    `status` raises `HTTPError` the way real urllib does on a 4xx/5xx — it does
+    NOT return a response object carrying a status. An earlier version of this
+    helper returned a fake response, which made the rejection test pass against
+    behaviour urllib does not have.
+    """
     seen: list[urllib.request.Request] = []
 
     def _urlopen(req, timeout=None):
         seen.append(req)
-        return _FakeResponse(status)
+        if status is not None:
+            raise urllib.error.HTTPError(
+                req.full_url, status, "rejected", hdrs=None, fp=None
+            )
+        return None
 
     monkeypatch.setattr(analytics.urllib.request, "urlopen", _urlopen)
     return seen
@@ -345,22 +343,28 @@ def test_posthog_request_is_a_post_with_json(monkeypatch):
     assert "python-urllib" not in seen[0].get_header("User-agent", "").lower()
 
 
-def test_posthog_rejection_is_logged_and_swallowed(monkeypatch, caplog):
-    """A non-2xx must leave a trace locally and still not raise.
+def test_posthog_rejection_logs_the_status_code(monkeypatch, caplog):
+    """A rejection must name its status, and still not raise.
 
-    Note what this can and cannot buy, measured against the live endpoint on
+    The stub **raises** `HTTPError`, which is what real urllib does on a 4xx —
+    it does not return a response whose `.status` can be read. That distinction
+    is the whole point of this test: a previous version asserted against a
+    fake that returned, so it passed while the code under it could never run.
+
+    What this can and cannot buy, measured against the live endpoint on
     2026-08-13: a **bogus api_key returns HTTP 200** `{"status":"Ok"}`, so a
-    wrong/rotated/revoked token is NOT detectable here. Only a malformed payload
-    (400) and transport failures are. The zero-volume alert remains the only
-    defence against a token problem — this test exists so that the errors which
-    *are* visible stop being silent, not to suggest all of them are.
+    wrong/rotated/revoked token is NOT detectable here at all. The 401 exists
+    only for an absent key, which `send_event` short-circuits before building a
+    request. Only malformed payloads and transport failures are visible. The
+    zero-volume alert stays the only possible detector for a token problem.
     """
     seen = _capture_posthog_request(monkeypatch, status=400)
 
     with caplog.at_level("DEBUG", logger=analytics.logger.name):
         analytics._fire_posthog("https://ph.example.test/capture/", b'{"bad":1}')
 
-    assert len(seen) == 1  # still sent; never raises
+    assert len(seen) == 1  # still attempted; never raises
+    # The code, not just a traceback — someone reading a user's logs needs it.
     assert any("400" in r.getMessage() for r in caplog.records), caplog.text
 
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -474,3 +474,40 @@ def test_rule_retrieval_goes_to_posthog(monkeypatch):
     assert props["stop_reason"] == "end_turn"
     assert props["kept_rules"] == "3"
     assert props["$process_person_profile"] is False
+
+
+def test_blanking_analytics_url_stops_the_routed_events_too(monkeypatch):
+    """`ANTON_ANALYTICS_URL=""` is a de-facto kill switch and must stay one.
+
+    Before ENG-1495 the `if not url: return` guard sat above the routing branch,
+    so blanking the URL stopped every event. Moving it into the `else` let the
+    two routed events out regardless — so someone who had switched telemetry off
+    would have started shipping turn metadata to PostHog on upgrade, silently.
+    That is a consent regression, not a behaviour change.
+    """
+    _clear_ci(monkeypatch)
+
+    class _Blanked(_PosthogSettings):
+        analytics_url = ""
+
+    monkeypatch.setattr(
+        analytics,
+        "_fire_posthog",
+        lambda url, body: pytest.fail(f"sent to PostHog despite a blanked URL: {url}"),
+    )
+    monkeypatch.setattr(
+        analytics, "_fire", lambda url: pytest.fail(f"sent to the collector: {url}")
+    )
+
+    class _SyncThread:
+        def __init__(self, target=None, args=(), daemon=None):
+            self._target, self._args = target, args
+
+        def start(self):
+            self._target(*self._args)
+
+    monkeypatch.setattr(analytics.threading, "Thread", _SyncThread)
+
+    analytics.send_event(_Blanked(), "turn_completed", tokens_total="1")
+    analytics.send_event(_Blanked(), "rule_retrieval", outcome="ok")
+    analytics.send_event(_Blanked(), "ds_connect_success", engine="pg")

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -379,6 +379,43 @@ def test_posthog_transport_failure_never_raises(monkeypatch):
     analytics._fire_posthog("https://ph.example.test/capture/", b'{"a":1}')  # no raise
 
 
+def test_posthog_malformed_host_never_raises():
+    """`Request()` itself raises ValueError on a malformed URL, and the host is
+    a user-supplied setting (`ANTON_POSTHOG_HOST`).
+
+    This runs in a daemon thread, *outside* `send_event`'s guard, so anything
+    escaping reaches the user as a traceback mid-session. A previous version of
+    `_fire_posthog` built the Request above the `try` and did exactly that.
+    """
+    analytics._fire_posthog("garbage-not-a-url/capture/", b'{"a":1}')  # no raise
+
+
+def test_send_event_with_a_bad_posthog_host_kills_no_thread(monkeypatch):
+    """End to end through the real path: a bad host must not surface at all."""
+    _clear_ci(monkeypatch)
+
+    class _BadHost(_PosthogSettings):
+        posthog_host = "garbage-not-a-url"
+
+    escaped: list[str] = []
+
+    class _SyncThread:
+        def __init__(self, target=None, args=(), daemon=None):
+            self._target, self._args = target, args
+
+        def start(self):
+            try:
+                self._target(*self._args)
+            except BaseException as exc:  # what threading would report and print
+                escaped.append(type(exc).__name__)
+
+    monkeypatch.setattr(analytics.threading, "Thread", _SyncThread)
+
+    analytics.send_event(_BadHost(), "turn_completed", tokens_total="1")
+
+    assert escaped == [], f"escaped the daemon thread: {escaped}"
+
+
 def test_rule_retrieval_goes_to_posthog(monkeypatch):
     """ENG-1390's signal, on the same path (ENG-1495).
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -321,3 +321,41 @@ def test_posthog_request_is_a_post_with_json(monkeypatch):
     assert seen[0].method == "POST"
     assert seen[0].get_header("Content-type") == "application/json"
     assert "python-urllib" not in seen[0].get_header("User-agent", "").lower()
+
+
+def test_rule_retrieval_goes_to_posthog(monkeypatch):
+    """ENG-1390's signal, on the same path (ENG-1495).
+
+    It shipped as `rule_retrieval` — no `anton_` prefix — so the collector
+    dropped it on the action filter, exactly as it dropped `turn_completed`.
+    anton#332 proposed renaming it to `anton_rule_retrieval` to satisfy that
+    filter; this makes the rename unnecessary, and the prefix would have been
+    wrong in a project whose other events carry no prefix at all.
+    """
+    _clear_ci(monkeypatch)
+    captured = _capture_posthog(monkeypatch)
+
+    analytics.send_event(
+        _PosthogSettings(),
+        "rule_retrieval",
+        outcome="ok",
+        when_rules="12",
+        kept_rules="3",
+        rules_chars="1840",
+        stop_reason="end_turn",
+        duration_ms="412",
+    )
+
+    assert len(captured) == 1
+    _, body = captured[0]
+    # The name stays unprefixed: nothing filters on it any more, and the other
+    # emitters in project 424726 (first_query, agent_session_started) carry no
+    # prefix either.
+    assert body["event"] == "rule_retrieval"
+    props = body["properties"]
+    # `outcome` and `stop_reason` are the two the collector's five-name
+    # allowlist would have eaten — they are the whole point of the signal.
+    assert props["outcome"] == "ok"
+    assert props["stop_reason"] == "end_turn"
+    assert props["kept_rules"] == "3"
+    assert props["$process_person_profile"] is False

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -7,7 +7,11 @@ anything) would be sent, without network or threads.
 
 from __future__ import annotations
 
+import json
 import urllib.parse
+import urllib.request
+
+import pytest
 
 import anton.analytics as analytics
 
@@ -103,3 +107,217 @@ def test_send_event_sends_when_not_ci(monkeypatch):
     assert params["action"] == "anton_query"
     assert params["llm_provider"] == "openai"
     assert "is_ci" not in params  # flag removed; CI events aren't sent at all
+
+
+# ── The PostHog direct sink (ENG-1495) ──────────────────────────────
+# `turn_completed` bypasses the collector and posts straight to PostHog. The
+# collector allowlists five property names and relays only `anton_`/`ds_connect`
+# actions, returning HTTP 200 either way, so every one of these assertions
+# guards something that previously failed invisibly.
+
+
+class _PosthogSettings(_Settings):
+    posthog_host = "https://ph.example.test"
+    posthog_key = "phc_test"
+
+
+def _capture_posthog(monkeypatch) -> list[tuple[str, dict]]:
+    """Run send_event's thread target synchronously; record (url, body).
+
+    Also fails the test outright if the collector path is taken, so "went to
+    the wrong sink" can never read as "sent nothing".
+    """
+    captured: list[tuple[str, dict]] = []
+
+    class _SyncThread:
+        def __init__(self, target=None, args=(), daemon=None):
+            self._target = target
+            self._args = args
+
+        def start(self):
+            if self._target:
+                self._target(*self._args)
+
+    monkeypatch.setattr(analytics.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(
+        analytics,
+        "_fire_posthog",
+        lambda url, body: captured.append((url, json.loads(body))),
+    )
+    monkeypatch.setattr(
+        analytics,
+        "_fire",
+        lambda url: pytest.fail(f"took the collector path instead: {url}"),
+    )
+    return captured
+
+
+def test_turn_completed_goes_to_posthog_not_the_collector(monkeypatch):
+    """The whole point: this event must not touch the dropping collector."""
+    _clear_ci(monkeypatch)
+    captured = _capture_posthog(monkeypatch)
+
+    analytics.send_event(_PosthogSettings(), "turn_completed", tokens_total="24970")
+
+    assert len(captured) == 1
+    url, body = captured[0]
+    assert url == "https://ph.example.test/capture/"
+    assert body["api_key"] == "phc_test"
+    assert body["event"] == "turn_completed"
+
+
+def test_unregistered_events_still_use_the_collector(monkeypatch):
+    """Scope guard. Only names in `_POSTHOG_EVENTS` move; nothing else does.
+
+    Without this, a change that routed everything would look identical to a
+    change that routed one event — and would drag the ~105k/30d ds_connect
+    volume into the production project.
+    """
+    _clear_ci(monkeypatch)
+    captured = _capture_url(monkeypatch)  # asserts on the collector GET
+    monkeypatch.setattr(
+        analytics,
+        "_fire_posthog",
+        lambda url, body: pytest.fail("ds_connect_success must stay on the collector"),
+    )
+
+    analytics.send_event(_PosthogSettings(), "ds_connect_success", engine="postgres")
+
+    assert len(captured) == 1
+    assert _query(captured[0])["action"] == "ds_connect_success"
+
+
+def test_person_profile_is_disabled(monkeypatch):
+    """Load-bearing: without this flag every install fingerprint becomes a
+    PostHog *Person* in a project keyed on Keycloak subs — roughly 800 of them
+    against ~1,098 real identified people — silently inflating every
+    person-count metric and cohort in it. Not cosmetic, and not recoverable by
+    a later query."""
+    _clear_ci(monkeypatch)
+    captured = _capture_posthog(monkeypatch)
+
+    analytics.send_event(_PosthogSettings(), "turn_completed")
+
+    assert captured[0][1]["properties"]["$process_person_profile"] is False
+
+
+def test_distinct_id_is_the_install_fingerprint(monkeypatch):
+    _clear_ci(monkeypatch)
+    monkeypatch.setattr(analytics, "_cached_aid", "abc123def456abcd")
+    captured = _capture_posthog(monkeypatch)
+
+    analytics.send_event(_PosthogSettings(), "turn_completed")
+
+    _, body = captured[0]
+    assert body["distinct_id"] == "abc123def456abcd"
+    # Kept as a property too, so a query can group on the install without
+    # reaching into person data.
+    assert body["properties"]["aid"] == "abc123def456abcd"
+
+
+def test_every_property_survives(monkeypatch):
+    """The collector allowlisted five names and dropped the other 26. The
+    direct path must carry all of them, so assert on ones the collector is
+    known to have eaten (`tokens_total`, `ended_by`) alongside one it passed
+    (`llm_provider`)."""
+    _clear_ci(monkeypatch)
+    captured = _capture_posthog(monkeypatch)
+
+    analytics.send_event(
+        _PosthogSettings(),
+        "turn_completed",
+        tokens_total="24970",
+        ended_by="round_cap",
+        llm_provider="anthropic",
+        planning_model="haiku",
+        harness="cli",
+        conversation_id="conv-1",
+        turn_index="3",
+    )
+
+    props = captured[0][1]["properties"]
+    assert props["tokens_total"] == "24970"
+    assert props["ended_by"] == "round_cap"      # the Phase 0 criterion-3 field
+    assert props["llm_provider"] == "anthropic"
+    assert props["planning_model"] == "haiku"
+    assert props["harness"] == "cli"
+    assert props["conversation_id"] == "conv-1"
+    assert props["turn_index"] == "3"
+
+
+def test_transport_noise_is_not_a_property(monkeypatch):
+    """`_` is a GET cache buster and `action`/`timestamp` are top-level fields
+    on the Capture API. Leaking them into properties would create three
+    permanent junk property definitions in the project."""
+    _clear_ci(monkeypatch)
+    captured = _capture_posthog(monkeypatch)
+
+    analytics.send_event(_PosthogSettings(), "turn_completed")
+
+    _, body = captured[0]
+    props = body["properties"]
+    assert "_" not in props
+    assert "action" not in props
+    assert "timestamp" not in props
+    # Promoted to PostHog's own field: the turn's end, not the daemon thread's
+    # eventual send.
+    assert body["timestamp"]
+    assert body["properties"]["$lib"] == "anton-library"
+
+
+def test_empty_key_disables_the_direct_sink_without_falling_back(monkeypatch):
+    """`ANTON_POSTHOG_KEY=""` is the documented opt-out. It must not silently
+    reroute the event onto the collector, which would drop it anyway."""
+    _clear_ci(monkeypatch)
+
+    class _NoKey(_PosthogSettings):
+        posthog_key = ""
+
+    captured = _capture_posthog(monkeypatch)  # fails the test on collector use
+
+    analytics.send_event(_NoKey(), "turn_completed")
+
+    assert captured == []
+
+
+def test_turn_completed_still_dropped_in_ci(monkeypatch):
+    """The CI gate has to apply to the new path too — it is how anton keeps
+    test runs out of the funnel, and there is no `environment` tag to filter
+    on afterwards."""
+    _clear_ci(monkeypatch)
+    monkeypatch.setenv("ANTON_IS_CI", "true")
+    captured = _capture_posthog(monkeypatch)
+
+    analytics.send_event(_PosthogSettings(), "turn_completed")
+
+    assert captured == []
+
+
+def test_turn_completed_respects_the_opt_out(monkeypatch):
+    _clear_ci(monkeypatch)
+
+    class _OptedOut(_PosthogSettings):
+        analytics_enabled = False
+
+    captured = _capture_posthog(monkeypatch)
+
+    analytics.send_event(_OptedOut(), "turn_completed")
+
+    assert captured == []
+
+
+def test_posthog_request_is_a_post_with_json(monkeypatch):
+    """Exercises the real `_fire_posthog` rather than a stub: a GET would land
+    the whole payload in gateway and CDN access logs, which is exactly how the
+    sibling endpoint ended up logging email addresses."""
+    seen: list[urllib.request.Request] = []
+    monkeypatch.setattr(
+        analytics.urllib.request, "urlopen", lambda req, timeout=None: seen.append(req)
+    )
+
+    analytics._fire_posthog("https://ph.example.test/capture/", b'{"a":1}')
+
+    assert len(seen) == 1
+    assert seen[0].method == "POST"
+    assert seen[0].get_header("Content-type") == "application/json"
+    assert "python-urllib" not in seen[0].get_header("User-agent", "").lower()

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -379,14 +379,25 @@ def test_posthog_transport_failure_never_raises(monkeypatch):
     analytics._fire_posthog("https://ph.example.test/capture/", b'{"a":1}')  # no raise
 
 
-def test_posthog_malformed_host_never_raises():
+def test_posthog_malformed_host_never_raises(monkeypatch):
     """`Request()` itself raises ValueError on a malformed URL, and the host is
     a user-supplied setting (`ANTON_POSTHOG_HOST`).
 
     This runs in a daemon thread, *outside* `send_event`'s guard, so anything
     escaping reaches the user as a traceback mid-session. A previous version of
     `_fire_posthog` built the Request above the `try` and did exactly that.
+
+    `urlopen` is stubbed to fail rather than merely mocked, for two reasons: it
+    proves the failure comes from `Request()` and not from the send, and it means
+    this test cannot reach the network if someone later edits the URL to
+    something well-formed.
     """
+    monkeypatch.setattr(
+        analytics.urllib.request,
+        "urlopen",
+        lambda req, timeout=None: pytest.fail("Request() should have raised first"),
+    )
+
     analytics._fire_posthog("garbage-not-a-url/capture/", b'{"a":1}')  # no raise
 
 
@@ -404,12 +415,23 @@ def test_send_event_with_a_bad_posthog_host_kills_no_thread(monkeypatch):
             self._target, self._args = target, args
 
         def start(self):
+            # Catch here rather than re-raise: in production the target runs in
+            # a real thread, so an escape reaches `threading.excepthook` and is
+            # printed, NOT caught by `send_event`'s guard. Re-raising would let
+            # that guard swallow it and the test would pass on a bug.
             try:
                 self._target(*self._args)
-            except BaseException as exc:  # what threading would report and print
+            except BaseException as exc:
                 escaped.append(type(exc).__name__)
 
     monkeypatch.setattr(analytics.threading, "Thread", _SyncThread)
+    # Belt and braces: this test must never reach the network even if the host
+    # above is later changed to something well-formed.
+    monkeypatch.setattr(
+        analytics.urllib.request,
+        "urlopen",
+        lambda req, timeout=None: pytest.fail("should not have reached the network"),
+    )
 
     analytics.send_event(_BadHost(), "turn_completed", tokens_total="1")
 

--- a/tests/test_session_tools.py
+++ b/tests/test_session_tools.py
@@ -32,3 +32,32 @@ def test_both_session_builders_use_the_shared_tool_list():
     rebuild = (_ANTON_DIR / "chat_session.py").read_text()
     assert "DEFAULT_SESSION_TOOLS" in fresh, "fresh session builder (chat.py) must use the shared tool list"
     assert "DEFAULT_SESSION_TOOLS" in rebuild, "rebuild_session (chat_session.py) must use the shared tool list"
+
+
+def test_both_session_builders_identify_the_host_as_cli():
+    """Same drift class as the tool list above, one field over.
+
+    `ChatSessionConfig.harness` reserves `None` for "a host that did not
+    identify itself". The CLI leaving it unset is what made `""` mean both
+    "this is the CLI" and "nobody said", so the two could never be told apart —
+    and that value reaches PostHog and Langfuse tags, not just a log line.
+
+    Source inspection rather than a behavioural test, for the same reason the
+    test above gives: exercising `rebuild_session` means standing up an
+    LLMClient, a Cortex and a knowledge refresh. The property being guarded is
+    structural — both builders must pass the argument — so asserting on the
+    call site is the honest check rather than a weaker substitute.
+
+    Verified to be needed: deleting `harness="cli"` from both files leaves the
+    entire suite green.
+    """
+    fresh = (_ANTON_DIR / "chat.py").read_text()
+    rebuild = (_ANTON_DIR / "chat_session.py").read_text()
+    assert 'harness="cli"' in fresh, (
+        "fresh session builder (chat.py) must identify the host, or telemetry "
+        "and Langfuse tags cannot tell the CLI from an unidentified host"
+    )
+    assert 'harness="cli"' in rebuild, (
+        "rebuild_session (chat_session.py) must identify the host — a resumed "
+        "session that drops it reintroduces the ambiguity mid-session"
+    )


### PR DESCRIPTION
Closes ENG-1495. Related: ENG-1288 (shipped the counter), ENG-1355 (the collector fix, independent of this), ENG-1286 (downstream), ENG-1459 (desktop-vs-web split).

## The problem

ENG-1288 shipped per-turn cost accounting. The `turn_cost` log line works. **The PostHog sink has produced nothing, ever.** Measured 2026-08-10 in project 355390:

```
events matching %turn% or %cost%, all time  →  0
control — all events, any type               →  12 types, ~27k events
```

The control is what makes that evidence rather than an absence: the project is healthy and anton is definitely reaching it. The collector filters twice — actions must begin `anton_`/`ds_connect`, and only `action`, `aid`, `engine`, `llm_provider`, `has_mdb_key` survive — and it returns **HTTP 200 while dropping**, so `send_event`'s fire-and-forget path never learns.

This blocks **Phase 0 criteria 3 and 6**, and ENG-1286's spend ceiling was deliberately deferred so it could be derived from real distribution rather than guessed.

## What this does

Routes **two** events direct to PostHog **MindsHub main (424726)** — `turn_completed` and `rule_retrieval`. `_POSTHOG_EVENTS` is the register; anything absent keeps the collector path, so the ~105k/30d `ds_connect_*` volume stays exactly where it is.

`rule_retrieval` (ENG-1390) shipped without the `anton_` prefix, so the collector dropped it on the action filter just like `turn_completed` — and its eight properties (`outcome`, `when_rules`, `kept_rules`, `rules_chars`, `stop_reason`, `input_tokens`, `output_tokens`, `duration_ms`) would have been cut to nothing by the property allowlist even if the name had passed. Adding it is one register entry, because the first commit already built the path.

Note it does not by itself close **Phase 0 criterion 5**, which asks for the call's frequency. That arrives one release later — ENG-1390's instrumentation and this PR's working sink ship in the same train, so there is no production data yet by construction, not by fault.

Worth knowing when the data does land: the call is heavily gated (non-empty user message with an LLM available, total rules over `_RULES_BUDGET_CHARS`, at least one `when` rule, conditional rules alone ≥1000 chars), so a low rate is the expected result. And `cortex.py`'s comment records *"Measured shares before this shipped: 55.7% filtered, 30.2% dropped_all, 14.2% kept_all_no_match"* — if that 30.2% holds, a third of invocations discard every conditional rule from the prompt, which would be a behaviour bug worth its own ticket.

**This supersedes [anton#332](https://github.com/mindsdb/anton/pull/332)**, which renamed the action to `anton_rule_retrieval` purely to satisfy the collector's prefix filter. That rename would then have been *wrong* in project 424726, where every other event (`first_query`, `agent_session_started`, `boot_screen_resolved`) carries no prefix — and its test asserted `startswith("anton_")`, so it would have actively blocked the correct name later.

Not waiting on ENG-1355. The independence is **in outcome, not in text**: this works whichever way ENG-1355 goes, because it does not depend on the collector being fixed. But the two PRs **do conflict textually** — `anton#333` (open, head `1d5638a`) touches the same three files, and a real merge conflicts in `anton/analytics.py` and `tests/test_analytics.py` (`config/settings.py` auto-merges cleanly). **Whoever merges second resolves them.** An earlier version of this body claimed the two touched no common lines; that was asserted without checking and is false.

## Note on anton#333 — no longer applicable

This body previously carried a four-row conflict-resolution table for merging alongside `anton#333`. **@lucas-koontz has cancelled ENG-1355 and closed #333** (plus the cowork, terraform and mindshub_services PRs), because ENG-1524's scoping showed one event out of 122k/month actually migrates — so fixing the collector bought a firehose we are retiring. The table is moot and has been removed, along with David's finding 4: there is no #333 acceptance criterion left to become unsatisfiable.

The collector therefore stays the legacy `zoomInfoCollector`, which means `analytics.py`'s description of its prefix filter and five-name property allowlist is now permanently accurate rather than about to go stale.

## Design decisions worth reviewing

| Decision | Why |
|---|---|
| **POST + JSON**, not GET + query string | A query string is copied into gateway, CDN and WAF access logs — how the sibling endpoint ended up logging real email addresses (ENG-1355 §2) |
| **`$process_person_profile: false`** | Without it every install fingerprint becomes a PostHog *Person* in project 424726, which is keyed on the Keycloak `sub` — so machine fingerprints get counted alongside real identified users in every person metric and cohort, and no later query can separate them. Deliberately unquantified: an earlier version of this line carried a ratio that could not be reproduced |
| **No `$insert_id`** | The natural key `(conversation_id, turn_index)` can be legitimately shared by an abandoned turn's books and a later retry; dropping that row loses exactly the runaway a cancel was investigating (#309). `TurnCost.emitted` already prevents double-emit |
| **Token baked, not env-only** | anton runs inside cowork-server on machines we don't configure. Requiring a host to supply it would fail the one way this change exists to prevent — silently. It's a write-only project token already served publicly in the console bundle |
| **No `environment` property** | Follows the client convention: gate the send, don't tag the event. anton already has `analytics_enabled` + `_is_ci()` |
| **Register, not a runtime allowlist** | Matches `cowork/src/renderer/cowork/lib/analytics.js`. All ~31 properties are fixed literals, so there is nothing dynamic to pollute PostHog's permanent property namespace |

## Two docstrings that were actively false

- **`anton/analytics.py`** claimed every kwarg becomes a queryable property, *"not an allowlist"*. It never was. That claim is the likeliest reason this shipped unnoticed — it told the author no collector work was needed.
- **`ChatSessionConfig.harness`** documented values (`"cowork"`, `"cli"`) that nothing emits. cowork-server passes its *agent* id `"anton"`; the CLI set nothing, so `""` meant both "CLI" and "unidentified host" — fine with two hosts, broken on the third. The CLI now passes `harness="cli"` explicitly.

## Verification

**End to end against production PostHog**, real code path, no stubs (probe `aid=probe1495eng1495`):

```
event            turn_completed
distinct_id      probe1495eng1495
tokens_total     24970          ← the collector always dropped this
ended_by         round_cap      ← the Phase 0 criterion-3 field
harness          cli
$lib             anton-library
$process_person_profile  False
property count   44
Person rows for that id: 0      ← the flag held
```

**Tests:** `tests/test_analytics.py` has 22 passing; `test_session_tools.py` gained a harness drift guard. Each assertion mutation-verified — implementation broken six ways, each caught by its own test and nothing else:

| Mutation | Test that failed |
|---|---|
| drop `$process_person_profile` | `test_person_profile_is_disabled` |
| route every event to PostHog | `test_unregistered_events_still_use_the_collector` |
| stop filtering transport noise | `test_transport_noise_is_not_a_property` |
| empty key falls through to collector | `test_empty_key_disables_the_direct_sink_without_falling_back` |
| remove the CI gate | `test_turn_completed_still_dropped_in_ci` |
| POST → GET | `test_posthog_request_is_a_post_with_json` |
| drop `rule_retrieval` from the register | `test_rule_retrieval_goes_to_posthog` |

**Full suite:** 2007+ passed, 9 failed. All 9 reproduce identically on untouched `origin/staging` (`test_chat_scratchpad` ×2, `test_cloud_turn_process` ×5, `test_datasource` ×2) — pre-existing, baselined by stashing this branch's changes and re-running. None is analytics-related; `test_cloud_turn_process`'s `turn_completed` is the cloud *protocol* event, not this one.

## Security pass

Payload is numbers, model names and opaque ids — no message text, prompts, tool output, file paths, credentials, hostnames or emails. `conversation_id` is a join key that needs Langfuse to resolve, and Langfuse already holds the full conversation for that session. Query string → POST body is a net reduction in log exposure. The token is write-only (cannot read a single row) and already public in the shipped console bundle.

## Not in this PR

- **A PostHog alert on `turn_completed` volume hitting zero.** Console action, not code — but it's in the ticket's `Done when`, and it's the only defence against this failing silently again.
- **`ds_connect` double-counting** — now tracked as ENG-1525 under the ENG-1524 umbrella, along with a much larger finding: one install emitted 11,009 `ds_connect_success` events in a single hour. Independent of this PR, and only urgent if those events are ever re-pointed at MindsHub main, which this PR explicitly does not do.
- **desktop vs hosted web.** Both remain `harness="anton"`; cowork-server knows via `tenancy_mode` but doesn't pass it down. That's ENG-1459 — until then `"anton"` must not be read as "desktop".

## One thing to know about timing

Delivery is anton → PyPI → cowork-server's `[tool.uv.sources]` pin → weekly train. Data starts accumulating when that lands, not at merge. Already-installed older anton copies keep posting to the old collector and stay dark — expected and unavoidable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







