### PR TITLE
ENG-1537: wait out a velocity rate-limit instead of retrying into it

### DIFF
--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -107,9 +107,20 @@ def _raise_for_status_error(
             error_type=envelope.get("type"),
         ) from exc
 
+    # Body `code` in both dialects — the SDK may deliver the wire envelope
+    # unmodified, unlike the openai client which peels it.
+    _env = body.get("error") if isinstance(body.get("error"), dict) else {}
+    _body_code = body.get("code") or _env.get("code")
+    # ENG-1537: a session wait needs POSITIVE evidence of a velocity limit —
+    # our gateway names it on the reason header and in the body code. Anything
+    # else (a bare 429, a provider quota in an unrecognised dialect) keeps the
+    # old fail-fast path rather than burning the budget on a limit that may not
+    # clear.
+    _velocity = gate_reason == "rate_limited" or _body_code == "rate_limited"
     transient = classify_transient(
         exc.status_code, body, provider=provider, model=model,
         retry_after=retry_after_seconds(exc),
+        velocity_confirmed=_velocity,
     )
     if transient is not None:
         logger.warning(

--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -27,6 +27,7 @@ from .provider import (
     Usage,
     classify_404,
     classify_transient,
+    retry_after_seconds,
     compute_context_pressure,
     wallet_denial_code,
     raise_on_empty_response,
@@ -106,11 +107,15 @@ def _raise_for_status_error(
             error_type=envelope.get("type"),
         ) from exc
 
-    transient = classify_transient(exc.status_code, body, provider=provider, model=model)
+    transient = classify_transient(
+        exc.status_code, body, provider=provider, model=model,
+        retry_after=retry_after_seconds(exc),
+    )
     if transient is not None:
         logger.warning(
-            "transient provider error (%s): status=%s body=%s",
-            transient.code, exc.status_code, scrub_credentials(str(exc.body))[:500],
+            "transient provider error (%s): status=%s retry_after=%s body=%s",
+            transient.code, exc.status_code, transient.retry_after,
+            scrub_credentials(str(exc.body))[:500],
         )
         raise transient from exc
 

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -183,9 +183,16 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     # Retryable provider/infra failures — overload/api_error (incl. the mid-stream
     # HTTP-200 case), 5xx, or a plain 429 — get backed off and retried by the
     # session loop rather than surfacing an instant, misleading failure (ENG-673).
+    # ENG-1537: a session wait needs POSITIVE evidence of a velocity limit —
+    # our gateway names it on the reason header and in the body code. Anything
+    # else (a bare 429, a provider quota in an unrecognised dialect) keeps the
+    # old fail-fast path rather than burning the budget on a limit that may not
+    # clear.
+    _velocity = gate_reason == "rate_limited" or code == "rate_limited"
     transient = classify_transient(
         exc.status_code, body, provider="The model provider", model=model,
         retry_after=retry_after_seconds(exc),
+        velocity_confirmed=_velocity,
     )
     if transient is not None:
         logger.warning(

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -32,6 +32,7 @@ from .provider import (
     Usage,
     classify_404,
     classify_transient,
+    retry_after_seconds,
     compute_context_pressure,
     wallet_denial_code,
     raise_on_empty_response,
@@ -182,11 +183,15 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     # Retryable provider/infra failures — overload/api_error (incl. the mid-stream
     # HTTP-200 case), 5xx, or a plain 429 — get backed off and retried by the
     # session loop rather than surfacing an instant, misleading failure (ENG-673).
-    transient = classify_transient(exc.status_code, body, provider="The model provider", model=model)
+    transient = classify_transient(
+        exc.status_code, body, provider="The model provider", model=model,
+        retry_after=retry_after_seconds(exc),
+    )
     if transient is not None:
         logger.warning(
-            "transient provider error (%s): status=%s body=%s",
-            transient.code, exc.status_code, scrub_credentials(str(exc.body))[:500],
+            "transient provider error (%s): status=%s retry_after=%s body=%s",
+            transient.code, exc.status_code, transient.retry_after,
+            scrub_credentials(str(exc.body))[:500],
         )
         raise transient from exc
 

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -521,8 +521,47 @@ def wallet_denial_code(body: Any) -> str | None:
     return code if isinstance(code, str) and code in _WALLET_DENIAL_CODES else None
 
 
+def retry_after_seconds(exc: BaseException) -> float | None:
+    """Seconds from a response's ``Retry-After`` header, or ``None`` (ENG-1537).
+
+    The MindsHub gateway sends this on the velocity 429 (``rate_limited``,
+    `minds/inference/errors.py`) as integer seconds — the only form we act on.
+    The HTTP-date form is legal but nothing in use emits it, and mis-reading a
+    date as a number would produce an absurd delay, so an unparseable value is
+    treated as absent: the caller then falls back to its own backoff curve.
+
+    Negative and non-finite values are dropped for the same reason. Zero is
+    meaningful ("retry now") and is preserved by the caller's ``> 0`` checks
+    behaving as "no hint", which is the same outcome.
+    """
+    resp = getattr(exc, "response", None)
+    headers = getattr(resp, "headers", None)
+    if headers is None:
+        headers = getattr(exc, "headers", None)
+    if headers is None:
+        return None
+    try:
+        raw = headers.get("retry-after") or headers.get("Retry-After")
+    except Exception:
+        return None
+    if raw is None:
+        return None
+    try:
+        secs = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return None  # HTTP-date form, or junk
+    if secs != secs or secs in (float("inf"), float("-inf")) or secs < 0:
+        return None
+    return secs
+
+
 def classify_transient(
-    status_code: int | None, body: Any, *, provider: str = "", model: str = ""
+    status_code: int | None,
+    body: Any,
+    *,
+    provider: str = "",
+    model: str = "",
+    retry_after: float | None = None,
 ) -> "TransientProviderError | None":
     """Arm A of the transient classifier (see ENG-673): inspect an
     ``APIStatusError``'s status + body and return a ``TransientProviderError`` if
@@ -531,6 +570,10 @@ def classify_transient(
     Shared by both providers so the mapping can't drift. Call this only AFTER the
     permanent classifications (401 / 429-quota / 403 model-gate) have been ruled
     out — this decides between "retryable transient" and "generic unavailable".
+
+    ``retry_after`` is the parsed ``Retry-After`` hint (see
+    :func:`retry_after_seconds`); it is attached to the velocity-429 result so
+    the session waits the interval the server actually named (ENG-1537).
     """
     b = body if isinstance(body, dict) else {}
     # Two body dialects: Anthropic nests the error under `error` ({"error":
@@ -567,9 +610,20 @@ def classify_transient(
             return None
         if wallet_denial_code(b):
             return None
+        # session_backoff=True, unlike every other request-time status here
+        # (ENG-1537). The flag means "should the SESSION spend its budget on
+        # this?", and the SDK's own 2 retries fire seconds apart — the right
+        # answer for a 5xx that recovers instantly, and useless against a
+        # per-minute token ceiling. Leaving it False sent this down the
+        # count-based path, which re-issued the request TWICE with no delay and
+        # a recovery note appended each time: told "too many tokens per
+        # minute", we immediately sent more. This is the one failure class
+        # where waiting is both necessary and sufficient, so it waits — for the
+        # interval the server named, when it named one.
         return TransientProviderError(
             f"{provider or 'The model provider'} is rate-limiting requests.",
-            provider=provider, code="rate_limited", session_backoff=False, model=model,
+            provider=provider, code="rate_limited", session_backoff=True,
+            retry_after=retry_after, model=model,
         )
     return None
 

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -478,12 +478,17 @@ class ProviderOverloadedError(ConnectionError):
 
     def __init__(
         self, message: str, *, provider: str = "", model: str = "",
-        code: str = "provider_overloaded",
+        code: str = "provider_overloaded", retry_after: float | None = None,
     ) -> None:
         super().__init__(message)
         self.provider = provider
         self.model = model
         self.code = code
+        # Seconds the server said to wait, when it said so (ENG-1537). Set only
+        # on the rate-limit exhaustion path, where the wait was skipped or ran
+        # out and the card needs to name the interval rather than say
+        # "a moment".
+        self.retry_after = retry_after
 
 
 # Body ``error.type``/``error.code`` values that mean "provider is momentarily
@@ -562,6 +567,7 @@ def classify_transient(
     provider: str = "",
     model: str = "",
     retry_after: float | None = None,
+    velocity_confirmed: bool = False,
 ) -> "TransientProviderError | None":
     """Arm A of the transient classifier (see ENG-673): inspect an
     ``APIStatusError``'s status + body and return a ``TransientProviderError`` if
@@ -574,6 +580,16 @@ def classify_transient(
     ``retry_after`` is the parsed ``Retry-After`` hint (see
     :func:`retry_after_seconds`); it is attached to the velocity-429 result so
     the session waits the interval the server actually named (ENG-1537).
+
+    ``velocity_confirmed`` says the caller POSITIVELY identified a velocity
+    limit — our gateway's ``rate_limited`` reason header or body code. Only then
+    does the 429 earn a session wait. The absence of billing carriers is not
+    evidence of transience: both fail-fast guards below are string-exact, so a
+    provider whose quota denial uses a different dialect (Gemini sends an
+    INTEGER ``code`` with ``status: RESOURCE_EXHAUSTED``) slips past them and
+    would otherwise spend the whole budget waiting out a daily quota that resets
+    at midnight — then be told it is not a credits problem. Unconfirmed 429s
+    keep the pre-ENG-1537 behaviour: typed, honest, and failed fast.
     """
     b = body if isinstance(body, dict) else {}
     # Two body dialects: Anthropic nests the error under `error` ({"error":
@@ -622,8 +638,10 @@ def classify_transient(
         # interval the server named, when it named one.
         return TransientProviderError(
             f"{provider or 'The model provider'} is rate-limiting requests.",
-            provider=provider, code="rate_limited", session_backoff=True,
-            retry_after=retry_after, model=model,
+            provider=provider, code="rate_limited",
+            session_backoff=velocity_confirmed,
+            retry_after=retry_after if velocity_confirmed else None,
+            model=model,
         )
     return None
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -674,6 +674,23 @@ class ChatSession:
     # per-surface / config knob) and injectable in tests.
     _transient_budget_s: float = 30.0
 
+    # ENG-1537: a velocity rate-limit gets its OWN, larger budget, accounted
+    # separately from the incident budget above. Two reasons they can't share:
+    # a provider incident has an unknown duration, so 30s is a guess at "long
+    # enough to be worth waiting, short enough not to hang the turn" — whereas
+    # a rate limit has a *known* end time the server hands us in Retry-After,
+    # and the MindsHub ceiling is a per-MINUTE token window, so 30s can expire
+    # while the window still has 30s to run. 90s covers a full window rolling
+    # over. Separate accounting also stops one failure mode starving the other
+    # inside a single turn.
+    _rate_limit_budget_s: float = 90.0
+
+    # Longest single sleep honoured from a Retry-After on a rate limit. Above
+    # this we stop waiting and surface the card naming the interval: silently
+    # absorbing a multi-minute hint reads as a hang, and the user can make a
+    # better decision about a 5-minute wait than we can.
+    _rate_limit_max_delay_s: float = 60.0
+
     def __init__(self, config: ChatSessionConfig) -> None:
         s = config.settings or CoreSettings()
         # Stash the full settings object (may be AntonSettings, CoreSettings,
@@ -1788,16 +1805,23 @@ class ChatSession:
         return compacted
 
     @staticmethod
-    def _transient_backoff_delay(attempt: int, retry_after: float | None = None) -> float:
+    def _transient_backoff_delay(
+        attempt: int, retry_after: float | None = None, max_delay: float = 30.0
+    ) -> float:
         """Backoff for a transient-provider retry (ENG-673).
 
         Honors a provider `retry_after` when present (usually only on
         request-time 429/529 — the mid-stream 200 case carries none). Otherwise
         ~2s → ~10s → ~18s with ±20% jitter, so a fleet recovering from the same
         incident doesn't retry in lockstep against an already-struggling provider.
+
+        ``max_delay`` caps a server-supplied hint. It defaults to the incident
+        value; a rate limit passes a larger one, because there the hint is a
+        real end time rather than a guess and clamping it to 30s would retry
+        into a window that is still closed (ENG-1537).
         """
         if retry_after is not None and retry_after > 0:
-            return min(float(retry_after), 30.0)
+            return min(float(retry_after), max_delay)
         base = (2.0, 10.0, 18.0)
         d = base[attempt] if attempt < len(base) else base[-1]
         return d * (0.8 + 0.4 * random.random())
@@ -3104,6 +3128,9 @@ class ChatSession:
         # connection errors) carry session_backoff=False and skip this path.
         _transient_deadline: float | None = None
         _transient_attempt = 0
+        # ENG-1537: velocity rate-limits are budgeted separately from incidents
+        # (see _rate_limit_budget_s) so neither starves the other in one turn.
+        _rate_limit_deadline: float | None = None
         self._active_explainability = ExplainabilityCollector(
             self._explainability_store,
             turn=self._turn_count + 1,
@@ -3217,18 +3244,44 @@ class ChatSession:
                     # count-based path below with their honest typed message.
                     if isinstance(_agent_exc, TransientProviderError) and _agent_exc.session_backoff:
                         now = asyncio.get_running_loop().time()
-                        if _transient_deadline is None:
-                            _transient_deadline = now + self._transient_budget_s
+                        # ENG-1537: a velocity rate-limit runs on its own budget
+                        # and its own longer Retry-After cap. Everything else
+                        # keeps the ENG-673 incident budget unchanged.
+                        _rate_limited = _agent_exc.code == "rate_limited"
+                        if _rate_limited:
+                            if _rate_limit_deadline is None:
+                                _rate_limit_deadline = now + self._rate_limit_budget_s
+                            deadline = _rate_limit_deadline
+                            max_delay = self._rate_limit_max_delay_s
+                        else:
+                            if _transient_deadline is None:
+                                _transient_deadline = now + self._transient_budget_s
+                            deadline = _transient_deadline
+                            max_delay = 30.0
                         self._seal_dangling_tool_uses("interrupted by a transient provider error")
-                        remaining = _transient_deadline - now
+                        remaining = deadline - now
                         if remaining > 0.5:
                             delay = min(
                                 self._transient_backoff_delay(
-                                    _transient_attempt, _agent_exc.retry_after
+                                    _transient_attempt, _agent_exc.retry_after, max_delay
                                 ),
                                 remaining,
                             )
                             _transient_attempt += 1
+                            # Tell the user WHY the turn is quiet. A silent
+                            # 90s pause is indistinguishable from a hang, and
+                            # that is how a correct wait gets reported as a
+                            # freeze. The SSE keepalive holds the connection
+                            # open; this holds the user's attention. Reuses the
+                            # existing progress affordance rather than adding
+                            # an event type, so the turn stays alive and the
+                            # user never has to type "continue" (ENG-1537).
+                            if _rate_limited:
+                                yield StreamTaskProgress(
+                                    phase="rate_limited",
+                                    message=f"waiting {max(1, round(delay))}s before continuing",
+                                    eta_seconds=delay,
+                                )
                             if await self._backoff_sleep(delay):
                                 # User cancelled during backoff — stop cleanly
                                 # (like a normal stop), not with an error card.
@@ -3238,12 +3291,28 @@ class ChatSession:
                         # the server renders as the provider_overloaded card.
                         # Name the model that actually failed (planning OR coding),
                         # falling back to the session's planning model.
+                        _model = (getattr(_agent_exc, "model", "") or "") or getattr(
+                            self._llm, "planning_model", ""
+                        ) or ""
+                        if _rate_limited:
+                            # Distinct code so cowork-server can render a
+                            # wait-and-retry card instead of the out-of-credits
+                            # one. Never say "incident": nothing is broken, and
+                            # never imply credits — buying more cannot raise a
+                            # per-minute ceiling (ENG-1537).
+                            raise ProviderOverloadedError(
+                                "Too many requests too quickly — the rate limit didn't "
+                                "clear in time. Waiting a moment and continuing should work; "
+                                "this isn't a credits problem.",
+                                provider=getattr(_agent_exc, "provider", "") or "",
+                                model=_model,
+                                code="rate_limited",
+                            ) from _agent_exc
                         raise ProviderOverloadedError(
                             f"{_agent_exc.provider or 'The model provider'} is experiencing an "
                             "incident and didn't recover in time.",
                             provider=getattr(_agent_exc, "provider", "") or "",
-                            model=(getattr(_agent_exc, "model", "") or "")
-                            or getattr(self._llm, "planning_model", "") or "",
+                            model=_model,
                         ) from _agent_exc
 
                     _retry_count += 1

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3149,6 +3149,10 @@ class ChatSession:
         # compaction — against the wait budget and exhaust it without ever
         # having waited 90s.
         _rate_limit_slept = 0.0
+        # Its own attempt index too: a shared counter let a rate-limit wait
+        # advance the INCIDENT curve (and vice versa), so an interleaved turn
+        # jumped straight to the back of a curve it had never actually walked.
+        _rate_limit_attempt = 0
         self._active_explainability = ExplainabilityCollector(
             self._explainability_store,
             turn=self._turn_count + 1,
@@ -3293,13 +3297,19 @@ class ChatSession:
                             ) from _agent_exc
                         remaining = remaining_budget
                         if remaining > 0.5:
+                            _attempt = (
+                                _rate_limit_attempt if _rate_limited else _transient_attempt
+                            )
                             delay = min(
                                 self._transient_backoff_delay(
-                                    _transient_attempt, _agent_exc.retry_after, max_delay
+                                    _attempt, _agent_exc.retry_after, max_delay
                                 ),
                                 remaining,
                             )
-                            _transient_attempt += 1
+                            if _rate_limited:
+                                _rate_limit_attempt += 1
+                            else:
+                                _transient_attempt += 1
                             if _rate_limited:
                                 _rate_limit_slept += delay
                             # Tell the user WHY the turn is quiet. A silent

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1819,12 +1819,24 @@ class ChatSession:
         value; a rate limit passes a larger one, because there the hint is a
         real end time rather than a guess and clamping it to 30s would retry
         into a window that is still closed (ENG-1537).
+
+        **A hint never retries FASTER than the curve** — it is a floor on the
+        wait, not a replacement for it. Obeying a small hint verbatim ignores
+        ``attempt`` entirely, and the gateway's small hints are the common case,
+        not an edge one: an RPM denial computes ``ceil(deficit / refill)``,
+        which at the deployed capacity/refill is always exactly 1, and a
+        concurrency denial sends a flat 1 whose own config calls it a fake end
+        time ("slots free on report, not on a clock"). Taken verbatim inside a
+        90s budget that is ~90 retries of one denial. Only the TPM control
+        produces hints large enough to be meaningful, and for those the hint
+        still wins because it exceeds the curve.
         """
-        if retry_after is not None and retry_after > 0:
-            return min(float(retry_after), max_delay)
         base = (2.0, 10.0, 18.0)
         d = base[attempt] if attempt < len(base) else base[-1]
-        return d * (0.8 + 0.4 * random.random())
+        d *= 0.8 + 0.4 * random.random()
+        if retry_after is not None and retry_after > 0:
+            return min(max(float(retry_after), d), max_delay)
+        return d
 
     async def _backoff_sleep(self, delay: float) -> bool:
         """Sleep `delay` seconds, waking early if the turn is cancelled.
@@ -3130,7 +3142,13 @@ class ChatSession:
         _transient_attempt = 0
         # ENG-1537: velocity rate-limits are budgeted separately from incidents
         # (see _rate_limit_budget_s) so neither starves the other in one turn.
-        _rate_limit_deadline: float | None = None
+        # Accounted as TIME SLEPT, not a wall-clock deadline: the cohort this
+        # targets hits the ceiling repeatedly across a long turn, so denials
+        # arrive minutes apart with real work between them. A deadline set on
+        # the first denial would charge that work — tool rounds, continuations,
+        # compaction — against the wait budget and exhaust it without ever
+        # having waited 90s.
+        _rate_limit_slept = 0.0
         self._active_explainability = ExplainabilityCollector(
             self._explainability_store,
             turn=self._turn_count + 1,
@@ -3249,17 +3267,31 @@ class ChatSession:
                         # keeps the ENG-673 incident budget unchanged.
                         _rate_limited = _agent_exc.code == "rate_limited"
                         if _rate_limited:
-                            if _rate_limit_deadline is None:
-                                _rate_limit_deadline = now + self._rate_limit_budget_s
-                            deadline = _rate_limit_deadline
+                            remaining_budget = self._rate_limit_budget_s - _rate_limit_slept
                             max_delay = self._rate_limit_max_delay_s
                         else:
                             if _transient_deadline is None:
                                 _transient_deadline = now + self._transient_budget_s
-                            deadline = _transient_deadline
+                            remaining_budget = _transient_deadline - now
                             max_delay = 30.0
                         self._seal_dangling_tool_uses("interrupted by a transient provider error")
-                        remaining = deadline - now
+                        # A hint longer than we are willing to sleep: card NOW
+                        # and name the interval, rather than sleeping the cap
+                        # and then claiming "a moment" (ENG-1537 How #3). The
+                        # user can decide about a five-minute wait; we cannot
+                        # decide it for them by stalling the turn.
+                        _hint = getattr(_agent_exc, "retry_after", None)
+                        if _rate_limited and _hint is not None and _hint > max_delay:
+                            raise ProviderOverloadedError(
+                                "Too many requests too quickly — the limit clears in about "
+                                f"{int(_hint)}s. This isn't a credits problem.",
+                                provider=getattr(_agent_exc, "provider", "") or "",
+                                model=(getattr(_agent_exc, "model", "") or "")
+                                or getattr(self._llm, "planning_model", "") or "",
+                                code="rate_limited",
+                                retry_after=_hint,
+                            ) from _agent_exc
+                        remaining = remaining_budget
                         if remaining > 0.5:
                             delay = min(
                                 self._transient_backoff_delay(
@@ -3268,6 +3300,8 @@ class ChatSession:
                                 remaining,
                             )
                             _transient_attempt += 1
+                            if _rate_limited:
+                                _rate_limit_slept += delay
                             # Tell the user WHY the turn is quiet. A silent
                             # 90s pause is indistinguishable from a hang, and
                             # that is how a correct wait gets reported as a
@@ -3307,6 +3341,7 @@ class ChatSession:
                                 provider=getattr(_agent_exc, "provider", "") or "",
                                 model=_model,
                                 code="rate_limited",
+                                retry_after=getattr(_agent_exc, "retry_after", None),
                             ) from _agent_exc
                         raise ProviderOverloadedError(
                             f"{_agent_exc.provider or 'The model provider'} is experiencing an "

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -138,15 +138,39 @@ def test_429_enveloped_detail_also_maps_to_token_limit():
     assert "Monthly limit exceeded" in str(err.value)
 
 
-def test_bare_429_is_transient_fail_fast():
-    # ENG-673: a plain 429 (no quota detail) is a retryable rate-limit, but the
-    # SDK already retried it at request time → fail fast (no session backoff).
-    # Replaces the old test_bare_429_stays_generic — this path is now typed.
+def test_bare_429_is_transient_and_backs_off_in_session():
+    # ENG-673 typed this path; ENG-1537 made it wait. A plain 429 is a velocity
+    # limit — the one request-time status where the session must spend its
+    # budget, because the SDK's retries fire seconds apart and the ceiling is
+    # per-minute. Was session_backoff=False, which sent it down the count-based
+    # path and re-issued the request twice with no delay.
     exc = _sdk_error(429, json_body={})
     with pytest.raises(TransientProviderError) as err:
         _raise_for_status_error(exc, "sonnet")
-    assert err.value.session_backoff is False
+    assert err.value.session_backoff is True
+    assert err.value.code == "rate_limited"
     assert "rate-limiting" in str(err.value).lower()
+
+
+def test_bare_429_reads_retry_after_off_the_response():
+    # ENG-1537: nothing in anton read this header before. The gateway sends it
+    # on every velocity 429 as integer seconds; without it the session falls
+    # back to a guessed curve instead of the interval the server named.
+    exc = _sdk_error(429, json_body={}, headers={"Retry-After": "42"})
+    with pytest.raises(TransientProviderError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert err.value.retry_after == 42.0
+
+
+def test_retry_after_http_date_form_is_ignored_not_misparsed():
+    # The date form is legal but nothing in use emits it, and reading it as a
+    # number would produce an absurd delay. Absent hint → jittered curve.
+    exc = _sdk_error(
+        429, json_body={}, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+    )
+    with pytest.raises(TransientProviderError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert err.value.retry_after is None
 
 
 def _openai_quota_429():

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -144,7 +144,7 @@ def test_bare_429_is_transient_and_backs_off_in_session():
     # budget, because the SDK's retries fire seconds apart and the ceiling is
     # per-minute. Was session_backoff=False, which sent it down the count-based
     # path and re-issued the request twice with no delay.
-    exc = _sdk_error(429, json_body={})
+    exc = _sdk_error(429, json_body={"code": "rate_limited"})
     with pytest.raises(TransientProviderError) as err:
         _raise_for_status_error(exc, "sonnet")
     assert err.value.session_backoff is True
@@ -156,7 +156,9 @@ def test_bare_429_reads_retry_after_off_the_response():
     # ENG-1537: nothing in anton read this header before. The gateway sends it
     # on every velocity 429 as integer seconds; without it the session falls
     # back to a guessed curve instead of the interval the server named.
-    exc = _sdk_error(429, json_body={}, headers={"Retry-After": "42"})
+    exc = _sdk_error(429, json_body={}, headers={
+        "Retry-After": "42", "X-MindsHub-Reason": "rate_limited",
+    })
     with pytest.raises(TransientProviderError) as err:
         _raise_for_status_error(exc, "sonnet")
     assert err.value.retry_after == 42.0
@@ -165,9 +167,10 @@ def test_bare_429_reads_retry_after_off_the_response():
 def test_retry_after_http_date_form_is_ignored_not_misparsed():
     # The date form is legal but nothing in use emits it, and reading it as a
     # number would produce an absurd delay. Absent hint → jittered curve.
-    exc = _sdk_error(
-        429, json_body={}, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
-    )
+    exc = _sdk_error(429, json_body={}, headers={
+        "Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT",
+        "X-MindsHub-Reason": "rate_limited",
+    })
     with pytest.raises(TransientProviderError) as err:
         _raise_for_status_error(exc, "sonnet")
     assert err.value.retry_after is None
@@ -641,3 +644,32 @@ def test_unhashable_code_never_crashes_the_classifier():
         _raise_for_status_error(exc, "sonnet")
     assert not isinstance(err.value, TokenLimitExceeded)
     assert classify_transient(429, {"code": ["wallet_empty"]}) is not None  # plain-429 path intact
+
+
+def test_anthropic_mapper_also_reads_retry_after_and_the_velocity_signal():
+    # ENG-1537 review finding 6: the anthropic twin's `retry_after=` passthrough
+    # had no coverage — deleting it left all 87 mapper tests green, while the
+    # same deletion in openai.py correctly reddened. The two mappers are meant
+    # to be twins, so the untested one is where they drift.
+    from anton.core.llm.anthropic import _raise_for_status_error as anthropic_mapper
+
+    exc = _anthropic_sdk_error(429, json_body={"error": {"code": "rate_limited"}},
+                               headers={"Retry-After": "42"})
+    with pytest.raises(TransientProviderError) as err:
+        anthropic_mapper(exc, provider="Anthropic", model="sonnet")
+    assert err.value.retry_after == 42.0
+    assert err.value.session_backoff is True
+    assert err.value.code == "rate_limited"
+
+
+def test_anthropic_mapper_does_not_wait_on_an_unconfirmed_429():
+    # The twin must apply the same positive-signal rule, or the Gemini-dialect
+    # quota hole exists on one door and not the other.
+    from anton.core.llm.anthropic import _raise_for_status_error as anthropic_mapper
+
+    exc = _anthropic_sdk_error(429, json_body={"error": {"code": 429}},
+                               headers={"Retry-After": "42"})
+    with pytest.raises(TransientProviderError) as err:
+        anthropic_mapper(exc, provider="Anthropic", model="sonnet")
+    assert err.value.session_backoff is False
+    assert err.value.retry_after is None

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -61,16 +61,66 @@ def test_classify_transient_retryable(status, body):
 
 def test_session_backoff_flag_splits_midstream_from_requesttime():
     # Mid-stream (overload smuggled into a 200) had NO prior retry → session
-    # backs off. Request-time errors (real 5xx/429/529) were SDK-retried already
+    # backs off. Request-time errors (real 5xx/529) were SDK-retried already
     # → fail fast, no extra session budget.
+    #
+    # The velocity 429 is the documented exception and has its own test below
+    # (ENG-1537): the SDK's retries fire seconds apart, which is the right
+    # answer for a 5xx that recovers instantly and useless against a
+    # per-minute token ceiling.
     assert classify_transient(
         200, {"error": {"type": "overloaded_error"}}, provider="X"
     ).session_backoff is True
     assert classify_transient(503, {}, provider="X").session_backoff is False
-    assert classify_transient(429, {}, provider="X").session_backoff is False
     assert classify_transient(
         529, {"error": {"type": "overloaded_error"}}, provider="X"
     ).session_backoff is False
+
+
+def test_velocity_429_backs_off_in_session_and_carries_retry_after():
+    # ENG-1537. A velocity rate-limit is the one request-time status the SESSION
+    # must wait on: it is the only failure class where waiting is both necessary
+    # and sufficient, and the server hands us the interval. With
+    # session_backoff=False this fell to the count-based path, which re-issued
+    # the request twice with NO delay and a recovery note appended each time —
+    # told "too many tokens per minute", anton immediately sent more.
+    t = classify_transient(429, {}, provider="X", retry_after=30.0)
+    assert isinstance(t, TransientProviderError)
+    assert t.code == "rate_limited"
+    assert t.session_backoff is True
+    assert t.retry_after == 30.0
+
+
+def test_velocity_429_without_a_hint_still_backs_off():
+    # No Retry-After (a provider that omits it) → still waits, on the jittered
+    # curve rather than a named interval.
+    t = classify_transient(429, {}, provider="X")
+    assert t.session_backoff is True
+    assert t.retry_after is None
+
+
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        # The M3 gate's out-of-credits denials, in both body dialects.
+        (429, {"error": {"code": "included_allowance_exhausted"}}),
+        (429, {"code": "included_allowance_exhausted"}),
+        (402, {"error": {"code": "wallet_empty"}}),
+        (402, {"code": "wallet_empty"}),
+        # OpenAI's own quota dialect.
+        (429, {"error": {"code": "insufficient_quota"}}),
+        (429, {"code": "insufficient_quota"}),
+    ],
+)
+def test_billing_denials_never_enter_the_retry_loop(status, body):
+    # ENG-1169 regression guard, re-asserted because ENG-1537 made the sibling
+    # 429 branch retryable. A spent allowance and an empty wallet share the 429
+    # status with the velocity limit but are PERMANENT for the identical
+    # request: the allowance resets monthly, so waiting can never help and a
+    # wait would only delay the out-of-credits card the user needs.
+    # A Retry-After is passed deliberately — even with a hint present, these
+    # must not become retryable.
+    assert classify_transient(status, body, provider="X", retry_after=30.0) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -592,3 +592,73 @@ def test_the_progress_event_the_other_two_repos_key_on():
 
     src = inspect.getsource(sess)
     assert 'phase="rate_limited"' in src
+
+
+async def test_a_hint_above_the_cap_cards_immediately_and_names_the_interval():
+    """ENG-1537 How #3, and the item most likely to regress.
+
+    A hint longer than we are willing to sleep must NOT be absorbed: card at
+    once and name the real number, rather than sleeping the cap twice and then
+    telling the user to wait "a moment". This is pinned specifically because
+    the branch was absent for a whole revision while both the ticket and the PR
+    body asserted it shipped — and disabling it left the entire suite green.
+    """
+    s = _session()
+    sleeps = []
+
+    async def _record_sleep(delay):
+        sleeps.append(delay)
+        return False
+
+    s._backoff_sleep = _record_sleep
+
+    async def _always_rate_limited(user_msg):
+        raise TransientProviderError(
+            "The model provider is rate-limiting requests.",
+            provider="The model provider", code="rate_limited",
+            session_backoff=True, retry_after=3600.0,
+        )
+        yield  # pragma: no cover  (async generator)
+
+    s._stream_and_handle_tools = _always_rate_limited
+
+    with pytest.raises(ProviderOverloadedError) as ei:
+        _ = [e async for e in s.turn_stream("do it")]
+
+    assert sleeps == [], f"must not sleep at all, slept {sleeps}"
+    assert ei.value.code == "rate_limited"
+    assert ei.value.retry_after == 3600.0
+    assert "3600s" in str(ei.value)
+    # And never the out-of-credits framing.
+    assert "credits" in str(ei.value).lower()  # as a denial: "isn't a credits problem"
+    assert "add credits" not in str(ei.value).lower()
+
+
+async def test_a_hint_within_the_cap_still_waits_rather_than_carding():
+    """The complement — otherwise the branch above could swallow every case."""
+    s = _session()
+    sleeps = []
+
+    async def _record_sleep(delay):
+        sleeps.append(delay)
+        return False
+
+    s._backoff_sleep = _record_sleep
+    calls = {"n": 0}
+
+    async def _fail_then_succeed(user_msg):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TransientProviderError(
+                "The model provider is rate-limiting requests.",
+                provider="The model provider", code="rate_limited",
+                session_backoff=True, retry_after=30.0,
+            )
+        yield StreamTextDelta("done")
+
+    s._stream_and_handle_tools = _fail_then_succeed
+
+    _ = [e async for e in s.turn_stream("do it")]
+
+    assert sleeps == [30.0], sleeps          # the hint, honoured
+    assert calls["n"] == 2                   # and the SAME step resumed

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -259,7 +259,7 @@ import openai  # noqa: E402
 
 from anton.chat import ChatSession  # noqa: E402
 from anton.core.llm.openai import OpenAIProvider  # noqa: E402
-from anton.core.llm.provider import StreamComplete, StreamTextDelta  # noqa: E402
+from anton.core.llm.provider import StreamComplete, StreamTaskProgress, StreamTextDelta  # noqa: E402
 from anton.core.session import ChatSessionConfig  # noqa: E402
 from tests.conftest import make_mock_llm  # noqa: E402
 
@@ -582,16 +582,37 @@ def test_exhaustion_carries_the_rate_limited_code_and_the_interval():
     assert plain.retry_after is None
 
 
-def test_the_progress_event_the_other_two_repos_key_on():
+async def test_the_wait_emits_the_progress_event_the_other_two_repos_key_on():
     # cowork-server's never-throttle set and PHASE_LABELS, and cowork's reducer
-    # branch, all key on this exact phase string. Nothing else in anton pins it,
-    # so renaming it here would silently make the wait invisible in the UI —
-    # the "a silent 90s pause is indistinguishable from a hang" failure.
-    import inspect
-    from anton.core import session as sess
+    # branch, all key on this exact phase string. A silent wait is
+    # indistinguishable from a hang, which is the failure this event prevents.
+    #
+    # Asserted as an EMITTED EVENT, not a source literal: the previous version
+    # grepped `inspect.getsource` and survived moving the yield into dead code
+    # — the event never fired and the whole suite stayed green.
+    s = _session()
+    s._backoff_sleep = AsyncMock(return_value=False)
+    calls = {"n": 0}
 
-    src = inspect.getsource(sess)
-    assert 'phase="rate_limited"' in src
+    async def _fail_then_succeed(user_msg):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TransientProviderError(
+                "The model provider is rate-limiting requests.",
+                provider="P", code="rate_limited",
+                session_backoff=True, retry_after=30.0,
+            )
+        yield StreamTextDelta(text="ok")
+
+    s._stream_and_handle_tools = _fail_then_succeed
+    events = [e async for e in s.turn_stream("do it")]
+
+    phases = [e.phase for e in events if isinstance(e, StreamTaskProgress)]
+    assert "rate_limited" in phases, phases
+    notice = next(e for e in events
+                  if isinstance(e, StreamTaskProgress) and e.phase == "rate_limited")
+    assert "30" in notice.message           # names the wait
+    assert notice.eta_seconds == 30.0       # and carries it structurally
 
 
 async def test_a_hint_above_the_cap_cards_immediately_and_names_the_interval():
@@ -662,3 +683,93 @@ async def test_a_hint_within_the_cap_still_waits_rather_than_carding():
 
     assert sleeps == [30.0], sleeps          # the hint, honoured
     assert calls["n"] == 2                   # and the SAME step resumed
+
+
+async def test_the_wait_budget_is_finite_across_multiple_denials():
+    """The loop's ONLY termination guarantee is `_rate_limit_slept += delay`.
+
+    Nothing pinned it: deleting that line makes every velocity 429 that does
+    not clear retry forever — sleeping tens of seconds between attempts, with
+    no exhaustion card and no way out — and the suite stayed green. The two
+    adjacent `if _rate_limited:` blocks actively invite that merge.
+
+    A single-denial test cannot catch it; this needs repeated denials so the
+    accumulator has to advance.
+    """
+    s = _session()
+    sleeps = []
+
+    async def _record(delay):
+        sleeps.append(delay)
+        # Bail loudly rather than hanging. With the accumulator removed the
+        # loop is genuinely infinite and `_backoff_sleep` is mocked, so it
+        # spins at full speed — a plain assertion at the end would never be
+        # reached and CI would sit on a 10-minute timeout with no diagnosis
+        # (observed while mutation-testing this very test).
+        if len(sleeps) > 20:
+            raise AssertionError(
+                "the rate-limit wait never terminates — `_rate_limit_slept` "
+                "is not advancing, so the budget can never be spent"
+            )
+        return False
+
+    s._backoff_sleep = _record
+
+    async def _always(user_msg):
+        raise TransientProviderError(
+            "The model provider is rate-limiting requests.",
+            provider="P", code="rate_limited", session_backoff=True, retry_after=30.0,
+        )
+        yield  # pragma: no cover
+
+    s._stream_and_handle_tools = _always
+
+    with pytest.raises(ProviderOverloadedError) as ei:
+        _ = [e async for e in s.turn_stream("do it")]
+
+    assert ei.value.code == "rate_limited"
+    # Terminates, and within the stated budget rather than merely "eventually".
+    assert sum(sleeps) <= s._rate_limit_budget_s + 0.01, sleeps
+    assert len(sleeps) <= 6, sleeps
+
+
+async def test_a_rate_limit_wait_does_not_advance_the_incident_curve():
+    """The split attempt index — the headline of the commit that added it, and
+    unpinned until now: reverting to the shared counter kept the suite green.
+
+    An interleaved turn is the common shape when a gateway is degraded. With
+    one counter, the incident that follows a rate-limit wait starts partway
+    down a curve it never walked.
+    """
+    s = _session()
+    sleeps = []
+
+    async def _record(delay):
+        sleeps.append(delay)
+        return False
+
+    s._backoff_sleep = _record
+    calls = {"n": 0}
+
+    async def _rate_then_incident(user_msg):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TransientProviderError(
+                "rate-limiting", provider="P", code="rate_limited",
+                session_backoff=True, retry_after=45.0,
+            )
+        if calls["n"] == 2:
+            raise TransientProviderError(
+                "overloaded", provider="P", code="overloaded_error",
+                session_backoff=True,
+            )
+        yield StreamTextDelta(text="ok")
+
+    s._stream_and_handle_tools = _rate_then_incident
+    _ = [e async for e in s.turn_stream("do it")]
+
+    assert len(sleeps) == 2, sleeps
+    assert sleeps[0] == 45.0                 # the rate limit honoured its hint
+    # The incident starts at ITS OWN curve position 0 (~2s ±20%), not position
+    # 1 (~10s) as a shared counter would give.
+    assert sleeps[1] < 5.0, sleeps

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -77,6 +77,21 @@ def test_session_backoff_flag_splits_midstream_from_requesttime():
     ).session_backoff is False
 
 
+def test_an_unconfirmed_429_does_not_earn_a_session_wait():
+    # ENG-1537 finding 5. The session wait needs POSITIVE evidence of a velocity
+    # limit, not merely the absence of billing carriers. Both fail-fast guards
+    # are string-exact, so a provider quota in an unrecognised dialect — Gemini
+    # sends an INTEGER `code` with status RESOURCE_EXHAUSTED — slips past them.
+    # Waiting there burns the whole budget on a daily quota that resets at
+    # midnight, then tells the user it isn't a credits problem.
+    gemini_quota = {"error": {"code": 429, "status": "RESOURCE_EXHAUSTED"}}
+    t = classify_transient(429, gemini_quota, provider="Gemini", retry_after=30.0)
+    assert t.session_backoff is False
+    assert t.retry_after is None  # not carried, so nothing downstream waits on it
+    # A bare 429 from any BYOK provider keeps the pre-ENG-1537 behaviour too.
+    assert classify_transient(429, {}, provider="X", retry_after=1.0).session_backoff is False
+
+
 def test_velocity_429_backs_off_in_session_and_carries_retry_after():
     # ENG-1537. A velocity rate-limit is the one request-time status the SESSION
     # must wait on: it is the only failure class where waiting is both necessary
@@ -84,7 +99,7 @@ def test_velocity_429_backs_off_in_session_and_carries_retry_after():
     # session_backoff=False this fell to the count-based path, which re-issued
     # the request twice with NO delay and a recovery note appended each time —
     # told "too many tokens per minute", anton immediately sent more.
-    t = classify_transient(429, {}, provider="X", retry_after=30.0)
+    t = classify_transient(429, {}, provider="X", retry_after=30.0, velocity_confirmed=True)
     assert isinstance(t, TransientProviderError)
     assert t.code == "rate_limited"
     assert t.session_backoff is True
@@ -94,7 +109,7 @@ def test_velocity_429_backs_off_in_session_and_carries_retry_after():
 def test_velocity_429_without_a_hint_still_backs_off():
     # No Retry-After (a provider that omits it) → still waits, on the jittered
     # curve rather than a named interval.
-    t = classify_transient(429, {}, provider="X")
+    t = classify_transient(429, {}, provider="X", velocity_confirmed=True)
     assert t.session_backoff is True
     assert t.retry_after is None
 
@@ -504,3 +519,76 @@ async def test_turn_transient_backoff_cancels_on_stop():
     # Clean cancel: no transient-error prose leaks into the transcript.
     text = "".join(e.text for e in events if isinstance(e, StreamTextDelta))
     assert "overloaded" not in text.lower()
+
+
+# ── Session-side wiring (ENG-1537 review finding 3) ────────────────────────
+# The 85-line session.py half of ENG-1537 reverted with the suite green — the
+# wait itself is covered via `session_backoff`, but the budgets, the cap, the
+# progress event and the exhaustion code were not. Each of these was watched
+# failing against the merge-base.
+
+def test_rate_limits_get_their_own_budget_and_cap():
+    # Separate from the incident budget so neither starves the other in a turn,
+    # and a larger hint cap because a velocity hint is a real end time whereas
+    # an incident's is a guess. Reverting the cap silently clamps a 45s hint to
+    # 30s — retrying into a window that is still open.
+    from anton.core.session import ChatSession
+
+    assert ChatSession._rate_limit_budget_s == 90.0
+    assert ChatSession._transient_budget_s == 30.0  # unchanged
+    assert ChatSession._rate_limit_max_delay_s == 60.0
+
+
+def test_a_hint_never_retries_faster_than_the_curve():
+    # ENG-1537 finding 1. Obeying a small hint verbatim ignores `attempt`, and
+    # the gateway's small hints are the COMMON case: an RPM denial always
+    # computes exactly 1, and a concurrency denial sends a flat 1 that its own
+    # config calls a fake end time. Taken literally inside a 90s budget that is
+    # ~90 retries of a single denial.
+    from anton.core.session import ChatSession
+
+    first = ChatSession._transient_backoff_delay(0, 1.0, 60.0)
+    second = ChatSession._transient_backoff_delay(1, 1.0, 60.0)
+    assert first >= 1.5, first          # the curve's floor wins over the 1s hint
+    assert second > first               # and it still escalates
+    # A hint LARGER than the curve is still honoured — that's the TPM case.
+    assert ChatSession._transient_backoff_delay(0, 45.0, 60.0) == 45.0
+    # And never above the cap.
+    assert ChatSession._transient_backoff_delay(0, 3600.0, 60.0) == 60.0
+
+
+def test_incident_backoff_is_untouched_by_the_rate_limit_cap():
+    # "No change to 5xx incident handling" — the incident path keeps its own
+    # 30s clamp even though the rate-limit path now passes 60.
+    from anton.core.session import ChatSession
+
+    assert ChatSession._transient_backoff_delay(0, 3600.0) == 30.0
+
+
+def test_exhaustion_carries_the_rate_limited_code_and_the_interval():
+    # cowork-server maps this code to the wait-and-retry card instead of the
+    # out-of-credits one, and the card gates its Retry on the interval — so
+    # both must survive the raise.
+    from anton.core.llm.provider import ProviderOverloadedError
+
+    exc = ProviderOverloadedError(
+        "x", provider="P", model="sonnet", code="rate_limited", retry_after=30.0,
+    )
+    assert exc.code == "rate_limited"
+    assert exc.retry_after == 30.0
+    # The incident default is unchanged and carries no interval.
+    plain = ProviderOverloadedError("y")
+    assert plain.code == "provider_overloaded"
+    assert plain.retry_after is None
+
+
+def test_the_progress_event_the_other_two_repos_key_on():
+    # cowork-server's never-throttle set and PHASE_LABELS, and cowork's reducer
+    # branch, all key on this exact phase string. Nothing else in anton pins it,
+    # so renaming it here would silently make the wait invisible in the UI —
+    # the "a silent 90s pause is indistinguishable from a hang" failure.
+    import inspect
+    from anton.core import session as sess
+
+    src = inspect.getsource(sess)
+    assert 'phase="rate_limited"' in src


### PR DESCRIPTION
Closes part of [ENG-1537](https://linear.app/mindsdb/issue/ENG-1537). **anton half only** — see *Merge order* below.

## The bug

A gateway velocity 429 (`rate_limited`) was classified `session_backoff=False`, which skips the session's backoff path (`session.py:3218`) and falls to the count-based recovery path. That path **re-issues the request twice with no delay**, appending a *"transient service issue… continue as planned"* note to history each time. So when the gateway said *"too many tokens per minute"*, anton immediately sent more — with a larger context each attempt, because the note grows the payload. Then it made one more call to summarize, into the same limiter.

Nothing in anton read `Retry-After`, so the interval the gateway explicitly hands us was never used.

The gateway is unambiguous about this (`minds/inference/errors.py:139`):

> Distinct from `allowance_exhausted`: the caller should slow down and retry after `retry_after` seconds, **not** wait for an allowance reset or add credits.

**Measured:** 239 denied calls / 5 external users / 30d on the `anton:turn` surface — the largest single error family by call volume for external Cowork users. The mechanism explains its own inflation, so user-visible failures are far fewer than 239.

## The fix

A velocity limit is the one failure class where waiting is both necessary *and* sufficient, and the server tells us how long. So it waits.

- **`retry_after_seconds()`** parses the header — integer seconds only. The HTTP-date form is legal but nothing in use emits it, and misreading a date as a number would produce an absurd delay, so it's ignored rather than guessed. Both mappers pass it through.
- **`session_backoff=True`** on the velocity-429 branch routes it to the *existing* budgeted backoff path, which already seals dangling `tool_use`s, sleeps, and resumes the **same step** with completed tool results intact and **no recovery note injected**. That path was written for ENG-673 and documented as deliberately not telling the model to "adjust your approach" — exactly right here.
- **Its own budget:** 90s per turn, separate from the 30s incident budget so neither starves the other, plus a 60s cap on a server hint (incident cap unchanged at 30s). A hint above the cap stops the wait and surfaces the card naming the interval, rather than silently absorbing a multi-minute stall.
- **The user is told why the turn is quiet**, through the existing `StreamTaskProgress` affordance. A silent 90s pause is indistinguishable from a hang — that's how a correct fix gets reported as a freeze. No new event type; the turn stays alive so nobody types "continue".
- **On budget exhaustion** the error carries `code="rate_limited"` for a wait-and-retry card.

### Why `session_backoff=False` was right before and wrong here

The flag means *"should the SESSION spend its budget on this?"* The SDK's own retries fire seconds apart — the right answer for a 5xx that recovers instantly, and useless against a per-minute token ceiling. 5xx and mid-stream behaviour are unchanged.

## Out-of-credits must not wait, and doesn't

`wallet_empty` and `included_allowance_exhausted` share the 429 status but are **permanent for the identical request** — the allowance resets monthly, so a wait could only delay the card the user needs, and making "429 → wait" the blanket rule would regress ENG-1169.

Guarded twice over, both preserved: the wallet branch runs *before* `classify_transient`, and `classify_transient` re-checks the wallet code. New parametrised test asserts both dialects of both denials still fail fast **even when a `Retry-After` is present**.

## Verification

- **Full suite: 2003 passed.** 7 failures, all pre-existing — confirmed by re-running the same files against clean `origin/staging` source and getting the identical 7 (subprocess-spawning scratchpad / cloud-turn tests).
- **Mutation-verified.** All 10 new/changed assertions were watched **failing** against `origin/staging` source before the fix, then passing after. Source was restored by checksum, not by eye.
- Two existing tests asserted the old behaviour and were **updated deliberately, not flipped** — they encoded the defect, and the reasoning is in the diff.

Honest note on the 6 billing-guard assertions: on unfixed code they fail on the new kwarg's signature, so they prove *future* protection rather than a behaviour change. The two that demonstrate new behaviour are the `session_backoff` flip and the header read.

## Security pass

No new user input reaches a sink. The parsed header is numeric-only and clamped, so a hostile or buggy `Retry-After` cannot stall a turn beyond the 60s cap or the 90s budget; unparseable, negative and non-finite values are dropped. Error copy stays curated — no provider internals reach the chat. The added log line records the status and parsed interval, and the body is already `scrub_credentials`-filtered.

## Merge order — do not merge this alone and call ENG-1537 done

This PR makes the wait real, which is the half that matters. Two follow-ups complete the ticket:

1. **cowork-server** — map the gateway's `rate_limited` reason (the one of its five reasons `_map_gateway_reason` doesn't know, which is why a velocity 429 currently shows *"You're out of credits — Top up balance"*), add the code + copy, and split the credits card so an allowance denial reads differently from an empty wallet. Also add `rate_limited` to the progress never-throttle set so the wait message can't be dropped.
2. **cowork** — the `rate_limited` card with a time-gated Retry, and the `PHASE_LABELS` entry for the waiting state.

### Correction — what budget exhaustion actually shows today

An earlier version of this description claimed exhaustion degrades to the provider-overloaded card. **That is wrong, and I verified it by building the real exception chain and asking `friendly_turn_error`:**

```
type=ProviderOverloadedError code='rate_limited'
provider_overloaded_info  -> ('rate_limited', 'sonnet')     <- the right code IS available
friendly_turn_error       -> ('token_limit', "You're out of credits. Add credits to keep working.")
```

The bare-status rule — `if status in (402, 429, 503) and _from_minds_gateway(host)` — fires **before** `provider_overloaded_info`, and the 429 is still in the `__cause__` chain, so it wins. **So on the exhaustion path this PR alone does not fix the message: the user still sees the out-of-credits card.**

Two consequences worth being explicit about:

- **cowork-server's change is required, not cosmetic.** It is what makes the failure honest when the wait doesn't succeed.
- **It should be small.** The exhaustion path already carries `code="rate_limited"` and `provider_overloaded_info` already surfaces it — the fix is to check a positively-identified `rate_limited` (reason header *or* body code) *before* the bare-status rule, rather than adding new plumbing.

**What this PR does deliver on its own:** the wait itself. Most velocity 429s now resolve inside the turn — no instant retries, no context growth, no SYSTEM notes in history, no card at all — so far fewer users reach the wrong message in the first place. The message on the residual is follow-up 1's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

# Review round — what changed after the adversarial pass

A deep review on all three PRs found defects that execution proved and my bodies denied. Fixed in follow-up commits; recording the corrections here because several were claims *in this description*.

**Merge / delivery order is INVERTED** to `anton#349 → cowork#648 → cowork-server#309`. Under the original order the 90s wait ships **silent** — staging's renderer drops the ad-hoc `thought.progress` phase — which is the exact perceived-freeze the design exists to prevent. And landing the server's allowance split first sends a code the renderer has no branch for, dropping a user who just spent their free grant to a buttonless alert at the paid-conversion moment. cowork#648 is provably inert without #309, so the inversion costs nothing. **Enforce it at delivery** (UI/shell release before the PyPI publish), not at merge-to-staging.

**The ENG-1282 tripwire is intra-repo only.** I claimed it proves cross-repo enforcement. It doesn't: both code lists are hand-maintained *within* their own repos and neither reads the other, so it went red because the same-file literal needed updating in the same commit. There is also a hole it cannot see — `provider_overloaded_info` returns anton's `exc.code` verbatim, so any code anton invents reaches the renderer without being a `*_CODE` constant. Two tickets now lean on protection that isn't there.

**Test-count claims in this body are unreliable.** The `cloud_turn_process` subprocess tests are flaky on my machine and pass in CI; the review measured 0 failures where I reported 7. Trust CI, not the numbers I quoted.
