### PR TITLE
ENG-1633: mark every clip in the verify transcript, widen the judged reply (hotfix)

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -520,6 +520,7 @@ def _render_verify_transcript(
     max_tool: int = 12,
     tool_cap: int = 400,
     text_cap: int = 2000,
+    final_cap: int = 12000,
 ) -> str:
     """Render a compact, text-only view of the recent conversation for the
     completion verifier.
@@ -535,9 +536,36 @@ def _render_verify_transcript(
     injections are dropped before budgeting so they don't consume slots. Keeps
     the call cheap and free of tool_use/tool_result pairing constraints
     (ENG-716).
+
+    EVERY cap here goes through ``_clip_keep_cause``, so no text reaches the
+    verifier cut without an explicit ``[... N chars elided ...]`` marker. The
+    conversational path used to use a bare ``text[:text_cap]``, which handed the
+    verifier a reply ending mid-word with nothing saying it had been cut — and,
+    asked whether a complete answer was delivered, the verifier correctly
+    reported what it was shown. It was not judging badly; it was reasoning from
+    a false premise. 31% of anton's replies exceed 2,000 chars, and 44% of all
+    production continuations carried a truncation-worded reason (ENG-1633).
+
+    Two budgets, because the verifier is judging exactly ONE message:
+    ``final_cap`` for the last assistant turn (the reply under judgment) and
+    ``text_cap`` for everything else.
+
+    A flat cap is NOT sufficient, and this is the part that is easy to get
+    wrong. Measured live: with one cap for every entry, a reply that opens "all
+    three done" and buries "(3) I could NOT send the email" in the elided middle
+    is graded COMPLETE 3/3 — while both the shipped code and an unclipped
+    control catch it. Head-clipping deletes the tail; a flat both-ends clip
+    deletes the middle. Any fixed window has a hole, so the window for the one
+    message actually being judged has to be wide enough that the hole rarely
+    opens. Raising the cap for that entry alone also bounds the added cost to a
+    single message rather than ``max_convo`` of them: +276 tokens/turn on
+    average at 12,000, which sends 97.2% of real replies whole.
     """
-    convo: list[tuple[int, str]] = []   # (orig_index, line) — user/assistant text
-    tools: list[tuple[int, str]] = []   # (orig_index, line) — tool activity
+    # (orig_index, speaker, unclipped text) — conversational entries are held
+    # raw until the loop ends, because which one is "last" (and therefore gets
+    # ``final_cap``) is not known until then.
+    convo: list[tuple[int, str, str]] = []
+    tools: list[tuple[int, str]] = []   # (orig_index, line) — already rendered
 
     for i, msg in enumerate(history):
         role = msg.get("role")
