### PR TITLE
[12484] scratchpad uv discovery

### DIFF
--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -338,21 +338,28 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
 
         uv = self._find_uv()
         if uv:
-            _sp.run(
-                [
-                    uv,
-                    "venv",
-                    self._venv_dir,
-                    "--python",
-                    sys.executable,
-                    "--system-site-packages",
-                    "--seed",
-                    "--quiet",
-                ],
-                check=True,
-                capture_output=True,
-                timeout=30,
-            )
+            try:
+                _sp.run(
+                    [
+                        uv,
+                        "venv",
+                        self._venv_dir,
+                        "--python",
+                        sys.executable,
+                        "--system-site-packages",
+                        "--seed",
+                        "--quiet",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    timeout=30,
+                )
+            except (_sp.CalledProcessError, _sp.TimeoutExpired) as exc:
+                # CalledProcessError/TimeoutExpired.__str__ omits the captured
+                # stderr, so uv's actual reason (bad --python, disk full) was
+                # never seen — only "returned non-zero exit status N".
+                stderr = (exc.stderr or b"").decode("utf-8", errors="replace").strip()
+                raise RuntimeError(f"uv venv failed: {stderr}" if stderr else str(exc)) from exc
         else:
             # symlinks=False is venv.create()'s own default on every platform
             # (only the `python -m venv` CLI defaults it per-OS); a copied
@@ -399,11 +406,10 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         return self.venv_python()
 
     def _verify_venv_python(self) -> bool:
+        self._last_verify_error = None
         if self._venv_python is None:
-            self._last_verify_error = None
             return False
         if not os.path.exists(self._venv_python):
-            self._last_verify_error = None
             return False
         try:
             import subprocess
@@ -414,9 +420,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 timeout=5,
             )
             ok = result.returncode == 0 and "ok" in result.stdout.decode("utf-8", errors="replace")
-            if ok:
-                self._last_verify_error = None
-            else:
+            if not ok:
                 stderr = result.stderr.decode("utf-8", errors="replace").strip()
                 self._last_verify_error = f"exit {result.returncode}" + (f": {stderr}" if stderr else "")
             return ok

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -307,9 +307,12 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         if uv:
             return uv
         if sys.platform == "win32":
+            local_app_data = os.environ.get("LOCALAPPDATA", "")
             candidates = (
                 os.path.expanduser("~/.local/bin/uv.exe"),
                 os.path.expanduser("~/.cargo/bin/uv.exe"),
+                os.path.expanduser("~/scoop/shims/uv.exe"),
+                os.path.join(local_app_data, "Microsoft", "WinGet", "Links", "uv.exe"),
             )
         else:
             # Package-manager locations a GUI-launched parent's PATH may miss.

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -312,8 +312,8 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 os.path.expanduser("~/.cargo/bin/uv.exe"),
             )
         else:
-            # Package-manager locations a GUI-launched parent's PATH may miss
-            # (mindshub#12484). Keep in sync with cowork's uv-paths.ts.
+            # Package-manager locations a GUI-launched parent's PATH may miss.
+            # Keep in sync with cowork's uv-paths.ts.
             candidates = (
                 os.path.expanduser("~/.local/bin/uv"),
                 os.path.expanduser("~/.cargo/bin/uv"),

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -310,9 +310,15 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 os.path.expanduser("~/.cargo/bin/uv.exe"),
             )
         else:
+            # Package-manager locations a GUI-launched parent's PATH may miss
+            # (mindshub#12484). Keep in sync with cowork's uv-paths.ts.
             candidates = (
                 os.path.expanduser("~/.local/bin/uv"),
                 os.path.expanduser("~/.cargo/bin/uv"),
+                "/opt/homebrew/bin/uv",
+                "/usr/local/bin/uv",
+                "/opt/local/bin/uv",
+                "/home/linuxbrew/.linuxbrew/bin/uv",
             )
         for candidate in candidates:
             if os.path.isfile(candidate) and os.access(candidate, os.X_OK):

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -397,8 +397,10 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
 
     def _verify_venv_python(self) -> bool:
         if self._venv_python is None:
+            self._last_verify_error = None
             return False
         if not os.path.exists(self._venv_python):
+            self._last_verify_error = None
             return False
         try:
             import subprocess

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -219,6 +219,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         self._boot_path: str | None = None
         self._venv_dir: str | None = None
         self._venv_python: str | None = None
+        self._last_verify_error: str | None = None
         self._venvs_base = (
             _venvs_base if _venvs_base is not None else default_venvs_base(workspace_path)
         )
