### PR TITLE
Feat/efs shared storage

### DIFF
--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -312,9 +312,11 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
     settings.resolve_workspace(str(base))
     if request.model:
         settings.planning_model = request.model
-    # Skills come from the request, staged outside the workspace (the PVC would
-    # persist — and cells could read — anything under it). Builtins resolve via
-    # SkillStore's package root regardless.
+    # Mounted (_SKILLS_ROOT_ENV set): the organization's own live skills tree,
+    # owned by cowork-server, read directly. Unmounted (desktop, CI): the
+    # request's skills are staged outside the workspace instead, since that PVC
+    # outlives the turn and cells could read anything left under it. Builtins
+    # resolve via SkillStore's package root regardless.
     settings.skills_root = _stage_skills(request.skills)
 
     workspace = Workspace(base, settings=settings)

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -56,17 +56,30 @@ CLOUD_TOOL_ALLOWLIST = frozenset(
 )
 
 #: Per-turn staging: Hippocampus reads slots from disk, so the payload has to land
-#: as files. Not the workspace — its PVC outlives the turn and cells can read it.
+#: as files. Used only as a fallback when no shared mount is configured (desktop,
+#: CI); see _MEMORY_GLOBAL_ROOT_ENV below for the mounted, cross-turn-persistent path.
 _MEMORY_DIR = Path(tempfile.gettempdir()) / "anton-cloud-memory"
 
 #: Wire slot name -> the filename Hippocampus reads. Unknown slots are ignored.
 _MEMORY_SLOT_FILES = {"profile": "profile.md", "rules": "rules.md", "lessons": "lessons.md"}
 
+#: Pod-side mount of this (org, user)'s global memory. When set, global memory
+#: slots are read straight off the mount and the wire payload's `global` block is
+#: ignored: cowork-server owns that tree and the pod sees the live copy, not a
+#: per-turn snapshot. Writes still go out as `turn_memory` events regardless;
+#: cowork-server remains the trust boundary for what gets persisted.
+_MEMORY_GLOBAL_ROOT_ENV = "ANTON_CLOUD_MEMORY_GLOBAL_ROOT"
+
 #: Per-turn skills staging: a FRESH mkdtemp each turn (unlike _MEMORY_DIR).
 #: Skills carry no cross-turn state, and the unpredictable path stops prior-turn
-#: cell code planting a symlink or two turns wiping each other's tree. Still in
-#: pod tmp, never the workspace mount (PVC outlives the turn, cells can read it).
+#: cell code planting a symlink or two turns wiping each other's tree. Used only
+#: as a fallback when no shared mount is configured; see _SKILLS_ROOT_ENV below.
 _SKILLS_DIR_PREFIX = "anton-cloud-skills-"
+
+#: Pod-side mount of the org's skills tree. When set, skills are read from it
+#: directly and the wire payload's `skills` block is ignored: cowork-server owns
+#: that tree and the pod sees the live copy, not a per-turn snapshot.
+_SKILLS_ROOT_ENV = "ANTON_CLOUD_SKILLS_ROOT"
 
 
 def _safe_skill_file(skill_dir: Path, rel: str) -> Path | None:
@@ -85,13 +98,24 @@ def _safe_skill_file(skill_dir: Path, rel: str) -> Path | None:
 
 
 def _stage_skills(skills: dict | None) -> Path:
-    """Materialize the request's skills into a fresh per-turn dir for
-    SkillStore to read; returns that dir (the session's skills_root).
+    """The session's skills_root.
 
-    Wire data is untrusted (like memory): bad slugs and escaping paths are
-    dropped, no single bad entry fails the turn. Builtins resolve via SkillStore
+    With the org tree mounted (_SKILLS_ROOT_ENV set), this is the mount itself
+    and nothing is staged: cowork-server owns that tree and the pod reads it
+    live, so the wire payload's `skills` block is ignored entirely.
+
+    Without a mount (desktop, CI), the request's skills are materialized into a
+    fresh per-turn dir for SkillStore to read, as before. Wire data is
+    untrusted (like memory): bad slugs and escaping paths are dropped, no
+    single bad entry fails the turn. Builtins resolve via SkillStore
     regardless; a wire skill shadowing one is logged (the prompt mandates some).
     """
+    mounted = os.environ.get(_SKILLS_ROOT_ENV, "").strip()
+    if mounted:
+        root = Path(mounted)
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+
     from anton.core.memory import skills as skills_memory
     from anton.core.tools.skill_format import validate_name
 
@@ -175,16 +199,34 @@ def _cloud_cortex_class():
     return _CloudCortex
 
 
+def _global_memory_dir(memory: dict | None) -> Path:
+    """Directory Hippocampus reads global slots from.
+
+    With the org+user tree mounted (_MEMORY_GLOBAL_ROOT_ENV set), this is that
+    mount, read live; the wire payload's `global` block is ignored. Without a
+    mount (desktop, CI), the per-turn tmp staging dir is written from the wire,
+    as before.
+    """
+    mounted = os.environ.get(_MEMORY_GLOBAL_ROOT_ENV, "").strip()
+    if mounted:
+        root = Path(mounted)
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+
+    global_dir = _MEMORY_DIR / "global"
+    _write_memory_slots(global_dir, (memory or {}).get("global"))
+    return global_dir
+
+
 def _build_cortex(memory: dict | None, llm_client):
     """Cortex over cowork's memory. Built even for an empty store, or an org could
-    never record its first memory — core only registers `memorize` with a cortex."""
+    never record its first memory: core only registers `memorize` with a cortex."""
     from anton.core.memory.hippocampus import Hippocampus
 
     memory = memory if isinstance(memory, dict) else {}
 
