### PR TITLE
chore(ci): move release-train alerts into the shared reusables (ENG-1549)

### DIFF
--- a/.github/workflows/staging-freeze.yml
+++ b/.github/workflows/staging-freeze.yml
@@ -17,10 +17,13 @@ jobs:
     # left the channel holding a red alert.
     permissions:
       contents: read
-      # Turns the "recovered" message on. The reusable's notify step reads run
-      # history to tell a recovery from an ordinary green run, and the default
-      # workflow token carries contents + packages read only. Without this the
-      # lookup is refused, logs why, and stays quiet.
+      # Turns the "recovered" message on, and it is the ONLY thing that does. The
+      # reusable declares no `permissions:` block of its own, so its job inherits
+      # exactly what is granted here; a block there would cap the token instead and
+      # the lookup would be refused however much this granted. The default workflow
+      # token carries contents + packages read only, and without the grant the
+      # lookup is refused, logs why, and stays quiet — a missing recovery message
+      # rather than a broken run.
       actions: read
     uses: mindsdb/github-actions/.github/workflows/release-freeze.yml@main
     secrets: inherit

--- a/.github/workflows/staging-freeze.yml
+++ b/.github/workflows/staging-freeze.yml
@@ -11,24 +11,16 @@ permissions:
 
 jobs:
   freeze:
-    uses: mindsdb/github-actions/.github/workflows/release-freeze.yml@75df118f3b003625052c4f14e7b90817fb8b2784 # v1
-    secrets: inherit
-
-  notify:
-    # Alert the eng channel if the freeze fails (e.g. missing ruleset) — otherwise
-    # a broken freeze is silent and the code-freeze window never opens.
-    needs: [freeze]
-    if: failure()
+    # No notify job here any more. The reusable ends with one, which covers both
+    # a failed freeze and the re-run that fixes it. A wrapper-owned `if: failure()`
+    # job could only ever report the first half, so a freeze that was repaired
+    # left the channel holding a red alert.
     permissions:
       contents: read
-      # Declared even though this caller never runs the prior-run lookup: a
-      # reusable workflow's requested permissions are validated when the file
-      # is parsed, not when the step that needs them runs, so a caller that
-      # grants less than the reusable asks for is INVALID rather than merely
-      # degraded, and the whole workflow fails to load.
+      # Turns the "recovered" message on. The reusable's notify step reads run
+      # history to tell a recovery from an ordinary green run, and the default
+      # workflow token carries contents + packages read only. Without this the
+      # lookup is refused, logs why, and stays quiet.
       actions: read
-    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
-    with:
-      env-name: "staging freeze"
-      runs-on: ubuntu-latest
+    uses: mindsdb/github-actions/.github/workflows/release-freeze.yml@main
     secrets: inherit

--- a/.github/workflows/staging-unfreeze.yml
+++ b/.github/workflows/staging-unfreeze.yml
@@ -26,10 +26,13 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-      # Turns the "recovered" message on. The reusable's notify step reads run
-      # history to tell a recovery from an ordinary green run, and the default
-      # workflow token carries contents + packages read only. Without this the
-      # lookup is refused, logs why, and stays quiet.
+      # Turns the "recovered" message on, and it is the ONLY thing that does. The
+      # reusable declares no `permissions:` block of its own, so its job inherits
+      # exactly what is granted here; a block there would cap the token instead and
+      # the lookup would be refused however much this granted. The default workflow
+      # token carries contents + packages read only, and without the grant the
+      # lookup is refused, logs why, and stays quiet — a missing recovery message
+      # rather than a broken run.
       actions: read
     uses: mindsdb/github-actions/.github/workflows/release-unfreeze.yml@main
     secrets: inherit

--- a/.github/workflows/staging-unfreeze.yml
+++ b/.github/workflows/staging-unfreeze.yml
@@ -18,29 +18,18 @@ concurrency:
 
 jobs:
   unfreeze:
+    # No notify job here any more; the reusable ends with one. See staging-freeze.yml.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
        github.event.pull_request.head.ref == 'staging' &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: mindsdb/github-actions/.github/workflows/release-unfreeze.yml@75df118f3b003625052c4f14e7b90817fb8b2784 # v1
-    secrets: inherit
-
-  notify:
-    # Alert the eng channel if the unfreeze or main->staging sync-back fails —
-    # otherwise staging stays frozen (or drifts from main) with no signal.
-    needs: [unfreeze]
-    if: failure()
     permissions:
       contents: read
