### PR TITLE
ENG-1679: Fix create skill from chat

### DIFF
--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -24,7 +24,11 @@ import sys
 import time
 
 from anton.cloud_turn.contract import TurnRequestV1
-from anton.cloud_turn.session import build_cloud_chat_session, drain_pending_memory
+from anton.cloud_turn.session import (
+    build_cloud_chat_session,
+    drain_pending_memory,
+    drain_pending_skills,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -253,6 +257,13 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
             # Before the terminal event: cowork persists on this, then stops reading.
             logger.info("emitting %d memory entr(ies)", len(entries))
             emit({"kind": "memory", "entries": entries})
+        drafts = drain_pending_skills(session)
+        if drafts:
+            # Pre-terminal for the same reason as memory. Staged only — cowork
+            # surfaces a card the user saves; nothing reaches their skill store.
+            logger.info("emitting %d skill draft(s): %s",
+                        len(drafts), ", ".join(d["slug"] for d in drafts))
+            emit({"kind": "skill", "entries": drafts})
         logger.info("cloud turn completed")
         emit({"kind": "turn_completed"})
     except Exception as exc:

--- a/anton/cloud_turn/contract.py
+++ b/anton/cloud_turn/contract.py
@@ -4,9 +4,12 @@ Matches what the controller sends (`scratchpad_controller.anton_turn.request_lin
 and what cowork-server consumes off the reply stream. Intentionally minimal and
 data-only: the entrypoint reads ONE newline-terminated JSON line on stdin.
 
-Events written back on stdout (JSONL) are the four the controller translates:
+Events written back on stdout (JSONL) are the five the controller translates:
   {"kind": "delta", "text": "..."}   - streamed assistant text, one per chunk
   {"kind": "memory", "entries": [...]}  - pre-terminal; cowork persists these
+  {"kind": "skill", "entries": [...]}   - pre-terminal; skill drafts the agent
+      built this turn, as [{"slug", "files": {name: text}}]. Staged only: cowork
+      surfaces a card and the user saves it, so nothing reaches the skill store.
   {"kind": "turn_completed"}          - terminal success (no payload)
   {"kind": "turn_failed", "error": "..."}  - terminal failure (scrubbed string)
 """

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -168,6 +168,11 @@ _DRAFT_FILE_MAX = 200_000
 #: Drafts reported per turn. A prompt-confused agent looping over
 #: `create_skill_draft` must not flood the wire; the excess is logged, not silent.
 _MAX_DRAFTS_PER_TURN = 20
+#: Whole-draft budget. The per-file cap alone bounds nothing: a skill may carry
+#: any number of siblings, so 20 drafts x N files x 200 KB is unbounded on the
+#: reply stream. SKILL.md is read first and always fits, so exhausting the budget
+#: costs siblings, never the procedure itself.
+_DRAFT_TOTAL_MAX = 1_000_000
 
 
 def _draft_files(folder: Path) -> dict[str, str] | None:
@@ -181,7 +186,9 @@ def _draft_files(folder: Path) -> dict[str, str] | None:
         return None
     resolved = folder.resolve()
     files: dict[str, str] = {}
-    for child in sorted(folder.iterdir()):
+    budget = _DRAFT_TOTAL_MAX
+    # SKILL.md first so the procedure is never the thing the budget squeezes out.
+    for child in sorted(folder.iterdir(), key=lambda p: p.name != SKILL_FILE):
         if child.is_symlink() or not child.is_file():
             continue
         if child.resolve().parent != resolved:
@@ -192,13 +199,19 @@ def _draft_files(folder: Path) -> dict[str, str] | None:
         except (OSError, UnicodeDecodeError):
             logger.warning("skill drafts: %r skipping unreadable file %r", folder.name, child.name)
             continue
-        if len(text.encode("utf-8", "replace")) > _DRAFT_FILE_MAX:
+        size = len(text.encode("utf-8", "replace"))
+        if size > _DRAFT_FILE_MAX:
             if child.name == SKILL_FILE:
                 logger.warning("skill drafts: dropping %r (SKILL.md over %d bytes)",
                                folder.name, _DRAFT_FILE_MAX)
                 return None
             logger.warning("skill drafts: %r skipping oversized file %r", folder.name, child.name)
             continue
+        if size > budget:
+            logger.warning("skill drafts: %r over the %d-byte draft budget, dropping %r "
+                           "and every later sibling", folder.name, _DRAFT_TOTAL_MAX, child.name)
+            break
+        budget -= size
         files[child.name] = text
     # A draft is its SKILL.md — siblings alone are a folder, not a procedure.
     # Checked on the collected files, not on disk: SKILL.md can exist and still

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -187,8 +187,10 @@ def _draft_files(folder: Path) -> dict[str, str] | None:
     resolved = folder.resolve()
     files: dict[str, str] = {}
     budget = _DRAFT_TOTAL_MAX
-    # SKILL.md first so the procedure is never the thing the budget squeezes out.
-    for child in sorted(folder.iterdir(), key=lambda p: p.name != SKILL_FILE):
+    # SKILL.md first so the procedure is never the thing the budget squeezes out,
+    # then by name — sorting on the flag alone is stable, so siblings would keep
+    # readdir order and the budget would drop different files on different hosts.
+    for child in sorted(folder.iterdir(), key=lambda p: (p.name != SKILL_FILE, p.name)):
         if child.is_symlink() or not child.is_file():
             continue
         if child.resolve().parent != resolved:

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -52,6 +52,11 @@ CLOUD_TOOL_ALLOWLIST = frozenset(
         # some builtins, so stripping the tool would point the model at a
         # missing tool. Only writes a stats counter in the discarded staging dir.
         "recall_skill",
+        # Safe to list only because `skill_drafts_root` is always set below —
+        # core registers the tool with one, and an allowlist name matching no
+        # tool is fatal. Writes only into this conversation's drafts dir; the
+        # tenant's skill store is never touched from the pod.
+        "create_skill_draft",
     }
 )
 
@@ -274,6 +279,13 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
     # persist — and cells could read — anything under it). Builtins resolve via
     # SkillStore's package root regardless.
     settings.skills_root = _stage_skills(request.skills)
+    # Skills the agent builds stage here instead of the store, and the entrypoint
+    # reports them for cowork to surface. ON the workspace, unlike everything
+    # staged above — editing a skill spans turns, and the workspace PVC is the
+    # only per-conversation storage that outlives the pod. Same layout as the
+    # desktop harness (`<project>/.anton/skill_drafts`).
+    settings.skill_drafts_root = base / settings.memory_dir / "skill_drafts"
+    settings.skill_drafts_root.mkdir(parents=True, exist_ok=True)
 
     workspace = Workspace(base, settings=settings)
     workspace.initialize()

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -18,6 +18,7 @@ Safety posture (all internal — nothing here is on the wire):
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import logging
 import os
 import tempfile
@@ -25,6 +26,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from anton.cloud_turn.contract import TurnRequestV1
+from anton.core.tools.skill_format import SKILL_FILE
 
 if TYPE_CHECKING:
     from anton.core.session import ChatSession
@@ -135,6 +137,76 @@ def _stage_skills(skills: dict | None) -> Path:
     return dest
 
 
+#: Per-file cap on a reported draft. Skills are small text, so the cap only
+#: catches a mispackaged blob before it reaches the reply stream. An oversized
+#: SKILL.md drops the whole draft: a truncated procedure is worse than none.
+_DRAFT_FILE_MAX = 200_000
+#: Drafts reported per turn. A prompt-confused agent looping over
+#: `create_skill_draft` must not flood the wire; the excess is logged, not silent.
+_MAX_DRAFTS_PER_TURN = 20
+
+
+def _draft_files(folder: Path) -> dict[str, str] | None:
+    """One draft folder as ``{filename: text}``, or None to skip it.
+
+    Top-level text files only, mirroring the desktop draft card (skills are flat
+    text). The drafts path is predictable and cell code can write anywhere in
+    the workspace, so symlinks and anything resolving outside `folder` go.
+    """
+    if folder.is_symlink() or not (folder / SKILL_FILE).is_file():
+        return None
+    resolved = folder.resolve()
+    files: dict[str, str] = {}
+    for child in sorted(folder.iterdir()):
+        if child.is_symlink() or not child.is_file():
+            continue
+        if child.resolve().parent != resolved:
+            logger.warning("skill drafts: %r skipping out-of-tree file %r", folder.name, child.name)
+            continue
+        try:
+            text = child.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            logger.warning("skill drafts: %r skipping unreadable file %r", folder.name, child.name)
+            continue
+        if len(text.encode("utf-8", "replace")) > _DRAFT_FILE_MAX:
+            if child.name == SKILL_FILE:
+                logger.warning("skill drafts: dropping %r (SKILL.md over %d bytes)",
+                               folder.name, _DRAFT_FILE_MAX)
+                return None
+            logger.warning("skill drafts: %r skipping oversized file %r", folder.name, child.name)
+            continue
+        files[child.name] = text
+    # A draft is its SKILL.md — siblings alone are a folder, not a procedure.
+    # Checked on the collected files, not on disk: SKILL.md can exist and still
+    # be dropped above for being oversized.
+    return files if SKILL_FILE in files else None
+
+
+def _snapshot_skill_drafts(root: Path) -> dict[str, str]:
+    """``slug -> content hash`` for every staged draft, for the end-of-turn diff.
+
+    Keyed on content, not just the folder name: drafts live on the workspace and
+    outlive the turn, so a draft refined in place has to re-report and not only
+    one appearing for the first time. Hashes every top-level file, so a
+    sibling-only edit counts as a change too.
+    """
+    if not root.is_dir():
+        return {}
+    snapshot: dict[str, str] = {}
+    for child in sorted(root.iterdir()):
+        if child.is_symlink() or not child.is_dir():
+            continue
+        digest = hashlib.sha256()
+        for f in sorted(child.iterdir()):
+            if f.is_symlink() or not f.is_file():
+                continue
+            digest.update(f.name.encode("utf-8", "replace"))
+            with contextlib.suppress(OSError):
+                digest.update(f.read_bytes())
+        snapshot[child.name] = digest.hexdigest()
+    return snapshot
+
+
 def _write_memory_slots(dest: Path, slots: dict | None) -> None:
     """Write `slots` into `dest`, clearing any this turn didn't send — the dir is
     reused across turns, so a server-side deletion must not linger."""
@@ -211,6 +283,44 @@ def drain_pending_memory(session) -> list[dict]:
     drained = list(pending)
     pending.clear()
     return drained
+
+
+def drain_pending_skills(session) -> list[dict]:
+    """Skill drafts this turn created or changed, as ``[{"slug", "files"}]``.
+
+    Raw file text rather than a parsed skill: cowork is the trust boundary and
+    validates slugs, paths and sizes itself. Advances the baseline as it reads,
+    so a second call reports nothing — the drafts folder survives the turn, and
+    re-reporting an untouched draft every turn would re-raise a card the user
+    already dismissed. Best-effort: a lost draft must not cost the turn its reply.
+    """
+    root = getattr(session, "_skill_drafts_root", None)
+    if not root:
+        return []
+    before = getattr(session, "_skill_drafts_before", None) or {}
+    try:
+        after = _snapshot_skill_drafts(Path(root))
+    except OSError:
+        logger.warning("skill drafts: could not diff the staging dir", exc_info=True)
+        return []
+    session._skill_drafts_before = after
+
+    changed = sorted(slug for slug, digest in after.items() if before.get(slug) != digest)
+    if len(changed) > _MAX_DRAFTS_PER_TURN:
+        logger.warning("skill drafts: %d changed, reporting the first %d",
+                       len(changed), _MAX_DRAFTS_PER_TURN)
+        changed = changed[:_MAX_DRAFTS_PER_TURN]
+
+    entries: list[dict] = []
+    for slug in changed:
+        try:
+            files = _draft_files(Path(root) / slug)
+        except OSError:
+            logger.warning("skill drafts: could not read %r", slug, exc_info=True)
+            continue
+        if files is not None:
+            entries.append({"slug": slug, "files": files})
+    return entries
 
 
 def resolve_trusted_workspace_path() -> Path:
@@ -319,6 +429,10 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
     )
 
     session = ChatSession(config)
+    # Baseline for `drain_pending_skills`, taken before the turn runs. Drafts
+    # from earlier turns are already on the workspace, so without this every
+    # turn would re-report all of them.
+    session._skill_drafts_before = _snapshot_skill_drafts(settings.skill_drafts_root)
     logger.info(
         "cloud session built conversation=%s workspace=%s tools=%s",
         request.conversation_id, base, sorted(CLOUD_TOOL_ALLOWLIST),

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -237,9 +237,16 @@ def _snapshot_skill_drafts(root: Path) -> dict[str, str]:
         for f in sorted(child.iterdir()):
             if f.is_symlink() or not f.is_file():
                 continue
-            digest.update(f.name.encode("utf-8", "replace"))
+            # Length-prefixed: concatenating name and body unseparated makes
+            # {"ab": "c"} and {"a": "bc"} hash the same, so a rename plus a
+            # compensating edit would read as "unchanged".
+            name = f.name.encode("utf-8", "replace")
+            digest.update(f"{len(name)}:".encode())
+            digest.update(name)
             with contextlib.suppress(OSError):
-                digest.update(f.read_bytes())
+                body = f.read_bytes()
+                digest.update(f"{len(body)}:".encode())
+                digest.update(body)
         snapshot[child.name] = digest.hexdigest()
     return snapshot
 
@@ -344,10 +351,15 @@ def drain_pending_skills(session) -> list[dict]:
     """Skill drafts this turn created or changed, as ``[{"slug", "files"}]``.
 
     Raw file text rather than a parsed skill: cowork is the trust boundary and
-    validates slugs, paths and sizes itself. Advances the baseline as it reads,
-    so a second call reports nothing — the drafts folder survives the turn, and
-    re-reporting an untouched draft every turn would re-raise a card the user
-    already dismissed. Best-effort: a lost draft must not cost the turn its reply.
+    re-validates slugs and paths. Sizes are bounded here, at the producer, since
+    the reply stream is what an unbounded payload would flood.
+
+    The baseline advances only for drafts actually returned, so a second call
+    reports nothing (the folder survives the turn, and re-reporting an untouched
+    draft would re-raise a card the user already dismissed) while anything the
+    caps held back stays pending and goes out next turn instead of being
+    silently dropped forever. Best-effort: a lost draft must not cost the turn
+    its reply.
     """
     root = getattr(session, "_skill_drafts_root", None)
     if not root:
@@ -358,16 +370,15 @@ def drain_pending_skills(session) -> list[dict]:
     except OSError:
         logger.warning("skill drafts: could not diff the staging dir", exc_info=True)
         return []
-    session._skill_drafts_before = after
-
     changed = sorted(slug for slug, digest in after.items() if before.get(slug) != digest)
-    if len(changed) > _MAX_DRAFTS_PER_TURN:
-        logger.warning("skill drafts: %d changed, reporting the first %d",
-                       len(changed), _MAX_DRAFTS_PER_TURN)
-        changed = changed[:_MAX_DRAFTS_PER_TURN]
+    this_turn = changed[:_MAX_DRAFTS_PER_TURN]
+    if len(changed) > len(this_turn):
+        logger.warning("skill drafts: %d changed, reporting %d this turn, the rest next",
+                       len(changed), len(this_turn))
 
     entries: list[dict] = []
-    for slug in changed:
+    delivered: dict[str, str] = {}
+    for slug in this_turn:
         try:
             files = _draft_files(Path(root) / slug)
         except OSError:
@@ -375,6 +386,14 @@ def drain_pending_skills(session) -> list[dict]:
             continue
         if files is not None:
             entries.append({"slug": slug, "files": files})
+            delivered[slug] = after[slug]
+
+    # Unchanged drafts keep their hash; changed ones advance ONLY if they went
+    # out. A draft held back by the per-turn cap, or unreadable this time, keeps
+    # its old hash and so is still "changed" next turn.
+    session._skill_drafts_before = {
+        slug: digest for slug, digest in after.items() if slug not in changed
+    } | delivered
     return entries
 
 

--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -104,6 +104,12 @@ class AntonSettings(CoreSettings):
     # Read-only skill roots the host ships alongside its own tools (ENG-764).
     # Take precedence over anton's built-ins; user skills still shadow them.
     skills_extra_roots: list[Path] | None = None
+    # Staging area for skills the agent builds, drained by the host at end of
+    # turn. Unset means the agent gets no skill-authoring tool:
+    # - a host with no drafts area has nowhere to put a built skill
+    # - a host that stages drafts its own way registers its own tool instead,
+    #   and two tools of one name would silently shadow each other
+    skill_drafts_root: Path | None = None
 
     memory_enabled: bool = True
     # TODO: Calling this memory_dir is a bit misleading, because there are other directories that live here

--- a/anton/core/memory/skills.py
+++ b/anton/core/memory/skills.py
@@ -340,6 +340,15 @@ class SkillStore:
 
     # ── reading ─────────────────────────────────────────────────────
 
+    def dir_for(self, label: str) -> Path | None:
+        """The user-root directory holding `label`, or None.
+
+        Built-ins and `extra_roots` are deliberately not searched: this exists
+        for callers that copy a skill's files to edit them, and those roots are
+        read-only.
+        """
+        return self._find_dir(label)
+
     def load(self, label: str) -> Skill | None:
         """Read a single skill by label. Returns None if absent or unreadable.
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -27,6 +27,7 @@ from anton.core.memory.base import Engram
 from anton.core.memory.cerebellum import Cerebellum
 from anton.core.memory.skills import SkillStore
 from anton.core.tools.recall_skill import RECALL_SKILL_TOOL
+from anton.core.tools.skill_draft import CREATE_SKILL_DRAFT_TOOL
 from anton.memory.history_store import is_user_turn
 from anton.core.llm.prompts import (
     RESILIENCE_NUDGE,
@@ -903,6 +904,9 @@ class ChatSession:
             root=getattr(s, "skills_root", None),
             extra_roots=getattr(s, "skills_extra_roots", None),
         )
+        # Where `create_skill_draft` stages skills the agent builds. None means
+        # the host stages none, and the tool is not registered at all.
+        self._skill_drafts_root = getattr(s, "skill_drafts_root", None)
         # Cerebellum: supervised error learning over scratchpad cells.
         # Buffers errored/warning cells across the turn, runs one diff
         # call at end-of-turn, and encodes lessons via cortex.encode().
@@ -1665,6 +1669,12 @@ class ChatSession:
 
         # Procedural memory retrieval — always available, no-op if no skills.
         self.tool_registry.register_tool(RECALL_SKILL_TOOL)
+
+        # Procedural memory authoring. Gated on the host giving us somewhere to
+        # stage drafts, so a host with its own equivalent tool (cowork desktop)
+        # doesn't end up with two registrations of this name shadowing.
+        if self._skill_drafts_root is not None:
+            self.tool_registry.register_tool(CREATE_SKILL_DRAFT_TOOL)
 
         # Handler-dispatched web tools — registered only when the LLM provider
         # does NOT execute them natively. On Anthropic / OpenAI BYOK / mdb.ai

--- a/anton/core/tools/skill_draft.py
+++ b/anton/core/tools/skill_draft.py
@@ -1,0 +1,128 @@
+"""The `create_skill_draft` tool — claim a staging folder for an agent-built skill.
+
+A skill the agent builds is never written into the live store: it is staged in
+a drafts folder the host drains at end of turn and shows to the user, who saves
+it explicitly. This tool claims that folder and, when a skill of the same name
+is already saved, pre-fills it so an edit starts from the current version
+rather than a blank file.
+
+The LLM-facing contract (description + schema) is deliberately identical to the
+one cowork-server's harnesses register, so the tool reads the same to the model
+whichever host is driving.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from anton.core.tools.skill_format import SKILL_FILE, normalize_name
+from anton.core.tools.tool_defs import ToolDef
+
+if TYPE_CHECKING:
+    from anton.core.session import ChatSession
+
+logger = logging.getLogger(__name__)
+
+#: Per-skill counters live with the store, not with the skill's content — a
+#: draft carrying them back would re-import another store's usage history.
+_NOT_CONTENT = {"stats.json"}
+
+
+_DESCRIPTION = (
+    "Claim a staging folder for a skill you are building or improving for the "
+    "user (e.g. while running the skill-creator skill). Call this BEFORE writing "
+    "the skill; it returns {slug, path, skill_file} — write your SKILL.md to "
+    "`skill_file` (and any sibling files into `path`). If a skill with this name "
+    "is already saved, the folder is pre-filled with its current contents so you "
+    "edit from the saved version. The skill is staged, NOT saved: it surfaces as "
+    "a card the user explicitly saves or downloads. NEVER write a skill into the "
+    "project `skills/` directory and NEVER use `create_artifact` for a skill."
+)
+
+_INPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The skill's name (becomes its slug, e.g. 'competitive-analysis').",
+        },
+        "description": {
+            "type": "string",
+            "description": "Optional one-line trigger description shown on the card.",
+        },
+    },
+    "required": ["name"],
+}
+
+
+def _seed_from_store(folder: Path, slug: str, store) -> None:
+    """Copy the saved skill's files into `folder` so an edit starts from it.
+
+    Best-effort: an unseeded draft is a worse starting point, not a failed turn.
+    Symlinks and out-of-tree children are skipped — a shared store could link
+    into files this turn has no business reading.
+    """
+    if store is None:
+        return
+    try:
+        src = store.dir_for(slug)
+    except Exception:
+        logger.warning("skill draft %r: could not locate the saved skill", slug, exc_info=True)
+        return
+    if src is None or src.is_symlink() or not (src / SKILL_FILE).is_file():
+        return
+    src_resolved = src.resolve()
+    try:
+        for child in src.iterdir():
+            if child.is_symlink() or not child.is_file() or child.name in _NOT_CONTENT:
+                continue
+            if child.resolve().parent != src_resolved:
+                logger.warning("skill draft %r: skipping out-of-tree file %r", slug, child.name)
+                continue
+            shutil.copy2(child, folder / child.name)
+    except OSError:
+        logger.warning("skill draft %r: could not seed from the store", slug, exc_info=True)
+
+
+async def handle_create_skill_draft(session: "ChatSession", tc_input: dict) -> str:
+    """Claim `<skill_drafts_root>/<slug>`; return `{slug, path, skill_file}`."""
+    root = getattr(session, "_skill_drafts_root", None)
+    if root is None:
+        return json.dumps({"error": "Skill drafts are unavailable in this session."})
+
+    name = str(tc_input.get("name") or "").strip()
+    if not name:
+        return json.dumps({"error": "`name` is required."})
+    slug = normalize_name(name)
+    if not slug:
+        return json.dumps({"error": "`name` must contain at least one letter or digit."})
+
+    folder = Path(root) / slug
+    try:
+        folder.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("skill draft %r: could not claim a folder", slug, exc_info=True)
+        return json.dumps({"error": f"Could not claim a folder for {slug!r}: {exc}"})
+
+    # Only seed an unclaimed folder: a second call in the same turn must not
+    # overwrite what the agent has already written into it.
+    if not (folder / SKILL_FILE).is_file():
+        _seed_from_store(folder, slug, getattr(session, "_skill_store", None))
+
+    return json.dumps({
+        "slug": slug,
+        "path": str(folder),
+        "skill_file": str(folder / SKILL_FILE),
+    })
+
+
+CREATE_SKILL_DRAFT_TOOL = ToolDef(
+    name="create_skill_draft",
+    description=_DESCRIPTION,
+    input_schema=_INPUT_SCHEMA,
+    handler=handle_create_skill_draft,
+)

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -322,6 +322,49 @@ def test_failed_turn_emits_no_memory():
     assert kinds == ["turn_failed"]
 
 
+_DRAFT_MD = "---\nname: my-skill\ndescription: d\n---\nsteps"
+
+
+class _DraftSession(_FakeSession):
+    """A session that writes a skill draft mid-turn, like the tool would."""
+
+    def __init__(self, drafts_root, *, write=True, **kwargs):
+        super().__init__(**kwargs)
+        self._skill_drafts_root = drafts_root
+        self._skill_drafts_before = {}
+        self._write = write
+
+    async def turn_stream(self, user_input, **kwargs):
+        if self._write:
+            folder = self._skill_drafts_root / "my-skill"
+            folder.mkdir(parents=True, exist_ok=True)
+            (folder / "SKILL.md").write_text(_DRAFT_MD)
+        async for event in super().turn_stream(user_input, **kwargs):
+            yield event
+
+
+def test_skill_draft_emitted_before_the_terminal_event(tmp_path):
+    """Same reason as memory: cowork stops reading at the terminal reply."""
+    events = _drive(_DraftSession(tmp_path, deltas=["ok"]))
+    assert events == [
+        {"kind": "delta", "text": "ok"},
+        {"kind": "skill", "entries": [{"slug": "my-skill", "files": {"SKILL.md": _DRAFT_MD}}]},
+        {"kind": "turn_completed"},
+    ]
+
+
+def test_no_skill_event_when_no_draft_was_built(tmp_path):
+    events = _drive(_DraftSession(tmp_path, write=False, deltas=["ok"]))
+    assert events == [{"kind": "delta", "text": "ok"}, {"kind": "turn_completed"}]
+
+
+def test_failed_turn_emits_no_skill_draft(tmp_path):
+    """A turn that raised has no trustworthy result — same rule as memory."""
+    session = _DraftSession(tmp_path, deltas=["ok"])
+    session._raise = RuntimeError("boom")
+    assert [e["kind"] for e in _drive(session)] == ["turn_failed"]
+
+
 def test_untracked_late_write_is_not_awaited():
     """Settling is explicit: only registered writes are awaited, so the entrypoint
     never blocks on unrelated live tasks (scratchpad readers, the heartbeat)."""

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -557,6 +557,29 @@ def test_skills_root_is_a_fresh_dir_outside_the_workspace(tmp_path, monkeypatch,
     assert not str(cfg.settings.skills_root).startswith(str(cfg.workspace.base))
 
 
+def test_skill_drafts_root_is_on_the_workspace(tmp_path, monkeypatch, skills_tmp):
+    """The inverse of the staged skills above: drafts go ON the workspace, the
+    only per-conversation storage that outlives the pod."""
+    _, cfg = _build(tmp_path, monkeypatch)
+    drafts = cfg.settings.skill_drafts_root
+    assert drafts.is_dir()
+    assert drafts.is_relative_to(cfg.workspace.base)
+    assert not drafts.is_relative_to(skills_tmp)
+
+
+def test_a_draft_survives_into_the_next_turn(tmp_path, monkeypatch, skills_tmp):
+    """Editing a skill spans turns, so unlike the staged skills root this path
+    must be stable and its contents must carry over."""
+    _, cfg1 = _build(tmp_path, monkeypatch)
+    (cfg1.settings.skill_drafts_root / "my-skill").mkdir()
+    (cfg1.settings.skill_drafts_root / "my-skill" / "SKILL.md").write_text("turn 1 work")
+
+    _, cfg2 = _build(tmp_path, monkeypatch)
+    assert cfg2.settings.skill_drafts_root == cfg1.settings.skill_drafts_root
+    carried = cfg2.settings.skill_drafts_root / "my-skill" / "SKILL.md"
+    assert carried.read_text() == "turn 1 work"
+
+
 def test_recall_skill_survives_the_real_tool_build(tmp_path, monkeypatch, skills_tmp):
     session = _real_cloud_session(tmp_path, monkeypatch, skills=_SKILLS)
     session._build_tools()

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -580,6 +580,27 @@ def test_a_draft_survives_into_the_next_turn(tmp_path, monkeypatch, skills_tmp):
     assert carried.read_text() == "turn 1 work"
 
 
+def test_a_skill_the_agent_builds_comes_back_out(tmp_path, monkeypatch, skills_tmp):
+    """The whole point of the feature, end to end on a REAL session: the tool
+    claims a folder, the agent writes into it, and the drain reports it."""
+    import asyncio
+    import json
+    from pathlib import Path
+
+    from anton.cloud_turn.session import drain_pending_skills
+    from anton.core.tools.skill_draft import handle_create_skill_draft
+
+    session = _real_cloud_session(tmp_path, monkeypatch)
+    claimed = json.loads(asyncio.run(
+        handle_create_skill_draft(session, {"name": "Competitive Analysis"})
+    ))
+    Path(claimed["skill_file"]).write_text("---\nname: competitive-analysis\n---\nsteps")
+
+    entries = drain_pending_skills(session)
+    assert [e["slug"] for e in entries] == ["competitive-analysis"]
+    assert "steps" in entries[0]["files"]["SKILL.md"]
+
+
 def test_recall_skill_survives_the_real_tool_build(tmp_path, monkeypatch, skills_tmp):
     session = _real_cloud_session(tmp_path, monkeypatch, skills=_SKILLS)
     session._build_tools()

--- a/tests/test_cloud_turn_skill_drain.py
+++ b/tests/test_cloud_turn_skill_drain.py
@@ -1,0 +1,146 @@
+"""`drain_pending_skills` — the end-of-turn diff of the staged drafts folder.
+
+The drafts folder outlives the turn (it lives on the workspace PVC), so the
+interesting cases are all about the baseline: what counts as changed, what must
+not re-report, and what a hostile folder can smuggle onto the wire.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from anton.cloud_turn.session import (
+    _DRAFT_FILE_MAX,
+    _MAX_DRAFTS_PER_TURN,
+    _snapshot_skill_drafts,
+    drain_pending_skills,
+)
+
+SKILL_MD = "---\nname: my-skill\ndescription: d\n---\nbody"
+
+
+def _session(root: Path):
+    """A session whose baseline is the folder as it stands now — i.e. a turn
+    starting against existing drafts."""
+    root.mkdir(parents=True, exist_ok=True)
+    return SimpleNamespace(
+        _skill_drafts_root=root,
+        _skill_drafts_before=_snapshot_skill_drafts(root),
+    )
+
+
+def _write(root: Path, slug: str, skill_md: str = SKILL_MD, **siblings: str) -> Path:
+    folder = root / slug
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / "SKILL.md").write_text(skill_md)
+    for name, text in siblings.items():
+        (folder / name).write_text(text)
+    return folder
+
+
+def test_a_new_draft_is_reported(tmp_path):
+    session = _session(tmp_path)
+    _write(tmp_path, "my-skill")
+
+    entries = drain_pending_skills(session)
+    assert [e["slug"] for e in entries] == ["my-skill"]
+    assert entries[0]["files"]["SKILL.md"] == SKILL_MD
+
+
+def test_siblings_travel_with_the_draft(tmp_path):
+    session = _session(tmp_path)
+    _write(tmp_path, "my-skill", **{"recipe.md": "steps"})
+
+    files = drain_pending_skills(session)[0]["files"]
+    assert files["recipe.md"] == "steps"
+
+
+def test_a_draft_from_an_earlier_turn_is_not_reported_again(tmp_path):
+    _write(tmp_path, "my-skill")
+    # A later turn starts with the draft already on disk.
+    assert drain_pending_skills(_session(tmp_path)) == []
+
+
+def test_refining_an_existing_draft_reports_it(tmp_path):
+    _write(tmp_path, "my-skill")
+    session = _session(tmp_path)
+    _write(tmp_path, "my-skill", skill_md=SKILL_MD + "\nrefined")
+
+    assert [e["slug"] for e in drain_pending_skills(session)] == ["my-skill"]
+
+
+def test_a_sibling_only_edit_counts_as_a_change(tmp_path):
+    _write(tmp_path, "my-skill", **{"recipe.md": "v1"})
+    session = _session(tmp_path)
+    (tmp_path / "my-skill" / "recipe.md").write_text("v2")
+
+    assert [e["slug"] for e in drain_pending_skills(session)] == ["my-skill"]
+
+
+def test_draining_twice_reports_once(tmp_path):
+    session = _session(tmp_path)
+    _write(tmp_path, "my-skill")
+
+    assert len(drain_pending_skills(session)) == 1
+    # A dismissed card must not come back on the next drain.
+    assert drain_pending_skills(session) == []
+
+
+def test_a_folder_without_skill_md_is_not_a_draft(tmp_path):
+    session = _session(tmp_path)
+    (tmp_path / "junk").mkdir()
+    (tmp_path / "junk" / "notes.txt").write_text("x")
+
+    assert drain_pending_skills(session) == []
+
+
+def test_a_symlinked_file_never_reaches_the_wire(tmp_path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("tenant secret")
+    session = _session(tmp_path / "drafts")
+    folder = _write(tmp_path / "drafts", "my-skill")
+    (folder / "leak.txt").symlink_to(secret)
+
+    files = drain_pending_skills(session)[0]["files"]
+    assert "leak.txt" not in files
+    assert "tenant secret" not in str(files)
+
+
+def test_a_symlinked_draft_folder_is_dropped(tmp_path):
+    outside = tmp_path / "outside"
+    _write(outside.parent, "outside")
+    drafts = tmp_path / "drafts"
+    session = _session(drafts)
+    (drafts / "sneaky").symlink_to(tmp_path / "outside", target_is_directory=True)
+
+    assert drain_pending_skills(session) == []
+
+
+def test_an_oversized_skill_md_drops_the_whole_draft(tmp_path):
+    session = _session(tmp_path)
+    # With a readable sibling present: dropping only the oversized SKILL.md
+    # would otherwise report a draft carrying no procedure at all.
+    _write(tmp_path, "my-skill", skill_md="x" * (_DRAFT_FILE_MAX + 1),
+           **{"recipe.md": "steps"})
+
+    assert drain_pending_skills(session) == []
+
+
+def test_an_oversized_sibling_is_skipped_not_truncated(tmp_path):
+    session = _session(tmp_path)
+    _write(tmp_path, "my-skill", **{"blob.bin": "x" * (_DRAFT_FILE_MAX + 1)})
+
+    files = drain_pending_skills(session)[0]["files"]
+    assert "blob.bin" not in files
+    assert files["SKILL.md"] == SKILL_MD
+
+
+def test_the_per_turn_cap_bounds_what_goes_on_the_wire(tmp_path):
+    session = _session(tmp_path)
+    for i in range(_MAX_DRAFTS_PER_TURN + 3):
+        _write(tmp_path, f"skill-{i:02d}")
+
+    assert len(drain_pending_skills(session)) == _MAX_DRAFTS_PER_TURN
+
+
+def test_no_drafts_root_is_not_an_error(tmp_path):
+    assert drain_pending_skills(SimpleNamespace(_skill_drafts_root=None)) == []

--- a/tests/test_cloud_turn_skill_drain.py
+++ b/tests/test_cloud_turn_skill_drain.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from anton.cloud_turn.session import (
+    _DRAFT_TOTAL_MAX,
     _DRAFT_FILE_MAX,
     _MAX_DRAFTS_PER_TURN,
     _snapshot_skill_drafts,
@@ -144,3 +145,55 @@ def test_the_per_turn_cap_bounds_what_goes_on_the_wire(tmp_path):
 
 def test_no_drafts_root_is_not_an_error(tmp_path):
     assert drain_pending_skills(SimpleNamespace(_skill_drafts_root=None)) == []
+
+
+def test_drafts_over_the_cap_go_out_next_turn(tmp_path):
+    """The cap is backpressure, not a shredder: the baseline may only advance for
+    drafts actually returned, or the excess is lost for good."""
+    session = _session(tmp_path)
+    total = _MAX_DRAFTS_PER_TURN + 3
+    for i in range(total):
+        _write(tmp_path, f"skill-{i:02d}")
+
+    first = drain_pending_skills(session)
+    assert len(first) == _MAX_DRAFTS_PER_TURN
+
+    second = drain_pending_skills(session)
+    assert [e["slug"] for e in second] == [f"skill-{i:02d}" for i in range(_MAX_DRAFTS_PER_TURN, total)]
+    assert drain_pending_skills(session) == []          # and then it settles
+
+
+def test_an_undelivered_draft_is_retried_not_baselined(tmp_path):
+    """A draft dropped by the size caps must stay pending, so fixing it reports
+    it — rather than its hash being recorded as already sent."""
+    session = _session(tmp_path)
+    _write(tmp_path, "my-skill", skill_md="x" * (_DRAFT_FILE_MAX + 1))
+    assert drain_pending_skills(session) == []
+
+    _write(tmp_path, "my-skill", skill_md=SKILL_MD)      # author trims it
+    assert [e["slug"] for e in drain_pending_skills(session)] == ["my-skill"]
+
+
+def test_a_draft_is_bounded_in_total_not_just_per_file(tmp_path):
+    """Per-file caps bound nothing on their own — a skill may carry any number
+    of siblings, and every draft rides the same reply stream."""
+    session = _session(tmp_path)
+    siblings = {f"ref-{i:02d}.md": "x" * 150_000 for i in range(20)}   # 3 MB unbounded
+    _write(tmp_path, "my-skill", **siblings)
+
+    files = drain_pending_skills(session)[0]["files"]
+    wire = sum(len(t.encode()) for t in files.values())
+    assert wire <= _DRAFT_TOTAL_MAX
+    assert files["SKILL.md"] == SKILL_MD                 # the procedure survives
+    assert len(files) < len(siblings) + 1                # siblings are what gave way
+
+
+def test_a_rename_plus_compensating_edit_still_counts_as_a_change(tmp_path):
+    """Hashing name and body unseparated would make these two states identical."""
+    folder = _write(tmp_path, "my-skill")
+    (folder / "ab").write_text("c")
+    session = _session(tmp_path)
+
+    (folder / "ab").unlink()
+    (folder / "a").write_text("bc")
+    assert [e["slug"] for e in drain_pending_skills(session)] == ["my-skill"]

--- a/tests/test_cloud_turn_skill_drain.py
+++ b/tests/test_cloud_turn_skill_drain.py
@@ -197,3 +197,20 @@ def test_a_rename_plus_compensating_edit_still_counts_as_a_change(tmp_path):
     (folder / "ab").unlink()
     (folder / "a").write_text("bc")
     assert [e["slug"] for e in drain_pending_skills(session)] == ["my-skill"]
+
+
+def test_which_siblings_survive_the_budget_is_deterministic(tmp_path):
+    """Sorting on the SKILL.md flag alone is stable, so siblings would keep
+    readdir order and a budget overflow would drop different files per host."""
+    big = "x" * 200_000
+    kept = []
+    for run in range(2):
+        root = tmp_path / f"run{run}"
+        session = _session(root)
+        folder = _write(root, "my-skill")
+        # Created in opposite orders: readdir order differs, output must not.
+        names = [f"ref-{i:02d}.md" for i in range(10)]
+        for name in (names if run == 0 else reversed(names)):
+            (folder / name).write_text(big)
+        kept.append(sorted(drain_pending_skills(session)[0]["files"]))
+    assert kept[0] == kept[1]

--- a/tests/test_skill_draft_tool.py
+++ b/tests/test_skill_draft_tool.py
@@ -1,0 +1,91 @@
+"""`create_skill_draft` — folder claiming, seeding from the store, and the
+registration gate that keeps it from colliding with a host's own tool."""
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from anton.core.memory.skills import Skill, SkillStore
+from anton.core.tools.skill_draft import handle_create_skill_draft
+
+
+def _call(session, **args) -> dict:
+    return json.loads(asyncio.run(handle_create_skill_draft(session, args)))
+
+
+def _session(drafts_root, store=None):
+    return SimpleNamespace(_skill_drafts_root=drafts_root, _skill_store=store)
+
+
+def _store(root: Path, label: str = "csv-summary") -> SkillStore:
+    store = SkillStore(root=root)
+    store.save(Skill(
+        label=label,
+        name="CSV Summary",
+        description="Summarize a CSV",
+        declarative_md="1. Read it\n2. Summarize it",
+        created_at="2026-01-01T00:00:00+00:00",
+        provenance="manual",
+    ))
+    return store
+
+
+def test_claims_a_folder_under_the_drafts_root(tmp_path):
+    out = _call(_session(tmp_path), name="Competitive Analysis")
+    assert out["slug"] == "competitive-analysis"
+    assert Path(out["path"]) == tmp_path / "competitive-analysis"
+    assert Path(out["path"]).is_dir()
+    assert out["skill_file"].endswith("/competitive-analysis/SKILL.md")
+
+
+def test_name_is_slugified_not_taken_literally(tmp_path):
+    out = _call(_session(tmp_path), name="  Weekly   Report!!  ")
+    assert out["slug"] == "weekly-report"
+
+
+@pytest.mark.parametrize("name", ["", "   ", "!!!"])
+def test_unusable_name_is_an_error_not_a_folder(tmp_path, name):
+    assert "error" in _call(_session(tmp_path), name=name)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_no_drafts_root_is_an_error(tmp_path):
+    assert "error" in _call(_session(None), name="anything")
+
+
+def test_editing_a_saved_skill_seeds_the_draft_from_it(tmp_path):
+    store = _store(tmp_path / "store")
+    out = _call(_session(tmp_path / "drafts", store), name="csv-summary")
+
+    body = (Path(out["path"]) / "SKILL.md").read_text()
+    assert "Summarize it" in body, "an edit must start from the saved version"
+
+
+def test_seeding_leaves_store_only_files_behind(tmp_path):
+    store = _store(tmp_path / "store")
+    assert (store.root / "csv-summary" / "stats.json").is_file()
+
+    out = _call(_session(tmp_path / "drafts", store), name="csv-summary")
+    # Recall counters belong to the store, not to the skill's content.
+    assert not (Path(out["path"]) / "stats.json").exists()
+
+
+def test_a_second_call_does_not_clobber_what_the_agent_wrote(tmp_path):
+    store = _store(tmp_path / "store")
+    session = _session(tmp_path / "drafts", store)
+
+    out = _call(session, name="csv-summary")
+    Path(out["skill_file"]).write_text("agent's own draft")
+    _call(session, name="csv-summary")
+
+    assert Path(out["skill_file"]).read_text() == "agent's own draft"
+
+
+def test_unsaved_skill_yields_an_empty_folder_not_an_error(tmp_path):
+    store = _store(tmp_path / "store")
+    out = _call(_session(tmp_path / "drafts", store), name="brand-new")
+    assert "error" not in out
+    assert list(Path(out["path"]).iterdir()) == []


### PR DESCRIPTION


A cloud turn could read skills but never create one: no authoring tool was in the allowlist, and the contract stated the pod never writes skills back. Skills built in the cloud were silently lost.

Requires the cowork-server PR to be deployed first — see its description.

What changed:

- `core/tools/skill_draft.py` (new) — the `create_skill_draft` tool. Claims a staging folder and pre-fills it from the saved skill so editing starts from the current version. Description and schema are deliberately identical to the one cowork-server's harnesses register, so the tool reads the same to the model whichever host is driving.
- `config/settings.py` — `skill_drafts_root`. Unset means no authoring tool is registered, which is what keeps this from colliding with the equivalent tool cowork's desktop harness passes in: `register_tool` dedups by name, so two registrations would silently shadow.
- `core/session.py` — registers the tool only when that root is set.
- `cloud_turn/session.py` — `create_skill_draft` allowlisted; drafts staged at `<workspace>/.anton/skill_drafts`; `drain_pending_skills` diffs the folder at end of turn.
- `cloud_turn/__main__.py` — emits `{"kind": "skill", "entries": [...]}` before the terminal event, alongside the existing memory event.
- `core/memory/skills.py` — `dir_for()`, a public accessor the draft tool needs to copy a skill's files.

Drafts go ON the workspace, unlike the staged read-side which is a fresh temp dir per turn. Editing a skill spans several turns, and the workspace PVC is the only per-conversation storage that outlives the pod; a temp dir would hand turn 2 an empty folder and lose turn 1's work. Layout matches the desktop harness, and the folder dies with the conversation, so no cleanup is needed.

The drafts path is predictable and cell code can write anywhere in the workspace, so the drain drops symlinks and anything resolving outside a draft folder, caps per-file size, and bounds how many drafts one turn can report. Raw file text goes on the wire rather than a parsed skill — cowork validates, being the trust boundary.

Tests: 10 on the tool, 14 on the drain, plus entrypoint and session coverage. Verified by mutation; two guard pairs are mutually masking, so those are pinned by double mutation to confirm neither is dead code. One mutation found a real bug in the first draft of the drain, which reported a folder with siblings but no SKILL.md as a skill with no procedure.

Related PRs:
- https://github.com/mindsdb/scratchpad-controller/pull/19
- https://github.com/mindsdb/cowork-server/pull/326

Fixes https://linear.app/mindsdb/issue/ENG-1679/multi-tenant-cowork-cant-create-skill-in-chat