@@ -286,8 +287,9 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                     self._setup_parent_site_packages()
                     self._save_python_version()
                     return
+                detail = f" ({self._last_verify_error})" if self._last_verify_error else ""
                 raise RuntimeError(
-                    f"venv Python binary at {self._venv_python} is not functional"
+                    f"venv Python binary at {self._venv_python} is not functional{detail}"
                 )
             except Exception as exc:
                 last_error = exc
@@ -406,8 +408,15 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 capture_output=True,
                 timeout=5,
             )
-            return result.returncode == 0 and "ok" in result.stdout.decode("utf-8", errors="replace")
-        except Exception:
+            ok = result.returncode == 0 and "ok" in result.stdout.decode("utf-8", errors="replace")
+            if ok:
+                self._last_verify_error = None
+            else:
+                stderr = result.stderr.decode("utf-8", errors="replace").strip()
+                self._last_verify_error = f"exit {result.returncode}" + (f": {stderr}" if stderr else "")
+            return ok
+        except Exception as exc:
+            self._last_verify_error = str(exc)
             return False
 
     def _nuke_venv(self) -> None:

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -349,11 +349,15 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
                 timeout=30,
             )
         else:
+            # symlinks=False is venv.create()'s own default on every platform
+            # (only the `python -m venv` CLI defaults it per-OS); a copied
+            # macOS Python binary loses its @rpath and crashes on launch.
             venv.create(
                 self._venv_dir,
                 system_site_packages=True,
                 with_pip=False,
                 clear=True,
+                symlinks=sys.platform != "win32",
             )
 
         if sys.platform == "win32":

--- a/tests/test_local_venv_provisioning.py
+++ b/tests/test_local_venv_provisioning.py
@@ -29,42 +29,21 @@ def make_pad(tmp_path, name="probe"):
     return LocalScratchpadRuntime(name=name, _venvs_base=tmp_path, **_DEFAULTS)
 
 
-def test_find_uv_checks_homebrew_apple_silicon(monkeypatch):
+@pytest.mark.parametrize(
+    "expected_path",
+    [
+        "/opt/homebrew/bin/uv",  # Homebrew, Apple Silicon
+        "/usr/local/bin/uv",  # Homebrew, Intel Mac
+        "/opt/local/bin/uv",  # MacPorts
+        "/home/linuxbrew/.linuxbrew/bin/uv",  # Linuxbrew
+    ],
+)
+def test_find_uv_checks_extra_unix_locations(monkeypatch, expected_path):
     monkeypatch.setattr(local.shutil, "which", lambda _: None)
-    monkeypatch.setattr(
-        local.os.path, "isfile", lambda p: p == "/opt/homebrew/bin/uv"
-    )
+    monkeypatch.setattr(local.os.path, "isfile", lambda p: p == expected_path)
     monkeypatch.setattr(local.os, "access", lambda p, mode: True)
 
-    assert local.LocalScratchpadRuntime._find_uv() == "/opt/homebrew/bin/uv"
-
-
-def test_find_uv_checks_homebrew_intel(monkeypatch):
-    monkeypatch.setattr(local.shutil, "which", lambda _: None)
-    monkeypatch.setattr(local.os.path, "isfile", lambda p: p == "/usr/local/bin/uv")
-    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
-
-    assert local.LocalScratchpadRuntime._find_uv() == "/usr/local/bin/uv"
-
-
-def test_find_uv_checks_macports(monkeypatch):
-    monkeypatch.setattr(local.shutil, "which", lambda _: None)
-    monkeypatch.setattr(local.os.path, "isfile", lambda p: p == "/opt/local/bin/uv")
-    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
-
-    assert local.LocalScratchpadRuntime._find_uv() == "/opt/local/bin/uv"
-
-
-def test_find_uv_checks_linuxbrew(monkeypatch):
-    monkeypatch.setattr(local.shutil, "which", lambda _: None)
-    monkeypatch.setattr(
-        local.os.path,
-        "isfile",
-        lambda p: p == "/home/linuxbrew/.linuxbrew/bin/uv",
-    )
-    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
-
-    assert local.LocalScratchpadRuntime._find_uv() == "/home/linuxbrew/.linuxbrew/bin/uv"
+    assert local.LocalScratchpadRuntime._find_uv() == expected_path
 
 
 def test_find_uv_still_prefers_shutil_which(monkeypatch):
