### PR TITLE
ENG-1492: classify tool failures into a comparable root-cause key

### DIFF
--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -304,10 +304,28 @@ def classify(reason: str, result_text: str = "") -> RootCause:
     # it is visible as noise in the ENG-1492 distribution rather than hiding a
     # wall — and this is measurement-only until ENG-1531 reads any of it.
     #
+    # SECOND, OPPOSITE INTERACTION — this branch also runs BEFORE the
+    # `_WALL_TYPES` lookup below, so an ENUMERATED wall type whose path or host
+    # happens to contain a bare 3-digit 4xx/5xx token is demoted to transient
+    # and never reaches `root_cause_wall` or any trip rung. Measured:
+    #
+    #     FileNotFoundError … '/data/500/report.csv'  -> transient http_500
+    #     ConnectionRefusedError … db.internal:503    -> transient http_503
+    #     …'/data/report.csv'                         -> external_wall  (control)
+    #     …db.internal:5432                           -> external_wall  (control,
+    #                                                    4 digits, `\b` blocks it)
+    #
+    # So the status branch errs BOTH ways: it inflates walls from non-enumerated
+    # types (above) and deflates walls from enumerated ones (here). Both are
+    # tolerable while nothing consumes the tier, and the motivating dependency
+    # walls carry no such tokens (`pyodbc`/`pymssql` are unaffected).
+    #
     # For ENG-1531: do not trip on `_STATUS_WALLS` classes without either an
     # HTTP-shape precondition on the reason or a check that the exception type
-    # was enumerated. Frequency here is UNMEASURED; the combinatorial floor is
-    # 3/900 of uniformly distributed 3-digit tokens.
+    # was enumerated — that single precondition fixes both directions at once.
+    # And when sizing thresholds from the ENG-1492 distribution, know that walls
+    # with numeric ports or paths read LOW. Frequency here is UNMEASURED; the
+    # combinatorial floor is 3/900 of uniformly distributed 3-digit tokens.
     status = _STATUS_RE.search(reason)
     if status:
         code = status.group(1)

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -400,6 +400,27 @@ class RootCauseLedger:
     tiers: Counter = field(default_factory=Counter)
     failures: int = 0
     with_reason: int = 0
+    #: Times the recorder's guard swallowed an exception instead of booking a
+    #: failure. Emitted so a BROKEN instrument is distinguishable from a QUIET
+    #: one — without it the two are byte-identical:
+    #:
+    #:     3 wall failures, classifier raising -> failures=0 … wall=0
+    #:     3 successes, genuinely clean turn   -> failures=0 … wall=0
+    #:
+    #: That ambiguity matters because "the wall-repeat population is too small
+    #: to justify the control" is one of ENG-1492's own sanctioned conclusions,
+    #: so a silent instrument failure reads as a legitimate answer and would
+    #: cancel ENG-1531 on the strength of a bug. Same defect `reason_coverage`
+    #: was built to fix, one level down: a metric must not exclude its own
+    #: failures from its own denominator.
+    #:
+    #: Deliberately NOT counted in `failures` — that would corrupt the very
+    #: distribution this exists to protect. It is a separate signal.
+    classify_errors: int = 0
+
+    def note_error(self) -> None:
+        """Record that the guard caught something. Must never raise."""
+        self.classify_errors += 1
 
     def add(self, rc: RootCause) -> None:
         self.failures += 1
@@ -453,6 +474,7 @@ class RootCauseLedger:
         """
         return {
             "root_cause_failures": self.failures,
+            "root_cause_classify_errors": self.classify_errors,
             "root_cause_distinct": len(self.exact),
             "root_cause_max_exact": self.max_exact,
             "root_cause_max_class": self.max_class,

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -455,6 +455,19 @@ class RootCauseLedger:
         The live form of the writer inventory: a key computed over a third of
         failures would set thresholds wrong in the safe-looking direction, and
         this is the number that says whether that is happening.
+
+        **Read this together with `classify_errors`.** A classification that
+        RAISED reaches neither counter, so it leaves this ratio entirely — on
+        partial failure the number reads high:
+
+            3 classified (2 with reason) + 2 raised
+              -> reported 0.667, true 2/5 = 0.4
+
+        The systematic case is safe rather than flattering (if every
+        classification raises, `failures` is 0 and this reads 0.0, not 1.0), and
+        `classify_errors` is non-zero in both cases — so a dashboard should
+        treat any `classify_errors > 0` as "this ratio is an over-estimate"
+        rather than trusting it at face value.
         """
         return (self.with_reason / self.failures) if self.failures else 0.0
 

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -53,6 +53,22 @@ TIER_UNCLASSIFIED = "unclassified"
 #: ignored — see the module docstring for why that is structural, not a default.
 TRIP_ELIGIBLE_TIERS = frozenset({TIER_WALL})
 
