### PR TITLE
fix(artifacts): use POSIX separators for artifact-relative paths

### DIFF
--- a/anton/core/artifacts/snapshot.py
+++ b/anton/core/artifacts/snapshot.py
@@ -45,7 +45,12 @@ def snapshot_dir(root: Path) -> DirSnapshot:
             # Race against a concurrent write — skip the file. The
             # next snapshot pass will pick it up.
             continue
-        rel = str(p.relative_to(root))
+        # POSIX separators regardless of platform: these keys are compared
+        # against each other across snapshots, split on "/" by
+        # _files_by_artifact, and persisted in provenance records. On Windows
+        # str() yields backslashes, so the split silently matched nothing and
+        # every artifact file was dropped from the grouping.
+        rel = p.relative_to(root).as_posix()
         out[rel] = (stat.st_mtime_ns, stat.st_size)
     return out
 

--- a/anton/core/artifacts/store.py
+++ b/anton/core/artifacts/store.py
@@ -342,7 +342,11 @@ class ArtifactStore:
         for p in sorted(folder.rglob("*")):
             if not p.is_file() or p.is_symlink():
                 continue
-            rel = str(p.relative_to(folder))
+            # POSIX separators regardless of platform: FileEntry.path is
+            # persisted to metadata.json and compared against the stored
+            # fingerprint, so a Windows-written artifact must not disagree
+            # with the same artifact written anywhere else.
+            rel = p.relative_to(folder).as_posix()
             if rel in _HOUSEKEEPING_FILES:
                 continue
             try:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -365,6 +365,22 @@ def test_snapshot_lists_files(tmp_path: Path):
     assert "sub/b.txt" in snap
 
 
+def test_snapshot_keys_use_posix_separators(tmp_path: Path):
+    """Snapshot keys must be POSIX-separated on every platform.
+
+    The keys are split on "/" by `_files_by_artifact` and persisted in
+    provenance records, so a native-separator key silently groups to
+    nothing on Windows instead of failing loudly.
+    """
+    nested = tmp_path / "dashboard" / "data"
+    nested.mkdir(parents=True)
+    (nested / "prices.csv").write_text("a,b")
+    snap = snapshot_dir(tmp_path)
+    assert "dashboard/data/prices.csv" in snap
+    assert not any("\\" in key for key in snap)
+    assert diff_snapshots({}, snap) == ["dashboard/data/prices.csv"]
+
+
 def test_diff_picks_up_new_and_changed(tmp_path: Path):
     (tmp_path / "a.txt").write_text("x")
     before = snapshot_dir(tmp_path)


### PR DESCRIPTION
Closes https://github.com/mindsdb/anton/issues/355

## Summary

Artifact-relative paths were built with `str(Path.relative_to(...))`, which yields the platform separator. On Windows that produces `data\prices.csv`, and nothing raises — so two things fail silently rather than loudly.

`_files_by_artifact()` splits those keys on `"/"`, so on Windows every nested path failed the `len(parts) < 2` check and was discarded as a top-level file: grouping returned `{}` instead of `{"dashboard": ["data/prices.csv"]}`. Separately, `FileEntry.path` is persisted to `metadata.json` and compared against the stored fingerprint, so an artifact written on Windows disagrees with the same artifact written on any other platform.

## Changes

- `anton/core/artifacts/snapshot.py` — `snapshot_dir()` builds keys with `.as_posix()`.
- `anton/core/artifacts/store.py` — `ArtifactStore.rescan_files()` builds `FileEntry.path` with `.as_posix()`.
- `tests/test_artifacts.py` — adds `test_snapshot_keys_use_posix_separators`, asserting snapshot keys are POSIX-separated and that `diff_snapshots` preserves that.

This is the convention the codebase already uses elsewhere — `chat.py:537,590,614` and `publisher.py:231` all call `.as_posix()` for exactly these path-key purposes. These two sites were the stragglers.

## What is deliberately unchanged

`publisher.py:184,192` also use `str(relative_to(...))` for ZIP arcnames. I checked whether that was the same bug and **it is not**: `zipfile.ZipInfo.__init__` already replaces `os.sep` with `/`, and I confirmed on Windows that the produced archive's `namelist()` is correctly forward-slashed. Left alone.

I also did not touch the other Windows test failures on this clone. They are separate concerns — POSIX-only `termios`/`fcntl` and file-permission tests, and e2e scenarios that need a live model — and several look intentional rather than broken.

## Testing

Windows 11 (10.0.26200), Python 3.13.13, clean clone of `main` at `fdaa2f1`, `pip install -e ".[dev]"`.

- **Fail-before / pass-after on the product change**, with the new test present and the two-line fix reverted: `tests/test_artifacts.py` → **3 failed, 39 passed** (`test_snapshot_lists_files`, `test_rescan_picks_up_new_files`, `test_snapshot_keys_use_posix_separators`). With the fix applied: **42 passed**.
- **Full suite before:** 59 failed, 1798 passed. **After:** 57 failed, 1800 passed — this change clears exactly the two pre-existing failures and introduces no regressions.

I could not run the suite on Linux, so I have not verified there beyond the reasoning that `PurePath.as_posix()` returns the same string as `str()` whenever `os.sep` is `"/"`, which makes this a no-op on POSIX. Your CI is the authority on that — every workflow in `.github/workflows` is `runs-on: ubuntu-latest`, which is also why these two failures have never surfaced.

## Note on AI assistance

I used an AI assistant while working on this. The reproduction, the fail-before/pass-after runs, and the full-suite before/after counts quoted above were all executed by me on the Windows machine described. I specifically verified the `zipfile` claim in the "deliberately unchanged" section by building an archive and reading `namelist()`, rather than assuming it.
