### PR TITLE
ENG-1693: contain both raising httpx properties so the billing-origin fallback works

### DIFF
--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -576,6 +576,26 @@ _WALLET_DENIAL_CODES = frozenset({"wallet_empty", "included_allowance_exhausted"
 
 # Hosts that ARE the MindsHub gateway. Only a response from one of these may
 # select a billing verdict — see :func:`origin_is_known_third_party` (ENG-1693).
+#
+# VERIFIED COMPLETE for every host that can serve a gateway billing denial
+# (review question on #363, checked 2026-08-18 against the terraform host
+# inventory, which is the source of truth for zones and certs). Two apexes cover
+# it because every environment and vanity host is a subdomain of one of them:
+# prod `api.mindshub.ai`, `api.staging.mindshub.ai`, `api.dev.mindshub.ai`,
+# per-PR envs `api-pr<N>.dev.mindshub.ai`, and the white-label surfaces
+# `llm.mdb.ai`, `llm.staging.mdb.ai`, `writer.mdb.ai`, `terabase.dev.mdb.ai`,
+# `view.mindshub.ai`. Terraform declares no other apex zone, and the wildcards
+# `*.mindshub.ai` / `*.mdb.ai` cover anything added later under them. The
+# positive cases are pinned in tests/test_status_error_mapper.py so this
+# paragraph cannot quietly go stale.
+#
+# `4nton.ai` is a real production zone and is DELIBERATELY absent: it serves
+# agent provisioning and per-instance hosts (`sp_<hash>.4nton.ai`,
+# `cw-<id>.4nton.ai`) plus artifact publishing, never LLM inference. If an
+# inference endpoint is ever routed onto it, it MUST be added here — otherwise a
+# genuine out-of-credits denial from that host silently degrades to generic copy
+# and reopens ENG-1169's user-visible bug. Failing closed is the right default;
+# this note exists so the cost of that default is not discovered in production.
 _MINDSHUB_HOSTS = ("mindshub.ai", "mdb.ai")
 
 
@@ -611,9 +631,28 @@ def response_origin_host(exc: BaseException) -> str | None:
     """
     resp = getattr(exc, "response", None)
     try:
-        url = getattr(resp, "url", None) if resp is not None else None
-        if url is None and resp is not None:
-            url = getattr(getattr(resp, "request", None), "url", None)
+        url = None
+        if resp is not None:
+            # BOTH `httpx.Response.url` and `httpx.Response.request` are
+            # properties that RAISE RuntimeError when no request is attached, and
+            # `getattr(resp, name, None)` does NOT rescue that — getattr's
+            # default only covers AttributeError. Either one reaching the outer
+            # handler returned None, i.e. "origin unknown", a state this gate
+            # deliberately TRUSTS — so a request-less response shadowed a
+            # foreign host sitting on `exc.request`. Each read is contained
+            # individually so the next fallback stays reachable.
+            #
+            # The review nit on #363 named `.url`; `.request` has the identical
+            # trap, and guarding only `.url` still failed the test below.
+            try:
+                url = resp.url
+            except Exception:
+                url = None
+            if url is None:
+                try:
+                    url = resp.request.url
+                except Exception:
+                    url = None
         if url is None:
             url = getattr(getattr(exc, "request", None), "url", None)
         if url is None:

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -577,10 +577,12 @@ _WALLET_DENIAL_CODES = frozenset({"wallet_empty", "included_allowance_exhausted"
 # Hosts that ARE the MindsHub gateway. Only a response from one of these may
 # select a billing verdict — see :func:`origin_is_known_third_party` (ENG-1693).
 #
-# VERIFIED COMPLETE for every host that can serve a gateway billing denial
-# (review question on #363, checked 2026-08-18 against the terraform host
-# inventory, which is the source of truth for zones and certs). Two apexes cover
-# it because every environment and vanity host is a subdomain of one of them:
+# VERIFIED COMPLETE for every host MindsHub ITSELF serves (review question on
+# #363, checked 2026-08-18 against the terraform host inventory, which is the
+# source of truth for zones and certs). Deliberately not the broader claim
+# "every host that can serve a gateway billing denial" — see the relay note
+# below, where that is false by design. Two apexes cover the served set because
+# every environment and vanity host is a subdomain of one of them:
 # prod `api.mindshub.ai`, `api.staging.mindshub.ai`, `api.dev.mindshub.ai`,
 # per-PR envs `api-pr<N>.dev.mindshub.ai`, and the white-label surfaces
 # `llm.mdb.ai`, `llm.staging.mdb.ai`, `writer.mdb.ai`, `terabase.dev.mdb.ai`,
@@ -588,6 +590,16 @@ _WALLET_DENIAL_CODES = frozenset({"wallet_empty", "included_allowance_exhausted"
 # `*.mindshub.ai` / `*.mdb.ai` cover anything added later under them. The
 # positive cases are pinned in tests/test_status_error_mapper.py so this
 # paragraph cannot quietly go stale.
+#
+# A RELAY in front of MindsHub is the known, accepted exception: a corporate
+# proxy that forwards our denials resolves its own host, so a GENUINE
+# out-of-credits denial arriving through one loses the credits card and
+# ENG-1169's symptom returns for that shape. That is a decision, not an
+# oversight — a spoofed billing card asks the user for money, a spoofed wait
+# does not, which is why `_velocity` is ungated and this is not. Recorded on
+# ENG-1693 under "Accepted tradeoff". If relayed MindsHub ever becomes a
+# supported deployment the remedy is a CONFIGURABLE trusted-host list, never a
+# looser match here.
 #
 # `4nton.ai` is a real production zone and is DELIBERATELY absent: it serves
 # agent provisioning and per-instance hosts (`sp_<hash>.4nton.ai`,

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -904,3 +904,78 @@ def test_a_relayed_gateway_rate_limit_still_earns_the_session_wait():
     with pytest.raises(Exception) as err2:
         _raise_for_status_error(wallet, "sonnet")
     assert not isinstance(err2.value, TokenLimitExceeded)
+
+
+# ---------------------------------------------------------------------------
+# Review nits on #363 (ENG-1693).
+# ---------------------------------------------------------------------------
+
+
+def test_a_request_less_response_does_not_shadow_a_foreign_host():
+    """`httpx.Response.url` RAISES when no request is attached, and
+    `getattr(resp, "url", None)` does NOT rescue it — getattr's default only
+    covers AttributeError. That RuntimeError reached the outer handler, which
+    returned None ("origin unknown"), a state this gate deliberately TRUSTS —
+    so a request-less response shadowed a foreign host sitting on `exc.request`
+    and the attacker got the credits card back.
+
+    The function's own docstring already claimed it could not be a bare getattr
+    chain; this pins the behaviour to the claim.
+    """
+    from anton.core.llm.provider import origin_is_known_third_party, response_origin_host
+
+    # Confirm the premise rather than assuming it: this must raise, not return None.
+    bare = httpx.Response(402)
+    with pytest.raises(RuntimeError):
+        _ = bare.url
+
+    exc = openai.APIError(
+        "boom",
+        request=httpx.Request("POST", "https://evil.example.com/v1/chat/completions"),
+        body={"code": "wallet_empty"},
+    )
+    # A response IS present, carries no request, and its `.url` raises.
+    exc.response = bare
+
+    assert response_origin_host(exc) == "evil.example.com"
+    assert origin_is_known_third_party(exc) is True
+
+
+# Every environment and vanity host that can serve a real gateway billing
+# denial, from the terraform host inventory (review question on #363). These all
+# resolve as ours today; the test exists so that narrowing `_MINDSHUB_HOSTS`, or
+# adding an apex the allowlist misses, fails here instead of silently degrading
+# a genuine out-of-credits denial to generic copy (ENG-1169's user-visible bug).
+@pytest.mark.parametrize("host", [
+    "api.mindshub.ai",              # prod inference
+    "api.staging.mindshub.ai",      # staging
+    "api.dev.mindshub.ai",          # dev
+    "api-pr123.dev.mindshub.ai",    # ephemeral per-PR env
+    "llm.mdb.ai",                   # legacy vanity gateway
+    "llm.staging.mdb.ai",
+    "writer.mdb.ai",                # white-label surfaces
+    "terabase.dev.mdb.ai",
+    "view.mindshub.ai",
+])
+def test_every_real_gateway_host_is_trusted(host):
+    from anton.core.llm.provider import is_mindshub_host
+
+    assert is_mindshub_host(host) is True, (
+        f"{host} is a real MindsHub host but the allowlist rejects it — a genuine "
+        f"out-of-credits denial from it would lose the credits card (ENG-1169)"
+    )
+
+
+def test_the_agent_instance_zone_is_deliberately_untrusted():
+    """`4nton.ai` is a real production zone that serves agent provisioning and
+    per-instance hosts, never inference — so it must NOT be able to select a
+    billing verdict. If inference is ever routed onto it, this test is the
+    tripwire: it will still pass, but the comment on `_MINDSHUB_HOSTS` says the
+    host has to be added, and `test_every_real_gateway_host_is_trusted` is where
+    it goes.
+    """
+    from anton.core.llm.provider import is_mindshub_host
+
+    assert is_mindshub_host("sp_abc123.4nton.ai") is False
+    assert is_mindshub_host("cw-9a9e789c.4nton.ai") is False
+    assert is_mindshub_host("4nton.ai") is False

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -969,10 +969,12 @@ def test_every_real_gateway_host_is_trusted(host):
 def test_the_agent_instance_zone_is_deliberately_untrusted():
     """`4nton.ai` is a real production zone that serves agent provisioning and
     per-instance hosts, never inference — so it must NOT be able to select a
-    billing verdict. If inference is ever routed onto it, this test is the
-    tripwire: it will still pass, but the comment on `_MINDSHUB_HOSTS` says the
-    host has to be added, and `test_every_real_gateway_host_is_trusted` is where
-    it goes.
+    billing verdict, and this pins that.
+
+    It is an assertion about today, NOT a tripwire: if inference is ever routed
+    onto `4nton.ai` this test still passes while the card silently degrades to
+    generic copy. The comment on `_MINDSHUB_HOSTS` is what carries that warning,
+    and `test_every_real_gateway_host_is_trusted` is where the host would go.
     """
     from anton.core.llm.provider import is_mindshub_host
 


### PR DESCRIPTION
Follow-up to **#363**, which merged approved with two review nits from @pnewsam outstanding. Targets `staging` (#363's base), not a hotfix.

## Nit 2 — the ordering issue was real, and understated

`response_origin_host`'s own docstring says:

> `httpx.Response.url` is a property that RAISES when no request is attached, so this cannot be a bare `getattr` chain.

The code was a bare `getattr` chain. `getattr(resp, "url", None)` does **not** rescue a `RuntimeError` — its default only covers `AttributeError`. The exception reached the outer `except Exception: return None`, which means *"origin unknown"* — a state this gate deliberately **trusts** — so a request-less response shadowed a foreign host carried on `exc.request`, and a third party could select the credits card again.

**The review named `.url`. `httpx.Response.request` has the identical trap.** Guarding only `.url` still fails the new test, because the second fallback was `getattr(getattr(resp, "request", None), "url", None)` and that inner `getattr` triggers the same `RuntimeError`. Verified rather than assumed, against httpx 0.28.1:

```
getattr(resp,'url',None)     RAISED RuntimeError
getattr(resp,'request',None) RAISED RuntimeError
```

Both reads are now contained individually so each fallback stays reachable, and the docstring's existing claim becomes true.

Agreed with the review that this is **not reachable through the real SDK paths today** — request-time responses always carry a request, mid-stream errors have `.response is None`. This is defense-in-depth on a trust boundary where the failure direction is "silently trust a hostile origin".

## Nit 1 — the allowlist question, answered and pinned in code

The question was whether the production gateway is *always* served from `mindshub.ai` or `mdb.ai`, including regional and vanity hosts, since a missing apex fails closed to generic copy and reopens ENG-1169's user-visible bug.

**Answer: confirmed complete.** Checked against the terraform host inventory — the source of truth for zones and certs — plus every base URL configured across `anton`, `cowork`, `cowork-server`, `mdb-ai` and `mindshub_inference`:

| Surface | Host | Covered |
| -- | -- | -- |
| prod inference | `api.mindshub.ai` | ✅ |
| staging / dev | `api.staging.mindshub.ai`, `api.dev.mindshub.ai` | ✅ |
| ephemeral per-PR envs | `api-pr123.dev.mindshub.ai` | ✅ |
| legacy vanity gateway | `llm.mdb.ai`, `llm.staging.mdb.ai` | ✅ |
| white-label surfaces | `writer.mdb.ai`, `terabase.dev.mdb.ai`, `view.mindshub.ai` | ✅ |

Terraform declares **no other apex zone**, and the wildcards `*.mindshub.ai` / `*.mdb.ai` cover anything added later beneath them. I also checked the Kinaxis white-label branch for a customer-owned gateway domain — there isn't one.

Rather than leave that answer in a PR comment where it goes stale, those nine hosts are now a parametrised test. Narrowing the allowlist fails there instead of silently degrading a real out-of-credits denial.

**`4nton.ai` is the one real production zone deliberately excluded.** It serves agent provisioning, per-instance hosts (`sp_<hash>.4nton.ai`, `cw-<id>.4nton.ai`) and artifact publishing — never LLM inference. Its exclusion is now asserted, and the comment on `_MINDSHUB_HOSTS` records that it must be added if inference is ever routed onto it, so the cost of failing closed isn't discovered in production.

## Test plan

Three new cases in `tests/test_status_error_mapper.py`, all mutation-verified:

| mutation | reds |
| -- | -- |
| revert to the merged bare `getattr` chain | `test_a_request_less_response_does_not_shadow_a_foreign_host` |
| guard only `.url` (the incomplete fix) | same test — it discriminates the complete fix from a plausible one |
| narrow the allowlist to `mindshub.ai` only | `test_every_real_gateway_host_is_trusted[writer.mdb.ai]`, `[terabase.dev.mdb.ai]` |

The ordering test asserts its own premise (`pytest.raises(RuntimeError)` on the bare response) so it can't silently stop testing anything if httpx changes that behaviour.

`tests/test_status_error_mapper.py` 80 passed · touched-area suite 487 passed.

## Security check

Performed, and this change *is* the security surface. It widens the reachability of the origin fallback, so a hostile host that was previously resolved as "unknown" (trusted) is now resolved and correctly distrusted.

**Being precise about the direction, because it is the one that costs a user something.** The change can only move a verdict from trusted to distrusted, never the reverse — and trusted→distrusted is the *card-losing* direction, the one ENG-1169 exists to prevent. Executed on the only path this PR changes:

```
request-less response + RELAY    OLD  card=shown  ->  NEW  card=LOST
request-less response + GATEWAY  OLD  card=shown  ->  NEW  card=shown
```

That is safe for a specific reason rather than by construction: a relay in front of MindsHub **already** loses the card in the normal `response+request` path, as ENG-1693's "Accepted tradeoff" records. So this closes an accidental exception to a decision already taken instead of introducing a new loss. Self-review caught the original wording, which presented this as unconditionally harmless. No new input is parsed, nothing is logged, and the host comparison remains exact-domain-or-dot-delimited-subdomain, so a lookalike like `mindshub.ai.evil.com` is still rejected (existing test). The allowlist is unchanged in value; only its documentation and test coverage grew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
