### PR TITLE
ENG-1632: a deterministic verifier denial latches silently on first occurrence

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -109,7 +109,10 @@ _TIMEOUT = 3  # seconds
 # cowork's renderer register (``src/renderer/cowork/lib/analytics.js``), so
 # both clients read the same way.
 #
-#   turn_completed   ended_by, tokens_total, input_tokens, output_tokens,
+#   turn_completed   ended_by, verification_skipped ("true" when the turn
+#                    completed without a verifier verdict — denied/latched,
+#                    ENG-1632 — so honest-stop denominators can exclude it),
+#                    tokens_total, input_tokens, output_tokens,
 #                    cache_read_tokens, cache_creation_tokens, llm_calls,
 #                    rounds, continuations, peak_context_tokens, duration_ms,
 #                    {planning,coding,router}_{model,tokens,calls},

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2286,11 +2286,13 @@ class ChatSession:
         except Exception:  # pragma: no cover - defensive
             _root_cause_fields = {}
         logger.info(
-            "turn_cost session=%s turn=%d ended_by=%s tokens_total=%d "
+            "turn_cost session=%s turn=%d ended_by=%s verification_skipped=%s "
+            "tokens_total=%d "
             "input=%d output=%d cache_read=%d cache_creation=%d "
             "llm_calls=%d rounds=%d continuations=%d peak_context=%d duration_ms=%d "
             "by_role=%s %s",
-            self._session_id, turn_index, tc.ended_by, tc.total_tokens,
+            self._session_id, turn_index, tc.ended_by,
+            str(tc.verification_skipped).lower(), tc.total_tokens,
             tc.input_tokens, tc.output_tokens, tc.cache_read_tokens,
             tc.cache_creation_tokens, tc.llm_calls, tc.rounds,
             tc.continuations, tc.peak_context_tokens, tc.duration_ms,
@@ -2332,6 +2334,10 @@ class ChatSession:
                 # classification is broken.
                 **_root_cause_fields,
                 ended_by=tc.ended_by,
+                # A completed-but-unverified turn (denied/latched verifier,
+                # ENG-1632) must be excludable from the honest-stop
+                # denominator without a per-conversation Langfuse hop.
+                verification_skipped=str(tc.verification_skipped).lower(),
                 tokens_total=str(tc.total_tokens),
                 input_tokens=str(tc.input_tokens),
                 output_tokens=str(tc.output_tokens),
@@ -4529,6 +4535,14 @@ class ChatSession:
                         _VERIFIER_LATCH_REPROBE_TURNS, continuation,
                         self._max_continuations, tool_round,
                     )
+                    # Stamp the books: this turn books ended_by="completed"
+                    # but was NOT verified — without the flag it is
+                    # byte-identical in analytics to a verified pass and
+                    # silently joins the honest-stop denominator (ENG-1632
+                    # review). Stamped here, never read from latch state at
+                    # emit (late finalizers would see a later turn's state).
+                    if self._turn_cost is not None:
+                        self._turn_cost.verification_skipped = True
                     break
                 _verifier_log.info(
                     "completion-verifier re-probing after %d skipped verifications",
@@ -4652,6 +4666,9 @@ class ChatSession:
                         "verification this session; turn ends on the "
                         "already-streamed reply"
                     )
+                    # Unverified turn — see the latched-skip stamp above.
+                    if self._turn_cost is not None:
+                        self._turn_cost.verification_skipped = True
                     break
                 if verdict_failure == "hard":
                     self._verifier_hard_failures += 1
@@ -4664,6 +4681,9 @@ class ChatSession:
                         _verifier_log.info(
                             "completion-verifier re-probe failed — staying latched"
                         )
+                        # Unverified turn — see the latched-skip stamp above.
+                        if self._turn_cost is not None:
+                            self._turn_cost.verification_skipped = True
                         break
                     if self._verifier_hard_failures >= 2:
                         # Second hard failure in a row: the first could have been
@@ -4693,6 +4713,9 @@ class ChatSession:
                             "verification this session",
                             self._verifier_hard_failures,
                         )