-    global_dir = _MEMORY_DIR / "global"
+    global_dir = _global_memory_dir(memory)
     project_dir = _MEMORY_DIR / "project"
-    _write_memory_slots(global_dir, memory.get("global"))
     _write_memory_slots(project_dir, memory.get("project"))
     # Not "off", or `memorize` refuses to encode; the automatic passes that mode
     # also unlocks are disabled via `background_memory`.

--- a/tests/test_cloud_turn_shared_mount.py
+++ b/tests/test_cloud_turn_shared_mount.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from anton.cloud_turn import session as cloud_session
 
 
@@ -23,7 +21,7 @@ def test_skills_fall_back_to_tmp_staging_without_env(monkeypatch, tmp_path):
 
     root = cloud_session._stage_skills({"my-skill": {"files": {"SKILL.md": "x"}}})
 
-    assert root != Path("/mnt/cowork-shared/skills")
+    assert root.name.startswith(cloud_session._SKILLS_DIR_PREFIX)
     assert (root / "my-skill" / "SKILL.md").read_text() == "x"
 
 

--- a/tests/test_cloud_turn_shared_mount.py
+++ b/tests/test_cloud_turn_shared_mount.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from anton.cloud_turn import session as cloud_session
+
+
+def test_skills_read_from_mount_when_env_set(monkeypatch, tmp_path):
+    """No copying: the mounted dir IS the skills root."""
+    mount = tmp_path / "mnt" / "skills"
+    (mount / "my-skill").mkdir(parents=True)
+    (mount / "my-skill" / "SKILL.md").write_text("hello")
+    monkeypatch.setenv("ANTON_CLOUD_SKILLS_ROOT", str(mount))
+
+    root = cloud_session._stage_skills({"ignored": {"files": {"a.md": "x"}}})
+
+    assert root == mount
+    assert (root / "my-skill" / "SKILL.md").read_text() == "hello"
+    assert not (root / "ignored").exists()   # wire payload is not staged
+
+
+def test_skills_fall_back_to_tmp_staging_without_env(monkeypatch, tmp_path):
+    """Desktop and CI keep the old behaviour."""
+    monkeypatch.delenv("ANTON_CLOUD_SKILLS_ROOT", raising=False)
+
+    root = cloud_session._stage_skills({"my-skill": {"files": {"SKILL.md": "x"}}})
+
+    assert root != Path("/mnt/cowork-shared/skills")
+    assert (root / "my-skill" / "SKILL.md").read_text() == "x"
+
+
+def test_memory_read_from_mount_when_env_set(monkeypatch, tmp_path):
+    mount = tmp_path / "mnt" / "memory" / "users" / "u1"
+    mount.mkdir(parents=True)
+    (mount / "profile.md").write_text("from efs")
+    monkeypatch.setenv("ANTON_CLOUD_MEMORY_GLOBAL_ROOT", str(mount))
+
+    global_dir = cloud_session._global_memory_dir({"global": {"profile": "from wire"}})
+
+    assert global_dir == mount
+    assert (global_dir / "profile.md").read_text() == "from efs"   # wire did not overwrite
+
+
+def test_memory_falls_back_to_tmp_staging_without_env(monkeypatch):
+    monkeypatch.delenv("ANTON_CLOUD_MEMORY_GLOBAL_ROOT", raising=False)
+
+    global_dir = cloud_session._global_memory_dir({"global": {"profile": "from wire"}})
+
+    assert (global_dir / "profile.md").read_text() == "from wire"


### PR DESCRIPTION
## What

Lets a cloud turn read skills and global memory off the shared EFS mount instead of materialising them from the Redis job payload.

Two new pod-side env vars, both **defaulting to unset**:

- `ANTON_CLOUD_SKILLS_ROOT` makes `_stage_skills` return the mount directly and ignore the wire payload's `skills` block.
- `ANTON_CLOUD_MEMORY_GLOBAL_ROOT` makes the new `_global_memory_dir` read global slots from the mount.

The scratchpad-controller sets both (mindsdb/scratchpad-controller#20). With them unset, behaviour is byte-identical to before: desktop, CI and every existing cloud-turn test keep the tmp-staging path.

## What does not change

Memory **writes**. `_CloudCortex` still collects engrams and the entrypoint still emits them as `turn_memory` events for cowork-server to persist. cowork-server remains the trust boundary for what actually gets written. Only reads move.

Project-scope memory also stays in tmp staging. Only the global scope becomes mount-backed.

## A reversed decision, on purpose

The comments at `_MEMORY_DIR` and the skills-staging constants said memory and skills were deliberately kept **out** of the workspace mount, because the PVC outlived the turn and scratchpad cells could read anything left under it.

That reasoning is now inverted: the tree is the organization's own, cowork-server manages it, and surviving the turn is the point. Those comments are rewritten rather than left contradicting the code beside them, including a third one at `build_cloud_chat_session` that made the same claim.

## Review notes

Reviewed twice. The second pass checked that the wire-ignore test actually proves wire-ignore rather than passing incidentally, and replaced a near-tautological fallback assertion (`root != Path("/mnt/cowork-shared/skills")`, which a `mkdtemp` path would essentially always satisfy) with one that checks the returned root carries `_SKILLS_DIR_PREFIX`, so it fails if the fallback path is broken.

76 tests pass across `test_cloud_turn_shared_mount`, `test_cloud_turn_session`, `test_cloud_turn_entrypoint` and `test_skills_e2e`.

## Merge order

This is safe to merge first and on its own: both env vars default to unset, so it is a no-op until the controller sets them.

## Related

Part of the shared EFS storage change: mindsdb/terraform#165, mindsdb/Kubernetes-Foundational-Services#108, mindsdb/cowork-server#333, mindsdb/scratchpad-controller#20, mindsdb/argocd-envs#6
