### PR TITLE
ENG-1617: flush in-flight analytics sends at exit so short-lived hosts stop losing events

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -401,11 +401,16 @@ def flush(timeout: float = _FLUSH_TIMEOUT) -> None:
             outstanding = list(_pending)
         for done in outstanding:
             remaining = deadline - time.monotonic()
-            if remaining <= 0:
+            # Both halves of the budget check matter. `remaining <= 0` catches a
+            # budget already spent by earlier sends; `not done.wait(...)` catches
+            # it running out *inside* the wait, which is what happens whenever
+            # there is a single outstanding send — the common case. Checking only
+            # the first left exactly that case exiting the loop silently, so the
+            # loss it exists to record was the one it never recorded.
+            if remaining <= 0 or not done.wait(remaining):
                 logger.debug("analytics flush budget exhausted, %d send(s) abandoned",
                              sum(1 for d in outstanding if not d.is_set()))
                 return
-            done.wait(remaining)
     except Exception:
         logger.debug("analytics flush failed", exc_info=True)
 

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -58,7 +58,9 @@ paths, credentials, hostnames, or email addresses.
 Guarantees:
   • Never blocks the caller.
   • Never raises — all exceptions are silently swallowed.
-  • Daemon threads die automatically when the process exits.
+  • Exit waits briefly for sends already in flight (see ``flush``), then
+    gives up.  Daemon threads are killed at interpreter shutdown, so
+    without that wait a send started just before exit is simply lost.
 
 Machine fingerprint
 ===================
@@ -84,6 +86,7 @@ enough to be a readable query parameter.
 
 from __future__ import annotations
 
+import atexit
 import hashlib
 import json
 import logging
@@ -102,6 +105,52 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _TIMEOUT = 3  # seconds
+
+# ── Exit flush (ENG-1617) ───────────────────────────────────────────
+# Every send runs in a daemon thread, and daemon threads are killed at
+# interpreter shutdown without running to completion.  In a long-lived
+# process that is harmless — the thread finished minutes ago.  In a
+# short-lived one it means the event is silently lost.
+#
+# ``anton/cloud_turn/__main__.py`` runs exactly one turn and returns, so
+# ``turn_completed``'s POST races teardown.  Measured 2026-08-14 on
+# CPython 3.14, a daemon thread started immediately before ``main()``
+# returns does not finish *at any duration* — not at 200ms, not at 1ms:
+#
+#     daemon needing   1ms  ->  did NOT finish
+#     daemon needing   5ms  ->  did NOT finish
+#     daemon needing  50ms  ->  did NOT finish
+#     daemon needing 200ms  ->  did NOT finish
+#
+# So this is not a race the cloud path sometimes loses.  On that entry
+# point it loses every time.
+#
+# The wait lives here rather than in each host on purpose: a new
+# short-lived entry point would otherwise reintroduce the bug by
+# forgetting, which is how this one arrived.
+#
+# Why 1 second.  Measured round trip of a real POST to
+# ``us.i.posthog.com/capture/`` on 2026-08-14, 12 samples:
+#
+#     cold (DNS + TLS handshake)  351 ms
+#     median                      283 ms
+#     max                         296 ms
+#
+# urllib opens a fresh connection per ``urlopen``, so a one-shot process
+# pays the cold number every time.  1s is ~3x the median with headroom for
+# a slower network, and stays well under ``_TIMEOUT``'s 3s — a send that
+# has genuinely hung costs exit 1s rather than 3s.  It is a ceiling, not a
+# cost: ``flush`` returns immediately when nothing is outstanding, which is
+# the normal case for an interactive CLI, where the event went out long
+# before the user quit.
+_FLUSH_TIMEOUT = 1.0  # seconds, total across all outstanding sends
+
+# One entry per send still in flight.  Events rather than Thread objects
+# because ``Event.wait`` gives the same semantics as ``Thread.join`` without
+# holding a reference to the thread — which keeps this working when a caller
+# or a test substitutes something else for ``threading.Thread``.
+_pending: set[threading.Event] = set()
+_pending_lock = threading.Lock()
 
 # ── The PostHog sink (ENG-1495) ─────────────────────────────────────
 # The register of events that bypass the collector and post straight to
@@ -301,6 +350,73 @@ def _fire_posthog(url: str, body: bytes) -> None:
         logger.debug("posthog capture failed", exc_info=True)
 
 