-      # Declared even though this caller never runs the prior-run lookup: a
-      # reusable workflow's requested permissions are validated when the file
-      # is parsed, not when the step that needs them runs, so a caller that
-      # grants less than the reusable asks for is INVALID rather than merely
-      # degraded, and the whole workflow fails to load.
+      # Turns the "recovered" message on. The reusable's notify step reads run
+      # history to tell a recovery from an ordinary green run, and the default
+      # workflow token carries contents + packages read only. Without this the
+      # lookup is refused, logs why, and stays quiet.
       actions: read
-    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
-    with:
-      env-name: "staging unfreeze"
-      runs-on: ubuntu-latest
+    uses: mindsdb/github-actions/.github/workflows/release-unfreeze.yml@main
     secrets: inherit

--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -43,10 +43,13 @@ jobs:
     # holding a red alert for a sync that had already succeeded.
     permissions:
       contents: read
-      # Turns the "recovered" message on. The reusable's notify step reads run
-      # history to tell a recovery from an ordinary green run, and the default
-      # workflow token carries contents + packages read only. Without this the
-      # lookup is refused, logs why, and stays quiet.
+      # Turns the "recovered" message on, and it is the ONLY thing that does. The
+      # reusable declares no `permissions:` block of its own, so its job inherits
+      # exactly what is granted here; a block there would cap the token instead and
+      # the lookup would be refused however much this granted. The default workflow
+      # token carries contents + packages read only, and without the grant the
+      # lookup is refused, logs why, and stays quiet — a missing recovery message
+      # rather than a broken run.
       actions: read
     uses: mindsdb/github-actions/.github/workflows/sync-main-to-staging.yml@main
     secrets: inherit

--- a/.github/workflows/sync-main-to-staging.yml
+++ b/.github/workflows/sync-main-to-staging.yml
@@ -36,24 +36,17 @@ permissions:
 
 jobs:
   sync:
-    uses: mindsdb/github-actions/.github/workflows/sync-main-to-staging.yml@main
-    secrets: inherit
-
-  notify:
-    # A silently failing sync is the whole reason this workflow exists, so it
-    # alerts rather than trusting anyone to notice staging drifting behind main.
-    needs: [sync]
-    if: failure()
+    # No notify job here any more. The reusable ends with one, so a sync that
+    # fails and is then re-run successfully reports BOTH. It previously could not:
+    # on 2026-08-14 this workflow failed on cowork, alerted, was re-run green, and
+    # the wrapper's `if: failure()` notify was skipped, so the channel was left
+    # holding a red alert for a sync that had already succeeded.
     permissions:
       contents: read
-      # Declared even though this caller never runs the prior-run lookup: a
-      # reusable workflow's requested permissions are validated when the file
-      # is parsed, not when the step that needs them runs, so a caller that
-      # grants less than the reusable asks for is INVALID rather than merely
-      # degraded, and the whole workflow fails to load.
+      # Turns the "recovered" message on. The reusable's notify step reads run
+      # history to tell a recovery from an ordinary green run, and the default
+      # workflow token carries contents + packages read only. Without this the
+      # lookup is refused, logs why, and stays quiet.
       actions: read
-    uses: mindsdb/github-actions/.github/workflows/notify-main-failure.yml@main
-    with:
-      env-name: "main -> staging sync"
-      runs-on: ubuntu-latest
+    uses: mindsdb/github-actions/.github/workflows/sync-main-to-staging.yml@main
     secrets: inherit

--- a/.github/workflows/weekly-merge-staging.yml
+++ b/.github/workflows/weekly-merge-staging.yml
@@ -20,22 +20,48 @@ on:
 permissions:
   contents: read
 
+# Serialised because two runs can overlap: the Friday freeze and a staging merge
+# in the same minute both trigger this. The reusable reads "is there an open
+# release PR" and then creates or edits one, which is not atomic, so two runs race
+# on the same PR. GitHub rejects the losing `gh pr create` with a 422, and under
+# `set -euo pipefail` that fails the job, which now posts a red "release PR
+# pipeline failed" for a PR that exists and is fine.
+#
+# `cancel-in-progress: false` because the body is a commit list: the later run has
+# the newer list and must not be dropped, it just has to wait.
+concurrency:
+  group: release-pr
+  cancel-in-progress: false
+
 jobs:
   create-pr:
