### PR TITLE
Send events

### DIFF
--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -21,11 +21,53 @@ import json
 import logging
 import os
 import sys
+import time
 
 from anton.cloud_turn.contract import TurnRequestV1
 from anton.cloud_turn.session import build_cloud_chat_session, drain_pending_memory
 
 logger = logging.getLogger(__name__)
+
+#: Bound step-event payloads (tool args / results) on the wire. Matches the
+#: cap cowork's SSE formatter applies to the same content.
+MAX_STEP_CHARS = 65536
+MAX_PROGRESS_CHARS = 2000
+#: Per-string-field cap when shrinking a cell-result JSON to fit the wire.
+RESULT_FIELD_CAP = 16384
+#: Rate limit for repeat progress events on the wire — agent code can call
+#: progress() in a tight loop; step-creating/closing phases are never dropped.
+#: Matches cowork's SSE-side PROGRESS_THROTTLE.
+PROGRESS_WIRE_INTERVAL = 0.25
+
+_TRUNCATION_MARKER = "\n[… truncated …]\n"
+
+
+def _clip_result_content(content: str, cap: int = MAX_STEP_CHARS) -> str:
+    """Bound a tool result without losing its verdict.
+
+    Exec results are cell JSON whose `error` field decides ok/timeout/error
+    downstream (cowork's classify_cell_status parses it structurally), so
+    shrink the bulky fields and keep the JSON — and `error` — intact. A blind
+    prefix cut made long failed cells render as successful. Non-JSON content
+    falls back to a middle clip so trailing error text still survives."""
+    if len(content) <= cap:
+        return content
+    try:
+        cell = json.loads(content)
+    except (ValueError, TypeError):
+        cell = None
+    if isinstance(cell, dict):
+        for key, val in cell.items():
+            if key != "error" and isinstance(val, str) and len(val) > RESULT_FIELD_CAP:
+                keep = RESULT_FIELD_CAP // 2
+                cell[key] = val[:keep] + _TRUNCATION_MARKER + val[-keep:]
+        clipped = json.dumps(cell)
+        if len(clipped) <= cap:
+            return clipped
+        content = clipped
+    head = cap * 3 // 4
+    tail = cap - head - len(_TRUNCATION_MARKER)
+    return content[:head] + _TRUNCATION_MARKER + content[-tail:]
 
 #: Bound the single request line so a malformed/huge stdin can't exhaust memory.
 MAX_REQUEST_BYTES = 10 * 1024 * 1024
@@ -118,6 +160,8 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
         StreamTaskProgress,
         StreamTextDelta,
         StreamToolResult,
+        StreamToolUseDelta,
+        StreamToolUseEnd,
         StreamToolUseStart,
     )
 
@@ -137,24 +181,72 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
     try:
         req = TurnRequestV1.from_json(raw_line)
         session = builder(req)
+        # Tool-call args accumulate here and ship once on tool_end, so the
+        # wire carries one event per call instead of one per args token.
+        # Accumulation stops at the wire cap — a runaway call can't grow
+        # pod memory with args that would be clipped anyway.
+        tool_args: dict[str, list[str]] = {}
+        tool_args_len: dict[str, int] = {}
+        seen_tool_progress: set[str] = set()
+        last_progress_wire = 0.0
         async for event in session.turn_stream(req.input):
             if isinstance(event, StreamTextDelta):
                 emit({"kind": "delta", "text": event.text or ""})
-            # Narrate the discrete actions to stderr so the turn is observable
-            # in the controller logs (per-token deltas/reasoning are skipped to
-            # keep it readable). The turn loop itself logs nothing.
+            # Step events go on the wire for cowork's thinking/steps UI;
+            # stderr keeps the controller-log narration.
             elif isinstance(event, StreamToolUseStart):
                 logger.info("tool call: %s", event.name)