+                        # Unverified turn — see the latched-skip stamp above.
+                        if self._turn_cost is not None:
+                            self._turn_cost.verification_skipped = True
                         break
                 # The verifier call failed on every budget it was given —
                 # truncated past the last retry, an unusable tool call, or a

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -313,6 +313,29 @@ _TRANSIENT_VERDICT_ERRORS: tuple[type[BaseException], ...] = (
     httpx.TransportError,
 )
 
+# Verdict-call failures that are DETERMINISTIC DENIALS: the provider will give
+# the identical answer on every retry this session — a wallet that can't pay
+# for the verifier's model (TokenLimitExceeded: 402 ``wallet_empty`` / 429
+# ``included_allowance_exhausted``, both code-exact per ENG-1169; velocity 429s
+# map to TransientProviderError and never land here) or a model id that doesn't
+# resolve for this key (ModelUnavailableError: 404 model-not-found / 403
+# model-access-denied). These latch on the FIRST occurrence and stay silent:
+# the turn's work already succeeded, and "the task-completion check failed
+# (internal error)" is a lie when the check was merely priced out (ENG-1632 —
+# 208 aux-call wallet-402s across 33 users in 14 days, every one surfaced to
+# the user as an internal error and an apology).
+#
+# ORDER MATTERS in the verdict loop: this clause must precede
+# _TRANSIENT_VERDICT_ERRORS. ModelUnavailableError subclasses ConnectionError →
+# OSError, so the transient clause would otherwise swallow it as a blip and
+# re-diagnose every turn forever (its pre-ENG-1632 behavior). TokenLimitExceeded
+# is a plain Exception and would fall to the generic "hard" handler instead —
+# wrong the other way: a full-history diagnosis on turn one, latch only at two.
+_DENIED_VERDICT_ERRORS: tuple[type[BaseException], ...] = (
+    TokenLimitExceeded,
+    ModelUnavailableError,
+)
+
 # Turns a latched session skips before spending one verdict call to see whether
 # the cause has gone away (user switched model, gateway fix shipped). Without a
 # re-probe the latch is permanent for the session and "reset on a successful
@@ -761,6 +784,10 @@ class ChatSession:
         self._verifier_hard_failures = 0
         self._verifier_latched = False
         self._verifier_latch_skips = 0
+        # Why the latch is set — "hard" (capability, ENG-1095) or "denied"
+        # (billing/model access, ENG-1632) — so the skip log names the real
+        # cause instead of reporting "0 hard failures" for a denied latch.
+        self._verifier_latch_reason = ""
         self._context_pressure_threshold = s.context_pressure_threshold
         self._max_consecutive_errors = s.max_consecutive_errors
         self._resilience_nudge_at = s.resilience_nudge_at
@@ -4490,11 +4517,14 @@ class ChatSession:
                 self._verifier_latch_skips += 1
                 if self._verifier_latch_skips < _VERIFIER_LATCH_REPROBE_TURNS:
                     _verifier_log.info(
-                        "completion-verifier skipped — latched after %d hard "
-                        "failures with no successful verdict between them "
+                        "completion-verifier skipped — latched (%s) "
                         "(skip %d/%d before re-probe); "
                         "continuation=%d/%d tool_rounds=%d",
-                        self._verifier_hard_failures, self._verifier_latch_skips,
+                        "deterministic denial: billing or model access"
+                        if self._verifier_latch_reason == "denied"
+                        else f"{self._verifier_hard_failures} hard failures "
+                        "with no successful verdict between them",
+                        self._verifier_latch_skips,
                         _VERIFIER_LATCH_REPROBE_TURNS, continuation,
                         self._max_continuations, tool_round,
                     )
@@ -4542,6 +4572,17 @@ class ChatSession:
                     )
                     if not retrying:
                         break
+                except _DENIED_VERDICT_ERRORS as exc:
+                    # Deterministic denial — see _DENIED_VERDICT_ERRORS (and the
+                    # ordering note there: this clause must stay ahead of the
+                    # transient tuple). Retrying, diagnosing, or telling the
+                    # user buys nothing: handled below by latching silently.
+                    verdict_failure = "denied"
+                    _verifier_log.info(
+                        "completion-verifier verdict=DENIED budget=%d error=%s",
+                        budget, _safe_error_detail(exc),
+                    )
+                    break
                 except _TRANSIENT_VERDICT_ERRORS as exc:
                     # Explicitly NOT a latch candidate. The latch is for a model
                     # that cannot produce a verdict at all (kimi-K3 rejecting the