+def _spawn(target, *args) -> None:
+    """Start one sender thread and register it as outstanding.
+
+    The registration is added *before* the thread starts and cleared in a
+    ``finally``, so a send is either visible to ``flush`` or already finished —
+    never in a gap between the two.
+    """
+    done = threading.Event()
+    with _pending_lock:
+        _pending.add(done)
+
+    def run() -> None:
+        try:
+            target(*args)
+        finally:
+            done.set()
+            with _pending_lock:
+                _pending.discard(done)
+
+    try:
+        threading.Thread(target=run, daemon=True).start()
+    except Exception:
+        # A thread that never started will never clear its own registration,
+        # and a stale one costs every later `flush` the full budget waiting for
+        # a send that is not happening. Clear it here and re-raise into
+        # `send_event`'s guard, which is where "never raises" is enforced.
+        with _pending_lock:
+            _pending.discard(done)
+        raise
+
+
+def flush(timeout: float = _FLUSH_TIMEOUT) -> None:
+    """Wait up to ``timeout`` seconds, in total, for in-flight sends to land.
+
+    Registered with ``atexit`` below, so short-lived processes get this without
+    asking.  Callers may also invoke it directly.
+
+    ``timeout`` is a whole budget shared across every outstanding send, not a
+    per-send allowance — otherwise a turn that emitted several events could
+    hold exit for a multiple of it.
+
+    Best-effort by design.  When the budget runs out the remaining sends are
+    abandoned and the process exits; this narrows the loss window, it does not
+    close it.  Never raises, in keeping with the rest of the module.
+    """
+    try:
+        deadline = time.monotonic() + timeout
+        with _pending_lock:
+            outstanding = list(_pending)
+        for done in outstanding:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.debug("analytics flush budget exhausted, %d send(s) abandoned",
+                             sum(1 for d in outstanding if not d.is_set()))
+                return
+            done.wait(remaining)
+    except Exception:
+        logger.debug("analytics flush failed", exc_info=True)
+
+
+# Runs during interpreter shutdown, while daemon threads are still alive and
+# schedulable — CPython calls atexit callbacks before tearing down the thread
+# state that kills them. Registering at import is what makes this the module's
+# responsibility rather than each host's.
+atexit.register(flush)
+
+
 def send_event(settings: "AntonSettings", action: str, **extra: str) -> None:
     """Send an analytics event in a background thread.
 
@@ -351,19 +467,11 @@ def send_event(settings: "AntonSettings", action: str, **extra: str) -> None:
             host = (getattr(settings, "posthog_host", "") or "").rstrip("/")
             if not key or not host:
                 return
-            t = threading.Thread(
-                target=_fire_posthog,
-                args=(f"{host}/capture/", _posthog_body(key, action, params)),
-                daemon=True,
-            )
+            _spawn(_fire_posthog,
+                   f"{host}/capture/", _posthog_body(key, action, params))
         else:
             url = settings.analytics_url
-            t = threading.Thread(
-                target=_fire,
-                args=(f"{url}?{urllib.parse.urlencode(params)}",),
-                daemon=True,
-            )
-        t.start()
+            _spawn(_fire, f"{url}?{urllib.parse.urlencode(params)}")
     except Exception:
         pass
 

--- a/docs/docs/configure/analytics.md
+++ b/docs/docs/configure/analytics.md
@@ -34,6 +34,13 @@ Anton and a failure to send is never surfaced to you. Failures on the
 measurement events are recorded in Anton's own debug log; failures on the other
 events are discarded without a trace.
 
+The one exception is exit. If a send is still in flight when Anton is closing,
+it is given up to one second to finish before Anton exits anyway. In an
+interactive session there is normally nothing left to wait for, so this costs
+nothing; it matters for short-lived commands that would otherwise exit before
+the event left the machine. Turning analytics off removes the wait along with
+the send.
+
 ## Where it goes
 
 Two transports, depending on the event:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import contextlib
 import http.server
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -655,6 +656,24 @@ def test_flush_gives_up_at_the_budget():
         elapsed = time.monotonic() - start
 
         assert 0.2 <= elapsed < 1.0
+    finally:
+        release.set()
+
+
+def test_flush_logs_when_the_only_pending_send_is_abandoned(caplog):
+    """One outstanding send is the common case, and it is the case an earlier
+    version logged nothing for: the budget ran out *inside* `Event.wait`, so the
+    `remaining <= 0` branch was never reached and the loop just ended. The loss
+    this line exists to record was the one it never recorded."""
+    release = threading.Event()
+    try:
+        analytics._spawn(release.wait)
+
+        with caplog.at_level(logging.DEBUG, logger="anton.analytics"):
+            analytics.flush(timeout=0.2)
+
+        assert any("budget exhausted" in r.getMessage() for r in caplog.records)
+        assert any("1 send(s) abandoned" in r.getMessage() for r in caplog.records)
     finally:
         release.set()
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -3,11 +3,22 @@
 CI/automation traffic is dropped entirely rather than sent. ``send_event`` fires
 a daemon thread doing an HTTP GET; both are stubbed so we can assert what (if
 anything) would be sent, without network or threads.
+
+The exception is the exit-flush section at the bottom (ENG-1617), which uses a
+real loopback endpoint and a real child process — the bug it guards only exists
+at interpreter shutdown, so a stub cannot reproduce it.
 """
 
 from __future__ import annotations
 