-    # A failed FREEZE means staging was never locked, so opening the release PR
-    # would be premature. A failed staging PIPELINE says nothing about what is
-    # queued — the PR body is a commit list, not a health report — so the refresh
-    # still runs, and the red-branch sweep is what reports the pipeline.
+    # Both sources spelled out, rather than leaning on a `!=` that lets anything
+    # through. A failed FREEZE means staging was never locked, so opening the
+    # release PR would be premature. A failed staging PIPELINE says nothing about
+    # what is queued — the PR body is a commit list, not a health report — so the
+    # refresh still runs, and the red-branch sweep is what reports the pipeline.
+    #
+    # The staging pipeline is checked for `head_branch` because it can also be
+    # started by hand on another ref, and a refresh triggered by an unrelated
+    # branch's run is at best a wasted run and at worst opens the release PR at a
+    # moment nobody expected. The freeze cannot be checked the same way: it runs on
+    # `schedule`, which GitHub attributes to the DEFAULT branch, so its
+    # `head_branch` is `main`.
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.name != 'Staging Freeze' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.name == 'Staging Freeze' &&
+       github.event.workflow_run.conclusion == 'success') ||
+      (github.event.workflow_run.name == 'Staging pre-release and publish to PyPI' &&
+       github.event.workflow_run.head_branch == 'staging')
     permissions:
       contents: read
-      # Turns the "recovered" message on. The reusable's notify step reads run
-      # history to tell a recovery from an ordinary green run, and the default
-      # workflow token carries contents + packages read only. Without this the
-      # lookup is refused, logs why, and stays quiet.
+      # Turns the "recovered" message on, and it is the ONLY thing that does. The
+      # reusable declares no `permissions:` block of its own, so its job inherits
+      # exactly what is granted here; a block there would cap the token instead and
+      # the lookup would be refused however much this granted. The default workflow
+      # token carries contents + packages read only, and without the grant the
+      # lookup is refused, logs why, and stays quiet — a missing recovery message
+      # rather than a broken run.
       actions: read
     uses: mindsdb/github-actions/.github/workflows/release-pr.yml@main
     secrets: inherit

--- a/.github/workflows/weekly-merge-staging.yml
+++ b/.github/workflows/weekly-merge-staging.yml
@@ -1,7 +1,19 @@
 name: Create staging to main release PR
+
+# Fires at freeze time AND after every staging pipeline, so the release PR is a
+# live view of what is queued for production rather than a Friday-only snapshot.
+# The reusable opens it as a DRAFT and marks it ready for review when the freeze
+# window opens, so an always-open staging -> main PR is never a merge button
+# sitting next to production mid-week.
+#
+# `workflow_run` rather than `push: staging`, deliberately: a second workflow on
+# `push: staging` would be a second disconnected run tree, which is exactly what
+# the shared workflow lint forbids. `workflow_run` is its own event, so this stays
+# one entry point.
+
 on:
   workflow_run:
-    workflows: ["Staging Freeze"]
+    workflows: ["Staging Freeze", "Staging pre-release and publish to PyPI"]
     types: [completed]
   workflow_dispatch:
 
@@ -10,8 +22,20 @@ permissions:
 
 jobs:
   create-pr:
+    # A failed FREEZE means staging was never locked, so opening the release PR
+    # would be premature. A failed staging PIPELINE says nothing about what is
+    # queued — the PR body is a commit list, not a health report — so the refresh
+    # still runs, and the red-branch sweep is what reports the pipeline.
     if: >
       github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.name != 'Staging Freeze' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: mindsdb/github-actions/.github/workflows/release-pr.yml@75df118f3b003625052c4f14e7b90817fb8b2784 # v1
+    permissions:
+      contents: read
+      # Turns the "recovered" message on. The reusable's notify step reads run
+      # history to tell a recovery from an ordinary green run, and the default
+      # workflow token carries contents + packages read only. Without this the
+      # lookup is refused, logs why, and stays quiet.
+      actions: read
+    uses: mindsdb/github-actions/.github/workflows/release-pr.yml@main
     secrets: inherit


### PR DESCRIPTION
## User story

**As an** engineer whose merge broke the release train
**I want** the channel to tell me both that it broke and that my re-run fixed it
**So that** a red alert never outlives the problem it reported

## Why this matters

This repo's four release-train wrappers each carried their own notify job, written `if: failure()` with the default `status: failed`. That shape can only ever report bad news. On 14 August `cowork`'s `main → staging` sync failed and alerted, the re-run succeeded, and the notify job was **skipped** — leaving the engineering channel holding a red alert for a sync that had already recovered. The same was true of the freeze, the unfreeze, and every other repo: twenty-one callers, none able to say "fixed".

The alert now lives inside the shared reusables, so it covers both directions, and these wrappers shrink to triggers plus a `uses:`.

## What changed

| File | Change |
|---|---|
| `staging-freeze.yml` | notify job removed; grants `actions: read`; calls `@main` |
| `staging-unfreeze.yml` | notify job removed; grants `actions: read`; calls `@main` |
| `sync-main-to-staging.yml` | notify job removed; grants `actions: read` |
| `weekly-merge-staging.yml` | second `workflow_run` source so the release PR stays current all week; grants `actions: read` |