@@ -4576,9 +4617,31 @@ class ChatSession:
                 # is no longer failing.
                 self._verifier_hard_failures = 0
                 self._verifier_latched = False
+                self._verifier_latch_reason = ""
                 status = verdict.status
                 reason = verdict.reason.strip()
             else:
+                if verdict_failure == "denied":
+                    # A denied verdict recurs every turn by construction, so
+                    # don't wait for a second sample: latch NOW and end the
+                    # turn quietly on the reply that already streamed. No
+                    # history injection, no diagnosis stream — the work
+                    # succeeded and the user must not be told an "internal
+                    # error" occurred (ENG-1632). Deliberately silent rather
+                    # than auto-upgrading to the planning model: a missing
+                    # check beats a surprise bill. The periodic re-probe still
+                    # runs; a re-probe denied again lands back here and stays
+                    # latched, so adding credits self-heals within
+                    # _VERIFIER_LATCH_REPROBE_TURNS turns.
+                    self._verifier_latched = True
+                    self._verifier_latch_reason = "denied"
+                    _verifier_log.info(
+                        "completion-verifier latched after a deterministic "
+                        "denial (billing or model access) — skipping further "
+                        "verification this session; turn ends on the "
+                        "already-streamed reply"
+                    )
+                    break
                 if verdict_failure == "hard":
                     self._verifier_hard_failures += 1
                     if self._verifier_latched:
@@ -4612,6 +4675,7 @@ class ChatSession:
                         # produce one, and a truncation in between is no evidence
                         # that it can (review: pnewsam on #299).
                         self._verifier_latched = True