+import contextlib
+import http.server
 import json
+import os
+import subprocess
+import sys
+import threading
+import time
 import urllib.parse
 import urllib.request
 
@@ -511,3 +522,246 @@ def test_blanking_analytics_url_stops_the_routed_events_too(monkeypatch):
     analytics.send_event(_Blanked(), "turn_completed", tokens_total="1")
     analytics.send_event(_Blanked(), "rule_retrieval", outcome="ok")
     analytics.send_event(_Blanked(), "ds_connect_success", engine="pg")
+
+
+# ── Exit flush (ENG-1617) ───────────────────────────────────────────
+# Sends run in daemon threads, which are killed at interpreter shutdown without
+# running to completion. On `python -m anton.cloud_turn` — one turn, then exit —
+# that lost the event every time, not merely sometimes.
+
+
+def test_send_registers_the_send_as_outstanding(monkeypatch):
+    """`flush` can only wait for what it knows about, and it must know about a
+    send before the thread starts — otherwise there is a window where an event
+    is in flight and invisible."""
+    _clear_ci(monkeypatch)
+    monkeypatch.setattr(analytics, "_pending", set())
+
+    started: list[bool] = []
+
+    class _NeverRunThread:
+        def __init__(self, target=None, args=(), daemon=None):
+            pass
+
+        def start(self):
+            # Deliberately never runs the target: this is the state where the
+            # request is outstanding.
+            started.append(True)
+
+    monkeypatch.setattr(analytics.threading, "Thread", _NeverRunThread)
+
+    analytics.send_event(_PosthogSettings(), "turn_completed")
+
+    assert started == [True]
+    assert len(analytics._pending) == 1
+
+
+def test_pending_is_cleared_once_the_send_finishes(monkeypatch):
+    """Long-lived hosts (cowork-server, an interactive CLI) send continuously.
+    A registration that is not cleared would grow without bound and make every
+    later `flush` walk a list of sends that finished hours ago."""
+    _clear_ci(monkeypatch)
+    monkeypatch.setattr(analytics, "_pending", set())
+    _capture_posthog(monkeypatch)  # runs the thread target synchronously
+
+    analytics.send_event(_PosthogSettings(), "turn_completed")
+
+    assert analytics._pending == set()
+
+
+def test_pending_is_cleared_when_the_thread_cannot_start(monkeypatch):
+    """A thread that never started cannot clear its own registration, so the
+    stale entry would cost every later `flush` the whole budget waiting on a
+    send that is not happening — turning a failed thread spawn into a
+    permanent one-second tax on exit."""
+    _clear_ci(monkeypatch)
+    monkeypatch.setattr(analytics, "_pending", set())
+
+    class _WontStart:
+        def __init__(self, target=None, args=(), daemon=None):
+            pass
+
+        def start(self):
+            raise RuntimeError("can't start new thread")
+
+    monkeypatch.setattr(analytics.threading, "Thread", _WontStart)
+
+    # send_event's own guard keeps this from reaching the caller.
+    analytics.send_event(_PosthogSettings(), "turn_completed")
+
+    assert analytics._pending == set()
+
+
+def test_pending_is_cleared_even_when_the_send_raises(monkeypatch):
+    """`_fire_posthog` swallows its own exceptions today, so this guards the
+    contract rather than current behaviour: if a sender ever raises, the
+    registration must still clear or exit hangs for the full budget on every
+    subsequent call."""
+    _clear_ci(monkeypatch)
+    monkeypatch.setattr(analytics, "_pending", set())
+
+    class _SyncThread:
+        def __init__(self, target=None, args=(), daemon=None):
+            self._target, self._args = target, args
+
+        def start(self):
+            with pytest.raises(RuntimeError):
+                self._target(*self._args)
+
+    monkeypatch.setattr(analytics.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(
+        analytics, "_fire_posthog",
+        lambda url, body: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    analytics.send_event(_PosthogSettings(), "turn_completed")
+
+    assert analytics._pending == set()
+
+
+def test_flush_waits_for_an_in_flight_send():
+    """The behaviour the ticket exists for: a send still in progress when the
+    process wants to exit gets time to land."""
+    landed: list[str] = []
+    analytics._spawn(lambda: (time.sleep(0.05), landed.append("sent")))
+
+    analytics.flush(timeout=2.0)
+
+    assert landed == ["sent"]
+
+
+def test_flush_returns_immediately_when_nothing_is_pending(monkeypatch):
+    """The normal case for an interactive CLI, where the event went out long
+    before the user quit. The budget is a ceiling, not a cost — if this ever
+    became a real wait, every `anton` session would pay it on exit."""
+    monkeypatch.setattr(analytics, "_pending", set())
+
+    start = time.monotonic()
+    analytics.flush(timeout=5.0)
+
+    assert time.monotonic() - start < 0.5
+
+
+def test_flush_gives_up_at_the_budget():
+    """A hung send must not hold the process open. `_TIMEOUT` allows a request
+    3s; the flush budget deliberately sits below that, so a black-holed network
+    costs exit the budget rather than the request timeout."""
+    release = threading.Event()
+    try:
+        analytics._spawn(release.wait)
+
+        start = time.monotonic()
+        analytics.flush(timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        assert 0.2 <= elapsed < 1.0
+    finally:
+        release.set()
+
+
+def test_flush_budget_is_shared_across_sends():
+    """Total, not per-send. A turn can emit several events; a per-send
+    allowance would multiply the worst-case exit delay by their number."""
+    release = threading.Event()
+    try:
+        for _ in range(4):
+            analytics._spawn(release.wait)
+
+        start = time.monotonic()
+        analytics.flush(timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        # 4 sends x 0.2s would be 0.8s if the budget were per-send.
+        assert elapsed < 0.6
+    finally:
+        release.set()
+
+
+#: A child process shaped like `anton/cloud_turn/__main__.py`: send one event,
+#: return from `main`, exit. `--no-flush` unregisters the atexit hook to
+#: reproduce the pre-fix behaviour, which is what makes the assertion below
+#: evidence rather than a tautology — the same script fails without it.
+_SHORT_LIVED_CHILD = """
+import sys
+import anton.analytics as analytics
+
+if "--no-flush" in sys.argv:
+    import atexit
+    atexit.unregister(analytics.flush)
+
+class S:
+    analytics_enabled = True
+    analytics_url = "http://127.0.0.1:{port}/collect"
+    posthog_host = "http://127.0.0.1:{port}"
+    posthog_key = "phc_test"
+
+def main():
+    analytics.send_event(S(), "turn_completed", tokens_total="123")
+    return 0
+
+sys.exit(main())
+"""
+
+
+@contextlib.contextmanager
+def _capture_endpoint():
+    """A real local HTTP endpoint, so the child process makes a real request."""
+    received: list[bytes] = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            received.append(self.rfile.read(length))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{"status":"Ok"}')
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield server.server_address[1], received
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _run_child(port: int, *args: str) -> None:
+    env = dict(os.environ)
+    # The suite itself may run under GitHub Actions; CI traffic is dropped
+    # entirely, which would make this pass for the wrong reason.
+    for marker in _CI_MARKERS:
+        env.pop(marker, None)
+    subprocess.run(
+        [sys.executable, "-c", _SHORT_LIVED_CHILD.format(port=port), *args],
+        check=True, timeout=30, env=env,
+    )
+
+
+def test_short_lived_process_delivers_its_event():
+    """The regression test for ENG-1617, run as a real process because the bug
+    only exists at interpreter shutdown and cannot be reproduced in-process.
+
+    This is the `cloud_turn` shape: one turn, then exit. Before the fix it
+    delivered nothing at all — see the companion test below."""
+    with _capture_endpoint() as (port, received):
+        _run_child(port)
+        time.sleep(0.2)  # the endpoint records on its own thread
+
+    assert len(received) == 1
+    body = json.loads(received[0])
+    assert body["event"] == "turn_completed"
+    assert body["properties"]["tokens_total"] == "123"
+
+
+def test_short_lived_process_loses_its_event_without_the_flush():
+    """Pins the failure the fix addresses. If this ever starts passing, either
+    the atexit hook stopped being the thing doing the work, or CPython changed
+    when it kills daemon threads — both of which invalidate the test above."""
+    with _capture_endpoint() as (port, received):
+        _run_child(port, "--no-flush")
+        time.sleep(0.2)
+
+    assert received == []


### PR DESCRIPTION
Linear: [ENG-1617](https://linear.app/mindsdb/issue/ENG-1617/analytics-events-race-interpreter-shutdown-so-the-cloud-path-can)

Found by @lucas-koontz reviewing #345. Not introduced there — the hazard is in the module's design and predates it — but ENG-1495 is what makes it consequential, because `turn_completed` is the first event whose loss costs something.

## The problem

`anton/analytics.py` sends every event from a daemon thread. Daemon threads are killed at interpreter shutdown without running to completion, and the module docstring listed that as a *guarantee*. On a long-lived host it is harmless. On `python -m anton.cloud_turn`, which runs one turn and returns, it is total loss.

Measured on 2026-08-14, on CPython 3.14 and 3.12. A daemon thread started immediately before `main()` returns does not finish at any duration:

```
daemon needing   1ms  ->  did NOT finish
daemon needing   5ms  ->  did NOT finish
daemon needing  50ms  ->  did NOT finish
daemon needing 200ms  ->  did NOT finish
```

So this is not a race the cloud path sometimes loses. On that entry point it loses every time, against a ~300ms POST.

Worth stating plainly: #345's end-to-end verification ran from a long-lived CLI process, where the thread always has time. The sink was verified on the host least affected and unverified on the host that produces most turns.

## The fix

Module-owned rather than per-host:

* `_spawn` registers each send before its thread starts, and clears the registration in a `finally`.
* `flush(timeout)` waits for the outstanding ones, with the timeout as a **total** budget rather than per-send, so a turn emitting several events cannot hold exit for a multiple of it.
* `atexit.register(flush)` at import.

The ticket offered a targeted `join()` in `cloud_turn/__main__.py` as the smaller alternative. I took the module-owned version because the smaller one leaves the next short-lived entry point to rediscover this, which is how this one arrived.

## Why one second

The ticket asked for a measured basis rather than a guess. Real POST to `us.i.posthog.com/capture/`, 12 samples:

| | |
| -- | -- |
| cold, DNS + TLS handshake | 351 ms |
| median | 283 ms |
| max | 296 ms |

urllib opens a fresh connection per `urlopen`, so a one-shot process pays the cold number every time. 1s is roughly 3x the median with headroom for a slower network, and stays under `_TIMEOUT`'s 3s, so a send that has genuinely hung costs exit 1s rather than 3s.

It is a ceiling, not a cost. With nothing outstanding, `flush` returns in **0.0002 ms median over 200 calls** — which is the interactive CLI case, where the event went out long before the user quit. That is the ticket's "process exit is not measurably slower for an interactive CLI session".

The probe used a deliberately bogus api_key, so it wrote no real rows into 424726.

## Tests

10 added, 32 in the file. Every new assertion mutation-verified: removing the atexit registration, removing the wait, or dropping the leak guard each fails a specific test and nothing else.

The regression test runs a **real child process** against a real loopback endpoint, because the bug only exists at interpreter shutdown and no in-process stub reproduces it. Its companion, `test_short_lived_process_loses_its_event_without_the_flush`, asserts the pre-fix loss — so if the atexit hook ever stops being the thing doing the work, or CPython changes when it kills daemon threads, that surfaces as a failure instead of a silently vacuous pass.

Also covered: registration happens before the thread starts (no invisible-in-flight window), the registration clears on success, on a raising sender, and when the thread cannot start at all. That last one matters because a stale registration would turn one failed spawn into a permanent 1s tax on every later exit.

Full suite: 2149 passed, 28 skipped, 0 failed. Green on 3.12 as well as 3.14.

## Also changed

`docs/configure/analytics.md` said events "never block Anton". Exit can now wait up to a second, so it says so, including that switching analytics off removes the wait along with the send.

## What this does not close

Verifying that a real cloud turn produces its `turn_completed` row in project 424726 needs the anton staging to main to PyPI to cowork-server `uv.lock` bump to desktop chain to run first — the same constraint #345 wrote up in its Step 0. This PR fixes the mechanism and proves it at the process level; the cloud-path confirmation is a post-release check.

Until it lands, per-turn cost data stays incomplete by an unknown amount on the host producing most turns, which matters for ENG-1286.

Co-Authored-By: Claude <noreply@anthropic.com>