@@ -113,6 +92,27 @@ def test_stdlib_fallback_does_not_force_symlinks_on_windows(tmp_path, monkeypatc
     assert create.call_args.kwargs["symlinks"] is False
 
 
+def test_create_venv_surfaces_uvs_stderr_on_failure(tmp_path, monkeypatch):
+    # CalledProcessError.__str__ omits the captured stderr by default, so a
+    # real uv failure (bad --python, disk full) reached the user as just
+    # "returned non-zero exit status N" — the same masking this whole fix
+    # was about, just at venv CREATION instead of verification.
+    import subprocess
+
+    pad = make_pad(tmp_path)
+    monkeypatch.setattr(LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: "/fake/uv"))
+
+    def fake_run(args, **kwargs):
+        raise subprocess.CalledProcessError(
+            returncode=2, cmd=args, stderr=b"error: no interpreter found for python-3.99\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(Exception, match="no interpreter found for python-3.99"):
+        pad._create_venv()
+
+
 def _write_fake_python(tmp_path, *, exit_code, stderr_text):
     """A fake venv "python" that fails a specific way when invoked as
     ``<path> -c "..."`` — stands in for a real dyld crash without needing one."""
@@ -132,7 +132,7 @@ def test_verify_captures_exit_code_and_stderr_on_failure(tmp_path, monkeypatch):
     assert pad._last_verify_error == "exit 7: boom"
 
 
-def test_verify_clears_the_error_on_success(tmp_path, monkeypatch):
+def test_verify_clears_the_error_on_success(tmp_path):
     pad = make_pad(tmp_path)
     pad._last_verify_error = "stale error from a previous attempt"
     pad._venv_python = sys.executable
@@ -161,7 +161,7 @@ def test_verify_clears_a_stale_error_when_the_interpreter_is_missing(tmp_path):
     assert pad._last_verify_error is None
 
 
-def test_verify_captures_an_exception_reason(tmp_path, monkeypatch):
+def test_verify_captures_an_exception_reason(tmp_path):
     if sys.platform == "win32":
         pytest.skip("posix-only: exec-permission semantics differ on Windows")
     pad = make_pad(tmp_path)

--- a/tests/test_local_venv_provisioning.py
+++ b/tests/test_local_venv_provisioning.py
@@ -1,0 +1,66 @@
+"""LocalScratchpadRuntime venv provisioning (mindshub#12484).
+
+`_find_uv()` only checked a couple of hardcoded directories with no live PATH
+search beyond `shutil.which`, so a uv installed via Homebrew/MacPorts/Linuxbrew
+was invisible whenever the parent process's PATH didn't happen to include it
+(e.g. cowork's Electron app launching cowork-server with a minimal PATH on
+macOS). These tests pin the widened candidate list.
+"""
+from __future__ import annotations
+
+import anton.core.backends.local as local
+
+
+def test_find_uv_checks_homebrew_apple_silicon(monkeypatch):
+    monkeypatch.setattr(local.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        local.os.path, "isfile", lambda p: p == "/opt/homebrew/bin/uv"
+    )
+    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
+
+    assert local.LocalScratchpadRuntime._find_uv() == "/opt/homebrew/bin/uv"
+
+
+def test_find_uv_checks_homebrew_intel(monkeypatch):
+    monkeypatch.setattr(local.shutil, "which", lambda _: None)
+    monkeypatch.setattr(local.os.path, "isfile", lambda p: p == "/usr/local/bin/uv")
+    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
+
+    assert local.LocalScratchpadRuntime._find_uv() == "/usr/local/bin/uv"
+
+
+def test_find_uv_checks_macports(monkeypatch):
+    monkeypatch.setattr(local.shutil, "which", lambda _: None)
+    monkeypatch.setattr(local.os.path, "isfile", lambda p: p == "/opt/local/bin/uv")
+    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
+
+    assert local.LocalScratchpadRuntime._find_uv() == "/opt/local/bin/uv"
+
+
+def test_find_uv_checks_linuxbrew(monkeypatch):
+    monkeypatch.setattr(local.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        local.os.path,
+        "isfile",
+        lambda p: p == "/home/linuxbrew/.linuxbrew/bin/uv",
+    )
+    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
+
+    assert local.LocalScratchpadRuntime._find_uv() == "/home/linuxbrew/.linuxbrew/bin/uv"
+
+
+def test_find_uv_still_prefers_shutil_which(monkeypatch):
+    # A uv resolvable via PATH wins over every hardcoded fallback — no
+    # regression to the existing, most-common path.
+    monkeypatch.setattr(local.shutil, "which", lambda _: "/usr/bin/uv")
+    monkeypatch.setattr(local.os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
+
+    assert local.LocalScratchpadRuntime._find_uv() == "/usr/bin/uv"
+
+
+def test_find_uv_returns_none_when_nowhere_found(monkeypatch):
+    monkeypatch.setattr(local.shutil, "which", lambda _: None)
+    monkeypatch.setattr(local.os.path, "isfile", lambda p: False)
+
+    assert local.LocalScratchpadRuntime._find_uv() is None

--- a/tests/test_local_venv_provisioning.py
+++ b/tests/test_local_venv_provisioning.py
@@ -1,4 +1,4 @@
-"""LocalScratchpadRuntime venv provisioning (mindshub#12484).
+"""LocalScratchpadRuntime venv provisioning.
 
 `_find_uv()` only checked a couple of hardcoded directories with no live PATH
 search beyond `shutil.which`, so a uv installed via Homebrew/MacPorts/Linuxbrew

--- a/tests/test_local_venv_provisioning.py
+++ b/tests/test_local_venv_provisioning.py
@@ -186,3 +186,28 @@ def test_ensure_venv_failure_message_includes_the_verify_detail(tmp_path, monkey
 
     with pytest.raises(RuntimeError, match="dyld: Library not loaded"):
         pad._ensure_venv()
+
+
+def test_find_uv_checks_scoop_on_windows(monkeypatch):
+    # scoop (~/scoop/shims/uv.exe) is the Windows analogue of Homebrew — a
+    # package-manager install invisible to a GUI-launched parent's PATH.
+    monkeypatch.setattr(local.sys, "platform", "win32")
+    monkeypatch.setattr(local.shutil, "which", lambda _: None)
+    scoop_path = os.path.expanduser("~/scoop/shims/uv.exe")
+    monkeypatch.setattr(local.os.path, "isfile", lambda p: p == scoop_path)
+    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
+
+    assert local.LocalScratchpadRuntime._find_uv() == scoop_path
+
+
+def test_find_uv_checks_winget_links_on_windows(monkeypatch):
+    monkeypatch.setattr(local.sys, "platform", "win32")
+    monkeypatch.setattr(local.shutil, "which", lambda _: None)
+    monkeypatch.setenv("LOCALAPPDATA", "C:\\Users\\u\\AppData\\Local")
+    winget_path = os.path.join(
+        "C:\\Users\\u\\AppData\\Local", "Microsoft", "WinGet", "Links", "uv.exe"
+    )
+    monkeypatch.setattr(local.os.path, "isfile", lambda p: p == winget_path)
+    monkeypatch.setattr(local.os, "access", lambda p, mode: True)
+
+    assert local.LocalScratchpadRuntime._find_uv() == winget_path

--- a/tests/test_local_venv_provisioning.py
+++ b/tests/test_local_venv_provisioning.py
@@ -141,6 +141,26 @@ def test_verify_clears_the_error_on_success(tmp_path, monkeypatch):
     assert pad._last_verify_error is None
 
 
+def test_verify_clears_a_stale_error_when_venv_python_is_unset(tmp_path):
+    # A retry that never got as far as setting _venv_python must not carry
+    # a PREVIOUS attempt's error into this attempt's (unrelated) failure.
+    pad = make_pad(tmp_path)
+    pad._last_verify_error = "stale error from a previous attempt"
+    pad._venv_python = None
+
+    assert pad._verify_venv_python() is False
+    assert pad._last_verify_error is None
+
+
+def test_verify_clears_a_stale_error_when_the_interpreter_is_missing(tmp_path):
+    pad = make_pad(tmp_path)
+    pad._last_verify_error = "stale error from a previous attempt"
+    pad._venv_python = str(tmp_path / "does-not-exist")
+
+    assert pad._verify_venv_python() is False
+    assert pad._last_verify_error is None
+
+
 def test_verify_captures_an_exception_reason(tmp_path, monkeypatch):
     if sys.platform == "win32":
         pytest.skip("posix-only: exec-permission semantics differ on Windows")

--- a/tests/test_local_venv_provisioning.py
+++ b/tests/test_local_venv_provisioning.py
@@ -8,7 +8,25 @@ macOS). These tests pin the widened candidate list.
 """
 from __future__ import annotations
 
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
 import anton.core.backends.local as local
+from anton.core.backends.local import LocalScratchpadRuntime
+
+_DEFAULTS = dict(
+    coding_provider="anthropic",
+    coding_model="",
+    coding_api_key="",
+    coding_base_url="",
+)
+
+
+def make_pad(tmp_path, name="probe"):
+    return LocalScratchpadRuntime(name=name, _venvs_base=tmp_path, **_DEFAULTS)
 
 
 def test_find_uv_checks_homebrew_apple_silicon(monkeypatch):
@@ -64,3 +82,32 @@ def test_find_uv_returns_none_when_nowhere_found(monkeypatch):
     monkeypatch.setattr(local.os.path, "isfile", lambda p: False)
 
     assert local.LocalScratchpadRuntime._find_uv() is None
+
+
+def test_stdlib_fallback_symlinks_the_interpreter_on_posix(tmp_path, monkeypatch):
+    # venv.create()'s library default is symlinks=False on every platform (only
+    # the `python -m venv` CLI defaults it per-OS); a copied macOS Python binary
+    # loses its @rpath and crashes on launch.
+    if sys.platform == "win32":
+        pytest.skip("posix-only: symlink semantics differ on Windows")
+    pad = make_pad(tmp_path)
+    monkeypatch.setattr(LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: None))
+
+    pad._create_venv()
+
+    assert os.path.islink(pad._venv_python)
+
+
+def test_stdlib_fallback_does_not_force_symlinks_on_windows(tmp_path, monkeypatch):
+    # Creating a symlink on Windows needs Developer Mode / elevation; forcing
+    # it would trade this crash for that one on machines without it.
+    pad = make_pad(tmp_path)
+    monkeypatch.setattr(LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: None))
+    monkeypatch.setattr(local.sys, "platform", "win32")
+    monkeypatch.setattr(pad, "_add_windows_firewall_rule", lambda: None)
+    create = MagicMock()
+    monkeypatch.setattr(local.venv, "create", create)
+
+    pad._create_venv()
+
+    assert create.call_args.kwargs["symlinks"] is False

--- a/tests/test_local_venv_provisioning.py
+++ b/tests/test_local_venv_provisioning.py
@@ -111,3 +111,58 @@ def test_stdlib_fallback_does_not_force_symlinks_on_windows(tmp_path, monkeypatc
     pad._create_venv()
 
     assert create.call_args.kwargs["symlinks"] is False
+
+
+def _write_fake_python(tmp_path, *, exit_code, stderr_text):
+    """A fake venv "python" that fails a specific way when invoked as
+    ``<path> -c "..."`` — stands in for a real dyld crash without needing one."""
+    script = tmp_path / "fake_python"
+    script.write_text(f'#!/bin/sh\necho "{stderr_text}" >&2\nexit {exit_code}\n')
+    script.chmod(0o755)
+    return str(script)
+
+
+def test_verify_captures_exit_code_and_stderr_on_failure(tmp_path, monkeypatch):
+    if sys.platform == "win32":
+        pytest.skip("posix-only: shebang scripts don't run directly on Windows")
+    pad = make_pad(tmp_path)
+    pad._venv_python = _write_fake_python(tmp_path, exit_code=7, stderr_text="boom")
+
+    assert pad._verify_venv_python() is False
+    assert pad._last_verify_error == "exit 7: boom"
+
+
+def test_verify_clears_the_error_on_success(tmp_path, monkeypatch):
+    pad = make_pad(tmp_path)
+    pad._last_verify_error = "stale error from a previous attempt"
+    pad._venv_python = sys.executable
+
+    assert pad._verify_venv_python() is True
+    assert pad._last_verify_error is None
+
+
+def test_verify_captures_an_exception_reason(tmp_path, monkeypatch):
+    if sys.platform == "win32":
+        pytest.skip("posix-only: exec-permission semantics differ on Windows")
+    pad = make_pad(tmp_path)
+    not_executable = tmp_path / "not_a_python"
+    not_executable.write_text("not a real interpreter")
+    not_executable.chmod(0o644)
+    pad._venv_python = str(not_executable)
+
+    assert pad._verify_venv_python() is False
+    assert pad._last_verify_error
+
+
+def test_ensure_venv_failure_message_includes_the_verify_detail(tmp_path, monkeypatch):
+    pad = make_pad(tmp_path)
+
+    def fake_verify():
+        pad._last_verify_error = "exit 1: dyld: Library not loaded"
+        return False
+
+    monkeypatch.setattr(pad, "_create_venv", lambda: None)
+    monkeypatch.setattr(pad, "_verify_venv_python", fake_verify)
+
+    with pytest.raises(RuntimeError, match="dyld: Library not loaded"):
+        pad._ensure_venv()


### PR DESCRIPTION
Fixes #https://github.com/mindsdb/mindshub/issues/12484

- _find_uv() now also checks Homebrew MacPorts and Linuxbrew
- venv.create()'s stdlib fallback now passes symlinks=(not win32) 
- A failed venv verification now reports the real cause 
- Tests added