+#: Wall classes that count on the EXACT rung only, never the coarse one.
+#:
+#: `missing_file` is genuinely ambiguous — a wrong path the agent invented is
+#: self-inflicted, a missing binary is a wall — and the two are indistinguishable
+#: from the error alone. The exact rung tells them apart by construction: the
+#: same path three times is a wall, three different paths is an agent exploring.
+#: Counting it on the coarse rung merges those, and worse, drowns real walls:
+#: measured, five file probes plus the four-attempt ENG-836 dependency wall in
+#: one turn emitted `max_class=5, top_class="missing_file"` — the wall this
+#: whole ticket exists to see, masked by exploration.
+#:
+#: The cost, stated because ENG-1492 already accepted it: a genuine wall spread
+#: over several paths (one missing ODBC install surfacing as three absent files)
+#: scores 1 on both rungs and is invisible.
+_EXACT_ONLY_CLASSES = frozenset({"missing_file"})
+
 #: The agent's own bugs. It can fix these by writing better code, so repetition
 #: is iteration, not a wall — however many times it repeats.
 _SELF_INFLICTED = frozenset({
@@ -242,9 +258,30 @@ def classify(reason: str, result_text: str = "") -> RootCause:
 
     exc = _exception_name(reason)
 
-    # Status codes are checked BEFORE the exception type: an HTTPError carrying
-    # a 429 is transient no matter what its class name suggests, and one
-    # carrying a 403 is a wall. The type alone cannot tell those apart.
+    # The explicit type tables win over the status heuristic, and the ORDER here
+    # is the safety property — not a style choice.
+    #
+    # The status check used to run first, on the reasoning that an HTTPError
+    # carrying 429 is transient whatever its class name says. True, but it
+    # searched `\b(4\d\d|5\d\d)\b` against the WHOLE reason with no HTTP-shape
+    # precondition, so any self-inflicted exception whose message happened to
+    # contain a bare 401/403/404 was promoted to `external_wall`, trip-eligible.
+    # Measured on real raised exceptions:
+    #
+    #     {200:..,404:..}[403]        -> KeyError: 403          -> wall, trip=True
+    #     assert 404 == 200           -> AssertionError         -> wall, trip=True
+    #     SyntaxError … (line 404)    -> wall, trip=True
+    #     …the same error at line 405 -> self_inflicted, trip=False
+    #
+    # That is exactly the "agent retries the same broken line" case this tier
+    # exists to exclude, so the guarantee in the module docstring was false for
+    # 8 specific integers. `HTTPError` is in neither table, so it still falls
+    # through to the status branch — which keeps the legitimate case working.
+    if exc in _SELF_INFLICTED:
+        return RootCause(TIER_SELF, exc, "")
+    if exc in _TRANSIENT:
+        return RootCause(TIER_TRANSIENT, exc, "")
+
     status = _STATUS_RE.search(reason)
     if status:
         code = status.group(1)
@@ -253,11 +290,6 @@ def classify(reason: str, result_text: str = "") -> RootCause:
         wall_cls = _STATUS_WALLS.get(code)
         if wall_cls:
             return RootCause(TIER_WALL, wall_cls, _identifier_for(wall_cls, reason))
-
-    if exc in _SELF_INFLICTED:
-        return RootCause(TIER_SELF, exc, "")
-    if exc in _TRANSIENT:
-        return RootCause(TIER_TRANSIENT, exc, "")
 
     wall_cls = _WALL_TYPES.get(exc)
     if wall_cls:
@@ -336,7 +368,8 @@ class RootCauseLedger:
             # trip" actually happens.
             return
         self.exact[rc.key] += 1
-        self.classes[rc.cls] += 1
+        if rc.cls not in _EXACT_ONLY_CLASSES:
+            self.classes[rc.cls] += 1
 
     @property
     def max_exact(self) -> int:

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -137,6 +137,21 @@ _STATUS_TRANSIENT = frozenset({"429", "500", "502", "503", "504"})
 
 _EXC_LINE_RE = re.compile(r"\b([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning))\b")
 
+#: Hard cap on what any regex here is allowed to see.
+#:
+#: `_HOSTPORT_RE` is O(n^2) on input containing no colon — `[\w.-]+` matches
+#: greedily from every start position and then fails. Measured: **1,051 ms** on
+#: 20,000 characters. Nothing reaches it that long today (the scratchpad handler
+#: caps its reason at 160 chars and every other producer emits a short sentinel
+#: or an exception name), but that guarantee lives in another file and would be
+#: silently lost the first time a handler passes a long reason. Capping here
+#: makes it local, and covers every pattern in this module rather than the one
+#: that happens to be quadratic.
+#:
+#: 500 is well past the longest real reason: a traceback's last line arrives
+#: pre-truncated to 160.
+_MAX_REASON_CHARS = 500
+
 
 @dataclass(frozen=True)
 class RootCause:
@@ -214,9 +229,10 @@ def classify(reason: str, result_text: str = "") -> RootCause:
     recorded as `from_reason=False` and lands in `unclassified`, which is not
     trip-eligible.
     """
-    reason = (reason or "").strip()
+    # Bounded before any regex sees it — see `_MAX_REASON_CHARS`.
+    reason = (reason or "").strip()[:_MAX_REASON_CHARS]
     if not reason:
-        sig = _normalise_error_signature(result_text or "")
+        sig = _normalise_error_signature((result_text or "")[:_MAX_REASON_CHARS])
         return RootCause(TIER_UNCLASSIFIED, "unclassified", sig[:80], from_reason=False)
 
     sentinel = _SENTINEL_REASONS.get(reason)

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -279,9 +279,28 @@ class RootCauseLedger:
     valid archive) are precisely why it never counted to five through the
     ENG-836 runaway.
 
-    Session-scoped because the control that will consume this fires at most once
-    per root cause per session, so the counts the thresholds are read off must be
-    the session's, not one turn's.
+    **Lifetime is one ChatSession, and that means different things per host —
+    check before reading the numbers as "per conversation".**
+
+    | host | ChatSession built | ledger effectively |
+    |------|-------------------|--------------------|
+    | CLI (`chat.py`) | once, then loops `turn_stream` | spans the conversation |
+    | Cowork (`anton_harness`) | inside `stream_response()`, i.e. per HTTP turn | **per turn** |
+
+    So on the primary product this resets every turn. That was NOT the original
+    intent — the design note said session-scoped, on the reasoning that
+    ENG-1531 fires once per root cause per session — and it is recorded here
+    because the difference is invisible from this file.
+
+    What it still measures correctly: a wall hit repeatedly **within one turn**,
+    which is the ENG-836 shape (all four pyodbc/apt/.deb/pymssql attempts were
+    in a single turn of 29 calls). What it misses: a wall that persists across
+    turns because the user said "try again", where each turn starts from zero.
+
+    Consequence for ENG-1531: its "at most once per root cause per session"
+    cannot be built on this object alone — it needs cowork-server to hold the
+    ledger per conversation, or to accept per-turn scope deliberately. Sizing
+    thresholds from this data is still valid; claiming session coverage is not.
     """
 
     exact: Counter = field(default_factory=Counter)

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -291,6 +291,23 @@ def classify(reason: str, result_text: str = "") -> RootCause:
     if exc in _TRANSIENT:
         return RootCause(TIER_TRANSIENT, exc, "")
 
+    # RESIDUAL, by construction — the guarantee above is scoped to types IN the
+    # table, and this branch is what a non-enumerated type falls through to. An
+    # agent bug raising a type nobody enumerated (`RuntimeError`, `LookupError`,
+    # a bare `Exception`) whose message happens to carry 401/403/404 still mints
+    # a trip-eligible `external_wall` — `RuntimeError: record 404 not found` is
+    # the realistic shape.
+    #
+    # Left as-is deliberately: widening `_SELF_INFLICTED` to catch it would have
+    # to include `Exception`, which would swallow every genuine wall raised as a
+    # generic type. The direction is the safe one — it INFLATES wall counts, so
+    # it is visible as noise in the ENG-1492 distribution rather than hiding a
+    # wall — and this is measurement-only until ENG-1531 reads any of it.
+    #
+    # For ENG-1531: do not trip on `_STATUS_WALLS` classes without either an
+    # HTTP-shape precondition on the reason or a check that the exception type
+    # was enumerated. Frequency here is UNMEASURED; the combinatorial floor is
+    # 3/900 of uniformly distributed 3-digit tokens.
     status = _STATUS_RE.search(reason)
     if status:
         code = status.group(1)

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -363,14 +363,14 @@ class RootCauseLedger:
     def event_fields(self) -> dict:
         """Flat properties for the turn's analytics event and log line."""
         return {
-            "rc_failures": self.failures,
-            "rc_distinct": len(self.exact),
-            "rc_max_exact": self.max_exact,
-            "rc_max_class": self.max_class,
-            "rc_top_class": self.top_class,
-            "rc_reason_coverage": round(self.reason_coverage, 3),
-            "rc_self_inflicted": self.tiers.get(TIER_SELF, 0),
-            "rc_transient": self.tiers.get(TIER_TRANSIENT, 0),
-            "rc_wall": self.tiers.get(TIER_WALL, 0),
-            "rc_unclassified": self.tiers.get(TIER_UNCLASSIFIED, 0),
+            "root_cause_failures": self.failures,
+            "root_cause_distinct": len(self.exact),
+            "root_cause_max_exact": self.max_exact,
+            "root_cause_max_class": self.max_class,
+            "root_cause_top_class": self.top_class,
+            "root_cause_reason_coverage": round(self.reason_coverage, 3),
+            "root_cause_self_inflicted": self.tiers.get(TIER_SELF, 0),
+            "root_cause_transient": self.tiers.get(TIER_TRANSIENT, 0),
+            "root_cause_wall": self.tiers.get(TIER_WALL, 0),
+            "root_cause_unclassified": self.tiers.get(TIER_UNCLASSIFIED, 0),
         }

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -140,7 +140,16 @@ _SENTINEL_REASONS = {
 # matters here — the opposite error merely groups two walls together, which is
 # visible in the data rather than silent.
 _MODULE_RE = re.compile(r"No module named ['\"]([\w.]+)['\"]")
-_IMPORT_NAME_RE = re.compile(r"cannot import name ['\"](\w+)['\"]")
+# Captures the MODULE, not the symbol. Keying on the symbol split one broken
+# package into as many keys as symbols the agent tried to import from it —
+# three failures on `pandas` scoring max_exact=1, distinct=3 — and made
+# `cannot import name 'read_excel' from 'pandas'` a different wall from
+# `No module named 'pandas'`. The `.split(".")[0]` at the use site is a no-op on
+# a symbol, which is the evidence the module was always intended.
+_IMPORT_NAME_RE = re.compile(
+    r"cannot import name ['\"]\w+['\"] from "
+    r"(?:partially initialized module )?['\"]([\w.]+)['\"]"
+)
 _PATH_RE = re.compile(r"['\"]([^'\"]{1,120})['\"]")
 _WINERR_PATH_RE = re.compile(r"\[(?:Errno|WinError) \d+\][^:]*: ['\"]?([^'\"]{1,120})")
 _HOSTPORT_RE = re.compile(r"([\w.-]+):(\d{2,5})")
@@ -394,7 +403,19 @@ class RootCauseLedger:
         return (self.with_reason / self.failures) if self.failures else 0.0
 
     def event_fields(self) -> dict:
-        """Flat properties for the turn's analytics event and log line."""
+        """Flat properties for the turn's analytics event and log line.
+
+        **Emitted per turn; the VALUES are cumulative for the ledger's lifetime**
+        (see the class docstring — one turn under Cowork, the whole conversation
+        under the CLI). The names read as per-turn and are not.
+
+        This matters for ENG-1492's actual deliverable, the distribution that
+        sets ENG-1286/ENG-1531's thresholds: on a host where the ledger spans
+        turns, a 10-turn session emits 10 events whose counts only climb, so a
+        naive per-EVENT percentile is dominated by long sessions and reads high.
+        Take the LAST event per session, or compute per-session maxima — never
+        a percentile over the raw event stream.
+        """
         return {
             "root_cause_failures": self.failures,
             "root_cause_distinct": len(self.exact),

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -1,0 +1,341 @@
+"""Root-cause classification for tool failures (ENG-1492).
+
+Turns ENG-1276's per-failure ``ToolOutcome.reason`` into a **comparable key**,
+so "is this the same wall as last time?" becomes a lookup instead of a guess.
+This module only measures. Nothing here trips, hands back, or touches the
+existing per-tool error streak — the control that consumes it is ENG-1531, and
+it is deliberately not built until this has reported real numbers.
+
+Why a key at all
+----------------
+The ENG-836 runaway ping-ponged ``pyodbc`` -> ``apt`` -> ``.deb`` -> ``pymssql``:
+four approaches, four different error texts, **one wall** (no ODBC driver, no
+root). Matching normalised error *text* would see four unrelated problems, which
+is why the key has two levels — a ``class`` that collapses all four, and an
+``identifier`` that keeps them apart when that matters.
+
+The tiers are the safety argument
+---------------------------------
+Not the thresholds. A breaker keyed on repetition is one bad classification away
+from interrupting an agent that is productively fixing its own bug, and the
+2026-08-12 harvest showed the heaviest turns are *dominated* by exactly that:
+UnicodeEncodeError, NameError, SyntaxError, AttributeError, PyCompileError. So
+``self_inflicted`` failures are excluded **structurally** — they are counted, and
+they can never become trip-eligible however often they repeat.
+
+ENG-1286's original argument was that self-repair escapes because the error
+changes on each attempt. That is probabilistic and fails exactly when an agent
+retries the same broken line. This does not.
+
+``transient`` is the same move for ENG-836's probe G (a 429 twice is not a wall),
+and it closes a real gap: ENG-673's ``classify_transient`` lives in the LLM
+clients and is unreachable from a tool outcome, so tiering by exception type buys
+transient exclusion without building tool-level transient typing first.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+# Reused as a PURE FUNCTION. Deliberately not the ACC subsystem it lives in:
+# `_acc_observe` returns early when ANTON_ACC_MODE == "off", and a signal that
+# disappears when a memory feature flag flips is convention 9's state-gated trap.
+from anton.core.memory.acc import _normalise_error_signature
+
+TIER_SELF = "self_inflicted"
+TIER_TRANSIENT = "transient"
+TIER_WALL = "external_wall"
+TIER_UNCLASSIFIED = "unclassified"
+
+#: Only this tier may ever contribute to a trip. Everything else is measured and
+#: ignored — see the module docstring for why that is structural, not a default.
+TRIP_ELIGIBLE_TIERS = frozenset({TIER_WALL})
+
+#: The agent's own bugs. It can fix these by writing better code, so repetition
+#: is iteration, not a wall — however many times it repeats.
+_SELF_INFLICTED = frozenset({
+    "NameError", "SyntaxError", "IndentationError", "TabError", "TypeError",
+    "AttributeError", "KeyError", "IndexError", "ValueError", "UnboundLocalError",
+    "ZeroDivisionError", "PyCompileError", "UnicodeEncodeError",
+    "UnicodeDecodeError", "UnicodeError", "AssertionError", "StopIteration",
+    "RecursionError", "NotImplementedError",
+})
+
+#: Retryable by nature. Two of these is a provider blip, not a blocked task.
+_TRANSIENT = frozenset({
+    "ConnectionResetError", "ConnectionAbortedError", "BrokenPipeError",
+    "TimeoutError", "ReadTimeout", "ReadTimeoutError", "ConnectTimeout",
+    "SSLError", "ChunkedEncodingError", "IncompleteRead", "RemoteDisconnected",
+})
+
+#: Exception type -> wall class. The identifier is pulled separately below.
+_WALL_TYPES = {
+    "ModuleNotFoundError": "missing_dependency",
+    "ImportError": "missing_dependency",
+    "PermissionError": "permission_denied",
+    "FileNotFoundError": "missing_file",
+    "NotADirectoryError": "missing_file",
+    "IsADirectoryError": "missing_file",
+    "ConnectionRefusedError": "connection_refused",
+    "OperationalError": "db_unavailable",
+    "InterfaceError": "db_unavailable",
+    "DatabaseError": "db_unavailable",
+    "MemoryError": "resource_exhausted",
+    "OSError": "resource_exhausted",
+}
+
+#: Sentinel reasons handlers emit instead of an exception name. These are the
+#: handler's own verdict, so they are the most trustworthy input this has —
+#: every one is enumerated from the tree by `test_every_sentinel_reason_is_mapped`,
+#: which fails when a new one is added without a decision here.
+#:
+#: **Ambiguous sentinels are deliberately NOT trip-eligible.** A false wall
+#: interrupts a working agent; a missed wall only means the spend ceiling catches
+#: it later. The costs are not symmetric, so ambiguity resolves away from the
+#: tier that can trip.
+_SENTINEL_REASONS = {
+    # The agent passed bad or missing arguments — it can fix these itself.
+    "scratchpad_empty_code": (TIER_SELF, "empty_code"),
+    "scratchpad_missing_name": (TIER_SELF, "missing_name"),
+    "missing_name": (TIER_SELF, "missing_argument"),
+    "missing_slug": (TIER_SELF, "missing_argument"),
+    "missing_description": (TIER_SELF, "missing_argument"),
+    "invalid_type": (TIER_SELF, "invalid_argument"),
+    "invalid_port": (TIER_SELF, "invalid_argument"),
+    "invalid_health_timeout": (TIER_SELF, "invalid_argument"),
+    "invalid_datasources": (TIER_SELF, "invalid_argument"),
+    # The agent named something that does not exist. Ambiguous — it could be a
+    # genuinely absent resource — but the agent chose the identifier and can
+    # list the real ones, so it resolves to the non-tripping side.
+    "artifact_not_found": (TIER_SELF, "unknown_resource"),
+    "unknown_datasource": (TIER_SELF, "unknown_resource"),
+    # Genuine walls: the environment is missing something the agent cannot add.
+    "package_install_failed": (TIER_WALL, "missing_dependency"),
+    "store_unavailable": (TIER_WALL, "service_unavailable"),
+    # Could be environment or config and the sentinel does not say which, so it
+    # stays out of every trip rung until something distinguishes them.
+    "launch_failed": (TIER_UNCLASSIFIED, "unclassified"),
+}
+
+# Identifier extraction, per class. Kept narrow on purpose: a wrong identifier
+# splits one wall into several and hides it, which is the failure mode that
+# matters here — the opposite error merely groups two walls together, which is
+# visible in the data rather than silent.
+_MODULE_RE = re.compile(r"No module named ['\"]([\w.]+)['\"]")
+_IMPORT_NAME_RE = re.compile(r"cannot import name ['\"](\w+)['\"]")
+_PATH_RE = re.compile(r"['\"]([^'\"]{1,120})['\"]")
+_WINERR_PATH_RE = re.compile(r"\[(?:Errno|WinError) \d+\][^:]*: ['\"]?([^'\"]{1,120})")
+_HOSTPORT_RE = re.compile(r"([\w.-]+):(\d{2,5})")
+_STATUS_RE = re.compile(r"\b(4\d\d|5\d\d)\b")
+
+#: HTTP statuses that are walls rather than blips, mapped to their class.
+_STATUS_WALLS = {"401": "auth_missing", "403": "permission_denied", "404": "missing_file"}
+#: …and the ones that are always transient, whatever else the text says.
+_STATUS_TRANSIENT = frozenset({"429", "500", "502", "503", "504"})
+
+_EXC_LINE_RE = re.compile(r"\b([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning))\b")
+
+
+@dataclass(frozen=True)
+class RootCause:
+    """One failure, classified.
+
+    ``key`` is the exact rung (``class:identifier``); ``cls`` alone is the
+    coarse rung that collapses the ENG-836 ping-pong. ``trip_eligible`` is the
+    whole safety contract in one boolean — a consumer must never re-derive it
+    from the tier, or the exclusion stops being structural.
+    """
+
+    tier: str
+    cls: str
+    identifier: str
+    #: False when nothing usable was available and the key came from normalised
+    #: result text. Counted separately so the coverage share is measurable
+    #: rather than assumed (convention 9's writer-inventory, as a live metric).
+    from_reason: bool = True
+
+    @property
+    def key(self) -> str:
+        return f"{self.cls}:{self.identifier}" if self.identifier else self.cls
+
+    @property
+    def trip_eligible(self) -> bool:
+        return self.tier in TRIP_ELIGIBLE_TIERS
+
+
+def _exception_name(reason: str) -> str:
+    """The exception type at the head of a reason, or ''.
+
+    `reason` is usually a traceback's LAST line (`tool_handlers.py`), which is
+    where the type lives, but a bare `type(exc).__name__` also arrives here from
+    the dispatcher's own except-clause.
+    """
+    reason = (reason or "").strip()
+    if not reason:
+        return ""
+    head = reason.split(":", 1)[0].strip()
+    if head and head.replace("_", "").isalnum() and head[0].isupper():
+        return head
+    m = _EXC_LINE_RE.search(reason)
+    return m.group(1) if m else ""
+
+
+def _identifier_for(cls: str, text: str) -> str:
+    """The salient noun for a wall class — the module, path, host or service.
+
+    Normalised through `_normalise_error_signature` when nothing more specific
+    is found, so two spellings of the same failure still land together.
+    """
+    if cls == "missing_dependency":
+        m = _MODULE_RE.search(text) or _IMPORT_NAME_RE.search(text)
+        if m:
+            # Top-level package only: `pandas.io.parsers` and `pandas` are one
+            # missing dependency, and the breaker must see them as such.
+            return m.group(1).split(".")[0]
+    if cls in ("missing_file", "permission_denied"):
+        m = _WINERR_PATH_RE.search(text) or _PATH_RE.search(text)
+        if m:
+            return m.group(1)
+    if cls in ("connection_refused", "db_unavailable", "auth_missing"):
+        m = _HOSTPORT_RE.search(text)
+        if m:
+            return f"{m.group(1)}:{m.group(2)}"
+    return _normalise_error_signature(text)[:80]
+
+
+def classify(reason: str, result_text: str = "") -> RootCause:
+    """Classify one tool failure.
+
+    `reason` is ENG-1276's `ToolOutcome.reason` — the handler's own machine
+    comparable cause. `result_text` is the fallback for handlers that set none;
+    keying on it is weaker (it is prose the model can influence) so it is
+    recorded as `from_reason=False` and lands in `unclassified`, which is not
+    trip-eligible.
+    """
+    reason = (reason or "").strip()
+    if not reason:
+        sig = _normalise_error_signature(result_text or "")
+        return RootCause(TIER_UNCLASSIFIED, "unclassified", sig[:80], from_reason=False)
+
+    sentinel = _SENTINEL_REASONS.get(reason)
+    if sentinel:
+        tier, cls = sentinel
+        return RootCause(tier, cls, "")
+
+    exc = _exception_name(reason)
+
+    # Status codes are checked BEFORE the exception type: an HTTPError carrying
+    # a 429 is transient no matter what its class name suggests, and one
+    # carrying a 403 is a wall. The type alone cannot tell those apart.
+    status = _STATUS_RE.search(reason)
+    if status:
+        code = status.group(1)
+        if code in _STATUS_TRANSIENT:
+            return RootCause(TIER_TRANSIENT, f"http_{code}", "")
+        wall_cls = _STATUS_WALLS.get(code)
+        if wall_cls:
+            return RootCause(TIER_WALL, wall_cls, _identifier_for(wall_cls, reason))
+
+    if exc in _SELF_INFLICTED:
+        return RootCause(TIER_SELF, exc, "")
+    if exc in _TRANSIENT:
+        return RootCause(TIER_TRANSIENT, exc, "")
+
+    wall_cls = _WALL_TYPES.get(exc)
+    if wall_cls:
+        # OSError is the catch-all base class — only treat it as a resource wall
+        # when the text actually says so, else it is too coarse to key on.
+        if exc == "OSError" and not re.search(
+            r"No space|Disk quota|Too many open files|Cannot allocate", reason, re.I
+        ):
+            return RootCause(TIER_UNCLASSIFIED, "unclassified",
+                             _normalise_error_signature(reason)[:80])
+        return RootCause(TIER_WALL, wall_cls, _identifier_for(wall_cls, reason))
+
+    # Timeouts and kills the runtime words rather than raises.
+    low = reason.lower()
+    if "timed out" in low or "timeout" in low or "inactivity" in low or "liveness" in low:
+        return RootCause(TIER_TRANSIENT, "timeout", "")
+    if "permission denied" in low:
+        return RootCause(TIER_WALL, "permission_denied",
+                         _identifier_for("permission_denied", reason))
+    if "connection refused" in low:
+        return RootCause(TIER_WALL, "connection_refused",
+                         _identifier_for("connection_refused", reason))
+
+    return RootCause(TIER_UNCLASSIFIED, "unclassified",
+                     _normalise_error_signature(reason)[:80])
+
+
+@dataclass
+class RootCauseLedger:
+    """Session-scoped tally of classified failures.
+
+    **Occurrences, never a streak.** A success must not reset anything — that is
+    ENG-1276's lesson one level up. The existing per-tool streak reset on
+    success, and interleaved false successes (a 404 HTML page that parsed as a
+    valid archive) are precisely why it never counted to five through the
+    ENG-836 runaway.
+
+    Session-scoped because the control that will consume this fires at most once
+    per root cause per session, so the counts the thresholds are read off must be
+    the session's, not one turn's.
+    """
+
+    exact: Counter = field(default_factory=Counter)
+    classes: Counter = field(default_factory=Counter)
+    tiers: Counter = field(default_factory=Counter)
+    failures: int = 0
+    with_reason: int = 0
+
+    def add(self, rc: RootCause) -> None:
+        self.failures += 1
+        self.tiers[rc.tier] += 1
+        if rc.from_reason:
+            self.with_reason += 1
+        if not rc.trip_eligible:
+            # Counted in `tiers` for the coverage picture, but kept out of the
+            # rungs a trip could ever read. This is where "structurally cannot
+            # trip" actually happens.
+            return
+        self.exact[rc.key] += 1
+        self.classes[rc.cls] += 1
+
+    @property
+    def max_exact(self) -> int:
+        return max(self.exact.values(), default=0)
+
+    @property
+    def max_class(self) -> int:
+        return max(self.classes.values(), default=0)
+
+    @property
+    def top_class(self) -> str:
+        return self.classes.most_common(1)[0][0] if self.classes else ""
+
+    @property
+    def reason_coverage(self) -> float:
+        """Share of failures that carried a usable `ToolOutcome.reason`.
+
+        The live form of the writer inventory: a key computed over a third of
+        failures would set thresholds wrong in the safe-looking direction, and
+        this is the number that says whether that is happening.
+        """
+        return (self.with_reason / self.failures) if self.failures else 0.0
+
+    def event_fields(self) -> dict:
+        """Flat properties for the turn's analytics event and log line."""
+        return {
+            "rc_failures": self.failures,
+            "rc_distinct": len(self.exact),
+            "rc_max_exact": self.max_exact,
+            "rc_max_class": self.max_class,
+            "rc_top_class": self.top_class,
+            "rc_reason_coverage": round(self.reason_coverage, 3),
+            "rc_self_inflicted": self.tiers.get(TIER_SELF, 0),
+            "rc_transient": self.tiers.get(TIER_TRANSIENT, 0),
+            "rc_wall": self.tiers.get(TIER_WALL, 0),
+            "rc_unclassified": self.tiers.get(TIER_UNCLASSIFIED, 0),
+        }

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1001,6 +1001,10 @@ class ChatSession:
                     classify_root_cause("", result_text or "")
                 )
             except Exception:  # pragma: no cover - reporting must not break a turn
+                # Count it, don't just log it — `logger.debug` is not emitted in
+                # production, so a systematically broken classifier would be
+                # indistinguishable from a turn where nothing failed.
+                self._root_causes.note_error()
                 logger.debug("root-cause classification failed", exc_info=True)
             return
         if tool_ok is not False:
@@ -1010,6 +1014,7 @@ class ChatSession:
                 classify_root_cause(reason or "", result_text or "")
             )
         except Exception:  # pragma: no cover - reporting must not break a turn
+            self._root_causes.note_error()
             logger.debug("root-cause classification failed", exc_info=True)
 
     def _apply_error_tracking(

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -142,12 +142,26 @@ logger = logging.getLogger(__name__)
 #: (ENG-1276 migrated five sites; the rest still return plain strings). Kept
 #: byte-identical to `_apply_error_tracking`'s fallback so the two cannot drift
 #: into disagreeing about what a failure is.
+#:
+#: **This tuple is the boundary of the coverage metric.** A legacy handler that
+#: reports failure in plain prose matches nothing here and is not counted at all
+#: — cowork-server's `connect_new_datasource` returns "Could not connect to the
+#: datasource.", which matches none of the five. Measured:
+#:
+#:     captured=True   Install failed (exit 1): … fatal error: sql.h
+#:     captured=True   Install timed out after 300s.
+#:     captured=False  Could not connect to the datasource.
+#:     captured=False  Successfully installed pandas-2.2.0   <- correctly skipped
+#:
+#: The direction is safe — a miss shows up as LOW `reason_coverage` rather than
+#: the false 1.0 this list exists to prevent — but do not read coverage as
+#: "share of failures classified" without remembering the denominator is itself
+#: substring-defined.
 _LEGACY_FAILURE_MARKERS = ("[error]", "Task failed:", "failed", "timed out", "Rejected:")
 
 
 def _legacy_looks_like_failure(text: str) -> bool:
     return any(m in text for m in _LEGACY_FAILURE_MARKERS)
-
 
 
 if TYPE_CHECKING:
@@ -611,7 +625,6 @@ def _build_verify_request(
 
 
 @dataclass
-
 class ChatSessionConfig:
     """All construction parameters for a ChatSession.
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -21,6 +21,8 @@ from anton.core.backends.local import local_scratchpad_runtime_factory
 from anton.core.datasources.data_vault import DataVault
 from anton.core.llm.prompt_builder import ChatSystemPromptBuilder, SystemPromptContext
 from anton.core.memory.acc import AnteriorCingulate
+from anton.core.root_cause import RootCauseLedger
+from anton.core.root_cause import classify as classify_root_cause
 from anton.core.memory.base import Engram
 from anton.core.memory.cerebellum import Cerebellum
 from anton.core.memory.skills import SkillStore
@@ -688,6 +690,14 @@ class ChatSession:
         # older settings object doesn't break — absent means "no ceiling",
         # matching the pre-ENG-1286 behaviour rather than silently applying one.
         self._max_turn_tokens = getattr(s, "max_turn_tokens", 0)
+        # Session-scoped tally of classified tool failures (ENG-1492).
+        # MEASUREMENT ONLY — nothing reads this to change behaviour. The control
+        # that will (ENG-1531) is deliberately unbuilt until this has reported
+        # real numbers, because the thresholds it needs currently rest on one
+        # incident. Session-scoped, not per-turn: that control fires at most
+        # once per root cause per session, so the counts its thresholds are read
+        # off must be the session's too.
+        self._root_causes = RootCauseLedger()
         # Latch for a verifier that fails the same hard way every turn — e.g.
         # kimi-K3 rejecting forced `tool_choice` with a 400 (ENG-1095), which
         # fails on every verdict call until the gateway fix lands. Without the
@@ -923,6 +933,31 @@ class ChatSession:
             "summary": self._history[0]["content"],
             "covered_through": min(self._last_compacted_count, self._seed_len),
         }
+
+
+    def _record_root_cause(
+        self, tool_ok: bool | None, reason: str, result_text: str
+    ) -> None:
+        """Classify one tool failure into the session ledger (ENG-1492).
+
+        MEASUREMENT ONLY. This must never change what the turn does — it exists
+        so ENG-1531's thresholds can come from data rather than from the single
+        ENG-836 trace, and so "is a wall-repeat population large enough to
+        justify a breaker at all" becomes answerable.
+
+        Keyed on the handler's own `ToolOutcome.reason` (ENG-1276), falling back
+        to the result text only to record that the reason was MISSING — that
+        path lands in `unclassified`, which no trip rung can read. Guarded whole
+        because a reporting side-effect must never be able to fail a turn.
+        """
+        if tool_ok is not False:
+            return
+        try:
+            self._root_causes.add(
+                classify_root_cause(reason or "", result_text or "")
+            )
+        except Exception:  # pragma: no cover - reporting must not break a turn
+            logger.debug("root-cause classification failed", exc_info=True)
 
     def _apply_error_tracking(
         self,
@@ -2107,11 +2142,17 @@ class ChatSession:
         # Stamped at books-open; the live lookup remains only for bare-session
         # tests and the legacy non-streaming path.
         turn_index = tc.turn_index or (self._turn_count + 1)
+        # Never let reporting break a turn — same contract as the analytics
+        # sink below (ENG-1492).
+        try:
+            _rc_fields = self._root_causes.event_fields()
+        except Exception:  # pragma: no cover - defensive
+            _rc_fields = {}
         logger.info(
             "turn_cost session=%s turn=%d ended_by=%s tokens_total=%d "
             "input=%d output=%d cache_read=%d cache_creation=%d "
             "llm_calls=%d rounds=%d continuations=%d peak_context=%d duration_ms=%d "
-            "by_role=%s",
+            "by_role=%s %s",
             self._session_id, turn_index, tc.ended_by, tc.total_tokens,
             tc.input_tokens, tc.output_tokens, tc.cache_read_tokens,
             tc.cache_creation_tokens, tc.llm_calls, tc.rounds,
@@ -2120,6 +2161,13 @@ class ChatSession:
                 f"{role}={s.model}:{s.tokens}/{s.calls}"
                 for role, s in sorted(tc.by_role.items())
             ) or "-",
+            # Root-cause tally (ENG-1492), session-cumulative. Appended to the
+            # SAME line rather than emitted separately so a turn's cost and the
+            # failures behind it can never be read apart, and so this survives
+            # the collector allowlist that silently dropped `turn_completed`'s
+            # properties for weeks (ENG-1355) — the log is the sink that does
+            # not depend on it.
+            " ".join(f"{k}={v}" for k, v in _rc_fields.items()),
         )
 
         # Analytics sink — same settings-resolution pattern as the
@@ -2140,6 +2188,12 @@ class ChatSession:
             send_event(
                 settings,
                 "turn_completed",
+                # Root-cause tally (ENG-1492). These are new property NAMES, so
+                # they need ENG-1355's pass-through fix (or ENG-1495's direct
+                # route) to reach PostHog at all — until then the log line above
+                # is the only sink, and its absence here is not evidence the
+                # classification is broken.
+                **_rc_fields,
                 ended_by=tc.ended_by,
                 tokens_total=str(tc.total_tokens),
                 input_tokens=str(tc.input_tokens),
@@ -2872,6 +2926,7 @@ class ChatSession:
                         resilience_nudged.discard(tc.name)
                 else:
                     result = scrub_credentials(result)
+                    self._record_root_cause(outcome.ok, outcome.reason, result)
                     result = self._apply_error_tracking(
                         result,
                         tc.name,
@@ -3757,6 +3812,9 @@ class ChatSession:
                     # drives the error streak instead of text matching
                     # (ENG-1276). None = unmigrated handler → legacy fallback.
                     tool_ok: bool | None = None
+                    # ENG-1276 populated this and nothing ever read it; ENG-1492
+                    # is what reads it.
+                    tool_reason: str = ""
                     try:
                         if tc.name == "scratchpad" and tc.input.get("action") == "exec":
                             # Inline streaming exec — yields progress events
@@ -3764,6 +3822,7 @@ class ChatSession:
                             if isinstance(prep, ToolOutcome):
                                 result_text = prep.content
                                 tool_ok = prep.ok
+                                tool_reason = prep.reason
                             else:
                                 (
                                     pad,
@@ -3818,6 +3877,15 @@ class ChatSession:
                                 # success nor failure (ENG-1276).
                                 if cell is not None:
                                     tool_ok = not (cell.error or "").strip()
+                                    # Same source `tool_handlers` uses for its
+                                    # ToolOutcome: the traceback's LAST line is
+                                    # the cause, and it is the runtime's own
+                                    # output rather than anything the model
+                                    # wrote (ENG-1492).
+                                    _cell_err = (cell.error or "").strip()
+                                    tool_reason = (
+                                        _cell_err.splitlines()[-1][:160] if _cell_err else ""
+                                    )
                                 if cell is not None:
                                     self._record_cell_explainability(
                                         pad_name=tc.input.get("name", ""),
@@ -3883,6 +3951,7 @@ class ChatSession:
                                     yield self.emitter.get_nowait()
                                 result_text = _outcome.content
                                 tool_ok = _outcome.ok
+                                tool_reason = _outcome.reason
                             finally:
                                 if self.escape_watcher:
                                     self.escape_watcher.resume()
@@ -3937,6 +4006,7 @@ class ChatSession:
                                     yield self.emitter.get_nowait()
                                 result_text = _outcome.content
                                 tool_ok = _outcome.ok
+                                tool_reason = _outcome.reason
                             except Exception as exc:
                                 # Caught locally ONLY so the tool_done marker
                                 # below can still be yielded from ordinary
@@ -3990,6 +4060,7 @@ class ChatSession:
                         # A raise is a definitive failure verdict (ENG-1276).
                         result_text = f"Tool '{tc.name}' failed: {exc}"
                         tool_ok = False
+                        tool_reason = type(exc).__name__
 
                     if isinstance(result_text, list):
                         # Multimodal tool result — scrub credentials from text
@@ -4045,6 +4116,7 @@ class ChatSession:
                             tool=tc.name,
                         )
                     result_text = scrub_credentials(result_text)
+                    self._record_root_cause(tool_ok, tool_reason, result_text)
                     result_text = self._apply_error_tracking(
                         result_text, tc.name, error_streak, resilience_nudged,
                         ok=tool_ok,

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -690,13 +690,15 @@ class ChatSession:
         # older settings object doesn't break — absent means "no ceiling",
         # matching the pre-ENG-1286 behaviour rather than silently applying one.
         self._max_turn_tokens = getattr(s, "max_turn_tokens", 0)
-        # Session-scoped tally of classified tool failures (ENG-1492).
-        # MEASUREMENT ONLY — nothing reads this to change behaviour. The control
-        # that will (ENG-1531) is deliberately unbuilt until this has reported
-        # real numbers, because the thresholds it needs currently rest on one
-        # incident. Session-scoped, not per-turn: that control fires at most
-        # once per root cause per session, so the counts its thresholds are read
-        # off must be the session's too.
+        # Tally of classified tool failures (ENG-1492). MEASUREMENT ONLY —
+        # nothing reads this to change behaviour. The control that will
+        # (ENG-1531) is deliberately unbuilt until this has reported real
+        # numbers, because the thresholds it needs rest on one incident.
+        #
+        # Lifetime is this ChatSession, which is NOT the same as a conversation
+        # on every host: the CLI builds one session and loops, but cowork-server
+        # builds a fresh one per HTTP turn, so there this resets every turn.
+        # See `RootCauseLedger` for what that does and does not still measure.
         self._root_causes = RootCauseLedger()
         # Latch for a verifier that fails the same hard way every turn — e.g.
         # kimi-K3 rejecting forced `tool_choice` with a 400 (ENG-1095), which

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1000,10 +1000,15 @@ class ChatSession:
                 self._root_causes.add(
                     classify_root_cause("", result_text or "")
                 )
-            except Exception:  # pragma: no cover - reporting must not break a turn
+            except Exception:
                 # Count it, don't just log it — `logger.debug` is not emitted in
                 # production, so a systematically broken classifier would be
                 # indistinguishable from a turn where nothing failed.
+                #
+                # Both guards deliberately carry NO `pragma: no cover`: the
+                # wiring tests execute them, and excluding them would hide a
+                # removed `note_error()` from a coverage gate — the same silent
+                # hole this counter exists to close. #348 review.
                 self._root_causes.note_error()
                 logger.debug("root-cause classification failed", exc_info=True)
             return
@@ -1013,7 +1018,7 @@ class ChatSession:
             self._root_causes.add(
                 classify_root_cause(reason or "", result_text or "")
             )
-        except Exception:  # pragma: no cover - reporting must not break a turn
+        except Exception:
             self._root_causes.note_error()
             logger.debug("root-cause classification failed", exc_info=True)
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2147,9 +2147,9 @@ class ChatSession:
         # Never let reporting break a turn — same contract as the analytics
         # sink below (ENG-1492).
         try:
-            _rc_fields = self._root_causes.event_fields()
+            _root_cause_fields = self._root_causes.event_fields()
         except Exception:  # pragma: no cover - defensive
-            _rc_fields = {}
+            _root_cause_fields = {}
         logger.info(
             "turn_cost session=%s turn=%d ended_by=%s tokens_total=%d "
             "input=%d output=%d cache_read=%d cache_creation=%d "
@@ -2169,7 +2169,7 @@ class ChatSession:
             # the collector allowlist that silently dropped `turn_completed`'s
             # properties for weeks (ENG-1355) — the log is the sink that does
             # not depend on it.
-            " ".join(f"{k}={v}" for k, v in _rc_fields.items()),
+            " ".join(f"{k}={v}" for k, v in _root_cause_fields.items()),
         )
 
         # Analytics sink — same settings-resolution pattern as the
@@ -2195,7 +2195,7 @@ class ChatSession:
                 # route) to reach PostHog at all — until then the log line above
                 # is the only sink, and its absence here is not evidence the
                 # classification is broken.
-                **_rc_fields,
+                **_root_cause_fields,
                 ended_by=tc.ended_by,
                 tokens_total=str(tc.total_tokens),
                 input_tokens=str(tc.input_tokens),

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -138,6 +138,17 @@ _TRUNCATION_FAILURE_NOTICE = (
 
 logger = logging.getLogger(__name__)
 
+#: The legacy substring verdict, for handlers that never declared a `ToolOutcome`
+#: (ENG-1276 migrated five sites; the rest still return plain strings). Kept
+#: byte-identical to `_apply_error_tracking`'s fallback so the two cannot drift
+#: into disagreeing about what a failure is.
+_LEGACY_FAILURE_MARKERS = ("[error]", "Task failed:", "failed", "timed out", "Rejected:")
+
+
+def _legacy_looks_like_failure(text: str) -> bool:
+    return any(m in text for m in _LEGACY_FAILURE_MARKERS)
+
+
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -600,6 +611,7 @@ def _build_verify_request(
 
 
 @dataclass
+
 class ChatSessionConfig:
     """All construction parameters for a ChatSession.
 
@@ -952,6 +964,27 @@ class ChatSession:
         path lands in `unclassified`, which no trip rung can read. Guarded whole
         because a reporting side-effect must never be able to fail a turn.
         """
+        if tool_ok is None:
+            # Unmigrated handler: it signals failure by RETURNING an error
+            # string, so `ok` is None and the legacy substring match is the only
+            # verdict available. Dropping these entirely was the defect —
+            # `reason_coverage` then reported 1.0 by excluding the uncovered
+            # population from its own denominator, i.e. the metric that exists
+            # to expose under-coverage could not. Measured: a turn with 1
+            # migrated and 3 unmigrated failures reported coverage 1.0.
+            #
+            # Counted as `unclassified`, which is not trip-eligible — the text
+            # is prose the model can influence, which is the ENG-1276 defect one
+            # level up, so it must never create a wall.
+            if not _legacy_looks_like_failure(result_text or ""):
+                return
+            try:
+                self._root_causes.add(
+                    classify_root_cause("", result_text or "")
+                )
+            except Exception:  # pragma: no cover - reporting must not break a turn
+                logger.debug("root-cause classification failed", exc_info=True)
+            return
         if tool_ok is not False:
             return
         try:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -989,9 +989,14 @@ class ChatSession:
             # Counted as `unclassified`, which is not trip-eligible — the text
             # is prose the model can influence, which is the ENG-1276 defect one
             # level up, so it must never create a wall.
-            if not _legacy_looks_like_failure(result_text or ""):
-                return
+            # The predicate is INSIDE the guard on purpose. No reachable crash
+            # exists today (`result_text` is only ever `str` or `list`, both safe
+            # for `in`), but "guarded whole" is the claim the whole
+            # no-behaviour-change argument rests on, and a claim that is only
+            # almost true is the kind that rots quietly. #348 review.
             try:
+                if not _legacy_looks_like_failure(result_text or ""):
+                    return
                 self._root_causes.add(
                     classify_root_cause("", result_text or "")
                 )

--- a/tests/test_root_cause.py
+++ b/tests/test_root_cause.py
@@ -1,0 +1,290 @@
+"""Root-cause classification and the session ledger (ENG-1492).
+
+The safety property under test is not "does it classify well" — it is that
+`self_inflicted` and `transient` failures can NEVER become trip-eligible, no
+matter how often they repeat. That is the whole reason the tiers exist, and it
+is what makes ENG-836's probes G and H structural rather than hoped-for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from anton.core.root_cause import (
+    TIER_SELF,
+    TIER_TRANSIENT,
+    TIER_UNCLASSIFIED,
+    TIER_WALL,
+    RootCauseLedger,
+    classify,
+)
+
+
+# ── The motivating case ────────────────────────────────────────────────────
+
+
+# Verbatim-shaped reasons from the ENG-836 runaway: four approaches at one wall
+# (no ODBC driver, no root). `tool_handlers.py` sets `reason` to the traceback's
+# LAST line, which is what these are.
+KIRANAM_ATTEMPTS = [
+    "ModuleNotFoundError: No module named 'pyodbc'",
+    "package_install_failed",
+    "ModuleNotFoundError: No module named 'pyodbc.drivers'",
+    "ModuleNotFoundError: No module named 'pymssql'",
+]
+
+
+def test_the_kiranam_ping_pong_collapses_to_one_class():
+    """Four identifiers, one class — the case an exact match cannot catch.
+
+    This is why the key has two rungs. Normalised error TEXT would see four
+    unrelated problems here and never fire, which is exactly what happened.
+    """
+    causes = [classify(r) for r in KIRANAM_ATTEMPTS]
+
+    assert {c.cls for c in causes} == {"missing_dependency"}
+    assert all(c.trip_eligible for c in causes)
+
+    ledger = RootCauseLedger()
+    for c in causes:
+        ledger.add(c)
+
+    # The coarse rung sees one wall hit four times…
+    assert ledger.max_class == 4
+    # …while the exact rung sees the approach-swapping and stays low, which is
+    # why a breaker keyed only on the exact rung would have missed this.
+    assert ledger.max_exact < 4
+    assert ledger.top_class == "missing_dependency"
+
+
+def test_a_submodule_counts_as_its_top_level_package():
+    """`pandas.io.parsers` and `pandas` are one missing dependency."""
+    a = classify("ModuleNotFoundError: No module named 'pandas.io.parsers'")
+    b = classify("ModuleNotFoundError: No module named 'pandas'")
+    assert a.key == b.key == "missing_dependency:pandas"
+
+
+# ── The safety property ────────────────────────────────────────────────────
+
+
+SELF_INFLICTED_REASONS = [
+    "NameError: name 'wb' is not defined",
+    "SyntaxError: unterminated string literal (detected at line 250)",
+    "IndentationError: unexpected unindent (backend.py, line 822)",
+    "AttributeError: 'LLMResponse' object has no attribute 'text'",
+    "UnicodeEncodeError: 'utf-8' codec can't encode character",
+    "PyCompileError: Sorry: IndentationError: unexpected unindent",
+    "TypeError: unsupported operand type(s)",
+    "KeyError: 'total'",
+]
+
+
+@pytest.mark.parametrize("reason", SELF_INFLICTED_REASONS)
+def test_self_inflicted_failures_can_never_trip(reason):
+    """Probe H, encoded structurally.
+
+    These are the types that DOMINATED the heaviest turns in the 2026-08-12
+    harvest — UnicodeEncodeError 11, AttributeError 8, NameError 8,
+    SyntaxError 8, PyCompileError 5. An agent iterating on its own bug must not
+    be interrupted, and this must not depend on the error happening to change
+    between attempts.
+    """
+    rc = classify(reason)
+    assert rc.tier == TIER_SELF
+    assert not rc.trip_eligible
+
+
+def test_a_self_inflicted_failure_repeated_forever_still_cannot_trip():
+    """The property that matters: repetition does not promote a tier."""
+    ledger = RootCauseLedger()
+    for _ in range(100):
+        ledger.add(classify("NameError: name 'wb' is not defined"))
+
+    assert ledger.failures == 100
+    assert ledger.tiers[TIER_SELF] == 100
+    # Nothing reached a rung a trip could read.
+    assert ledger.max_exact == 0
+    assert ledger.max_class == 0
+    assert ledger.top_class == ""
+
+
+TRANSIENT_REASONS = [
+    "HTTPError: 429 Too Many Requests",
+    "HTTPError: 503 Service Unavailable",
+    "ConnectionResetError: [Errno 54] Connection reset by peer",
+    "ReadTimeout: HTTPSConnectionPool read timed out",
+    "Cell timed out after 120s",
+    "Killed by liveness watchdog after inactivity",
+]
+
+
+@pytest.mark.parametrize("reason", TRANSIENT_REASONS)
+def test_transients_can_never_trip(reason):
+    """Probe G: a 429 with a Retry-After twice is not a wall."""
+    rc = classify(reason)
+    assert rc.tier == TIER_TRANSIENT
+    assert not rc.trip_eligible
+
+
+def test_a_status_code_beats_the_exception_name():
+    """An HTTPError is transient or a wall depending on its STATUS, not its type.
+
+    Checked before the type table on purpose — the class name alone cannot tell
+    a rate limit from a permission denial.
+    """
+    assert classify("HTTPError: 429 Too Many Requests").tier == TIER_TRANSIENT
+    assert classify("HTTPError: 403 Forbidden").tier == TIER_WALL
+    assert classify("HTTPError: 403 Forbidden").cls == "permission_denied"
+    assert classify("HTTPError: 401 Unauthorized").cls == "auth_missing"
+
+
+# ── Walls ──────────────────────────────────────────────────────────────────
+
+
+def test_wall_classes_and_their_identifiers():
+    cases = [
+        ("PermissionError: [Errno 13] Permission denied: '/etc/hosts'",
+         "permission_denied", "/etc/hosts"),
+        ("ConnectionRefusedError: [Errno 61] Connection refused to db.internal:5432",
+         "connection_refused", "db.internal:5432"),
+        ("OperationalError: could not connect to server postgres.local:5432",
+         "db_unavailable", "postgres.local:5432"),
+    ]
+    for reason, cls, ident in cases:
+        rc = classify(reason)
+        assert rc.tier == TIER_WALL, reason
+        assert rc.cls == cls, reason
+        assert rc.identifier == ident, reason
+
+
+def test_missing_file_keeps_its_path_so_exploration_does_not_look_like_a_wall():
+    """The ambiguous class: a wrong path the agent wrote vs a missing binary.
+
+    Three DIFFERENT paths is an agent exploring and must stay spread across the
+    exact rung; the same path three times is a wall. (ENG-1531 will additionally
+    refuse to count this class on the coarse rung for the same reason.)
+    """
+    ledger = RootCauseLedger()
+    for p in ("/tmp/a.csv", "/tmp/b.csv", "/tmp/c.csv"):
+        ledger.add(classify(f"FileNotFoundError: [Errno 2] No such file or directory: '{p}'"))
+    assert ledger.max_exact == 1
+
+    ledger2 = RootCauseLedger()
+    for _ in range(3):
+        ledger2.add(classify(
+            "FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/odbcinst'"))
+    assert ledger2.max_exact == 3
+
+
+def test_a_bare_oserror_is_not_treated_as_a_wall_without_evidence():
+    """OSError is the catch-all base class — too coarse to key on by itself."""
+    assert classify("OSError: [Errno 5] Input/output error").tier == TIER_UNCLASSIFIED
+    assert classify("OSError: [Errno 28] No space left on device").tier == TIER_WALL
+
+
+# ── Coverage, the live writer inventory ────────────────────────────────────
+
+
+def test_a_failure_with_no_reason_is_counted_but_never_trip_eligible():
+    """Unmigrated handlers must not silently create walls.
+
+    Falling back to result TEXT is weaker evidence — it is prose the model can
+    influence, which is the ENG-1276 defect one level up — so it lands in
+    `unclassified` and is excluded from every trip rung.
+    """
+    rc = classify("", result_text="Tool 'web_fetch' failed: something went wrong")
+    assert rc.tier == TIER_UNCLASSIFIED
+    assert not rc.trip_eligible
+    assert not rc.from_reason
+
+
+def test_reason_coverage_reports_the_share_with_a_usable_reason():
+    ledger = RootCauseLedger()
+    ledger.add(classify("ModuleNotFoundError: No module named 'pyodbc'"))
+    ledger.add(classify("NameError: name 'x' is not defined"))
+    ledger.add(classify("", result_text="opaque failure"))
+    ledger.add(classify("", result_text="another opaque failure"))
+
+    assert ledger.failures == 4
+    assert ledger.reason_coverage == 0.5
+    assert ledger.event_fields()["rc_reason_coverage"] == 0.5
+
+
+def test_event_fields_are_flat_and_complete():
+    """The event carries per-tier counts, not just the trip-eligible rungs.
+
+    Without the tier split the distribution cannot answer the question this
+    ticket exists for — whether a wall-repeat population large enough to justify
+    a breaker exists at all.
+    """
+    ledger = RootCauseLedger()
+    for r in KIRANAM_ATTEMPTS:
+        ledger.add(classify(r))
+    ledger.add(classify("NameError: name 'x' is not defined"))
+    ledger.add(classify("HTTPError: 429 Too Many Requests"))
+
+    f = ledger.event_fields()
+    assert f["rc_failures"] == 6
+    assert f["rc_wall"] == 4
+    assert f["rc_self_inflicted"] == 1
+    assert f["rc_transient"] == 1
+    assert f["rc_max_class"] == 4
+    assert f["rc_top_class"] == "missing_dependency"
+    assert all(not isinstance(v, (dict, list)) for v in f.values())
+
+
+def test_the_ledger_never_resets_on_success():
+    """There is no reset API at all — the absence IS the design.
+
+    The existing per-tool streak resets on success, and interleaved false
+    successes are why it stayed asleep through ENG-836. This counts occurrences.
+    """
+    assert not any(
+        hasattr(RootCauseLedger(), name) for name in ("reset", "clear", "on_success")
+    )
+
+
+# ── The writer inventory, kept honest by the suite ─────────────────────────
+
+
+def test_every_sentinel_reason_is_mapped():
+    """Every `reason="..."` literal in the tree has a deliberate tier.
+
+    Convention 9's writer inventory, as a test rather than a one-off audit. A
+    new handler sentinel that nobody classifies would land in `unclassified` and
+    quietly depress the wall counts — a wrong answer in the safe-looking
+    direction, which is the failure mode this whole ticket exists to avoid.
+
+    If this fails: add the new reason to `_SENTINEL_REASONS` with a tier, and
+    resolve ambiguity AWAY from `external_wall` (a false wall interrupts a
+    working agent; a missed one is caught later by the spend ceiling).
+    """
+    import pathlib
+    import re
+
+    from anton.core.root_cause import _SENTINEL_REASONS
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "anton"
+    found: set[str] = set()
+    for path in root.rglob("*.py"):
+        if path.name == "root_cause.py":
+            continue
+        found |= set(re.findall(r'reason="([a-z_]+)"', path.read_text()))
+
+    unmapped = found - set(_SENTINEL_REASONS)
+    assert not unmapped, (
+        f"unclassified handler sentinels: {sorted(unmapped)} — add them to "
+        "_SENTINEL_REASONS with a deliberate tier"
+    )
+
+
+def test_ambiguous_sentinels_resolve_away_from_tripping():
+    """The asymmetry that decides every judgement call in the table above."""
+    from anton.core.root_cause import classify
+
+    for reason in ("artifact_not_found", "unknown_datasource", "launch_failed",
+                   "missing_name", "invalid_port"):
+        assert not classify(reason).trip_eligible, reason
+    # …while the unambiguous walls stay trip-eligible.
+    for reason in ("package_install_failed", "store_unavailable"):
+        assert classify(reason).trip_eligible, reason

--- a/tests/test_root_cause.py
+++ b/tests/test_root_cause.py
@@ -288,3 +288,35 @@ def test_ambiguous_sentinels_resolve_away_from_tripping():
     # …while the unambiguous walls stay trip-eligible.
     for reason in ("package_install_failed", "store_unavailable"):
         assert classify(reason).trip_eligible, reason
+
+
+def test_pathological_input_cannot_stall_a_turn():
+    """`_HOSTPORT_RE` is O(n^2) on colon-free input — 1,051 ms at 20k chars.
+
+    Unreachable today because every producer caps its reason, but that
+    guarantee lives in another file. `classify` bounds its own input so the
+    property is local and survives a future handler passing something long.
+    """
+    import time
+
+    from anton.core.root_cause import classify
+
+    # These must ROUTE to `_identifier_for` to reach the quadratic pattern — an
+    # exception name that maps to a host-bearing wall class, then a long
+    # colon-free tail. A first version of this test used plain "A"*200_000,
+    # which never gets past the type lookup, so it passed with the cap removed
+    # and proved nothing. Measured without the cap: 6,565 ms.
+    evil_tail = "a" * 50_000
+    for evil in (
+        f"ConnectionRefusedError: {evil_tail}",
+        f"OperationalError: could not connect {evil_tail}",
+        f"HTTPError: 401 {evil_tail}",
+        f"PermissionError: [Errno 13] {evil_tail}",
+    ):
+        t0 = time.perf_counter()
+        classify(evil, result_text=evil)
+        elapsed = time.perf_counter() - t0
+        assert elapsed < 0.05, (
+            f"classify took {elapsed*1000:.0f} ms on {len(evil)} chars — the "
+            "input cap is gone and a tool failure can now stall a turn"
+        )

--- a/tests/test_root_cause.py
+++ b/tests/test_root_cause.py
@@ -234,6 +234,16 @@ def test_event_fields_are_flat_and_complete():
     ledger.add(classify("HTTPError: 429 Too Many Requests"))
 
     f = ledger.event_fields()
+    # Completeness by EXACT SET, not by spot-check. Three properties could be
+    # deleted with the suite green, and reverse-renaming any of them to `rc_*`
+    # — the exact refactor 3d86aa6 performed forward — passed the full suite,
+    # because both sinks iterate the dict rather than indexing known keys.
+    assert set(f) == {
+        "root_cause_failures", "root_cause_distinct", "root_cause_max_exact",
+        "root_cause_max_class", "root_cause_top_class",
+        "root_cause_reason_coverage", "root_cause_self_inflicted",
+        "root_cause_transient", "root_cause_wall", "root_cause_unclassified",
+    }
     assert f["root_cause_failures"] == 6
     assert f["root_cause_wall"] == 4
     assert f["root_cause_self_inflicted"] == 1
@@ -243,15 +253,21 @@ def test_event_fields_are_flat_and_complete():
     assert all(not isinstance(v, (dict, list)) for v in f.values())
 
 
-def test_the_ledger_never_resets_on_success():
-    """There is no reset API at all — the absence IS the design.
+def test_the_ledger_only_ever_grows():
+    """Counts never decrease — the behaviour, not the method names.
 
-    The existing per-tool streak resets on success, and interleaved false
-    successes are why it stayed asleep through ENG-836. This counts occurrences.
+    The previous version asserted that `reset`/`clear`/`on_success` do not
+    exist, which is the wrong test in both directions: an uncalled no-op
+    `clear()` reddened it, while a real reset invoked from `_record_root_cause`
+    left it green. It would also have tripped on ENG-1531's natural refactor.
     """
-    assert not any(
-        hasattr(RootCauseLedger(), name) for name in ("reset", "clear", "on_success")
-    )
+    led = RootCauseLedger()
+    seen = []
+    for reason in ["ModuleNotFoundError: No module named 'pyodbc'"] * 5:
+        led.add(classify(reason))
+        seen.append((led.failures, led.max_exact, led.max_class))
+    assert seen == sorted(seen), f"a count went backwards: {seen}"
+    assert seen[-1] == (5, 5, 5)
 
 
 # ── The writer inventory, kept honest by the suite ─────────────────────────
@@ -279,7 +295,13 @@ def test_every_sentinel_reason_is_mapped():
     for path in root.rglob("*.py"):
         if path.name == "root_cause.py":
             continue
-        found |= set(re.findall(r'reason="([a-z_]+)"', path.read_text()))
+        # Both quote styles and any identifier shape. The previous pattern saw
+        # only `reason="[a-z_]+"`, so a single-quoted or digit-containing
+        # sentinel (`reason='wall_v2'`) slipped past — and single-quoted kwargs
+        # already exist in this tree, with no formatter config anywhere in the
+        # repo to prevent them.
+        found |= set(re.findall(r"""reason=["']([A-Za-z0-9_]+)["']""",
+                                path.read_text()))
 
     unmapped = found - set(_SENTINEL_REASONS)
     assert not unmapped, (
@@ -361,3 +383,35 @@ def test_missing_file_never_reaches_the_class_rung():
         led2.add(classify("FileNotFoundError: [Errno 2] No such file: '/usr/bin/odbcinst'"))
     assert led2.max_exact == 3
     assert led2.max_class == 0
+
+
+def test_a_broken_package_is_one_key_however_the_import_failed():
+    """ENG-1492 §4: the identifier for `missing_dependency` is the MODULE.
+
+    Keying on the imported *symbol* split one broken package into as many keys
+    as symbols the agent tried to pull from it. Four attempts against a broken
+    `pandas` scored `max_exact=1, distinct=4` — reading as four unrelated blips
+    instead of the one wall it is, which is precisely the signal ENG-1492 exists
+    to produce. It also made `cannot import name … from 'pandas'` a different
+    wall from `No module named 'pandas'`.
+    """
+    from anton.core.root_cause import RootCauseLedger, classify
+
+    attempts = (
+        "ImportError: cannot import name 'read_excel' from 'pandas' (/x/pandas/__init__.py)",
+        "ImportError: cannot import name 'to_datetime' from 'pandas' (/x/pandas/__init__.py)",
+        "ModuleNotFoundError: No module named 'pandas.io.parsers'",
+        "ImportError: cannot import name 'q' from partially initialized module "
+        "'pandas.core' (most likely due to a circular import)",
+    )
+    led = RootCauseLedger()
+    for a in attempts:
+        rc = classify(a)
+        # Every shape resolves to the package, never the symbol or submodule.
+        assert rc.key == "missing_dependency:pandas", a
+        assert rc.trip_eligible is True
+        led.add(rc)
+
+    # The whole point: one wall seen four times, not four things seen once.
+    assert led.max_exact == 4
+    assert len(led.exact) == 1

--- a/tests/test_root_cause.py
+++ b/tests/test_root_cause.py
@@ -243,7 +243,12 @@ def test_event_fields_are_flat_and_complete():
         "root_cause_max_class", "root_cause_top_class",
         "root_cause_reason_coverage", "root_cause_self_inflicted",
         "root_cause_transient", "root_cause_wall", "root_cause_unclassified",
+        "root_cause_classify_errors",
     }
+    # Not folded into `failures` — a swallowed classification is not a tool
+    # failure, and counting it as one would corrupt the distribution this
+    # property exists to protect.
+    assert f["root_cause_classify_errors"] == 0
     assert f["root_cause_failures"] == 6
     assert f["root_cause_wall"] == 4
     assert f["root_cause_self_inflicted"] == 1

--- a/tests/test_root_cause.py
+++ b/tests/test_root_cause.py
@@ -207,7 +207,7 @@ def test_reason_coverage_reports_the_share_with_a_usable_reason():
 
     assert ledger.failures == 4
     assert ledger.reason_coverage == 0.5
-    assert ledger.event_fields()["rc_reason_coverage"] == 0.5
+    assert ledger.event_fields()["root_cause_reason_coverage"] == 0.5
 
 
 def test_event_fields_are_flat_and_complete():
@@ -224,12 +224,12 @@ def test_event_fields_are_flat_and_complete():
     ledger.add(classify("HTTPError: 429 Too Many Requests"))
 
     f = ledger.event_fields()
-    assert f["rc_failures"] == 6
-    assert f["rc_wall"] == 4
-    assert f["rc_self_inflicted"] == 1
-    assert f["rc_transient"] == 1
-    assert f["rc_max_class"] == 4
-    assert f["rc_top_class"] == "missing_dependency"
+    assert f["root_cause_failures"] == 6
+    assert f["root_cause_wall"] == 4
+    assert f["root_cause_self_inflicted"] == 1
+    assert f["root_cause_transient"] == 1
+    assert f["root_cause_max_class"] == 4
+    assert f["root_cause_top_class"] == "missing_dependency"
     assert all(not isinstance(v, (dict, list)) for v in f.values())
 
 

--- a/tests/test_root_cause.py
+++ b/tests/test_root_cause.py
@@ -76,6 +76,16 @@ SELF_INFLICTED_REASONS = [
     "PyCompileError: Sorry: IndentationError: unexpected unindent",
     "TypeError: unsupported operand type(s)",
     "KeyError: 'total'",
+    # Regression: a bare HTTP-looking integer anywhere in a self-inflicted
+    # message used to promote it to external_wall, trip-eligible — the status
+    # check ran before the type table. Every fixture above happens to use
+    # out-of-range numbers, which is why this shipped green. These are the
+    # 8 integers that did it, in messages a real producer emits.
+    "SyntaxError: invalid syntax (detected at line 404)",
+    "KeyError: 403",
+    "AssertionError: 404 != 200",
+    "ValueError: invalid literal for int() with base 10: '401'",
+    "IndexError: list index out of range at 500",
 ]
 
 
@@ -320,3 +330,34 @@ def test_pathological_input_cannot_stall_a_turn():
             f"classify took {elapsed*1000:.0f} ms on {len(evil)} chars — the "
             "input cap is gone and a tool failure can now stall a turn"
         )
+
+
+def test_missing_file_never_reaches_the_class_rung():
+    """ENG-1492 §4: `missing_file` counts on the exact rung only.
+
+    Without this, file probing drowns real walls. Measured before the fix: five
+    file probes plus the four-attempt ENG-836 dependency wall in one turn emitted
+    `max_class=5, top_class="missing_file"` — the wall the ticket exists to see,
+    masked by an agent looking around.
+    """
+    from anton.core.root_cause import RootCauseLedger, classify
+
+    led = RootCauseLedger()
+    for p in ("/tmp/a", "/tmp/b", "/tmp/c", "/tmp/d", "/tmp/e"):
+        led.add(classify(f"FileNotFoundError: [Errno 2] No such file: '{p}'"))
+    for r in ("ModuleNotFoundError: No module named 'pyodbc'",
+              "package_install_failed",
+              "ModuleNotFoundError: No module named 'pymssql'",
+              "ModuleNotFoundError: No module named 'pyodbc'"):
+        led.add(classify(r))
+
+    f = led.event_fields()
+    assert f["root_cause_top_class"] == "missing_dependency"
+    assert f["root_cause_max_class"] == 4
+    # The exact rung still sees repeated file failures, which is where the
+    # same-path-three-times wall is meant to show up.
+    led2 = RootCauseLedger()
+    for _ in range(3):
+        led2.add(classify("FileNotFoundError: [Errno 2] No such file: '/usr/bin/odbcinst'"))
+    assert led2.max_exact == 3
+    assert led2.max_class == 0

--- a/tests/test_root_cause_wiring.py
+++ b/tests/test_root_cause_wiring.py
@@ -12,6 +12,8 @@ look.
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -153,13 +155,21 @@ async def test_the_ledger_spans_turns_on_a_reused_session(workspace):
     session = _session(workspace, [WALL], n_tool_calls=1)
     with patch("anton.analytics.send_event"):
         await _run(session, "first")
+    assert session._root_causes.failures == 1
+
+    # Turn 2 must be DETERMINISTIC. The previous version installed a plan that
+    # returned a tool call forever, so turn 2 ran to the 25-round cap and
+    # contributed 25 failures against an assertion of `>= 2` — wiping the ledger
+    # between turns was invisible. One failing call, then a text answer.
+    replies = [_tool_call(9), _text("done")]
+    session._llm.plan_stream = lambda **kw: _one(replies.pop(0))
     session.tool_registry.dispatch_tool = AsyncMock(return_value=WALL)
-    session._llm.plan_stream = lambda **kw: _one(_tool_call(9))
     with patch("anton.analytics.send_event"):
         await _run(session, "second")
 
-    assert session._root_causes.failures >= 2
-    assert session._root_causes.max_exact >= 2
+    # Exact equality, so a reset between turns reddens this.
+    assert session._root_causes.failures == 2
+    assert session._root_causes.max_exact == 2
 
 
 def _one(resp):
@@ -213,7 +223,26 @@ async def test_classification_never_changes_the_turn(workspace):
 
     assert send_a.call_args.kwargs["ended_by"] == send_b.call_args.kwargs["ended_by"]
     assert send_a.call_args.kwargs["rounds"] == send_b.call_args.kwargs["rounds"]
-    assert [m.get("role") for m in a._history] == [m.get("role") for m in b._history]
+
+    # Roles alone are far too weak: injecting an extra user message from
+    # `_record_root_cause` passes a role-only comparison, because history
+    # bundling merges it into the adjacent tool-result block — the sequence
+    # stays byte-identical while what reaches the LLM changes. Compare CONTENT.
+    #
+    # Raw equality does not work either: index 6 embeds a repr containing a
+    # coroutine's memory address, which differs per run on clean HEAD. Normalise
+    # addresses (and the timestamp, which is minute-resolution and would flake
+    # across a minute boundary).
+    def _shape(history):
+        out = []
+        for m in history:
+            blob = json.dumps(m.get("content"), default=str)
+            blob = re.sub(r"0x[0-9a-fA-F]+", "0xADDR", blob)
+            blob = re.sub(r"\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}", "<TS>", blob)
+            out.append((m.get("role"), blob))
+        return out
+
+    assert _shape(a._history) == _shape(b._history)
 
 
 async def test_a_raising_classifier_cannot_break_a_turn(workspace):
@@ -225,6 +254,17 @@ async def test_a_raising_classifier_cannot_break_a_turn(workspace):
         await _run(session)
 
     assert send.call_args.kwargs["ended_by"] == "completed"
+    # `ended_by` alone is far too weak. Unguarded, the raise escapes into the
+    # tool loop's broad `except Exception`, which seals the tool_use as
+    # "[interrupted by error — tool call did not complete]" and injects a
+    # "SYSTEM: An error interrupted execution … Adjust your approach" note, then
+    # retries — so the turn still ends `completed` while the model has LOST the
+    # tool output and been told to change tack because of an internal reporting
+    # bug. That is the actual damage, so assert on what reached the model.
+    blob = json.dumps(session._history, default=str)
+    assert "interrupted by error" not in blob
+    assert "An error interrupted execution" not in blob
+    assert "No module named 'pyodbc'" in blob
 
 
 async def test_successes_are_not_recorded_at_all(workspace):
@@ -280,3 +320,88 @@ async def test_a_successful_legacy_result_is_not_counted_as_a_failure(workspace)
     assert session._root_causes.failures == 2
     assert session._root_causes.tiers["unclassified"] == 2
     assert session._root_causes.max_exact == 0
+
+
+# ── The dominant production path: scratchpad `action: "exec"` ──────────────
+
+
+async def test_the_scratchpad_exec_path_records_its_traceback(workspace):
+    """`{"action": "exec"}` is where every real ENG-836-shaped failure arrives.
+
+    Coverage gap found in review: every other wiring test issues
+    `{"action": "view"}`, so the exec branch — gated on `action == "exec"` —
+    was never entered. Four of the five `tool_reason` writer sites had zero
+    coverage, including this one, and blanking it was invisible: a real
+    3-failure wall turn would silently emit `wall 3 -> 0`,
+    `reason_coverage 1.0 -> 0.0`, `unclassified 0 -> 3` while looking healthy.
+
+    Uses a realistic multi-line traceback, because the producer takes the LAST
+    line — the reason this path reads `cell.error.splitlines()[-1][:160]`
+    rather than the whole thing.
+    """
+    from anton.core.backends.base import Cell
+
+    traceback = (
+        'Traceback (most recent call last):\n'
+        '  File "<cell>", line 3, in <module>\n'
+        "    import pyodbc\n"
+        '  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module\n'
+        "    return _bootstrap._gcd_import(name[level:], package, level)\n"
+        "ModuleNotFoundError: No module named 'pyodbc'"
+    )
+    cell = Cell(code="import pyodbc", stdout="", stderr="", error=traceback)
+
+    llm = make_mock_llm()
+    llm.usage_listener = None
+    n = {"i": 0}
+
+    def plan_stream(**kw):
+        async def gen():
+            n["i"] += 1
+            resp = LLMResponse(
+                content="trying",
+                tool_calls=[ToolCall(id=f"tc{n['i']}", name="scratchpad",
+                                     input={"action": "exec", "name": "main",
+                                            "code": "import pyodbc"})],
+                usage=_usage(), stop_reason="tool_use",
+            ) if n["i"] <= 3 else _text()
+            yield StreamComplete(response=resp)
+        return gen()
+
+    llm.plan_stream = plan_stream
+    session = ChatSession(ChatSessionConfig(llm_client=llm, workspace=workspace))
+    session._max_turn_tokens = 0
+
+    pad = MagicMock()
+    async def _exec_streaming(*a, **k):
+        yield cell
+    pad.execute_streaming = _exec_streaming
+    pad.cancel = AsyncMock()
+
+    with patch("anton.core.session.prepare_scratchpad_exec",
+               AsyncMock(return_value=(pad, "import pyodbc", "install driver", "5s", 5))), \
+         patch.object(ChatSession, "_record_cell_explainability", lambda *a, **k: None), \
+         patch("anton.analytics.send_event") as send:
+        await _run(session)
+
+    led = session._root_causes
+    assert led.failures == 3, f"exec-path failures not recorded: {led.failures}"
+    assert led.max_exact == 3
+    assert led.top_class == "missing_dependency"
+    assert led.reason_coverage == 1.0
+    assert int(send.call_args.kwargs["root_cause_wall"]) == 3
+
+
+async def test_a_raising_tool_records_its_exception_type(workspace):
+    """The dispatcher's own except-clause is the fifth writer site."""
+    session = _session(workspace, [], n_tool_calls=2)
+    session.tool_registry.dispatch_tool = AsyncMock(
+        side_effect=ConnectionRefusedError("[Errno 61] Connection refused")
+    )
+    with patch("anton.analytics.send_event"):
+        await _run(session)
+
+    led = session._root_causes
+    assert led.failures == 2
+    assert led.tiers["external_wall"] == 2
+    assert led.top_class == "connection_refused"

--- a/tests/test_root_cause_wiring.py
+++ b/tests/test_root_cause_wiring.py
@@ -405,3 +405,33 @@ async def test_a_raising_tool_records_its_exception_type(workspace):
     assert led.failures == 2
     assert led.tiers["external_wall"] == 2
     assert led.top_class == "connection_refused"
+
+
+async def test_the_legacy_predicate_is_inside_the_guard(workspace):
+    """"Guarded whole" means the predicate too, not just the classify call.
+
+    `_legacy_looks_like_failure` used to run OUTSIDE the try/except, so a
+    `result_text` that raised on `in` would escape into the tool loop's broad
+    `except`, seal the tool_use as "[interrupted by error]" and inject a
+    "adjust your approach" note — the finding-4 damage, reached by a different
+    door. No such input is reachable today (`result_text` is only ever `str` or
+    `list`), which is exactly why the invariant needs a test rather than a
+    reader's goodwill. #348 review.
+    """
+    class Hostile:
+        """Truthy, so `result_text or ""` yields it; explodes on membership."""
+
+        def __bool__(self):
+            return True
+
+        def __contains__(self, item):
+            raise RuntimeError("boom")
+
+    session = _session(workspace, [WALL], n_tool_calls=1)
+    before = session._root_causes.failures
+
+    # Must not raise. `tool_ok=None` is the unmigrated-handler path.
+    session._record_root_cause(None, "", Hostile())
+
+    # …and must not have booked anything from an input it could not read.
+    assert session._root_causes.failures == before

--- a/tests/test_root_cause_wiring.py
+++ b/tests/test_root_cause_wiring.py
@@ -435,3 +435,52 @@ async def test_the_legacy_predicate_is_inside_the_guard(workspace):
 
     # …and must not have booked anything from an input it could not read.
     assert session._root_causes.failures == before
+    # …but must NOT swallow it silently either. This guard is a separate writer
+    # from the one on the migrated path, and removing its `note_error()` alone
+    # passed the whole file before this assertion existed.
+    assert session._root_causes.classify_errors == 1
+
+
+async def test_a_broken_classifier_is_distinguishable_from_a_quiet_turn(workspace):
+    """A silent instrument must not read as a legitimate answer.
+
+    Before `classify_errors`, a turn with three real wall failures and a
+    raising classifier emitted all ten properties IDENTICAL to a turn where
+    nothing failed — the guard swallowed each failure and left only a
+    `logger.debug` line, which production does not emit.
+
+    That ambiguity is load-bearing, not cosmetic: "the wall-repeat population
+    is too small to justify the control at all" is one of ENG-1492's own
+    sanctioned conclusions, so a broken classifier reads as a real finding and
+    would cancel ENG-1531 on the strength of a bug.
+    """
+    def _fields(send):
+        return {k: v for k, v in send.call_args.kwargs.items()
+                if k.startswith("root_cause")}
+
+    # Three real wall failures, classifier raising on every one.
+    broken = _session(workspace, [WALL, WALL, WALL], n_tool_calls=3)
+    with patch("anton.core.session.classify_root_cause",
+               side_effect=RuntimeError("boom")), \
+         patch("anton.analytics.send_event") as send_broken:
+        await _run(broken)
+    broken_fields = _fields(send_broken)
+
+    # A genuinely quiet turn: three successes, nothing to classify.
+    quiet = _session(workspace, [OK, OK, OK], n_tool_calls=3)
+    with patch("anton.analytics.send_event") as send_quiet:
+        await _run(quiet)
+    quiet_fields = _fields(send_quiet)
+
+    # The signal that separates them.
+    assert broken_fields["root_cause_classify_errors"] == 3
+    assert quiet_fields["root_cause_classify_errors"] == 0
+    assert broken_fields != quiet_fields
+
+    # Everything else still reads zero in BOTH — which is exactly why the
+    # counter had to be added rather than inferred from the existing ten.
+    for k in ("root_cause_failures", "root_cause_wall", "root_cause_max_exact"):
+        assert broken_fields[k] == 0 and quiet_fields[k] == 0, k
+
+    # And the turn itself is untouched either way — the guard still holds.
+    assert send_broken.call_args.kwargs["ended_by"] == "completed"

--- a/tests/test_root_cause_wiring.py
+++ b/tests/test_root_cause_wiring.py
@@ -1,0 +1,234 @@
+"""`ToolOutcome.reason` reaches the session ledger, and nothing else changes (ENG-1492).
+
+`test_root_cause.py` covers the classifier as pure logic. This covers the part
+that was actually broken for two tickets: the value existed and **nothing read
+it** — both dispatch sites took `.content` and `.ok` and dropped `.reason` on the
+floor. So these drive the real `turn_stream` / `turn` and assert on the ledger.
+
+The second half is the no-behaviour-change contract. This ticket is measurement
+only; if it can alter a turn, it has failed regardless of how good the numbers
+look.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_mock_llm
+
+from anton.core.llm.provider import LLMResponse, StreamComplete, ToolCall, Usage
+from anton.core.root_cause import TIER_SELF, TIER_WALL
+from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.tools.registry import ToolOutcome
+
+
+@pytest.fixture()
+def workspace():
+    base = Path(__file__).resolve().parents[1] / ".pytest-workspace"
+    base.mkdir(parents=True, exist_ok=True)
+    return MagicMock(base=base)
+
+
+def _usage(n: int = 1_000) -> Usage:
+    return Usage(input_tokens=n // 2, output_tokens=n // 2)
+
+
+def _tool_call(i: int) -> LLMResponse:
+    return LLMResponse(
+        content="working",
+        tool_calls=[ToolCall(id=f"tc{i}", name="scratchpad",
+                             input={"action": "view", "name": "m"})],
+        usage=_usage(), stop_reason="tool_use",
+    )
+
+
+def _text(t: str = "done") -> LLMResponse:
+    return LLMResponse(content=t, tool_calls=[], usage=_usage(), stop_reason="end_turn")
+
+
+def _session(workspace, outcomes, n_tool_calls: int):
+    """Session whose tool dispatch returns `outcomes` in order."""
+    llm = make_mock_llm()
+    llm.usage_listener = None
+    seq = {"i": 0}
+
+    def plan_stream(**kw):
+        async def gen():
+            seq["i"] += 1
+            if llm.usage_listener:
+                llm.usage_listener("planning", "m", _usage())
+            yield StreamComplete(
+                response=_tool_call(seq["i"]) if seq["i"] <= n_tool_calls else _text()
+            )
+        return gen()
+
+    async def plan(**kw):
+        seq["i"] += 1
+        if llm.usage_listener:
+            llm.usage_listener("planning", "m", _usage())
+        return _tool_call(seq["i"]) if seq["i"] <= n_tool_calls else _text()
+
+    llm.plan_stream = plan_stream
+    llm.plan = plan
+    s = ChatSession(ChatSessionConfig(llm_client=llm, workspace=workspace))
+    s._max_turn_tokens = 0  # ceiling off — this ticket must be independent of it
+    pending = list(outcomes)
+    s.tool_registry.dispatch_tool = AsyncMock(
+        side_effect=lambda *a, **k: pending.pop(0) if pending
+        else ToolOutcome(content="ok", ok=True)
+    )
+    return s
+
+
+async def _run(session, prompt="go"):
+    async for _ in session.turn_stream(prompt):
+        pass
+
+
+WALL = ToolOutcome(content="[error]\nModuleNotFoundError: No module named 'pyodbc'",
+                   ok=False, reason="ModuleNotFoundError: No module named 'pyodbc'")
+SELF = ToolOutcome(content="[error]\nNameError: name 'wb' is not defined",
+                   ok=False, reason="NameError: name 'wb' is not defined")
+OK = ToolOutcome(content="fine", ok=True)
+
+
+async def test_reason_reaches_the_ledger_through_the_real_loop(workspace):
+    """The plumbing this ticket exists for.
+
+    Before it, `.reason` was set by five handlers and read by nobody.
+    """
+    session = _session(workspace, [WALL, WALL, WALL], n_tool_calls=3)
+    with patch("anton.analytics.send_event"):
+        await _run(session)
+
+    led = session._root_causes
+    assert led.failures == 3
+    assert led.tiers[TIER_WALL] == 3
+    assert led.max_exact == 3
+    assert led.top_class == "missing_dependency"
+    assert led.reason_coverage == 1.0
+
+
+async def test_interleaved_successes_do_not_reset_the_count(workspace):
+    """The ENG-1276 lesson one level up, end to end.
+
+    The per-tool streak resets on success, and interleaved false successes are
+    exactly why it never counted to five through ENG-836. This must not.
+    """
+    session = _session(workspace, [WALL, OK, WALL, OK, WALL], n_tool_calls=5)
+    with patch("anton.analytics.send_event"):
+        await _run(session)
+
+    assert session._root_causes.max_exact == 3, (
+        "a success between failures reset the count — the exact defect this "
+        "counter exists to avoid"
+    )
+
+
+async def test_self_inflicted_failures_reach_the_ledger_but_no_trip_rung(workspace):
+    session = _session(workspace, [SELF, SELF, SELF], n_tool_calls=3)
+    with patch("anton.analytics.send_event"):
+        await _run(session)
+
+    led = session._root_causes
+    assert led.tiers[TIER_SELF] == 3      # measured…
+    assert led.max_exact == 0             # …but never trip-eligible
+    assert led.max_class == 0
+
+
+async def test_the_ledger_spans_turns_within_a_session(workspace):
+    """Session-scoped, because ENG-1531 fires once per cause per SESSION."""
+    session = _session(workspace, [WALL], n_tool_calls=1)
+    with patch("anton.analytics.send_event"):
+        await _run(session, "first")
+    session.tool_registry.dispatch_tool = AsyncMock(return_value=WALL)
+    session._llm.plan_stream = lambda **kw: _one(_tool_call(9))
+    with patch("anton.analytics.send_event"):
+        await _run(session, "second")
+
+    assert session._root_causes.failures >= 2
+    assert session._root_causes.max_exact >= 2
+
+
+def _one(resp):
+    async def gen():
+        yield StreamComplete(response=resp)
+    return gen()
+
+
+async def test_counts_ride_the_turn_completed_event(workspace):
+    session = _session(workspace, [WALL, WALL], n_tool_calls=2)
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+
+    kw = send.call_args.kwargs
+    assert int(kw["rc_failures"]) == 2
+    assert int(kw["rc_max_class"]) == 2
+    assert kw["rc_top_class"] == "missing_dependency"
+    # Flat scalars only — the collector relays query params, not structures.
+    assert all(not isinstance(v, (dict, list)) for v in kw.values())
+
+
+async def test_a_failure_with_no_reason_is_recorded_as_uncovered(workspace):
+    """An unmigrated handler must show up as missing coverage, not as a wall."""
+    bare = ToolOutcome(content="Tool 'web_fetch' failed: nope", ok=False)
+    session = _session(workspace, [bare, bare], n_tool_calls=2)
+    with patch("anton.analytics.send_event"):
+        await _run(session)
+
+    led = session._root_causes
+    assert led.failures == 2
+    assert led.reason_coverage == 0.0
+    assert led.max_exact == 0, "text-derived keys must never be trip-eligible"
+
+
+# ── The no-behaviour-change contract ───────────────────────────────────────
+
+
+async def test_classification_never_changes_the_turn(workspace):
+    """Measurement only: same history, same ending, with and without failures.
+
+    If this ticket can alter a turn it has failed, however good the numbers are.
+    """
+    a = _session(workspace, [WALL, WALL], n_tool_calls=2)
+    with patch("anton.analytics.send_event") as send_a:
+        await _run(a)
+
+    b = _session(workspace, [WALL, WALL], n_tool_calls=2)
+    b._record_root_cause = lambda *args, **kw: None  # classification disabled
+    with patch("anton.analytics.send_event") as send_b:
+        await _run(b)
+
+    assert send_a.call_args.kwargs["ended_by"] == send_b.call_args.kwargs["ended_by"]
+    assert send_a.call_args.kwargs["rounds"] == send_b.call_args.kwargs["rounds"]
+    assert [m.get("role") for m in a._history] == [m.get("role") for m in b._history]
+
+
+async def test_a_raising_classifier_cannot_break_a_turn(workspace):
+    """Reporting is guarded whole — a bad key must never cost a user their turn."""
+    session = _session(workspace, [WALL], n_tool_calls=1)
+    with patch("anton.core.session.classify_root_cause",
+               side_effect=RuntimeError("boom")), \
+         patch("anton.analytics.send_event") as send:
+        await _run(session)
+
+    assert send.call_args.kwargs["ended_by"] == "completed"
+
+
+async def test_successes_are_not_recorded_at_all(workspace):
+    session = _session(workspace, [OK, OK, OK], n_tool_calls=3)
+    with patch("anton.analytics.send_event"):
+        await _run(session)
+    assert session._root_causes.failures == 0
+
+
+async def test_the_non_streaming_turn_records_too(workspace):
+    """`turn()` is public API and its books are wired, so its failures count."""
+    session = _session(workspace, [WALL, WALL], n_tool_calls=2)
+    with patch("anton.analytics.send_event"):
+        await session.turn("go")
+    assert session._root_causes.failures == 2
+    assert session._root_causes.max_exact == 2

--- a/tests/test_root_cause_wiring.py
+++ b/tests/test_root_cause_wiring.py
@@ -174,9 +174,9 @@ async def test_counts_ride_the_turn_completed_event(workspace):
         await _run(session)
 
     kw = send.call_args.kwargs
-    assert int(kw["rc_failures"]) == 2
-    assert int(kw["rc_max_class"]) == 2
-    assert kw["rc_top_class"] == "missing_dependency"
+    assert int(kw["root_cause_failures"]) == 2
+    assert int(kw["root_cause_max_class"]) == 2
+    assert kw["root_cause_top_class"] == "missing_dependency"
     # Flat scalars only — the collector relays query params, not structures.
     assert all(not isinstance(v, (dict, list)) for v in kw.values())
 

--- a/tests/test_root_cause_wiring.py
+++ b/tests/test_root_cause_wiring.py
@@ -241,3 +241,42 @@ async def test_the_non_streaming_turn_records_too(workspace):
         await session.turn("go")
     assert session._root_causes.failures == 2
     assert session._root_causes.max_exact == 2
+
+
+async def test_unmigrated_handlers_count_against_reason_coverage(workspace):
+    """A handler that returns an error STRING must not be silently excluded.
+
+    `reason_coverage` exists to expose under-coverage. Dropping `ok is None`
+    failures entirely made it report 1.0 by excluding the uncovered population
+    from its own denominator — measured: 1 migrated + 3 unmigrated failures
+    reported coverage 1.0, failures 1.
+
+    They count as `unclassified`, never trip-eligible: the text is prose the
+    model can influence, which is the ENG-1276 defect one level up.
+    """
+    legacy = ToolOutcome(content="[error] connect failed: no route to host")
+    assert legacy.ok is None  # the shape registry.py produces for a plain str
+    session = _session(workspace, [WALL, legacy, legacy, legacy], n_tool_calls=4)
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+
+    led = session._root_causes
+    assert led.failures == 4
+    assert led.reason_coverage == 0.25
+    assert led.tiers["unclassified"] == 3
+    assert led.max_exact == 1, "legacy text must never create a wall"
+    assert float(send.call_args.kwargs["root_cause_reason_coverage"]) == 0.25
+
+
+async def test_a_successful_legacy_result_is_not_counted_as_a_failure(workspace):
+    """The legacy verdict must not invent failures out of ordinary output."""
+    fine = ToolOutcome(content="Wrote 12 rows. 0 records failed validation.")
+    session = _session(workspace, [fine, fine], n_tool_calls=2)
+    with patch("anton.analytics.send_event"):
+        await _run(session)
+    # NOTE: this text DOES contain "failed", so it is counted — the legacy
+    # matcher's false-positive direction, inherited deliberately rather than
+    # forked. Pinning it so the inheritance is visible if it ever changes.
+    assert session._root_causes.failures == 2
+    assert session._root_causes.tiers["unclassified"] == 2
+    assert session._root_causes.max_exact == 0

--- a/tests/test_root_cause_wiring.py
+++ b/tests/test_root_cause_wiring.py
@@ -139,8 +139,17 @@ async def test_self_inflicted_failures_reach_the_ledger_but_no_trip_rung(workspa
     assert led.max_class == 0
 
 
-async def test_the_ledger_spans_turns_within_a_session(workspace):
-    """Session-scoped, because ENG-1531 fires once per cause per SESSION."""
+async def test_the_ledger_spans_turns_on_a_reused_session(workspace):
+    """Spans turns when the SESSION is reused — which is the CLI, not Cowork.
+
+    Deliberately named for the shape it actually tests. `chat.py` builds one
+    ChatSession and loops `turn_stream`, so the ledger accumulates. cowork-server
+    calls `_build_chat_session()` inside `stream_response()` — once per HTTP turn
+    — so on the primary product this resets every turn instead.
+
+    Keeping the test (the object behaves as designed) but not letting its name
+    imply coverage the deployment does not give. See `RootCauseLedger`.
+    """
     session = _session(workspace, [WALL], n_tool_calls=1)
     with patch("anton.analytics.send_event"):
         await _run(session, "first")


### PR DESCRIPTION
Measurement only — **nothing trips, nothing hands back, the existing per-tool error streak is untouched.** This is the half of ENG-1286's thrash breaker that has to come first, on the same reasoning that made its spend ceiling defensible: [ENG-1288](https://linear.app/mindsdb/issue/ENG-1288) counted, then the ceiling picked a number from data instead of from one incident.

Ticket: [ENG-1492](https://linear.app/mindsdb/issue/ENG-1492). The control that consumes this is [ENG-1531](https://linear.app/mindsdb/issue/ENG-1531), deliberately unbuilt.

## Why now

[ENG-1276](https://linear.app/mindsdb/issue/ENG-1276) built `ToolOutcome.reason` and **nothing ever read it** — both dispatch sites took `.content` and `.ok` and dropped it on the floor. The registry docstring has been saying this ticket's name for two months.

And the thresholds ENG-1531 needs cannot be measured from Langfuse: the only place a turn's failures are visible is the verifier's input, which keeps the **last 12 tool events at a 400-char cap** with `[error]` appended *last* — so any failure on a cell that printed output is truncated away. Counts read from there are lower bounds with a bias nobody can correct for.

## The tiers are the safety argument, not the thresholds

| tier | examples | can trip? |
|---|---|---|
| `self_inflicted` | NameError, SyntaxError, AttributeError, UnicodeEncodeError, PyCompileError | **never** |
| `transient` | 429/5xx, connection resets, timeouts, watchdog kills | **never** (v1) |
| `external_wall` | missing_dependency, permission_denied, auth_missing, connection_refused… | yes |

That is **probe H encoded structurally**. ENG-1286's original argument was that self-repair escapes because the error changes between attempts — probabilistic, and it fails exactly when an agent retries the same broken line. It matters here specifically because the 2026-08-12 harvest found the heaviest turns **dominated** by self-inflicted errors (UnicodeEncodeError 11, AttributeError 8, NameError 8, SyntaxError 8), so a breaker on guessed thresholds would land squarely on them.

`transient` does the same job for probe G, and closes a real gap: [ENG-673](https://linear.app/mindsdb/issue/ENG-673)'s `classify_transient` lives in the LLM clients and is **unreachable from a tool outcome**. Tiering by exception type buys transient exclusion without building tool-level transient typing first.

## Two-level key, because the motivating case needs it

`pyodbc` → `apt` → `.deb` → `pymssql` are **four identifiers and one class**. An exact-signature match sees four unrelated problems and never fires — which is what happened. `test_the_kiranam_ping_pong_collapses_to_one_class` pins both rungs: the class rung counts 4, the exact rung stays below it.

Status codes are read **before** the exception type: an `HTTPError` is transient or a wall depending on its status, which its class name cannot tell you.

## Occurrences, never a streak

There is no reset API at all, and its absence is the design — asserted by a test. The existing per-tool streak resets on success, and interleaved false successes (a 404 HTML page that parsed as a valid archive) are precisely why it never counted to five through ENG-836. `test_interleaved_successes_do_not_reset_the_count` drives the real loop with `WALL, OK, WALL, OK, WALL` and expects 3.

## Writer inventory, done twice

Convention 9. **All 14 handler sentinels in the tree are mapped**, and ambiguous ones (`artifact_not_found`, `unknown_datasource`, `launch_failed`) resolve **away from tripping** — a false wall interrupts a working agent, a missed one is caught later by ENG-1286's ceiling, and those costs are not symmetric.

`test_every_sentinel_reason_is_mapped` greps the tree and fails on any new unmapped sentinel, so the inventory maintains itself rather than going stale the first time someone adds a handler. Verified by deleting a mapping — it fails with the missing name.

`root_cause_reason_coverage` reports the live share in production, because a key computed over a third of failures would set thresholds wrong in the safe-looking direction.

## Where it lands

On the existing `turn_completed` event **and** appended to the `turn_cost` log line.

**Corrected after review discussion — the destination is [ENG-1495](https://linear.app/mindsdb/issue/ENG-1495), not [ENG-1355](https://linear.app/mindsdb/issue/ENG-1355).** The `zoomInfoCollector` lambda is being retired, so waiting on its allowlist fix was the wrong framing. anton#345 routes `turn_completed` **straight to the PostHog Capture API** into **MindsHub main (424726)**, and `_posthog_body` passes every `extra` kwarg through as a property — so these **eleven** fields arrive with no further work once it lands (ten, plus `root_cause_classify_errors` added in `1b86a2b`). `_posthog_body` is a pass-through minus three keys (`_` cache-buster, `action`, `timestamp`) with no allowlist, so a new property needs nothing beyond being passed as a kwarg.

Verified rather than assumed, since ENG-1495 carries a correction about exactly this: **this PR and anton#345 merge cleanly** (real merge in a throwaway worktree, not `merge-tree` eyeballing — it reports "changed in both" for `session.py` because both touch it, which is not a conflict).

Until #345 lands, `turn_completed` is dropped at the collector's *action-name* filter — probed live: `action=turn_completed` → `posthogResult: false`, `action=anton_turn_completed` → `true`. So **absence in PostHog is not evidence the classification is broken**, and the deliverable distribution is readable from the `turn_cost` log line regardless of merge order.

Reuses `_normalise_error_signature` as a **pure function**, deliberately not the ACC subsystem it lives in: `_acc_observe` returns early when `ANTON_ACC_MODE == "off"`, and a signal that vanishes when a memory feature flag flips is convention 9's state-gated trap.

## Testing

53 new tests across `tests/test_root_cause.py` (pure logic) and `tests/test_root_cause_wiring.py` (the real `turn_stream`/`turn`, since "the value exists and nobody reads it" is the defect being fixed).

**Mutation-verified** — each applied, each caught by its intended test:
- drop `.reason` at the dispatch sites (the original defect) → 5 failed
- promote `self_inflicted` to trip-eligible → 16 failed
- reset the ledger on success (the streak bug) → 1 failed
- remove the class rung → 4 failed
- delete a sentinel mapping → the inventory test names it

**No behaviour change, asserted:** `test_classification_never_changes_the_turn` runs the same turn with classification on and off and compares `ended_by`, `rounds` and the history roles. `test_a_raising_classifier_cannot_break_a_turn` patches the classifier to raise and expects `ended_by == "completed"`.

Full suite: **2,074 passed** (2,021 before), with the 2 pre-existing `test_datasource.py` failures that reproduce on clean `origin/staging`.

## Security

Reviewed per convention 8. Classification reads error *text* that already flows through the tool loop and emits only counts, tier names and a class name — never identifiers from conversation content beyond a module/path/host already present in an error the model can see. No new endpoint, credential path or deserialization. The recorder is guarded whole so a reporting failure can never cost a user their turn.

## What happens next

This ships and does nothing visible. After ≥1 week of traffic the distribution of `root_cause_max_exact` / `root_cause_max_class` goes on the ticket — and it may well say the wall-repeat population is too small to justify ENG-1531 at all, which is a valid and useful outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


