### PR TITLE
ENG-1693: only OUR gateway may select a billing verdict

### DIFF
--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -29,6 +29,7 @@ from .provider import (
     classify_transient,
     retry_after_seconds,
     compute_context_pressure,
+    origin_is_known_third_party,
     wallet_denial_code,
     raise_on_empty_response,
 )
@@ -76,11 +77,18 @@ def _raise_for_status_error(
     # them — but a wallet denial that DOES arrive here must hit the credits
     # card, not the generic copy. Code/reason-exact: a BYOK Anthropic billing
     # error carries neither and stays generic.
+    # ENG-1693 — see the openai twin for the full reasoning. Both carriers are
+    # third-party controlled on a BYOK endpoint, and cowork-server's own gates
+    # run too late because anton converts a wallet denial into a typed error
+    # that is matched above all origin logic.
+    _foreign = origin_is_known_third_party(exc)
     gate_reason = ""
-    if getattr(exc, "response", None) is not None:
+    if not _foreign and getattr(exc, "response", None) is not None:
         gate_reason = exc.response.headers.get("x-mindshub-reason", "")
-    wallet_code = wallet_denial_code(body) or (
-        gate_reason if gate_reason in ("wallet_empty", "included_allowance_exhausted") else None
+    wallet_code = None if _foreign else (
+        wallet_denial_code(body) or (
+            gate_reason if gate_reason in ("wallet_empty", "included_allowance_exhausted") else None
+        )
     )
     if exc.status_code in (402, 429) and wallet_code:
         what = (

--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -65,8 +65,20 @@ def _raise_for_status_error(
         ) from exc
 
     body = exc.body if isinstance(exc.body, dict) else {}
-    if exc.status_code == 429 and body.get("detail"):
-        msg = f"Server returned 429 — {body['detail']}"
+
+    # Computed once, up front: several branches below can mint a MindsHub
+    # billing verdict and each must refuse a provably foreign origin (ENG-1693).
+    _foreign = origin_is_known_third_party(exc)
+
+    # Origin-gated, and `str`-guarded to match the openai twin. Two bugs the
+    # twin already avoided and this one did not: an unguarded `detail` lets a
+    # FastAPI validation error (whose `detail` is a LIST) render as a Python
+    # repr next to our billing link, and an ungated one lets any BYOK endpoint
+    # mint the credits card from a single JSON key with attacker-authored prose
+    # in it.
+    _detail = body.get("detail")
+    if not _foreign and exc.status_code == 429 and isinstance(_detail, str) and _detail:
+        msg = f"Server returned 429 — {_detail}"
         msg += " Visit https://console.mindshub.ai to upgrade or to top up your tokens."
         raise TokenLimitExceeded(msg) from exc
 
@@ -81,10 +93,12 @@ def _raise_for_status_error(
     # third-party controlled on a BYOK endpoint, and cowork-server's own gates
     # run too late because anton converts a wallet denial into a typed error
     # that is matched above all origin logic.
-    _foreign = origin_is_known_third_party(exc)
-    gate_reason = ""
-    if not _foreign and getattr(exc, "response", None) is not None:
-        gate_reason = exc.response.headers.get("x-mindshub-reason", "")
+    # Read once, UNGATED, then used two different ways below.
+    raw_gate_reason = ""
+    if getattr(exc, "response", None) is not None:
+        raw_gate_reason = exc.response.headers.get("x-mindshub-reason", "")
+    # Gated form — only this one may pick a BILLING verdict.
+    gate_reason = "" if _foreign else raw_gate_reason
     wallet_code = None if _foreign else (
         wallet_denial_code(body) or (
             gate_reason if gate_reason in ("wallet_empty", "included_allowance_exhausted") else None
@@ -124,7 +138,8 @@ def _raise_for_status_error(
     # else (a bare 429, a provider quota in an unrecognised dialect) keeps the
     # old fail-fast path rather than burning the budget on a limit that may not
     # clear.
-    _velocity = gate_reason == "rate_limited" or _body_code == "rate_limited"
+    # Ungated — see the openai twin: velocity is not a billing verdict.
+    _velocity = raw_gate_reason == "rate_limited" or _body_code == "rate_limited"
     transient = classify_transient(
         exc.status_code, body, provider=provider, model=model,
         retry_after=retry_after_seconds(exc),

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -34,6 +34,7 @@ from .provider import (
     classify_transient,
     retry_after_seconds,
     compute_context_pressure,
+    origin_is_known_third_party,
     wallet_denial_code,
     raise_on_empty_response,
 )
@@ -135,11 +136,29 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     # header is the fallback discriminator for a body that lost its code
     # (e.g. an anthropic-dialect proxy); detection stays code/reason-exact so
     # BYOK 402s fall through to the generic copy, never the credits card.
+    # ENG-1693: BOTH carriers are origin-checked. On a BYOK OPENAI_COMPATIBLE
+    # provider the whole response — header and body — is third-party
+    # controlled, so without this any endpoint could return 402 +
+    # `X-MindsHub-Reason: wallet_empty` (or the same `code` in the body) and
+    # put our out-of-credits card, with its top-up CTA, in front of a user
+    # whose MindsHub wallet is fine.
+    #
+    # cowork-server gates its own copies of these reads (ENG-1537, ENG-1686),
+    # but that is too late: anton converts a wallet denial into a typed
+    # TokenLimitExceeded, which cowork-server matches at the TOP of its ladder,
+    # above all origin logic. So the check has to happen here or not at all.
+    #
+    # Three-valued: only a PROVABLE third party is refused. An unknown origin
+    # stays trusted, because a real SDK error always carries its request, so
+    # only synthetic/mid-stream errors lack a host — nothing a remote can pick.
+    _foreign = origin_is_known_third_party(exc)
     gate_reason = ""
-    if getattr(exc, "response", None) is not None:
+    if not _foreign and getattr(exc, "response", None) is not None:
         gate_reason = exc.response.headers.get("x-mindshub-reason", "")
-    wallet_code = wallet_denial_code(raw_body) or (
-        gate_reason if gate_reason in ("wallet_empty", "included_allowance_exhausted") else None
+    wallet_code = None if _foreign else (
+        wallet_denial_code(raw_body) or (
+            gate_reason if gate_reason in ("wallet_empty", "included_allowance_exhausted") else None
+        )
     )
     if exc.status_code in (402, 429) and wallet_code:
         what = (
@@ -1187,7 +1206,13 @@ class OpenAIProvider(LLMProvider):
             # Checked BEFORE the transient classifier — permanent-first, the
             # same policy as the request-time mapper — so a wallet denial that
             # also carries a transient-looking `type` still fails fast.
-            wallet_code = wallet_denial_code(getattr(exc, "body", None))
+            # Origin-checked like the request-time mapper (ENG-1693). Almost
+            # always a no-op here: a mid-stream error carries no response, so
+            # the host is unknown and the three-valued rule keeps it trusted.
+            wallet_code = (
+                None if origin_is_known_third_party(exc)
+                else wallet_denial_code(getattr(exc, "body", None))
+            )
             if wallet_code:
                 what = (
                     "Your MindsHub credits are used up"
@@ -1513,7 +1538,13 @@ class OpenAIProvider(LLMProvider):
             # Checked BEFORE the transient classifier — permanent-first, the
             # same policy as the request-time mapper — so a wallet denial that
             # also carries a transient-looking `type` still fails fast.
-            wallet_code = wallet_denial_code(getattr(exc, "body", None))
+            # Origin-checked like the request-time mapper (ENG-1693). Almost
+            # always a no-op here: a mid-stream error carries no response, so
+            # the host is unknown and the three-valued rule keeps it trusted.
+            wallet_code = (
+                None if origin_is_known_third_party(exc)
+                else wallet_denial_code(getattr(exc, "body", None))
+            )
             if wallet_code:
                 what = (
                     "Your MindsHub credits are used up"

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -87,6 +87,10 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     with BYOK copy (OpenAI billing link, no MindsHub CTA) — detection is
     code-exact so arbitrary provider messages never get quota treatment.
     """
+    # Computed once, up front: several branches below can mint a MindsHub
+    # billing verdict and each must refuse a provably foreign origin (ENG-1693).
+    _foreign = origin_is_known_third_party(exc)
+
     if exc.status_code == 401:
         raise ConnectionError(
             "Invalid API key — check your OpenAI API key configuration."
@@ -106,7 +110,13 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     detail = body.get("detail") or envelope.get("detail")
     # str-only: FastAPI validation errors put a LIST in detail — rendering
     # its repr into user-facing copy (with an upgrade CTA!) helps nobody.
-    if exc.status_code == 429 and isinstance(detail, str) and detail:
+    # ENG-1693: origin-gated like every other branch that can mint a MindsHub
+    # billing verdict. This one is the cheapest to abuse — a single `detail`
+    # key on a 429, no header required — and it is the ONLY one whose copy is
+    # partly attacker-authored, since `detail` is interpolated into the message
+    # next to our console.mindshub.ai link. A foreign 429 falls through to
+    # classify_transient's honest rate-limit mapping instead.
+    if not _foreign and exc.status_code == 429 and isinstance(detail, str) and detail:
         msg = f"Server returned 429 — {detail}"
         msg += " Visit https://console.mindshub.ai to upgrade or top up your tokens."
         raise TokenLimitExceeded(msg) from exc
@@ -151,10 +161,12 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     # Three-valued: only a PROVABLE third party is refused. An unknown origin
     # stays trusted, because a real SDK error always carries its request, so
     # only synthetic/mid-stream errors lack a host — nothing a remote can pick.
-    _foreign = origin_is_known_third_party(exc)
-    gate_reason = ""
-    if not _foreign and getattr(exc, "response", None) is not None:
-        gate_reason = exc.response.headers.get("x-mindshub-reason", "")
+    # Read once, UNGATED, then used two different ways below.
+    raw_gate_reason = ""
+    if getattr(exc, "response", None) is not None:
+        raw_gate_reason = exc.response.headers.get("x-mindshub-reason", "")
+    # Gated form — only this one may pick a BILLING verdict.
+    gate_reason = "" if _foreign else raw_gate_reason
     wallet_code = None if _foreign else (
         wallet_denial_code(raw_body) or (
             gate_reason if gate_reason in ("wallet_empty", "included_allowance_exhausted") else None
@@ -171,7 +183,11 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
             "https://console.mindshub.ai/settings/organization/billing to continue."
         ) from exc
 
-    if exc.status_code == 403 and code in ("model_access_denied", "model_disabled"):
+    # Origin-gated too (ENG-1693 review): this branch's copy names a MindsHub
+    # PLAN and links console.mindshub.ai to upgrade, so it is a billing verdict
+    # by any useful definition. A third party emitting `model_access_denied`
+    # should get the generic message, not our upgrade CTA.
+    if not _foreign and exc.status_code == 403 and code in ("model_access_denied", "model_disabled"):
         if code == "model_access_denied":
             msg = (
                 f"The model '{model}' isn't included in your current MindsHub plan. "
@@ -207,7 +223,14 @@ def _raise_for_status_error(exc: "openai.APIStatusError", model: str) -> NoRetur
     # else (a bare 429, a provider quota in an unrecognised dialect) keeps the
     # old fail-fast path rather than burning the budget on a limit that may not
     # clear.
-    _velocity = gate_reason == "rate_limited" or code == "rate_limited"
+    # Uses the UNGATED read on purpose (ENG-1693 review). A velocity limit is
+    # not a billing verdict — it shows no CTA and asks for no money — so the
+    # origin gate, which exists to stop a third party selling our billing card,
+    # does not apply. Gating it also bought nothing: the body carrier below is
+    # ungated too, so a spoofer would just use that. What it DID cost was a
+    # real regression — a relay or corporate proxy in front of MindsHub
+    # forwarding our 429 and `Retry-After` lost its wait (ENG-1537).
+    _velocity = raw_gate_reason == "rate_limited" or code == "rate_limited"
     transient = classify_transient(
         exc.status_code, body, provider="The model provider", model=model,
         retry_after=retry_after_seconds(exc),
@@ -1206,9 +1229,15 @@ class OpenAIProvider(LLMProvider):
             # Checked BEFORE the transient classifier — permanent-first, the
             # same policy as the request-time mapper — so a wallet denial that
             # also carries a transient-looking `type` still fails fast.
-            # Origin-checked like the request-time mapper (ENG-1693). Almost
-            # always a no-op here: a mid-stream error carries no response, so
-            # the host is unknown and the three-valued rule keeps it trusted.
+            # Origin-checked like the request-time mapper (ENG-1693). NOT a
+            # no-op: an earlier revision claimed a mid-stream error carries no
+            # recoverable host so this was almost always inert, and that was
+            # wrong in the most dangerous direction. The bare `openai.APIError`
+            # raised here has no `.response` but DOES carry `.request` with the
+            # real URL, and answering 200 with the wallet code smuggled into an
+            # SSE frame is the remote's choice — so this is precisely where a
+            # hostile BYOK endpoint would aim. `response_origin_host` now falls
+            # back to `.request`, which is what makes this gate real.
             wallet_code = (
                 None if origin_is_known_third_party(exc)
                 else wallet_denial_code(getattr(exc, "body", None))
@@ -1538,9 +1567,15 @@ class OpenAIProvider(LLMProvider):
             # Checked BEFORE the transient classifier — permanent-first, the
             # same policy as the request-time mapper — so a wallet denial that
             # also carries a transient-looking `type` still fails fast.
-            # Origin-checked like the request-time mapper (ENG-1693). Almost
-            # always a no-op here: a mid-stream error carries no response, so
-            # the host is unknown and the three-valued rule keeps it trusted.
+            # Origin-checked like the request-time mapper (ENG-1693). NOT a
+            # no-op: an earlier revision claimed a mid-stream error carries no
+            # recoverable host so this was almost always inert, and that was
+            # wrong in the most dangerous direction. The bare `openai.APIError`
+            # raised here has no `.response` but DOES carry `.request` with the
+            # real URL, and answering 200 with the wallet code smuggled into an
+            # SSE frame is the remote's choice — so this is precisely where a
+            # hostile BYOK endpoint would aim. `response_origin_host` now falls
+            # back to `.request`, which is what makes this gate real.
             wallet_code = (
                 None if origin_is_known_third_party(exc)
                 else wallet_denial_code(getattr(exc, "body", None))

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -600,14 +600,22 @@ def response_origin_host(exc: BaseException) -> str | None:
 
     ``httpx.Response.url`` is a property that RAISES when no request is
     attached, so this cannot be a bare ``getattr`` chain.
+
+    Falls back to the exception's OWN ``request``, which is what makes this
+    work on the mid-stream lane. A mid-stream failure surfaces as a bare
+    ``openai.APIError`` — constructed as ``APIError(message, request, body=…)``,
+    so it has **no** ``.response`` but does carry ``.request`` with the real
+    URL. Reading only ``.response`` made the gate silently inert exactly where
+    an attacker has the freest hand: answering 200 and smuggling the wallet
+    code into an SSE frame is the remote's choice, not a quirk of our plumbing.
     """
     resp = getattr(exc, "response", None)
-    if resp is None:
-        return None
     try:
-        url = getattr(resp, "url", None)
-        if url is None:
+        url = getattr(resp, "url", None) if resp is not None else None
+        if url is None and resp is not None:
             url = getattr(getattr(resp, "request", None), "url", None)
+        if url is None:
+            url = getattr(getattr(exc, "request", None), "url", None)
         if url is None:
             return None
         host = getattr(url, "host", None)
@@ -761,11 +769,15 @@ def classify_transient(
         if etype == "insufficient_quota":
             return None
         if wallet_denial_code(b):
-            # Deliberately NOT origin-gated (ENG-1693). This guard suppresses
-            # RETRIES, and being conservative is right no matter who sent it:
-            # retrying a third party's quota denial is wasteful and cannot
-            # succeed either. Gating here would make a hostile wallet code
-            # RETRYABLE, which is worse than the card it would deny.
+            # Deliberately NOT origin-gated (ENG-1693), for a plainer reason
+            # than an earlier version of this comment claimed. It said gating
+            # would make a hostile wallet code "retryable"; that is false —
+            # both this branch and the fallthrough reach the same count-based
+            # retry, so retryability is unchanged either way. The real reasons
+            # are that this call site cannot see the origin (it receives only
+            # status + body, never the exception), and that suppressing a
+            # retry is conservative regardless of who sent the code: retrying
+            # a third party's quota denial cannot succeed either.
             return None
         # session_backoff=True, unlike every other request-time status here
         # (ENG-1537). The flag means "should the SESSION spend its budget on

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -574,6 +574,75 @@ _TRANSIENT_ERROR_TYPES = frozenset(
 _WALLET_DENIAL_CODES = frozenset({"wallet_empty", "included_allowance_exhausted"})
 
 
+# Hosts that ARE the MindsHub gateway. Only a response from one of these may
+# select a billing verdict — see :func:`origin_is_known_third_party` (ENG-1693).
+_MINDSHUB_HOSTS = ("mindshub.ai", "mdb.ai")
+
+
+def is_mindshub_host(host: str | None) -> bool:
+    """Whether ``host`` is the MindsHub gateway or one of its subdomains.
+
+    Deliberately NOT the ``"mindshub.ai" in base_url`` substring test used
+    elsewhere in this package for flavour detection and trace-header opt-in.
+    That form is fine for choosing an API dialect and unfit for a trust
+    decision: ``mindshub.ai.evil.com`` satisfies it. This matches the exact
+    domain or a dot-delimited subdomain of it, so an attacker cannot buy a
+    name that merely contains ours.
+    """
+    if not host:
+        return False
+    h = str(host).strip().lower().rstrip(".")
+    return any(h == d or h.endswith("." + d) for d in _MINDSHUB_HOSTS)
+
+
+def response_origin_host(exc: BaseException) -> str | None:
+    """Hostname the failing request was sent to, or ``None`` if unknowable.
+
+    ``httpx.Response.url`` is a property that RAISES when no request is
+    attached, so this cannot be a bare ``getattr`` chain.
+    """
+    resp = getattr(exc, "response", None)
+    if resp is None:
+        return None
+    try:
+        url = getattr(resp, "url", None)
+        if url is None:
+            url = getattr(getattr(resp, "request", None), "url", None)
+        if url is None:
+            return None
+        host = getattr(url, "host", None)
+        if not host:
+            from urllib.parse import urlparse
+
+            host = urlparse(str(url)).hostname
+    except Exception:
+        return None
+    return str(host).lower() if host else None
+
+
+def origin_is_known_third_party(exc: BaseException) -> bool:
+    """Whether this failure provably came from somewhere that is NOT our gateway.
+
+    Three-valued on purpose, mirroring cowork-server's gate (ENG-1686): it
+    answers "do we KNOW it was someone else", so an unknown origin stays
+    trusted rather than being treated as hostile. A real SDK error always
+    carries its request, so every genuine HTTP response resolves a host;
+    unknown origin means a synthetic or mid-stream error, which no remote
+    server can choose.
+
+    Used to stop a BYOK endpoint selecting a MindsHub billing verdict by
+    echoing our private ``X-MindsHub-Reason`` header or wallet ``code``
+    (ENG-1693). NOT used in :func:`classify_transient`'s wallet check — see
+    the comment there.
+    """
+    return origin_is_known_third_party_host(response_origin_host(exc))
+
+
+def origin_is_known_third_party_host(host: str | None) -> bool:
+    """Host-level form of :func:`origin_is_known_third_party`."""
+    return host is not None and not is_mindshub_host(host)
+
+
 def wallet_denial_code(body: Any) -> str | None:
     """The M3 gate's out-of-credits code carried in an error body, if any.
 
@@ -692,6 +761,11 @@ def classify_transient(
         if etype == "insufficient_quota":
             return None
         if wallet_denial_code(b):
+            # Deliberately NOT origin-gated (ENG-1693). This guard suppresses
+            # RETRIES, and being conservative is right no matter who sent it:
+            # retrying a third party's quota denial is wasteful and cannot
+            # succeed either. Gating here would make a hostile wallet code
+            # RETRYABLE, which is worse than the card it would deny.
             return None
         # session_backoff=True, unlike every other request-time status here
         # (ENG-1537). The flag means "should the SESSION spend its budget on

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -52,7 +52,10 @@ def _sdk_error(status_code, json_body=None, text_body=None, headers=None):
         )
 
     client = openai.OpenAI(
-        base_url="http://gateway.test/v1",
+        # A real MindsHub host: since ENG-1693 the ORIGIN decides whether a
+        # billing verdict is trusted, so a placeholder host would make every
+        # "gateway" test below silently exercise the third-party path.
+        base_url="https://api.mindshub.ai/v1",
         api_key="test-key",
         max_retries=0,
         http_client=httpx.Client(transport=httpx.MockTransport(handler)),
@@ -557,7 +560,7 @@ def _anthropic_sdk_error(status_code, json_body=None, headers=None):
         )
 
     client = anthropic.Anthropic(
-        base_url="http://gateway.test",
+        base_url="https://api.mindshub.ai",  # see the note in _sdk_error (ENG-1693)
         api_key="test-key",
         max_retries=0,
         http_client=httpx.Client(transport=httpx.MockTransport(handler)),
@@ -673,3 +676,81 @@ def test_anthropic_mapper_does_not_wait_on_an_unconfirmed_429():
         anthropic_mapper(exc, provider="Anthropic", model="sonnet")
     assert err.value.session_backoff is False
     assert err.value.retry_after is None
+
+
+# ── Only OUR gateway may select a billing verdict (ENG-1693) ───────────────
+# cowork-server gates its own copies of these carriers (ENG-1537, ENG-1686),
+# but that is too late: anton converts a wallet denial into a typed
+# TokenLimitExceeded, which cowork-server matches at the TOP of its ladder,
+# above all origin logic. So the check has to happen in these mappers.
+
+def _byok_error(host, reason=None, json_body=None, status=402):
+    """A real SDK error from an arbitrary OPENAI_COMPATIBLE endpoint."""
+    import httpx
+
+    def handler(request):
+        headers = {"X-MindsHub-Reason": reason} if reason else {}
+        return httpx.Response(status, json=json_body or {}, headers=headers)
+
+    client = openai.OpenAI(
+        base_url=f"https://{host}/v1", api_key="k", max_retries=0,
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        client.chat.completions.create(
+            model="m", max_tokens=1, messages=[{"role": "user", "content": "hi"}])
+    except openai.APIStatusError as exc:
+        return exc
+    raise AssertionError("the SDK did not raise")
+
+
+@pytest.mark.parametrize("host", [
+    "openrouter.ai",
+    "api.openai.com",
+    "mindshub.ai.evil.com",   # lookalike: the substring idiom used elsewhere accepts this
+    "notmindshub.ai",
+])
+@pytest.mark.parametrize("carrier", ["header", "body"])
+def test_a_third_party_cannot_conjure_the_credits_card(host, carrier):
+    kwargs = ({"reason": "wallet_empty"} if carrier == "header"
+              else {"json_body": {"code": "wallet_empty"}})
+    exc = _byok_error(host, **kwargs)
+    with pytest.raises(Exception) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert not isinstance(err.value, TokenLimitExceeded), (
+        f"{host} via {carrier} produced the out-of-credits card"
+    )
+
+
+@pytest.mark.parametrize("host", ["api.mindshub.ai", "mindshub.ai", "api.mdb.ai"])
+@pytest.mark.parametrize("carrier", ["header", "body"])
+def test_the_real_gateway_still_gets_the_credits_card(host, carrier):
+    # ENG-1169 must not reopen: a genuine denial still fails fast onto the card.
+    kwargs = ({"reason": "wallet_empty"} if carrier == "header"
+              else {"json_body": {"code": "wallet_empty"}})
+    with pytest.raises(TokenLimitExceeded):
+        _raise_for_status_error(_byok_error(host, **kwargs), "sonnet")
+
+
+def test_an_unknown_origin_still_maps():
+    # Three-valued, mirroring cowork-server's gate: only a PROVABLE third party
+    # is refused. A synthetic error carries no response, so the host is unknown
+    # and behaviour is unchanged — which is what keeps the mid-stream wallet
+    # paths working.
+    from anton.core.llm.provider import origin_is_known_third_party
+
+    assert origin_is_known_third_party(Exception("synthetic")) is False
+
+
+def test_the_host_match_is_not_a_substring_test():
+    # The idiom used elsewhere in this package for flavour detection
+    # (`"mindshub.ai" in base_url`) accepts an attacker-registered lookalike.
+    # A trust decision cannot use it.
+    from anton.core.llm.provider import is_mindshub_host
+
+    assert is_mindshub_host("api.mindshub.ai") is True
+    assert is_mindshub_host("mdb.ai") is True
+    assert is_mindshub_host("API.MINDSHUB.AI.") is True      # case + trailing dot
+    assert is_mindshub_host("mindshub.ai.evil.com") is False
+    assert is_mindshub_host("notmindshub.ai") is False
+    assert is_mindshub_host(None) is False

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -263,7 +263,9 @@ def _wire_shaped_error(status_code, body):
     anton's pyproject allows ``openai>=1.0`` and proxies exist that re-wrap,
     so the mapper's envelope fallback must stay pinned by a test that the
     MockTransport route physically cannot produce."""
-    request = httpx.Request("POST", "http://gateway.test/v1/chat/completions")
+    # A real MindsHub host — the origin is load-bearing since ENG-1693, and
+    # this fixture stands in for OUR gateway (see the two in _sdk_error).
+    request = httpx.Request("POST", "https://api.mindshub.ai/v1/chat/completions")
     response = httpx.Response(status_code, json=body if isinstance(body, dict) else None, request=request)
     return openai.APIStatusError("wire-shaped", response=response, body=body)
 
@@ -684,12 +686,13 @@ def test_anthropic_mapper_does_not_wait_on_an_unconfirmed_429():
 # TokenLimitExceeded, which cowork-server matches at the TOP of its ladder,
 # above all origin logic. So the check has to happen in these mappers.
 
-def _byok_error(host, reason=None, json_body=None, status=402):
+def _byok_error(host, reason=None, json_body=None, status=402, headers_extra=None):
     """A real SDK error from an arbitrary OPENAI_COMPATIBLE endpoint."""
     import httpx
 
     def handler(request):
         headers = {"X-MindsHub-Reason": reason} if reason else {}
+        headers.update(headers_extra or {})
         return httpx.Response(status, json=json_body or {}, headers=headers)
 
     client = openai.OpenAI(
@@ -754,3 +757,150 @@ def test_the_host_match_is_not_a_substring_test():
     assert is_mindshub_host("mindshub.ai.evil.com") is False
     assert is_mindshub_host("notmindshub.ai") is False
     assert is_mindshub_host(None) is False
+
+
+# ── Every carrier, both mappers, and the mid-stream lane (ENG-1693 review) ──
+# The first cut of this fix gated five sites and tested two. Reverting the
+# anthropic gate or either mid-stream gate left the whole suite green.
+
+@pytest.mark.parametrize("status,body,carrier", [
+    (402, {"code": "wallet_empty"}, "body wallet code"),
+    (429, {"detail": "you are out of credits, top up here"}, "FastAPI detail"),
+    (403, {"error": {"code": "model_access_denied"}}, "403 plan copy"),
+])
+def test_no_carrier_lets_a_third_party_mint_mindshub_billing_copy(status, body, carrier):
+    """Every branch that names MindsHub or links console.mindshub.ai must
+    refuse a provably foreign origin — not just the two the first cut covered.
+
+    The `detail` carrier is the cheapest to abuse (one JSON key, no header) and
+    the only one whose text is partly attacker-authored, since it is
+    interpolated into the message beside our billing link.
+    """
+    exc = _byok_error("openrouter.ai", json_body=body, status=status)
+    with pytest.raises(Exception) as err:
+        _raise_for_status_error(exc, "sonnet")
+    text = str(err.value)
+    assert not isinstance(err.value, TokenLimitExceeded), f"{carrier} minted the credits card"
+    assert "console.mindshub.ai" not in text, f"{carrier} leaked a MindsHub CTA: {text[:120]}"
+    assert "MindsHub plan" not in text, f"{carrier} leaked MindsHub plan copy: {text[:120]}"
+
+
+def test_the_gateway_keeps_all_three_carriers():
+    """The mirror: none of the gates may break a real gateway denial."""
+    with pytest.raises(TokenLimitExceeded):
+        _raise_for_status_error(_byok_error("api.mindshub.ai", json_body={"code": "wallet_empty"}), "s")
+    with pytest.raises(TokenLimitExceeded):
+        _raise_for_status_error(
+            _byok_error("api.mindshub.ai", json_body={"detail": "Monthly limit exceeded"}, status=429), "s")
+    with pytest.raises(ModelUnavailableError):
+        _raise_for_status_error(
+            _byok_error("api.mindshub.ai", json_body={"error": {"code": "model_access_denied"}}, status=403), "s")
+
+
+def _midstream_error(host, code="wallet_empty"):
+    """Drive the REAL streaming path: HTTP 200 carrying an SSE error frame.
+
+    This is the lane the first cut of the gate could not see — the bare
+    `openai.APIError` raised here has no `.response`, only `.request`.
+    """
+    import json as _json
+
+    frame = _json.dumps({"error": {"message": "nope", "type": "x", "code": code}})
+    payload = f"data: {frame}\n\n".encode()
+
+    def handler(request):
+        return httpx.Response(200, content=payload,
+                              headers={"Content-Type": "text/event-stream"})
+
+    client = openai.OpenAI(
+        base_url=f"https://{host}/v1", api_key="k", max_retries=0,
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        for _ in client.chat.completions.create(
+            model="m", messages=[{"role": "user", "content": "hi"}], stream=True,
+        ):
+            pass
+    except Exception as exc:
+        return exc
+    raise AssertionError("the stream did not raise")
+
+
+def test_the_midstream_lane_resolves_its_host():
+    """The bug the review caught: `response_origin_host` read only `.response`,
+    so this lane — where the attacker has the freest hand — was ungated."""
+    from anton.core.llm.provider import origin_is_known_third_party, response_origin_host
+
+    hostile = _midstream_error("evil.example.com")
+    assert getattr(hostile, "response", None) is None      # no response…
+    assert getattr(hostile, "request", None) is not None   # …but the host is right here
+    assert response_origin_host(hostile) == "evil.example.com"
+    assert origin_is_known_third_party(hostile) is True
+
+    ours = _midstream_error("api.mindshub.ai")
+    assert response_origin_host(ours) == "api.mindshub.ai"
+    assert origin_is_known_third_party(ours) is False
+
+
+@pytest.mark.parametrize("status,body", [
+    (402, {"code": "wallet_empty"}),
+    (429, {"detail": "out of credits"}),
+])
+def test_the_anthropic_twin_gates_the_same_carriers(status, body):
+    """The twin had NO origin coverage — reverting its gate left the suite
+    green, which is exactly how the two mappers drift apart."""
+    from anton.core.llm.anthropic import _raise_for_status_error as anthropic_mapper
+
+    exc = _anthropic_sdk_error(status, json_body=body)
+    exc.response.request = httpx.Request("POST", "https://openrouter.ai/v1/messages")
+    with pytest.raises(Exception) as err:
+        anthropic_mapper(exc, provider="Anthropic", model="sonnet")
+    assert not isinstance(err.value, TokenLimitExceeded)
+    assert "console.mindshub.ai" not in str(err.value)
+
+
+def test_the_anthropic_twin_still_cards_a_real_gateway_denial():
+    from anton.core.llm.anthropic import _raise_for_status_error as anthropic_mapper
+
+    exc = _anthropic_sdk_error(402, json_body={"code": "wallet_empty"})
+    exc.response.request = httpx.Request("POST", "https://api.mindshub.ai/v1/messages")
+    with pytest.raises(TokenLimitExceeded):
+        anthropic_mapper(exc, provider="Anthropic", model="sonnet")
+
+
+def test_the_anthropic_detail_branch_rejects_a_list():
+    """FastAPI validation errors put a LIST in `detail`; the openai twin has
+    guarded this for a while and the anthropic one did not, so a Python repr
+    could render next to our billing link."""
+    from anton.core.llm.anthropic import _raise_for_status_error as anthropic_mapper
+
+    exc = _anthropic_sdk_error(429, json_body={"detail": [{"loc": ["body"], "msg": "bad"}]})
+    exc.response.request = httpx.Request("POST", "https://api.mindshub.ai/v1/messages")
+    with pytest.raises(Exception) as err:
+        anthropic_mapper(exc, provider="Anthropic", model="sonnet")
+    assert not isinstance(err.value, TokenLimitExceeded)
+    assert "loc" not in str(err.value)
+
+
+def test_a_relayed_gateway_rate_limit_still_earns_the_session_wait():
+    """ENG-1537 must not regress through ENG-1693's gate.
+
+    A velocity limit is not a billing verdict — no CTA, no money — so the
+    origin gate does not apply to it. The first cut of the gate suppressed the
+    header read wholesale, which silently cost a relay or corporate proxy in
+    front of MindsHub its `Retry-After` wait. Nothing caught that: re-gating
+    `_velocity` left the entire suite green.
+    """
+    exc = _byok_error("relay.corp.internal", status=429,
+                      reason="rate_limited", headers_extra={"Retry-After": "42"})
+    with pytest.raises(TransientProviderError) as err:
+        _raise_for_status_error(exc, "sonnet")
+    assert err.value.code == "rate_limited"
+    assert err.value.session_backoff is True, "the relayed velocity wait was lost"
+    assert err.value.retry_after == 42.0
+
+    # …while the same foreign origin still cannot mint a BILLING verdict.
+    wallet = _byok_error("relay.corp.internal", status=402, reason="wallet_empty")
+    with pytest.raises(Exception) as err2:
+        _raise_for_status_error(wallet, "sonnet")
+    assert not isinstance(err2.value, TokenLimitExceeded)

--- a/tests/test_transient_retry_e2e.py
+++ b/tests/test_transient_retry_e2e.py
@@ -93,12 +93,19 @@ def _anthropic_provider(handler) -> AnthropicProvider:
     return prov
 
 
-def _openai_provider(handler) -> OpenAIProvider:
+def _openai_provider(handler, host: str = "api.mindshub.ai") -> OpenAIProvider:
     # Default flavor is openai-compatible-generic → the chat.completions path
     # (the MindsHub-passthrough dialect), which is what MindsHub routing uses.
-    prov = OpenAIProvider(api_key="test", base_url="http://mock/v1")
+    #
+    # Host defaults to a REAL MindsHub one (ENG-1693): the origin now decides
+    # whether a wallet code may mint the credits card, so the previous
+    # `http://mock/v1` placeholder meant every midstream wallet test below was
+    # silently exercising the third-party path. Pass a foreign host explicitly
+    # to test that direction.
+    base = f"https://{host}/v1"
+    prov = OpenAIProvider(api_key="test", base_url=base)
     prov._client = openai.AsyncOpenAI(
-        api_key="test", base_url="http://mock/v1",
+        api_key="test", base_url=base,
         http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
     )
     return prov
@@ -219,6 +226,24 @@ async def test_e2e_openai_midstream_wallet_denial_is_token_limit():
         await _drain(prov)
     assert "credit" in str(ei.value).lower()
     assert "billing" in str(ei.value)
+
+
+async def test_e2e_openai_midstream_wallet_denial_from_a_foreign_host_is_not_the_card():
+    """ENG-1693 review: the mid-stream lane was the one the origin gate missed.
+
+    Answering HTTP 200 and smuggling the wallet code into an SSE frame is the
+    remote's choice, and it produced a bare `openai.APIError` with no
+    `.response` — so the guard, which read only `.response`, saw no host and
+    trusted it. This is the end-to-end proof that a hostile BYOK endpoint can
+    no longer conjure the out-of-credits card, and the companion to the three
+    tests above (which now correctly run against a MindsHub host).
+    """
+    prov = _openai_provider(_static(_OAI_MIDSTREAM_WALLET), host="evil.example.com")
+    with pytest.raises(Exception) as ei:
+        await _drain(prov)
+    assert not isinstance(ei.value, TokenLimitExceeded), "a foreign host minted the credits card"
+    assert "billing" not in str(ei.value)
+    assert "console.mindshub.ai" not in str(ei.value)
 
 
 async def test_e2e_openai_midstream_wallet_beats_transient_type():


### PR DESCRIPTION
Closes [ENG-1693](https://linear.app/mindsdb/issue/ENG-1693). The half that [cowork-server#332](https://github.com/mindsdb/cowork-server/pull/332) (ENG-1686) could not reach.

## Why the previous two fixes didn't close this

ENG-1537 gated cowork-server's body-`code` carrier. ENG-1686 gated its header twin. **Both are in cowork-server, and anton reads the same two carriers one layer earlier — ungated.**

anton converts a wallet denial into a typed `TokenLimitExceeded`, and cowork-server matches that at the **top** of its ladder (`is_token_limit_error`), above all origin logic. So cowork-server's gate is correct and never consulted. Executed against ENG-1686's head:

```
raw third-party header             -> None                                      # its gate works
anton-shaped (TokenLimitExceeded)  -> ('token_limit', "You're out of credits…")
host resolved for the hostile case : openrouter.ai
gate says known-third-party?       : True                                       # never asked
```

The trigger is only `status ∈ {402, 429}` plus the header **or** the body code — both fully third-party controlled on a BYOK `OPENAI_COMPATIBLE` endpoint. A hostile or misconfigured provider could put our out-of-credits card, with its top-up CTA, in front of a user whose MindsHub wallet is fine.

## After

Verified through the real mapper with real SDK errors, not hand-built fixtures:

| Origin | Carrier | Result |
|---|---|---|
| `openrouter.ai` | header | `ConnectionError` → generic copy |
| `openrouter.ai` | body `code` | `ConnectionError` |
| `mindshub.ai.evil.com` | header | `ConnectionError` |
| `api.mindshub.ai` | header | **`TokenLimitExceeded`** → credits card |
| `api.mindshub.ai` | body `code` | **`TokenLimitExceeded`** |
| `api.mdb.ai` (legacy) | header | **`TokenLimitExceeded`** |

## Three decisions worth reviewing

**The host match is not the substring idiom.** This package already tests `"mindshub.ai" in base_url` in three places, but `mindshub.ai.evil.com` satisfies it. That's fine for picking an API dialect and unfit for a trust decision, so this matches the exact domain or a dot-delimited subdomain. Existing uses are untouched — they aren't trust decisions.

**Three-valued, mirroring ENG-1686.** Only a *provable* third party is refused; unknown origin stays trusted. That's what keeps the two **mid-stream** wallet paths working unchanged — they carry no response, so no host is resolvable. Treating unknown as hostile would have silently broken them.

**`classify_transient`'s wallet check is deliberately left ungated**, and now says so in the code. It suppresses *retries*, where being conservative is right regardless of origin — gating it would make a hostile wallet code **retryable**, which is worse than the card it would deny.

## Seven existing tests broke — I fixed the fixture, not the assertions

`_sdk_error` used a `gateway.test` placeholder. The host was incidental before and is load-bearing now, so every test named `test_gateway_*` was silently exercising the third-party path. They now use a real MindsHub host, which is what their names always claimed. **No assertion was changed** — worth checking that in review, since "tests broke so I edited them" is the shape of a bad fix.

## Verification

Mutation-verified against all three ways to get this wrong:

| Mutation | Result |
|---|---|
| no gate (pre-fix state) | **8 red** |
| the substring form (lookalike bypass) | **5 red** |
| unknown origin treated as hostile | **1 red** |

New tests parametrise origin × carrier, so neither lane can reopen alone, and cover the legacy `mdb.ai` host and the ENG-1169 direction (a genuine denial still cards).

Full suite: **2169 passed, 28 skipped, 0 failed.**

## Security pass

Narrows an existing capability; adds none. No new user input reaches a sink — the change is a hostname comparison, and all user-facing copy remains module constants. ENG-1169's Add-credits card is unaffected for real gateway denials, asserted in both mappers.

## Accepted tradeoff: a relay in front of MindsHub loses the credits card

Stated plainly because I reached it by accident, not by choice. The gate keys on the host being `mindshub.ai`/`mdb.ai` or a subdomain, so a user pointed at a corporate relay or LLM proxy that forwards our denials resolves a non-MindsHub host. Executed:

```
relay, wallet 402  -> ConnectionError        (credits card lost)
direct, wallet 402 -> TokenLimitExceeded     (card works)
relay, velocity429 -> TransientProviderError (wait preserved)
```

That is ENG-1169's symptom returning for that deployment shape. **And I treated the same shape two opposite ways in this PR**: `_velocity` is deliberately left ungated with a comment citing exactly "a relay or corporate proxy in front of MindsHub", while the wallet carrier is gated and breaks it.

The asymmetry is defensible — a spoofed billing card asks the user for money, a spoofed wait does not, so the carriers deserve different trust — but it should be a decision, not a side effect. Accepted as the cost of closing the spoof. If relayed MindsHub becomes a supported shape, the fix is a configurable trusted-host list rather than widening the match.

An earlier version of this section said "ENG-1169's Add-credits card is unaffected for real gateway denials". True as written, but it reads as fully unaffected. It isn't, for this shape.

## When this actually reaches users

**Merging to `staging` does not close the vector for desktop users.** cowork-server vendors anton as `anton-agent = { git = …, branch = "main" }`, and anton's staging is currently **119 commits ahead of main** — so this ships on the weekly staging→main train, not on merge. "Ships before or with cowork-server#332" below is about ordering between the two PRs, not about when the hole shuts.

**Ships before or with cowork-server#332** — the two are independent, but this is the one that closes the case the ticket describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Self-review round — four more lanes were open

An adversarial pass on this PR found the gate real on two carriers and inert or absent on four others. Same shape as the two rounds before it: I fixed the layer I was looking at.

**The mid-stream lane was fully open, and my comment claimed the opposite.** `response_origin_host` read only `exc.response`; a mid-stream failure raises a bare `openai.APIError` with no `.response` but a `.request` carrying the real URL. Executed pre-fix: `evil.example.com -> host=None foreign=False -> TokenLimitExceeded`. My comment said "nothing a remote can pick" — serving 200-with-an-SSE-error instead of 402 is entirely the remote's choice, and it's the *cheaper* attack. The repo's own e2e fixture proved it: those "midstream wallet" tests ran against `http://mock/v1` and passed.

**The 429 `detail` branch bypassed the gate entirely** — one JSON key, no header, and the only carrier whose text is partly attacker-authored:

```
Server returned 429 — PWNED: visit https://evil.example to fix
Visit https://console.mindshub.ai to upgrade or top up your tokens.
```

**Also fixed:** the 403 plan-copy branch (same class — names a MindsHub plan, links our upgrade page); an **ENG-1537 regression I introduced** (the gate suppressed the header read wholesale, and `_velocity` reads it too, so a relay in front of MindsHub lost its `Retry-After` wait); the anthropic twin's missing `isinstance(str)` guard; and my factually wrong justification for leaving `classify_transient` ungated.

**Coverage was the review's central finding** — three of five gate sites had none. Six mutations now verified red: the `.request` fallback, both `detail` gates, the 403 gate, the anthropic wallet gate, and re-gating velocity.

Full suite: **2180 passed, 28 skipped, 0 failed.**

