### PR TITLE
Feat/cloud attachment delivery

### DIFF
--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -24,7 +24,12 @@ import sys
 import time
 
 from anton.cloud_turn.contract import TurnRequestV1
-from anton.cloud_turn.session import build_cloud_chat_session, drain_pending_memory
+from anton.cloud_turn.session import (
+    build_cloud_chat_session,
+    build_turn_content,
+    drain_pending_memory,
+    resolve_trusted_workspace_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +186,15 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
     try:
         req = TurnRequestV1.from_json(raw_line)
         session = builder(req)
+        # Fold in any attachments cowork-server staged into the workspace (read
+        # off the mount, so image bytes never crossed the stdin wire). Plain
+        # string when there are none. Never fail the turn over this — degrade to
+        # the plain input if the workspace can't be resolved or a file is bad.
+        try:
+            turn_content = build_turn_content(resolve_trusted_workspace_path(), req.input)
+        except Exception:
+            logger.warning("cloud turn: attachment augmentation failed; using plain input", exc_info=True)
+            turn_content = req.input
         # Tool-call args accumulate here and ship once on tool_end, so the
         # wire carries one event per call instead of one per args token.
         # Accumulation stops at the wire cap — a runaway call can't grow
@@ -189,7 +203,7 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
         tool_args_len: dict[str, int] = {}
         seen_tool_progress: set[str] = set()
         last_progress_wire = 0.0
-        async for event in session.turn_stream(req.input):
+        async for event in session.turn_stream(turn_content):
             if isinstance(event, StreamTextDelta):
                 emit({"kind": "delta", "text": event.text or ""})
             # Step events go on the wire for cowork's thinking/steps UI;

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -272,6 +272,100 @@ def resolve_trusted_workspace_path() -> Path:
     return resolved
 
 
+#: Attachments cowork-server stages into the workspace for this conversation.
+_ATTACHMENTS_DIRNAME = "attachments"
+
+
+def _sniff_image_format(head: bytes) -> str | None:
+    """The real image format from magic bytes, or None if not a known image.
+    Content, never the extension — a BMP named ``.png`` must not ship as PNG,
+    and a text file named ``.png`` must not ship at all."""
+    if head.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "PNG"
+    if head.startswith(b"\xff\xd8\xff"):
+        return "JPEG"
+    if head.startswith((b"GIF87a", b"GIF89a")):
+        return "GIF"
+    if head.startswith(b"BM"):
+        return "BMP"
+    if head[:4] == b"RIFF" and head[8:12] == b"WEBP":
+        return "WEBP"
+    return None
+
+
+def _image_block_from_file(path: Path) -> dict | None:
+    """A base64 image content block for *path*, or None if it can't be shown.
+
+    Format is detected from magic bytes (not the extension: a mislabeled or
+    non-image file must not be shipped and rejected by the model, which would
+    fail every turn). Size is capped BEFORE the file is read, so a huge upload
+    can't OOM the pod. Pillow is optional in the deployed image, so it's used
+    only to convert BMP (via the shared ``clipboard.image_content_block``); a
+    BMP where Pillow is absent is skipped rather than crashing."""
+    from anton.utils.clipboard import MAX_IMAGE_BYTES, image_content_block
+
+    try:
+        if path.stat().st_size * 4 // 3 > MAX_IMAGE_BYTES:  # cap before reading into memory
+            return None
+        raw = path.read_bytes()
+    except OSError:
+        return None
+    fmt = _sniff_image_format(raw[:16])
+    if fmt is None:
+        return None
+    try:
+        return image_content_block(raw, fmt, oversize="skip")
+    except Exception:  # e.g. BMP with Pillow absent, or a decode failure
+        return None
+
+
+def build_turn_content(base: Path, user_text: str) -> "str | list[dict]":
+    """Turn input augmented with the conversation's attachments.
+
+    cowork-server stages uploads into ``<workspace>/attachments/`` on the shared
+    mount (they never cross the stdin wire). Returns the plain string when there
+    are none — unchanged behaviour. Otherwise a multimodal user message: an
+    image block per image (so the model can actually see it) plus a text block
+    that lists every attachment's path and carries the user's text. Never
+    raises: a bad attachment is skipped, the turn still runs.
+    """
+    attach_dir = base / _ATTACHMENTS_DIRNAME
+    try:
+        files = sorted(p for p in attach_dir.rglob("*") if p.is_file()) if attach_dir.is_dir() else []
+    except OSError:
+        files = []
+    if not files:
+        return user_text
+
+    from anton.clipboard import is_image_path
+
+    image_blocks: list[dict] = []
+    lines: list[str] = []
+    for f in files:
+        # One bad attachment must never sink the whole set — degrade it to a
+        # path listing line so the docstring's "never raises" actually holds.
+        try:
+            if is_image_path(f.name):
+                block = _image_block_from_file(f)
+                if block is not None:
+                    image_blocks.append(block)
+                    lines.append(f"  - {f.name} (image, shown above)")
+                else:
+                    lines.append(f"  - {f} (image could not be shown inline; read from this path if needed)")
+            else:
+                lines.append(f"  - {f}")
+        except Exception:
+            logger.warning("cloud turn: skipping unreadable attachment %s", f, exc_info=True)
+
+    listing = (
+        "The user attached the following files to this conversation. Any images "
+        "are included in this message; read other files from their absolute paths:\n"
+        + "\n".join(lines)
+    )
+    text = f"{listing}\n\n{user_text}" if user_text.strip() else listing
+    return [*image_blocks, {"type": "text", "text": text}]
+
+
 def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
     """Assemble a cloud-safe ChatSession for one turn.
 

--- a/anton/utils/clipboard.py
+++ b/anton/utils/clipboard.py
@@ -224,6 +224,35 @@ def _media_type_for(fmt: str) -> str:
     return "image/png"
 
 
+def image_content_block(raw: bytes, fmt: str, *, oversize: str = "raise") -> dict | None:
+    """A base64 image content block from raw bytes, or None.
+
+    Converts BMP→PNG (the model APIs reject BMP). Over ``MAX_IMAGE_BYTES``:
+    raises ``ImageTooLargeError`` when ``oversize="raise"`` (interactive paths
+    surface it to the user), or returns None when ``oversize="skip"`` (batch /
+    attachment paths that degrade silently). The single source of truth for the
+    image-block shape — reused by the paste path and the cloud attachment path.
+    """
+    if fmt.upper() == "BMP":
+        import io
+
+        from PIL import Image as _PILImage
+
+        buf = io.BytesIO()
+        _PILImage.open(io.BytesIO(raw)).save(buf, format="PNG")
+        raw = buf.getvalue()
+        fmt = "PNG"
+    if len(raw) * 4 // 3 > MAX_IMAGE_BYTES:
+        if oversize == "raise":
+            raise ImageTooLargeError(len(raw))
+        return None
+    b64 = base64.standard_b64encode(raw).decode("ascii")
+    return {
+        "type": "image",
+        "source": {"type": "base64", "media_type": _media_type_for(fmt), "data": b64},
+    }
+
+
 def make_image_paste_bindings(registry: PastedImageRegistry, console: Console):
     """Build a ``KeyBindings`` that swaps image paths in pasted text for [Image #N]."""
     from prompt_toolkit.key_binding import KeyBindings
@@ -377,26 +406,7 @@ def build_image_ref_message(
                 text_buf.append(m.group(0))
             else:
                 flush_text()
-                fmt = item.format
-                # BMP is not supported by OpenAI or Claude APIs — convert to PNG on the fly.
-                if fmt.upper() == "BMP":
-                    import io
-                    from PIL import Image as _PILImage
-                    buf = io.BytesIO()
-                    _PILImage.open(io.BytesIO(raw)).save(buf, format="PNG")
-                    raw = buf.getvalue()
-                    fmt = "PNG"
-                if len(raw) * 4 // 3 > MAX_IMAGE_BYTES:
-                    raise ImageTooLargeError(len(raw))
-                b64 = base64.standard_b64encode(raw).decode("ascii")
-                blocks.append({
-                    "type": "image",
-                    "source": {
-                        "type": "base64",
-                        "media_type": _media_type_for(fmt),
-                        "data": b64,
-                    },
-                })
+                blocks.append(image_content_block(raw, item.format, oversize="raise"))
         pos = m.end()
 
     if pos < len(text):

--- a/tests/test_cloud_turn_attachments.py
+++ b/tests/test_cloud_turn_attachments.py
@@ -1,13 +1,14 @@
-import io
+import base64
+
+import pytest
 
 from anton.cloud_turn import session as cloud_session
 
-
-def _real_png_bytes() -> bytes:
-    from PIL import Image
-    buf = io.BytesIO()
-    Image.new("RGB", (2, 2), (10, 20, 30)).save(buf, format="PNG")
-    return buf.getvalue()
+# Valid PNG signature + filler. The cloud image path only SNIFFS magic bytes
+# (it never decodes PNG/JPEG/etc), so a real decodable image isn't needed and
+# these tests don't depend on Pillow — which is an optional dep, absent in CI.
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+_FAKE_BMP = b"BM" + b"\x00" * 64          # sniffs as BMP; only a real convert needs Pillow
 
 
 def test_no_attachments_returns_plain_string(tmp_path):
@@ -17,7 +18,7 @@ def test_no_attachments_returns_plain_string(tmp_path):
 def test_image_attachment_becomes_a_vision_block(tmp_path):
     att = tmp_path / "attachments" / "fileid1"
     att.mkdir(parents=True)
-    (att / "shot.png").write_bytes(_real_png_bytes())
+    (att / "shot.png").write_bytes(_PNG)
 
     content = cloud_session.build_turn_content(tmp_path, "do you see the screenshot?")
     assert isinstance(content, list)
@@ -43,23 +44,23 @@ def test_non_image_is_listed_by_path_not_inlined(tmp_path):
 
 def test_oversized_image_is_skipped_not_inlined(tmp_path, monkeypatch):
     import anton.utils.clipboard as clip
-    monkeypatch.setattr(clip, "MAX_IMAGE_BYTES", 8)     # any real image exceeds this
+    monkeypatch.setattr(clip, "MAX_IMAGE_BYTES", 8)     # the fixture exceeds this
     att = tmp_path / "attachments" / "big"
     att.mkdir(parents=True)
-    (att / "huge.png").write_bytes(_real_png_bytes())
+    (att / "huge.png").write_bytes(_PNG)
 
     content = cloud_session.build_turn_content(tmp_path, "look")
     assert isinstance(content, list)
-    assert not [b for b in content if b["type"] == "image"]   # too large → no vision block
+    assert not [b for b in content if b["type"] == "image"]     # too large → no vision block
     assert "could not be shown" in next(b for b in content if b["type"] == "text")["text"]
 
 
 def test_corrupt_image_degrades_to_listing_not_a_broken_block(tmp_path):
-    """A mislabeled/corrupt .png must NOT be inlined (the model would reject it
-    and fail every turn) — it degrades to a path listing line."""
+    """A mislabeled/corrupt .png (no valid signature) must NOT be inlined — the
+    model would reject it and fail the turn — it degrades to a path listing."""
     att = tmp_path / "attachments" / "bad"
     att.mkdir(parents=True)
-    (att / "broken.png").write_bytes(b"\x89PNG\r\n not really a png")
+    (att / "broken.png").write_bytes(b"\x89PNG\r\n not really a png")   # partial sig only
 
     content = cloud_session.build_turn_content(tmp_path, "look")
     assert isinstance(content, list)
@@ -70,7 +71,7 @@ def test_corrupt_image_degrades_to_listing_not_a_broken_block(tmp_path):
 def test_one_bad_image_does_not_drop_the_good_ones(tmp_path):
     att = tmp_path / "attachments"
     (att / "good").mkdir(parents=True)
-    (att / "good" / "ok.png").write_bytes(_real_png_bytes())
+    (att / "good" / "ok.png").write_bytes(_PNG)
     (att / "bad").mkdir(parents=True)
     (att / "bad" / "broken.png").write_bytes(b"nope")
 
@@ -79,37 +80,13 @@ def test_one_bad_image_does_not_drop_the_good_ones(tmp_path):
     assert len(images) == 1        # the good one survives the bad one
 
 
-def _real_bmp_bytes() -> bytes:
-    from PIL import Image
-    buf = io.BytesIO()
-    Image.new("RGB", (2, 2), (1, 2, 3)).save(buf, format="BMP")
-    return buf.getvalue()
-
-
-def test_bmp_bytes_named_png_are_not_shipped_as_png(tmp_path):
-    """Format comes from content, not extension: a BMP named .png must be
-    converted (via Pillow, present here), never shipped as raw BMP labeled png."""
-    att = tmp_path / "attachments" / "id"
-    att.mkdir(parents=True)
-    (att / "scan.png").write_bytes(_real_bmp_bytes())   # BMP bytes, .png name
-
-    content = cloud_session.build_turn_content(tmp_path, "look")
-    images = [b for b in content if b["type"] == "image"]
-    assert len(images) == 1
-    assert images[0]["source"]["media_type"] == "image/png"       # converted, correct type
-    import base64
-    assert base64.standard_b64decode(images[0]["source"]["data"]).startswith(b"\x89PNG")  # real PNG bytes
-
-
 def test_png_works_without_pillow_bmp_degrades(tmp_path, monkeypatch):
     """Pillow is optional in the prod image. PNG/JPEG/etc must inline with no
     Pillow; a BMP (needs Pillow to convert) degrades to a listing line."""
-    png = _real_png_bytes()
-    bmp = _real_bmp_bytes()
     att = tmp_path / "attachments" / "id"
     att.mkdir(parents=True)
-    (att / "a.png").write_bytes(png)
-    (att / "b.bmp").write_bytes(bmp)
+    (att / "a.png").write_bytes(_PNG)
+    (att / "b.bmp").write_bytes(_FAKE_BMP)
 
     import builtins
     real_import = builtins.__import__
@@ -126,3 +103,22 @@ def test_png_works_without_pillow_bmp_degrades(tmp_path, monkeypatch):
     assert images[0]["source"]["media_type"] == "image/png"
     text = next(b for b in content if b["type"] == "text")["text"]
     assert "b.bmp" in text                                         # BMP degraded to listing
+
+
+def test_bmp_bytes_named_png_are_converted_not_shipped_as_raw(tmp_path):
+    """Format is by content, not extension: real BMP bytes named .png must be
+    converted to PNG (needs Pillow), never shipped as raw BMP labeled image/png."""
+    Image = pytest.importorskip("PIL.Image")
+    import io
+    buf = io.BytesIO()
+    Image.new("RGB", (2, 2), (1, 2, 3)).save(buf, format="BMP")
+
+    att = tmp_path / "attachments" / "id"
+    att.mkdir(parents=True)
+    (att / "scan.png").write_bytes(buf.getvalue())     # BMP bytes, .png name
+
+    content = cloud_session.build_turn_content(tmp_path, "look")
+    images = [b for b in content if b["type"] == "image"]
+    assert len(images) == 1
+    assert images[0]["source"]["media_type"] == "image/png"
+    assert base64.standard_b64decode(images[0]["source"]["data"]).startswith(b"\x89PNG")

--- a/tests/test_cloud_turn_attachments.py
+++ b/tests/test_cloud_turn_attachments.py
@@ -1,0 +1,128 @@
+import io
+
+from anton.cloud_turn import session as cloud_session
+
+
+def _real_png_bytes() -> bytes:
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (2, 2), (10, 20, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_no_attachments_returns_plain_string(tmp_path):
+    assert cloud_session.build_turn_content(tmp_path, "hello") == "hello"
+
+
+def test_image_attachment_becomes_a_vision_block(tmp_path):
+    att = tmp_path / "attachments" / "fileid1"
+    att.mkdir(parents=True)
+    (att / "shot.png").write_bytes(_real_png_bytes())
+
+    content = cloud_session.build_turn_content(tmp_path, "do you see the screenshot?")
+    assert isinstance(content, list)
+    images = [b for b in content if b["type"] == "image"]
+    assert len(images) == 1
+    assert images[0]["source"]["media_type"] == "image/png"
+    text = next(b for b in content if b["type"] == "text")["text"]
+    assert "shot.png" in text and "do you see the screenshot?" in text
+
+
+def test_non_image_is_listed_by_path_not_inlined(tmp_path):
+    att = tmp_path / "attachments" / "fileid2"
+    att.mkdir(parents=True)
+    (att / "notes.txt").write_text("hi")
+
+    content = cloud_session.build_turn_content(tmp_path, "read my notes")
+    assert isinstance(content, list)
+    assert not [b for b in content if b["type"] == "image"]
+    text = next(b for b in content if b["type"] == "text")["text"]
+    assert str(att / "notes.txt") in text            # absolute path so the agent can read it
+    assert "read my notes" in text
+
+
+def test_oversized_image_is_skipped_not_inlined(tmp_path, monkeypatch):
+    import anton.utils.clipboard as clip
+    monkeypatch.setattr(clip, "MAX_IMAGE_BYTES", 8)     # any real image exceeds this
+    att = tmp_path / "attachments" / "big"
+    att.mkdir(parents=True)
+    (att / "huge.png").write_bytes(_real_png_bytes())
+
+    content = cloud_session.build_turn_content(tmp_path, "look")
+    assert isinstance(content, list)
+    assert not [b for b in content if b["type"] == "image"]   # too large → no vision block
+    assert "could not be shown" in next(b for b in content if b["type"] == "text")["text"]
+
+
+def test_corrupt_image_degrades_to_listing_not_a_broken_block(tmp_path):
+    """A mislabeled/corrupt .png must NOT be inlined (the model would reject it
+    and fail every turn) — it degrades to a path listing line."""
+    att = tmp_path / "attachments" / "bad"
+    att.mkdir(parents=True)
+    (att / "broken.png").write_bytes(b"\x89PNG\r\n not really a png")
+
+    content = cloud_session.build_turn_content(tmp_path, "look")
+    assert isinstance(content, list)
+    assert not [b for b in content if b["type"] == "image"]
+    assert "could not be shown" in next(b for b in content if b["type"] == "text")["text"]
+
+
+def test_one_bad_image_does_not_drop_the_good_ones(tmp_path):
+    att = tmp_path / "attachments"
+    (att / "good").mkdir(parents=True)
+    (att / "good" / "ok.png").write_bytes(_real_png_bytes())
+    (att / "bad").mkdir(parents=True)
+    (att / "bad" / "broken.png").write_bytes(b"nope")
+
+    content = cloud_session.build_turn_content(tmp_path, "look")
+    images = [b for b in content if b["type"] == "image"]
+    assert len(images) == 1        # the good one survives the bad one
+
+
+def _real_bmp_bytes() -> bytes:
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (2, 2), (1, 2, 3)).save(buf, format="BMP")
+    return buf.getvalue()
+
+
+def test_bmp_bytes_named_png_are_not_shipped_as_png(tmp_path):
+    """Format comes from content, not extension: a BMP named .png must be
+    converted (via Pillow, present here), never shipped as raw BMP labeled png."""
+    att = tmp_path / "attachments" / "id"
+    att.mkdir(parents=True)
+    (att / "scan.png").write_bytes(_real_bmp_bytes())   # BMP bytes, .png name
+
+    content = cloud_session.build_turn_content(tmp_path, "look")
+    images = [b for b in content if b["type"] == "image"]
+    assert len(images) == 1
+    assert images[0]["source"]["media_type"] == "image/png"       # converted, correct type
+    import base64
+    assert base64.standard_b64decode(images[0]["source"]["data"]).startswith(b"\x89PNG")  # real PNG bytes
+
+
+def test_png_works_without_pillow_bmp_degrades(tmp_path, monkeypatch):
+    """Pillow is optional in the prod image. PNG/JPEG/etc must inline with no
+    Pillow; a BMP (needs Pillow to convert) degrades to a listing line."""
+    png = _real_png_bytes()
+    bmp = _real_bmp_bytes()
+    att = tmp_path / "attachments" / "id"
+    att.mkdir(parents=True)
+    (att / "a.png").write_bytes(png)
+    (att / "b.bmp").write_bytes(bmp)
+
+    import builtins
+    real_import = builtins.__import__
+
+    def no_pil(name, *a, **k):
+        if name == "PIL" or name.startswith("PIL."):
+            raise ImportError("simulating the Pillow-less prod image")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", no_pil)
+    content = cloud_session.build_turn_content(tmp_path, "look")
+    images = [b for b in content if b["type"] == "image"]
+    assert len(images) == 1                                        # PNG inlined without Pillow
+    assert images[0]["source"]["media_type"] == "image/png"
+    text = next(b for b in content if b["type"] == "text")["text"]
+    assert "b.bmp" in text                                         # BMP degraded to listing

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -327,3 +327,24 @@ def test_untracked_late_write_is_not_awaited():
     never blocks on unrelated live tasks (scratchpad readers, the heartbeat)."""
     events = _drive(_MemorySession([], deltas=["ok"], encode_late=True, track=False))
     assert events == [{"kind": "delta", "text": "ok"}, {"kind": "turn_completed"}]
+
+
+def test_entrypoint_wires_attachment_augmentation(tmp_path, monkeypatch):
+    """Removing the build_turn_content call in __main__ must fail a test: a
+    staged attachment has to reach the session as multimodal turn input."""
+    att = tmp_path / "attachments" / "fid"
+    att.mkdir(parents=True)
+    (att / "notes.txt").write_text("hi")
+    monkeypatch.setenv("ANTON_CLOUD_WORKSPACE_PATH", str(tmp_path))
+
+    captured = {}
+
+    class _S(_FakeSession):
+        async def turn_stream(self, user_input, **kwargs):
+            captured["input"] = user_input
+            for d in self._deltas:
+                yield StreamTextDelta(text=d)
+
+    _drive(_S())
+    assert isinstance(captured["input"], list)            # augmented, not the bare "hi"
+    assert any(b.get("type") == "text" and "notes.txt" in b.get("text", "") for b in captured["input"])


### PR DESCRIPTION
cowork-server now stages a conversation's attachments into the pod workspace at <workspace>/attachments/. This makes the cloud turn actually use them: images are sent to the model as vision blocks (so "do you see the screenshot?" works), and other files are listed by path so the agent can read them with its tools. Project instructions already work, anton reads <workspace>/.anton/anton.md, which cowork-server now populates. Fixes [ENG-1723](https://linear.app/mindsdb/issue/ENG-1723/instructions-are-not-followed-by-agent)