+                tool_args[event.id] = []
+                emit({"kind": "tool_start", "id": event.id, "name": event.name})
+            elif isinstance(event, StreamToolUseDelta):
+                parts = tool_args.get(event.id)
+                if parts is not None and tool_args_len.get(event.id, 0) < MAX_STEP_CHARS:
+                    parts.append(event.json_delta)
+                    tool_args_len[event.id] = (
+                        tool_args_len.get(event.id, 0) + len(event.json_delta)
+                    )
+            elif isinstance(event, StreamToolUseEnd):
+                args = "".join(tool_args.pop(event.id, []))
+                tool_args_len.pop(event.id, None)
+                emit({"kind": "tool_end", "id": event.id,
+                      "args": args[:MAX_STEP_CHARS]})
             elif isinstance(event, StreamTaskProgress):
                 logger.info("progress [%s]: %s", event.phase, event.message)
+                phase = event.phase or ""
+                first_progress = (phase == "tool_progress" and event.id
+                                  and event.id not in seen_tool_progress)
+                if first_progress:
+                    seen_tool_progress.add(event.id)
+                # Step-creating/closing phases and the first tool_progress per
+                # id must never be dropped (they open/close renderer steps);
+                # the rest is rate-limited.
+                always = bool(first_progress) or phase in (
+                    "scratchpad_start", "scratchpad_done", "tool_done")
+                now = time.monotonic()
+                if always or now - last_progress_wire >= PROGRESS_WIRE_INTERVAL:
+                    if not always:
+                        last_progress_wire = now
+                    emit({"kind": "progress", "phase": phase,
+                          "message": (event.message or "")[:MAX_PROGRESS_CHARS],
+                          "eta_seconds": event.eta_seconds,
+                          "id": event.id, "ok": event.ok})
             elif isinstance(event, StreamToolResult):
                 action = f" action={event.action}" if event.action else ""
                 logger.info("tool result: %s%s (%d chars)",
                             event.name, action, len(event.content or ""))
+                emit({"kind": "tool_result", "id": event.id, "name": event.name,
+                      "action": event.action,
+                      "content": _clip_result_content(event.content or "")})
             elif isinstance(event, StreamContextCompacted):
                 logger.info("context compacted: %s", event.message)
+                emit({"kind": "compacted", "message": event.message})
             elif isinstance(event, StreamComplete):
                 logger.info("model response complete")
+                # Round boundary: cowork's formatter separates rounds with a
+                # paragraph break unless the round was truncated mid-sentence.
+                emit({"kind": "round_end",
+                      "stop_reason": event.response.stop_reason,
+                      "had_tool_calls": bool(event.response.tool_calls)})
         await _settle_memory(session)
         entries = drain_pending_memory(session)
         if entries:

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -12,11 +12,16 @@ import json
 import logging
 
 from anton.cloud_turn.contract import TurnRequestV1
-from anton.cloud_turn.__main__ import stream_turn
+from anton.cloud_turn.__main__ import _clip_result_content, stream_turn
 from anton.core.llm.provider import (
+    LLMResponse,
+    StreamComplete,
+    StreamContextCompacted,
     StreamTaskProgress,
     StreamTextDelta,
     StreamToolResult,
+    StreamToolUseDelta,
+    StreamToolUseEnd,
     StreamToolUseStart,
 )
 
@@ -109,10 +114,86 @@ def test_text_only_no_deltas_still_completes():
     assert events == [{"kind": "turn_completed"}]
 
 