+                        self._verifier_latch_reason = "hard"
                         _verifier_log.info(
                             "completion-verifier latched after %d hard failures with "
                             "no successful verdict between them — skipping further "

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -4633,6 +4633,16 @@ class ChatSession:
                     # runs; a re-probe denied again lands back here and stays
                     # latched, so adding credits self-heals within
                     # _VERIFIER_LATCH_REPROBE_TURNS turns.
+                    #
+                    # Scope note: the latch is ChatSession state, and Cowork
+                    # rebuilds the session PER MESSAGE — there it only spans
+                    # one message's continuations, the steady-state cost of a
+                    # persistent denial is one silent verdict call per
+                    # message, and top-up recovery is simply the next message.
+                    # The re-probe window above is long-session (CLI)
+                    # behaviour. The cross-message fix is server-side model
+                    # resolution (cowork-server, same ticket); this branch is
+                    # the guarantee the user is never told the turn failed.
                     self._verifier_latched = True
                     self._verifier_latch_reason = "denied"
                     _verifier_log.info(

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -322,8 +322,9 @@ _TRANSIENT_VERDICT_ERRORS: tuple[type[BaseException], ...] = (
 # model-access-denied). These latch on the FIRST occurrence and stay silent:
 # the turn's work already succeeded, and "the task-completion check failed
 # (internal error)" is a lie when the check was merely priced out (ENG-1632 —
-# 208 aux-call wallet-402s across 33 users in 14 days, every one surfaced to
-# the user as an internal error and an apology).
+# of that ticket's 14-day baseline of 296 wallet-402s across 39 users, 208
+# were aux-surface calls like this one, across 33 of those users; every aux
+# one surfaced to the user as an internal error and an apology).
 #
 # ORDER MATTERS in the verdict loop: this clause must precede
 # _TRANSIENT_VERDICT_ERRORS. ModelUnavailableError subclasses ConnectionError →

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -105,6 +105,18 @@ class TurnCost:
     # specific exit; ``_emit_turn_cost`` overrides with cancelled/error when
     # the turn didn't end on its own terms.
     ended_by: str = "completed"
+    # The completion verifier was applicable but produced no verdict this turn
+    # (denied by billing/model access, or suppressed by the verifier latch —
+    # ENG-1632). Such turns deliberately book ended_by="completed" (the work
+    # succeeded; a priced-out check is not a broken turn), so WITHOUT this flag
+    # they are byte-identical in analytics to turns that were verified and
+    # passed — silently joining the honest-stop denominator, concentrated in
+    # exactly the wallet-locked cohort a measurement would want to isolate.
+    # Stamped at the skip/deny sites, never read from live session state at
+    # emit (late finalizers would read a later turn's latch state — see the
+    # note below on stamped-at-open fields). Handback terminals don't need it:
+    # their ended_by already distinguishes them.
+    verification_skipped: bool = False
     started_monotonic: float = field(default_factory=time.monotonic)
     # Set when these books have been reported. Replaces "the shared slot is
     # None" as the double-emit guard, because a late finalizer now emits the

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -20,6 +20,7 @@ from anton.core.llm.provider import (
     LLMResponse,
     StreamComplete,
     StreamTextDelta,
+    TokenLimitExceeded,
     ToolCall,
     Usage,
 )
@@ -363,6 +364,28 @@ async def test_verifier_failure_reports_handback_verifier_failure(workspace):
         async for _ in session.turn_stream("run my script"):
             pass
     assert _ended_by(send) == "handback_verifier_failure"
+
+
+async def test_denied_verdict_reports_completed_not_verifier_failure(workspace):
+    # ENG-1632: a deterministic denial (wallet 402 → TokenLimitExceeded)
+    # latches silently — the turn's work succeeded and the user saw a normal
+    # reply, so the terminal is "completed", NOT handback_verifier_failure.
+    # This is a deliberate taxonomy decision: `group by ended_by` error-rate
+    # queries must not count a priced-out completion check as a broken turn,
+    # and the denied probe stays countable from the gateway-side ERROR trace
+    # in Langfuse, so no signal is lost by booking the turn as completed.
+    mock_llm = _verdict_llm("COMPLETE")
+    mock_llm.generate_object_code = AsyncMock(
+        side_effect=TokenLimitExceeded(
+            "402: Your wallet has no balance to cover the model 'haiku'."
+        )
+    )
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    _stub_tools(session)
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("run my script"):
+            pass
+    assert _ended_by(send) == "completed"
 
 
 async def test_callers_already_handled_exception_is_not_reported_as_error(workspace):

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -541,3 +541,78 @@ async def test_host_supplied_turn_id_is_what_the_event_reports(workspace):
     assert send.call_args.kwargs["turn_index"] == "4242", (
         "the event must report the host's turn_id, not the internal counter"
     )
+
+
+async def test_latched_skip_turns_also_stamp_verification_skipped(workspace):
+    # The steady-state site: after the denied latch fires (turn 1), every
+    # later turn in the session takes the LATCHED-SKIP path — a different
+    # stamp site three lines long and visually identical to the tested one,
+    # which is exactly the shape that ships unpinned (review on #357; same
+    # pattern as anton#348's legacy guard and anton#339's PROGRESS_MARKER
+    # writer). Two turns, one session: turn 2's event must carry the flag.
+    mock_llm = _verdict_llm("COMPLETE", tool_rounds=1)
+    mock_llm.generate_object_code = AsyncMock(
+        side_effect=TokenLimitExceeded(
+            "402: Your wallet has no balance to cover the model 'haiku'."
+        )
+    )
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    _stub_tools(session)
+    rows = []
+    with patch("anton.analytics.send_event") as send:
+        for i in range(2):
+            # _verdict_llm's plan list is consumed by turn 1; re-arm per turn.
+            plans = [
+                _Iter([StreamComplete(response=_tool_call(1))]),
+                _Iter([StreamComplete(response=_text("reply"))]),
+            ]
+            mock_llm.plan_stream = MagicMock(
+                side_effect=lambda **kw: plans.pop(0) if plans else _Iter(
+                    [StreamComplete(response=_text("reply again"))]
+                )
+            )
+            async for _ in session.turn_stream(f"step {i}"):
+                pass
+            k = send.call_args.kwargs
+            rows.append((k["ended_by"], k["verification_skipped"]))
+    # Turn 1 = the denied-latch site; turn 2 = the latched-skip site.
+    assert rows == [("completed", "true"), ("completed", "true")]
+
+
+async def test_hard_latch_and_failed_reprobe_turns_also_stamp_verification_skipped(workspace):
+    # The remaining two stamp sites: the second-hard-failure latch (turn 2)
+    # and the failed re-probe (the turn after _VERIFIER_LATCH_REPROBE_TURNS
+    # skips). Turn 1 hands back (ended_by=handback_verifier_failure — its
+    # terminal already distinguishes it, no flag needed); everything after
+    # books "completed" without a verdict and must carry the flag.
+    from anton.core.session import _VERIFIER_LATCH_REPROBE_TURNS
+
+    mock_llm = _verdict_llm("COMPLETE", tool_rounds=1)
+    mock_llm.generate_object_code = AsyncMock(
+        side_effect=RuntimeError("400 tool_choice not supported")
+    )
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    _stub_tools(session)
+    rows = []
+    with patch("anton.analytics.send_event") as send:
+        for i in range(_VERIFIER_LATCH_REPROBE_TURNS + 2):
+            plans = [
+                _Iter([StreamComplete(response=_tool_call(1))]),
+                _Iter([StreamComplete(response=_text("reply"))]),
+            ]
+            mock_llm.plan_stream = MagicMock(
+                side_effect=lambda **kw: plans.pop(0) if plans else _Iter(
+                    [StreamComplete(response=_text("diagnosis or reply"))]
+                )
+            )
+            async for _ in session.turn_stream(f"step {i}"):
+                pass
+            k = send.call_args.kwargs
+            rows.append((k["ended_by"], k["verification_skipped"]))
+    # Turn 1: honest diagnosis, distinguished by its own terminal.
+    assert rows[0] == ("handback_verifier_failure", "false")
+    # Turn 2: the second-hard-failure latch site.
+    assert rows[1] == ("completed", "true")
+    # Every later turn — the latched skips AND the failed re-probe that falls
+    # inside this window — books completed and must carry the flag.
+    assert all(r == ("completed", "true") for r in rows[2:]), rows[2:]

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -386,6 +386,24 @@ async def test_denied_verdict_reports_completed_not_verifier_failure(workspace):
         async for _ in session.turn_stream("run my script"):
             pass
     assert _ended_by(send) == "completed"
+    # ...but never byte-identical to a verified pass: the flag is what lets
+    # honest-stop denominators exclude unverified turns without a
+    # per-conversation Langfuse hop (ENG-1632 review).
+    assert send.call_args.kwargs["verification_skipped"] == "true"
+
+
+async def test_verified_turn_reports_verification_not_skipped(workspace):
+    # The control for the flag above: a turn whose verdict actually ran
+    # (COMPLETE) books verification_skipped="false".
+    session = ChatSession(
+        ChatSessionConfig(llm_client=_verdict_llm("COMPLETE"), workspace=workspace)
+    )
+    _stub_tools(session)
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("run my script"):
+            pass
+    assert _ended_by(send) == "completed"
+    assert send.call_args.kwargs["verification_skipped"] == "false"
 
 
 async def test_callers_already_handled_exception_is_not_reported_as_error(workspace):

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -23,8 +23,10 @@ from tests.conftest import make_mock_llm
 from anton.core.session import ChatSession, ChatSessionConfig, _VerifierVerdict
 from anton.core.llm.provider import (
     LLMResponse,
+    ModelUnavailableError,
     StreamComplete,
     StreamTaskProgress,
+    TokenLimitExceeded,
     ToolCall,
     Usage,
 )
@@ -826,6 +828,144 @@ async def test_empty_diagnosis_is_logged_not_circular(workspace, caplog):
             m.get("content") not in ("",)
             for m in session.history
             if m.get("role") == "assistant"
+        )
+    finally:
+        await session.close()
+
+
+# ── Deterministic denials latch silently on the FIRST occurrence (ENG-1632) ──
+#
+# A wallet 402 / allowance 429 (TokenLimitExceeded, code-exact per ENG-1169) or
+# a 404'd/403'd model (ModelUnavailableError) recurs on every retry by
+# construction. The turn's work already succeeded — telling the user "the
+# task-completion check failed to run (internal error)" and streaming an
+# apology is a misreport (measured: 208 aux-call wallet-402s across 33 users in
+# 14 days, every one surfaced as an internal error). The denied path must be
+# SILENT: no history injection, no diagnosis stream, latch on call one.
+#
+# ModelUnavailableError additionally subclasses ConnectionError → OSError, so
+# before ENG-1632 it was swallowed by the TRANSIENT clause — diagnose every
+# turn, never latch. These tests pin the except-clause ordering that fixes that.
+
+@pytest.mark.parametrize("exc_factory, label", [
+    (lambda: TokenLimitExceeded(
+        "402: Your wallet has no balance to cover the model 'haiku'."), "wallet-402"),
+    (lambda: TokenLimitExceeded(
+        "429: Your included token allowance for 'haiku' is exhausted."), "allowance-429"),
+    (lambda: ModelUnavailableError(
+        "404: The model 'gemini-3.6-flash' does not exist",
+        code="model_not_found", model="gemini-3.6-flash"), "model-404"),
+])
+async def test_denied_verdict_latches_silently_on_first_occurrence(
+    workspace, caplog, exc_factory, label
+):
+    import logging
+
+    mock_llm = make_mock_llm()
+    calls = {"n": 0}
+
+    async def always_denied(_schema, *, system, messages, max_tokens):
+        calls["n"] += 1
+        raise exc_factory()
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=always_denied)
+    session = _make_session(workspace, mock_llm)
+
+    diagnoses = 0
+    progress_messages: list[str] = []
+    try:
+        with caplog.at_level(logging.INFO):
+            for turn in range(4):
+                plan, state = _tool_then_text_plan()
+                mock_llm.plan_stream = plan
+                async for event in session.turn_stream(f"do step {turn}"):
+                    if isinstance(event, StreamTaskProgress):
+                        progress_messages.append(event.message or "")
+                if state["n"] >= 3:
+                    diagnoses += 1
+
+        # Silent: no diagnosis stream ever fires, and the user never sees the
+        # "Something went wrong — checking in with you..." progress line.
+        assert diagnoses == 0, (
+            f"denied verdicts must not stream a diagnosis, got {diagnoses}"
+        )
+        assert not any("Something went wrong" in m for m in progress_messages)
+        # The "internal error" SYSTEM injection must never enter history —
+        # it persists into every later turn's payload once appended.
+        assert not any(
+            "task-completion check failed" in str(m.get("content", ""))
+            for m in session._history
+            if isinstance(m, dict)
+        ), "the internal-error injection reached history on a denied verdict"
+        # Latched on the FIRST call: turns 2-4 pay nothing.
+        assert calls["n"] == 1, (
+            f"denied verdict must latch on the first occurrence, got {calls['n']} calls"
+        )
+        assert session._verifier_latched is True
+        # Denied is not a capability failure — the hard counter stays clean so
+        # a later hard failure still gets its honest one-per-session diagnosis.
+        assert session._verifier_hard_failures == 0
+        announcements = [
+            r for r in caplog.records
+            if "latched after a deterministic denial" in r.message
+        ]
+        assert len(announcements) == 1, (
+            f"the denied latch must announce itself exactly once in the log, "
+            f"got {len(announcements)}"
+        )
+        # The per-turn skip log names the real cause, not "0 hard failures".
+        skips = [
+            r for r in caplog.records
+            if "completion-verifier skipped — latched" in r.getMessage()
+        ]
+        assert len(skips) == 3
+        assert all("deterministic denial" in r.getMessage() for r in skips)
+    finally:
+        await session.close()
+
+
+async def test_denied_reprobe_stays_latched_and_silent(workspace, caplog):
+    """After _VERIFIER_LATCH_REPROBE_TURNS skips, the latch re-probes once; a
+    still-denied re-probe must land back in the denied branch — stay latched,
+    stay silent, no diagnosis — so a top-up self-heals on a later re-probe
+    while a persistent denial costs one quiet call per re-probe window."""
+    import logging
+
+    from anton.core.session import _VERIFIER_LATCH_REPROBE_TURNS
+
+    mock_llm = make_mock_llm()
+    calls = {"n": 0}
+
+    async def always_denied(_schema, *, system, messages, max_tokens):
+        calls["n"] += 1
+        raise TokenLimitExceeded(
+            "402: Your wallet has no balance to cover the model 'haiku'."
+        )
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=always_denied)
+    session = _make_session(workspace, mock_llm)
+
+    diagnoses = 0
+    try:
+        with caplog.at_level(logging.INFO):
+            for turn in range(_VERIFIER_LATCH_REPROBE_TURNS + 2):
+                plan, state = _tool_then_text_plan()
+                mock_llm.plan_stream = plan
+                async for _ in session.turn_stream(f"do step {turn}"):
+                    pass
+                if state["n"] >= 3:
+                    diagnoses += 1
+
+        # Call 1 latches; the single re-probe is call 2; everything else skips.
+        assert calls["n"] == 2, (
+            f"expected first call + one re-probe, got {calls['n']}"
+        )
+        assert session._verifier_latched is True
+        assert diagnoses == 0
+        assert not any(
+            "task-completion check failed" in str(m.get("content", ""))
+            for m in session._history
+            if isinstance(m, dict)
         )
     finally:
         await session.close()