## Acceptance criteria

- [ ] A failed freeze, unfreeze or sync posts a red alert
- [ ] Re-running any of them successfully posts a green recovery
- [ ] A routine green run posts nothing
- [ ] The release PR exists as a draft from the first staging merge after an unfreeze, and its commit list grows as more merge
- [ ] The release PR is marked ready for review when the freeze window opens, and never re-drafted afterwards
- [ ] `push: staging` still starts exactly one run tree

## How to test

1. Actions tab, run **Staging Freeze** manually. It succeeds and posts nothing (a green run whose predecessor was green is silent). This only became true with #53's `26e1917`: the composite used to treat any `workflow_dispatch` as "post regardless", and since a called workflow inherits the caller's event, a manual freeze posted a green **Recovered** for a failure that had never happened.
2. Merge anything to `staging`. Within a minute the **Create staging to main release PR** run opens or updates a *draft* `staging → main` PR whose body lists the queued commits.
3. Merge again. The same PR's body is rewritten with both commits. No second PR is opened.
4. Run **Staging Freeze** manually again. The draft PR flips to ready for review.
5. Break the sync deliberately (dispatch **Sync main to staging** with the App variable unset), see the red alert, then re-run it and confirm a green **Recovered** arrives. This is the case that was silent before.

## Notes for the reviewer

**`actions: read` is the load-bearing addition.** The reusable's recovery lookup reads run history to tell a recovery from an ordinary green run, and a called workflow can never hold more than its caller grants. Without it the lookup is refused, logs why, and stays quiet, so a missing grant shows up as a missing recovery message rather than a broken run.

**The release-PR trigger is `workflow_run`, not `push: staging`.** A second workflow on `push: staging` would be a second disconnected run tree, which the shared workflow lint forbids. `workflow_run` is its own event, so this stays one entry point. Verified with the lint below.

**The freeze/unfreeze pins are gone.** They were pinned to `75df118f` and had gone two commits stale, so this repo was still running a `release-unfreeze.yml` that skipped the sync-back on a manual dispatch — the exact bug fixed upstream in July after it cost `auth` an hour of hand-merging. Every other call site in these repos already floats on `@main`.

## Verified locally

| Check | Result |
|---|---|
| `actionlint` | clean |
| `workflow_graph.py` run-tree + permission check | one run tree per event, every local call composes |

## Ships with

`mindsdb/github-actions#53`, which adds the notify step these wrappers now rely on. **Merge #53 first.**

Merging #53 first is safe: this repo's `staging-freeze.yml` and `staging-unfreeze.yml` on the default branch still pin `75df118f`, so they keep running the old code untouched. Merging the other way round would leave the release-train workflows with no alerting at all, since these wrappers drop their notify jobs, and would grant `actions: read` to reusables that (before #53's `569b6e4`) still capped it away.

**When this actually takes effect, which the first version of this section got wrong.** All four of these workflows execute only from the DEFAULT branch: `staging-freeze.yml` is `schedule`, `weekly-merge-staging.yml` is `workflow_run`, `staging-unfreeze.yml` is `pull_request` into `main`, and `sync-main-to-staging.yml` is `push: main`. This PR targets `staging`, so **nothing here changes when it merges.** It takes effect at the next `staging → main` release.

Two consequences:

* `sync-main-to-staging.yml` already floats `@main`, so from the moment #53 merges a failed sync posts twice (the reusable's new notify step plus the wrapper's surviving `if: failure()` job) until this PR reaches `main`. That window is a release cycle, not "briefly".
* Test steps 2 to 4 below are **post-release** checks, not performable when this merges. Step 1 is, and can be run against this branch.

`pipeline-watchdog.yml` is untouched here and also floats `@main`, so #53's new red-branch sweep goes live on the next 30-minute cron without anything in this PR opting in.



---

## Also in this PR, after self-review

* `weekly-merge-staging.yml` gains `concurrency: release-pr` and a tighter trigger guard (`2bb328b7`). Both from Copilot: the find-then-create in the reusable is not atomic, so two overlapping runs race and the loser's `gh pr create` takes a 422, which under `set -euo pipefail` posts a red "release PR pipeline failed" for a PR that is fine. And the old guard leaned on `name != 'Staging Freeze'`, so a staging pipeline dispatched on another ref refreshed the release PR.
* The `actions: read` comments now say the grant is the *only* thing that turns recovery on, and that a `permissions:` block in the callee would cap it instead. That was the blocker in #53 (`569b6e4`): these reusables declared `contents: read`, which capped their own token, so the grant these PRs exist to add was inert.