+def test_step_events_go_on_the_wire():
+    """Tool/progress/round events are emitted as structured wire events so the
+    cowork step UI can render them; tool args accumulate pod-side and ship once
+    on tool_end."""
+    class _S(_FakeSession):
+        async def turn_stream(self, user_input, **kwargs):
+            yield StreamToolUseStart(id="t1", name="scratchpad")
+            yield StreamToolUseDelta(id="t1", json_delta='{"code":')
+            yield StreamToolUseDelta(id="t1", json_delta='"1+1"}')
+            yield StreamToolUseEnd(id="t1")
+            yield StreamTaskProgress(phase="scratchpad_done", message="ran",
+                                     eta_seconds=1.5, id="t1", ok=True)
+            yield StreamToolResult(name="scratchpad", content="2", action="exec", id="t1")
+            yield StreamContextCompacted(message="squeezed")
+            yield StreamComplete(response=LLMResponse(content="", stop_reason="end_turn"))
+            yield StreamTextDelta(text="done")
+
+    events = _drive(_S())
+    assert {"kind": "tool_start", "id": "t1", "name": "scratchpad"} in events
+    assert {"kind": "tool_end", "id": "t1", "args": '{"code":"1+1"}'} in events
+    assert {"kind": "progress", "phase": "scratchpad_done", "message": "ran",
+            "eta_seconds": 1.5, "id": "t1", "ok": True} in events
+    assert {"kind": "tool_result", "id": "t1", "name": "scratchpad",
+            "action": "exec", "content": "2"} in events
+    assert {"kind": "compacted", "message": "squeezed"} in events
+    assert {"kind": "round_end", "stop_reason": "end_turn",
+            "had_tool_calls": False} in events
+    assert events[-1] == {"kind": "turn_completed"}
+
+
+def test_result_clip_preserves_error_verdict():
+    """A long failed cell must still classify as failed downstream: the clip
+    shrinks bulky fields but keeps the JSON and its error field intact."""
+    cell = {"code": "x", "stdout": "s" * 70_000, "error": "boom"}
+    clipped = _clip_result_content(json.dumps(cell))
+    assert len(clipped) <= 65536
+    parsed = json.loads(clipped)
+    assert parsed["error"] == "boom"
+    assert "truncated" in parsed["stdout"]
+
+
+def test_result_clip_non_json_keeps_tail():
+    text = "a" * 70_000 + "TAIL-ERROR"
+    clipped = _clip_result_content(text)
+    assert len(clipped) <= 65536
+    assert clipped.endswith("TAIL-ERROR")
+
+
+def test_progress_flood_is_rate_limited_but_step_phases_pass():
+    class _S(_FakeSession):
+        async def turn_stream(self, user_input, **kwargs):
+            yield StreamTaskProgress(phase="scratchpad_start", message="s", id="t1")
+            for i in range(50):
+                yield StreamTaskProgress(phase="progress", message=f"m{i}")
+            yield StreamTaskProgress(phase="scratchpad_done", message="d", id="t1")
+
+    events = _drive(_S())
+    progress = [e for e in events if e.get("kind") == "progress"]
+    phases = [e["phase"] for e in progress]
+    assert "scratchpad_start" in phases and "scratchpad_done" in phases
+    assert len(progress) < 10  # the 50-call flood collapses on the wire
+
+
+def test_tool_args_accumulation_is_bounded():
+    class _S(_FakeSession):
+        async def turn_stream(self, user_input, **kwargs):
+            yield StreamToolUseStart(id="t1", name="scratchpad")
+            for _ in range(20):
+                yield StreamToolUseDelta(id="t1", json_delta="x" * 10_000)
+            yield StreamToolUseEnd(id="t1")
+
+    events = _drive(_S())
+    end = next(e for e in events if e.get("kind") == "tool_end")
+    assert len(end["args"]) <= 65536
+
+
 def test_action_events_are_logged(caplog):
     """Discrete turn actions (tool calls, progress, results) are narrated to the
-    logs so the pod's activity is observable in the controller; text deltas are
-    NOT logged (they are emitted, not narrated)."""
+    logs so the pod's activity is observable in the controller, in addition to
+    the structured wire events; text deltas are NOT logged (emitted only)."""
     class _S(_FakeSession):
         async def turn_stream(self, user_input, **kwargs):
             yield StreamToolUseStart(id="t1", name="scratchpad")


### PR DESCRIPTION
Cloud turns only put text deltas on the wire — tool calls, progress, and results were stderr-only, so the hosted UI showed a flat answer with no steps or "Worked for" block.

The pod entrypoint now emits structured events alongside the existing stderr narration: tool_start, tool_end (args accumulated pod-side, 64KB cap), progress, tool_result, compacted, and round_end (stop_reason + had_tool_calls,
so cowork's formatter can separate rounds instead of gluing text mid-sentence). Fixes [ENG-1603](https://linear.app/mindsdb/issue/ENG-1603/missed-steps-or-worked-for-block)