### PR DESCRIPTION
## What

The completion verifier's verdict loop gets a typed clause for **deterministic denials** — a wallet 402 / allowance 429 (`TokenLimitExceeded`, code-exact per ENG-1169) or a 404'd/403'd model (`ModelUnavailableError`). A denied verdict now latches on the **first** occurrence and ends the turn quietly on the already-streamed reply: no `SYSTEM: The task-completion check failed to run (internal error)` history injection, no diagnosis stream, no "Something went wrong — checking in with you...".

Linear: [ENG-1632](https://linear.app/mindsdb/issue/ENG-1632) — full root cause, production-trace evidence, and the layer map live on the ticket.

## Why

A denial recurs on every retry by construction, yet it was handled as a generic hard failure: a full-history "internal error" handback on the first turn, latch only at two — and cowork-server rebuilds the ChatSession per message, so every message paid again. In production (14 days): **208 aux-call wallet-402s across 33 users**, each surfaced as an internal error and an apology **for turns whose work had succeeded**. Verified in-session (amdou440): work completes on the free model → verifier 402s on a pinned paid model → the user is told an internal check failed — every turn.

## How

- New `_DENIED_VERDICT_ERRORS` clause, ordered **before** `_TRANSIENT_VERDICT_ERRORS` — the ordering is load-bearing and commented on the constant: `ModelUnavailableError` subclasses `ConnectionError → OSError`, so the transient clause used to swallow it (diagnose every turn, never latch — this PR deliberately changes that behavior for model-404/403s too); `TokenLimitExceeded` fell to the generic "hard" handler.
- Handled via a `"denied"` sentinel in the post-loop `else` (a bare `break` in the except clause only exits the token-budget `for` and falls into the diagnosis block).
- Deliberately **silent, never auto-upgraded** to the planning model: a missing check beats a surprise bill. The existing 10-turn re-probe keeps recovery automatic — top up and the next re-probe restores verification; still-denied re-probes stay silently latched.
- The skip log names the latch reason (new `_verifier_latch_reason`) instead of printing "latched after 0 hard failures" for a denied latch. `_verifier_hard_failures` stays clean, so a later genuine capability failure still gets its one-per-session honest diagnosis.
- Safe by verification: `TokenLimitExceeded` is billing-only (context overflow is `ContextOverflowError`), propagates out of `generate_object_code` unwrapped, is never SDK-retried on 402, and velocity 429s map to `TransientProviderError` — they cannot land in the denied set.

## Coordination (no stacking)

Independent of the cowork-server and cowork PRs; merge in any order. Should ride the **same weekly train** as the cowork-server resolution fix (anton reaches desktop only via the cowork-server bump — ENG-1094).

## Test plan

- New in `tests/test_verifier_failsafe.py`: parametrized over wallet-402 / allowance-429 / model-404 — asserts **on history content and streamed events** (no SYSTEM injection, no diagnosis plan call, no progress line), latch-on-call-one, clean hard counter, single announcement, reason-bearing skip logs; plus the denied re-probe staying latched and silent.
- **Mutation-verified**: all four new tests fail on unfixed `session.py`, pass with the fix.
- Full suite on this base: green except the pre-existing `test_scratchpad.py::TestSessionPersistence::test_namespace_survives_restart`, which fails identically on pristine origin.

## Security pass

Reviewed the diff: the denied log line uses `_safe_error_detail` (type name only — no exception message, which can carry conversation or wallet content, per ENG-1081); no new input surface, no credential handling, nothing user-visible added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)