@@ -547,7 +575,7 @@ def _render_verify_transcript(
             text = content.strip()
             if not text or (role == "user" and text.startswith("SYSTEM:")):
                 continue
-            convo.append((i, f"{speaker}: {text[:text_cap]}"))
+            convo.append((i, speaker, text))
         elif isinstance(content, list):
             # Assistant text emitted alongside a tool call is preamble/narration
             # ("Processing step 4"), not a conversational turn — route it to the
@@ -564,17 +592,40 @@ def _render_verify_transcript(
                     text = (block.get("text") or "").strip()
                     if not text:
                         continue
-                    bucket = tools if preamble else convo
-                    bucket.append((i, f"{speaker}: {text[:text_cap]}"))
+                    if preamble:
+                        # A tool_use rides with this text, so it is never the
+                        # reply under judgment — clip it now, at the small cap.
+                        tools.append(
+                            (i, f"{speaker}: {_clip_keep_cause(text, text_cap)}")
+                        )
+                    else:
+                        convo.append((i, speaker, text))
                 elif btype in ("image", "image_url"):
-                    convo.append((i, f"{speaker}: [image]"))
+                    convo.append((i, speaker, "[image]"))
                 elif btype == "tool_use":
                     tools.append((i, f"ASSISTANT called tool: {block.get('name')}"))
                 elif btype == "tool_result":
                     rendered = _render_tool_result_content(block.get("content"), tool_cap)
                     tools.append((i, f"TOOL RESULT: {rendered}"))
 
-    kept = convo[-max_convo:] + tools[-max_tool:]
+    # The reply under judgment is the most recent ASSISTANT entry in the
+    # conversational budget — the only one that gets ``final_cap``. Computed
+    # over the whole list rather than the kept tail because it is at or near the
+    # end by construction, so the ``max_convo`` slice below never drops it.
+    judged = max(
+        (n for n, (_, speaker, _) in enumerate(convo) if speaker == "ASSISTANT"),
+        default=-1,
+    )
+    convo_lines = [
+        (
+            i,
+            f"{speaker}: "
+            f"{_clip_keep_cause(text, final_cap if n == judged else text_cap)}",
+        )
+        for n, (i, speaker, text) in enumerate(convo)
+    ]
+
+    kept = convo_lines[-max_convo:] + tools[-max_tool:]
     kept.sort(key=lambda entry: entry[0])
     return "\n".join(line for _, line in kept) or "(no conversation)"
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -513,6 +513,12 @@ def _render_tool_result_content(content, cap: int) -> str:
     return _clip_keep_cause(str(content), cap)
 
 
+# Stands in for a multimodal block in the verify transcript. Named because
+# the judged-entry selection below has to be able to tell it apart from a
+# real reply.
+_IMAGE_PLACEHOLDER = "[image]"
+
+
 def _render_verify_transcript(
     history: list[dict],
     *,
@@ -601,31 +607,39 @@ def _render_verify_transcript(
                     else:
                         convo.append((i, speaker, text))
                 elif btype in ("image", "image_url"):
-                    convo.append((i, speaker, "[image]"))
+                    convo.append((i, speaker, _IMAGE_PLACEHOLDER))
                 elif btype == "tool_use":
                     tools.append((i, f"ASSISTANT called tool: {block.get('name')}"))
                 elif btype == "tool_result":
                     rendered = _render_tool_result_content(block.get("content"), tool_cap)
                     tools.append((i, f"TOOL RESULT: {rendered}"))
 
-    # The reply under judgment is the most recent ASSISTANT entry in the
-    # conversational budget — the only one that gets ``final_cap``. Computed
-    # over the whole list rather than the kept tail because it is at or near the
-    # end by construction, so the ``max_convo`` slice below never drops it.
+    # Budget only what survives, and pick the judged entry from that same
+    # window — chosen over the full list, ``final_cap`` could land on an entry
+    # the slice then discards. Slicing first also stops us clipping entries that
+    # are about to be thrown away.
+    kept_convo = convo[-max_convo:]
+    # The reply under judgment is the most recent ASSISTANT *text* entry. One
+    # message contributes one entry per content block, so an image placeholder
+    # trailing the reply would otherwise be picked as "the last assistant
+    # entry", silently dropping the reply itself back to ``text_cap`` — the flat
+    # cap this function exists to avoid (caught in self-review on #364).
     judged = max(
-        (n for n, (_, speaker, _) in enumerate(convo) if speaker == "ASSISTANT"),
+        (
+            n
+            for n, (_, speaker, text) in enumerate(kept_convo)
+            if speaker == "ASSISTANT" and text != _IMAGE_PLACEHOLDER
+        ),
         default=-1,
     )
-    convo_lines = [
+    kept = [
         (
             i,
             f"{speaker}: "
             f"{_clip_keep_cause(text, final_cap if n == judged else text_cap)}",
         )
-        for n, (i, speaker, text) in enumerate(convo)
-    ]
-
-    kept = convo_lines[-max_convo:] + tools[-max_tool:]
+        for n, (i, speaker, text) in enumerate(kept_convo)
+    ] + tools[-max_tool:]
     kept.sort(key=lambda entry: entry[0])
     return "\n".join(line for _, line in kept) or "(no conversation)"
 

--- a/tests/test_verifier_eval_gate.py
+++ b/tests/test_verifier_eval_gate.py
@@ -316,6 +316,10 @@ def test_single_valued_cases_still_demand_that_exact_verdict():
         "genuine_question": "WAITING",
         "environment_wall": "STUCK",
         "stopped_partway": "INCOMPLETE",
+        # ENG-1633: INCOMPLETE here IS the incident — a complete reply
+        # failed as "truncated" because the TRANSCRIPT was clipped, not
+        # the answer.
+        "long_complete_reply": "COMPLETE",
     }
     for name, verdict in single.items():
         assert by_name[name].acceptable == (verdict,), (

--- a/tests/test_verifier_verdict_live.py
+++ b/tests/test_verifier_verdict_live.py
@@ -689,7 +689,41 @@ _PARTIAL = Case(
     source="baseline (multi-part request, stopped after step 1)",
 )
 
-_CASES = [_RECOVERED, _IMPLIED_SUCCESS, _WAITING, _STUCK, _PARTIAL]
+# --- 6. A long, complete reply must not be judged truncated -----------------
+# ENG-1633. `_render_verify_transcript` clipped conversational text with a bare
+# `text[:2000]`, so any reply over the cap reached the verifier ending mid-word
+# with nothing saying it had been cut. Asked whether a complete answer was
+# delivered, the verifier reported what it was shown — and 31 percent of
+# anton's replies are over that cap.
+#
+# Measured on this exact fixture through this exact code path, 3 runs on each
+# model: INCOMPLETE 6/6 before the fix, COMPLETE 6/6 after, matching an
+# unclipped control at 6/6. Both models quoted the cut back verbatim — "cuts
+# off mid-sentence ('That is')" — and the 2,000-char slice ends exactly on
+# `That is`, at characters 1993-1999 of the reply below.
+#
+# The fixture is deliberately PROSE with no tool calls. Table and search-result
+# shapes were tried first and discarded: their unclipped controls also returned
+# INCOMPLETE, on invented-description and unverified-source grounds, so they
+# could not isolate the clip. A self-contained explanation leaves the verifier
+# nothing else to legitimately object to, which is what makes this a clean
+# 3-of-3 rather than a coin flip.
+
+_LONG_COMPLETE_REPLY = '`contextlib.contextmanager` turns a single-yield generator function into a full context manager, so you can write setup/teardown as straight-line code instead of a class with two methods.\n\n**The mechanics.** When you decorate a generator function with `@contextmanager`, calling it does not run any of your code — it builds a `_GeneratorContextManager` object holding the generator function and the arguments you passed. The body only starts running when `__enter__` is called, which is when the `with` statement executes. `__enter__` calls `next()` on the generator, which runs everything up to your `yield` and returns the yielded value — that is what lands in the `as` variable. Everything before the `yield` is your setup; everything after it is your teardown.\n\n**On the way out.** If the `with` block finishes normally, `__exit__` calls `next()` on the generator a second time. Your code after the `yield` runs, the generator hits its end and raises `StopIteration`, and `__exit__` swallows that as the expected signal that teardown finished. If the generator does *not* stop there — if it yields a second time — you get a `RuntimeError("generator didn\'t stop")`, because a context manager has exactly one enter and one exit.\n\n**On exceptions.** This is the part people get wrong. If the `with` block raises, `__exit__` does not call `next()`; it calls `gen.throw(exc)`, which re-raises the exception *at the point of the yield inside your generator*. That is why the idiomatic shape is a `try/finally` around the `yield`: the `finally` is what guarantees teardown runs whether the block succeeded or blew up. If you write the cleanup as bare statements after the `yield` with no `try`, an exception in the `with` block propagates out of the `throw` and your cleanup never runs at all.\n\nTwo subtleties follow from `throw`. First, if your generator catches the exception and returns normally, `__exit__` returns True and the exception is **suppressed** — the `with` statement swallows it. That is the mechanism behind `contextlib.suppress`, and it is easy to do by accident with a bare `except`. Second, if your generator re-raises the *same* exception object, `__exit__` detects that identity and returns False, letting the original propagate with its traceback intact rather than reporting a confusing secondary failure.\n\n**When to write a class instead.** Reach for `__enter__`/`__exit__` on a class when you need any of: reuse — a `@contextmanager` object is single-use and raises on a second `with`, whereas a class can be re-entered; state or methods that outlive the block, since a class instance is a real object you can query afterwards; inspection of the exception without the `throw` gymnastics, because `__exit__` receives the type, value and traceback as plain arguments; or an async and sync variant sharing implementation. The decorator is the better default for the common case — acquire a thing, hand it over, release it — and the class is what you graduate to when the manager itself needs to be an object.\n\nIn short: `@contextmanager` is a thin adapter that maps `__enter__` onto the first `next()` and `__exit__` onto either a second `next()` or a `throw()` into the generator, which is why `try/finally` around the `yield` is not a style preference but a correctness requirement.'
+
+
+_LONG_REPLY = Case(
+    name="long_complete_reply",
+    user_message="Explain in detail how Python's contextlib.contextmanager decorator works under the hood — the generator protocol, what happens on exceptions, and when you'd write a class-based context manager instead.",
+    history=[
+        {"role": "user", "content": "Explain in detail how Python's contextlib.contextmanager decorator works under the hood — the generator protocol, what happens on exceptions, and when you'd write a class-based context manager instead."},
+        {"role": "assistant", "content": _LONG_COMPLETE_REPLY},
+    ],
+    expected="COMPLETE",
+    source="ENG-1633 (clipped mid-word at text_cap; INCOMPLETE 6/6 pre-fix)",
+)
+
+_CASES = [_RECOVERED, _IMPLIED_SUCCESS, _WAITING, _STUCK, _PARTIAL, _LONG_REPLY]
 
 
 def _runs_for(case: Case) -> int:

--- a/tests/test_verify_transcript.py
+++ b/tests/test_verify_transcript.py
@@ -233,8 +233,12 @@ def test_oversize_judged_reply_keeps_both_ends_and_marks_the_elision():
     assert out.rstrip().endswith("CONCLUSION_MARKER.")
 
 
-def test_buried_failure_admission_survives_in_the_judged_reply():
-    # The regression guard for the fix that was ALMOST shipped. A flat both-ends
+def test_buried_failure_admission_survives_under_final_cap():
+    # The regression guard for the fix that was ALMOST shipped. Scoped to
+    # UNDER `final_cap` on purpose: above it the middle really is elided and
+    # the admission really is lost — the residual this design accepts, pinned
+    # separately by the oversize case above. This test's job is to red under
+    # both wrong fixes, which it does. A flat both-ends
     # clip at 2,000 elides the middle of this reply, which is where the
     # assistant admits it could not do step 3 — measured live, that turns the
     # verdict into a false COMPLETE, i.e. the user is told the email was sent.
@@ -324,6 +328,31 @@ def test_a_trailing_image_block_does_not_steal_the_judged_budget():
             "content": [{"type": "text", "text": reply}, {"type": "image"}],
         },
     ]
+    out = _render_verify_transcript(history)
+    assert reply in out
+    assert "chars elided" not in out
+
+
+def test_the_judged_reply_survives_a_thread_longer_than_the_convo_budget():
+    # `judged` is an index into the SLICED window, so it has to be computed over
+    # that same window. Computed over the full list it is compared against a
+    # different enumeration, `final_cap` lands on nothing, and the reply drops
+    # back to `text_cap` — the flat-cap behaviour this function exists to avoid.
+    #
+    # Every other case in this file builds ten or fewer conversational entries,
+    # so none of them can see it, and the mutation survived the whole suite.
+    # Long threads are exactly where the oversized replies and the retry loops
+    # live, so this is the population that matters. Caught in review on #364.
+    reply = "LONG_HEAD. " + "The answer body continues here. " * 170 + "LONG_TAIL."
+    assert 2000 < len(reply) < 12000
+    history: list[dict] = []
+    for i in range(8):
+        history.append({"role": "user", "content": f"request number {i}"})
+        history.append({"role": "assistant", "content": f"reply number {i}"})
+    history.append({"role": "user", "content": "final request"})
+    history.append({"role": "assistant", "content": reply})
+    assert len(history) > 10, "must exceed max_convo or this proves nothing"
+
     out = _render_verify_transcript(history)
     assert reply in out
     assert "chars elided" not in out

--- a/tests/test_verify_transcript.py
+++ b/tests/test_verify_transcript.py
@@ -186,3 +186,123 @@ def test_system_injections_do_not_consume_budget():
     out = _render_verify_transcript(history, max_convo=3)
     assert "the actual request" in out
     assert "internal note" not in out
+
+
+# ---------------------------------------------------------------------------
+# ENG-1633 — the conversational path used a bare `text[:text_cap]`, so a reply
+# over the cap reached the verifier ending mid-word with nothing saying it had
+# been cut. Every case below fails on that code.
+# ---------------------------------------------------------------------------
+
+
+def test_judged_reply_under_final_cap_reaches_the_verifier_whole():
+    # 3,000 chars: over `text_cap` (2,000), under `final_cap` (12,000). The
+    # reply the verifier is judging must arrive intact — the whole bug is that
+    # it did not. Asserts the CONCLUSION specifically, because that is the
+    # evidence a completion verifier is actually looking for and it is exactly
+    # what a head-slice discards.
+    reply = "OPENING_MARKER. " + "The reconciliation matched every line. " * 74 + "CONCLUSION_MARKER."
+    assert 2000 < len(reply) < 12000
+    history = [
+        {"role": "user", "content": "reconcile the ledger"},
+        {"role": "assistant", "content": reply},
+    ]
+    out = _render_verify_transcript(history)
+    assert reply in out
+    assert "CONCLUSION_MARKER." in out
+    assert "chars elided" not in out
+
+
+def test_oversize_judged_reply_keeps_both_ends_and_marks_the_elision():
+    # Past `final_cap` the reply is clipped, but never silently: the opening,
+    # an explicit marker, and the closing sentence all survive. The last of
+    # those is what stops the verifier reading the clip as the assistant
+    # stopping mid-sentence.
+    reply = "OPENING_MARKER. " + "The reconciliation matched every line. " * 400 + "CONCLUSION_MARKER."
+    assert len(reply) > 12000
+    history = [
+        {"role": "user", "content": "reconcile the ledger"},
+        {"role": "assistant", "content": reply},
+    ]
+    out = _render_verify_transcript(history)
+    assert "OPENING_MARKER." in out
+    assert "chars elided" in out
+    assert "CONCLUSION_MARKER." in out
+    # The rendered reply must not end mid-word — that is the literal trigger
+    # the verifier quoted back ("cuts off mid-sentence").
+    assert out.rstrip().endswith("CONCLUSION_MARKER.")
+
+
+def test_buried_failure_admission_survives_in_the_judged_reply():
+    # The regression guard for the fix that was ALMOST shipped. A flat both-ends
+    # clip at 2,000 elides the middle of this reply, which is where the
+    # assistant admits it could not do step 3 — measured live, that turns the
+    # verdict into a false COMPLETE, i.e. the user is told the email was sent.
+    # Fails on the shipped head-slice too (the admission sits past 2,000).
+    head = "All three done — reconciliation, duplicates, and the summary is on its way.\n\n"
+    filler = "Matched 47 invoices against the bank export, all reconciled. " * 40
+    admission = "\n\nI could NOT send the email — there is no mail tool in this environment.\n\n"
+    appendix = "Appendix: the full register follows, one row per invoice. " * 30
+    reply = head + filler + admission + appendix
+    assert 2000 < len(reply) < 12000
+    history = [
+        {"role": "user", "content": "reconcile, flag duplicates, email finance"},
+        {"role": "assistant", "content": reply},
+    ]
+    out = _render_verify_transcript(history)
+    assert "I could NOT send the email" in out
+
+
+def test_prior_turns_keep_the_smaller_budget():
+    # Only the message under judgment gets `final_cap`. An identically sized
+    # EARLIER reply is still clipped — that asymmetry is what bounds the added
+    # cost to one entry instead of `max_convo` of them.
+    old = "OLD_HEAD. " + "Earlier turn body text goes here. " * 100 + "OLD_TAIL."
+    new = "NEW_HEAD. " + "Current turn body text goes here. " * 100 + "NEW_TAIL."
+    assert 2000 < len(old) < 12000 and 2000 < len(new) < 12000
+    history = [
+        {"role": "user", "content": "first request"},
+        {"role": "assistant", "content": old},
+        {"role": "user", "content": "second request"},
+        {"role": "assistant", "content": new},
+    ]
+    out = _render_verify_transcript(history)
+    assert new in out                 # judged reply: whole
+    assert old not in out             # prior reply: clipped
+    assert "chars elided" in out      # ...but marked, never silently
+    assert "OLD_HEAD." in out and "OLD_TAIL." in out
+
+
+def test_long_user_message_keeps_its_trailing_requirement():
+    # Same bare slice clipped USER messages, so a long pasted request lost its
+    # final requirement and the verifier judged completion against a truncated
+    # ask. Only bites prior turns (the current request is also passed unclipped
+    # in the header), but it is the same line and the same defect.
+    ask = "Please do the following.\n" + "Requirement X must be satisfied. " * 100 + "\nIMPORTANT: finish with a summary."
+    assert len(ask) > 2000
+    history = [
+        {"role": "user", "content": ask},
+        {"role": "assistant", "content": "Working on it."},
+    ]
+    out = _render_verify_transcript(history)
+    assert "IMPORTANT: finish with a summary." in out
+    assert "chars elided" in out
+
+
+def test_no_conversational_text_is_ever_clipped_without_a_marker():
+    # The ticket's headline invariant, asserted directly: for every entry the
+    # renderer shortens, the output says so. A speaker segment that is both
+    # shorter than its source and unmarked is the bug.
+    long_user = "U_HEAD " + "user text " * 400 + "U_TAIL"
+    long_reply = "A_HEAD " + "assistant text " * 2000 + "A_TAIL"
+    history = [
+        {"role": "user", "content": long_user},
+        {"role": "assistant", "content": long_reply},
+    ]
+    out = _render_verify_transcript(history)
+    for source in (long_user, long_reply):
+        if source not in out:
+            assert "chars elided" in out
+    # Neither original survives whole here, so the marker must be present.
+    assert long_user not in out and long_reply not in out
+    assert out.count("chars elided") == 2

--- a/tests/test_verify_transcript.py
+++ b/tests/test_verify_transcript.py
@@ -306,3 +306,24 @@ def test_no_conversational_text_is_ever_clipped_without_a_marker():
     # Neither original survives whole here, so the marker must be present.
     assert long_user not in out and long_reply not in out
     assert out.count("chars elided") == 2
+
+
+def test_a_trailing_image_block_does_not_steal_the_judged_budget():
+    # One assistant message contributes one entry per content block, so "the
+    # last assistant entry" is not necessarily the reply: a trailing image
+    # placeholder would take `final_cap` and drop the reply back to `text_cap`,
+    # which is the flat-cap behaviour this function exists to avoid. Caught in
+    # self-review on #364 — anton itself never builds this shape, but a host can
+    # supply it through `initial_history` / a cloud-turn request.
+    reply = "IMG_HEAD. " + "The answer body continues here. " * 100 + "IMG_TAIL."
+    assert 2000 < len(reply) < 12000
+    history = [
+        {"role": "user", "content": "describe the chart and answer"},
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": reply}, {"type": "image"}],
+        },
+    ]
+    out = _render_verify_transcript(history)
+    assert reply in out
+    assert "chars elided" not in out


### PR DESCRIPTION
> **Hotfix — targets `main`, so merging ships to production immediately.** Not stacked on anything; `_render_verify_transcript` is byte-identical on `main` and `origin/staging`, so this applies cleanly to both. **The back-merge is automated** — `.github/workflows/sync-main-to-staging.yml` fires on push to `main` and names this exact case; it succeeded on the last three pushes including the ENG-1632 hotfix. Confirm it ran rather than merging by hand.

Fixes ENG-1633.

## What was wrong

`_render_verify_transcript` clipped conversational text with a bare `text[:text_cap]`. Any reply over 2,000 characters reached the completion verifier ending mid-word with **nothing indicating it had been cut** — and, asked whether a complete answer was delivered, the verifier reported what it was shown.

It was not judging badly. It was reasoning correctly from a false premise: it believed it was looking at the whole reply, and that reply appeared to stop mid-sentence. Both models quote the cut back verbatim — *"cuts off mid-sentence ('That is')"* — where the 2,000-char slice ends exactly on `That is`.

Tool results have gone through `_clip_keep_cause` since ENG-836. **The conversational path in the same function never got the same treatment.**

## Impact, measured

| | |
| -- | -- |
| final replies over 2,000 chars (i.e. clipped, unmarked) | **31.1%** |
| production continuations carrying a truncation-worded reason | **74 of 169 — 44%** |
| user-billed tokens per false continuation | **~137,000** (full-context re-run × 2.6 downstream calls; the allowance charges cache reads at full weight) |

n = 1,401 anton final replies / 15,786 observations, gateway traffic, 51h.

## What changed

1. **Both conversational sites route through `_clip_keep_cause`** — head + `[... N chars elided ...]` + tail-biased remainder. Every cap in the function now goes through one helper, so nothing is clipped silently. This finishes a migration that stopped halfway rather than introducing a pattern (convention 7).
2. **The message under judgment gets its own budget: `final_cap = 12000`.** Prior turns stay at `text_cap = 2000`.

### Why a flat cap was not enough — the finding that changed the design

The obvious fix (route everything through `_clip_keep_cause` at one cap) **regresses**, in the dangerous direction. Measured live on a fixture where the reply opens *"All three done"* and buries *"(3) Email. I could NOT send this"* in the middle:

| arm | COMPLETE verdicts / 6 runs |
| -- | -- |
| shipped today | 0 — catches it |
| flat-cap fix | **3 — false COMPLETE on haiku, 3/3** |
| no-clip control | 0 — catches it |

Head-clipping deletes the *tail*; a flat both-ends clip deletes the *middle*. Any fixed window has a hole — so the window for the one message actually being judged has to be wide enough that it rarely opens. Widening only that entry also bounds the cost to one message instead of the ten the transcript carries.

`test_buried_failure_admission_survives_in_the_judged_reply` is the deterministic guard for this; it reds under both the shipped code and the flat-cap variant.

### Tradeoff, settled

`_clip_keep_cause` is tail-biased because a tool failure names its cause at the end. That is right for a conversational reply too, for the same underlying reason rather than by luck: in both cases the tail is *the part that answers the question being asked of this text* — the cause for a failure, the conclusion for a reply. A completion verifier asks "did the assistant finish?", and the evidence for finishing is the last paragraph, which is exactly what the head-slice discarded.

**Side-effect worth having:** today a genuinely truncated reply (ENG-1042) and a clipped complete one are byte-identical in shape — both end mid-word at 2,000, both unmarked. After this, the real one still ends mid-word *inside the tail* while a complete one ends on a period, so the verifier can separate them itself. Verified: the ENG-1042 shape is still graded INCOMPLETE 3/3.

## Cost

`final_cap = 12000` sized from the measured distribution (median 1,095 / p90 6,679 / p95 9,504 / p99 17,405):

- **+276 tokens/turn mean, +2,900 worst case** — one message, cannot compound.
- Sends **97.2%** of replies whole, up from 68.9%.
- Break-even false-continuation rate is 2.1% even at the maximum added cost; the measured rate is **5.4%**, so the change is net-positive by 2.6× in its own worst case. Measured over the same window: **+376k tokens added, 10.1M removed.**

8,000 was the first pick; 12,000 costs +48 mean tokens more and cuts residual clipping 2.8× (7.9% → 2.8%).

## Residual limit

A reply over 12,000 chars (2.8%) whose decisive negative evidence sits in the elided middle can still read COMPLETE. Today's equivalent exposure is 31.1% of replies losing their entire tail. Note also that **41% of the 12k+ population is itself generated by this bug's retry loop** — the nudge says *"pick up where you left off and finish the remaining work"* — so the residual should shrink after this lands rather than hold.

## Deliberately not changed

- **No global `text_cap` raise.** Measured: cap 6000 == cap 2000 == uncapped on every clean fixture.
- **No rubric change.** A prompt sentence explaining the elision marker scored identically to the marker alone; the rubric is a known binding lever (ENG-836 moved 12/12 on wording), so a change with no measured gain is pure regression risk.
- **`_summarize_history` (`:1908-1920`) has the identical bare-slice pattern**, but feeds the *compactor*, not the verifier. Different surface, different blast radius, no evidence yet on frequency. Left for its own ticket.

## Also fixed (small scope extension)

The same line clipped **USER** messages. Measured: a 3,466-char request rendered at 2,006 chars, silently dropping its trailing `IMPORTANT:` requirement — so the verifier judged completion against a truncated ask. Only bites prior turns (the current request is also passed unclipped in the header), but it is the same line and the same defect.

## Test plan

- **6 new deterministic unit cases** in `tests/test_verify_transcript.py`, all **mutation-verified**: reverting to the bare head-slice reds all 6; the flat-cap variant reds 3, including the buried-admission guard.
- **1 live verdict-quality case** in `tests/test_verifier_verdict_live.py` (ENG-1211's harness), pinned in `test_verifier_eval_gate.py`. Mutation-verified against the shipped code: **INCOMPLETE 3/3 on each model**, reasons quoting `That is`. Passes on this branch, both models.
- Full unit suite: **2,161 passed**.
- Fixture is prose, not a table — table and search-result shapes were tried first and discarded because their *unclipped controls* also returned INCOMPLETE (invented-description / unverified-source grounds), so they could not isolate the clip.

## Security check

Performed. No new surface: this changes how much of an already-in-context transcript is shown to an already-existing internal call — no new input, no new endpoint, no deserialization, no path handling, nothing logged. The elision marker is built from an integer character count (`len(text) - head - tail`) and never from user text, so it cannot be spoofed into the transcript by construction. No credentials or secrets touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
