### PR TITLE
feat(artifacts): put the artifact id in the folder slug (ENG-1680)

### DIFF
--- a/anton/core/artifacts/store.py
+++ b/anton/core/artifacts/store.py
@@ -67,23 +67,35 @@ def _new_id() -> str:
     return uuid.uuid4().hex[:8]
 
 
+#: Width of `_new_id()`, plus the hyphen joining it to the name. Every slug ends
+#: in `-<id>` (see `create`), and the name is trimmed by this much so the whole
+#: slug still respects `_NAME_MAX_LEN`.
+_ID_SUFFIX_LEN = 8 + 1
+
+
 _UNSET = object()
 
 
-def _sanitize_slug(value: str) -> str:
+def _sanitize_slug(value: str, max_len: int = _NAME_MAX_LEN) -> str:
     """Map any name to a folder-safe slug.
 
     Always returns a non-empty string. Strange characters collapse
     to hyphens; runs are deduped; leading/trailing punctuation is
     stripped. Lowercased so the slug reads consistently (matters for
     case-insensitive filesystems on macOS / Windows).
+
+    The whitelist is ASCII, so a name in a non-Latin script collapses
+    entirely and falls back to `_NAME_FALLBACK` — every artifact a
+    Russian- or Chinese-speaking user names gets the SAME base. That is
+    why `create` appends an id rather than relying on the name to
+    distinguish folders.
     """
     raw = (value or "").strip().lower()
     cleaned = _NAME_DISALLOWED.sub("-", raw)
     cleaned = _NAME_HYPHEN_RUNS.sub("-", cleaned)
     cleaned = cleaned.strip("-._")
-    if len(cleaned) > _NAME_MAX_LEN:
-        cleaned = cleaned[:_NAME_MAX_LEN].rstrip("-._")
+    if len(cleaned) > max_len:
+        cleaned = cleaned[:max_len].rstrip("-._")
     return cleaned or _NAME_FALLBACK
 
 
@@ -136,7 +148,13 @@ class ArtifactStore:
 
     def _unique_slug(self, base: str) -> str:
         """Append `-2`, `-3`, … on collision. Mirrors
-        `projects_store.unique_name` semantics."""
+        `projects_store.unique_name` semantics.
+
+        A backstop since `create` began ending every slug in a random id:
+        it now fires only on an id collision within one store, and cannot
+        help across stores (see `create`), which is why it is not the
+        thing keeping slugs distinct.
+        """
         if not self.folder_for(base).exists():
             return base
         i = 2
@@ -158,10 +176,29 @@ class ArtifactStore:
     ) -> Artifact:
         """Create a fresh artifact folder + metadata.json + README.
 
-        Slug derives from the name (sanitised + collision suffix).
+        Slug is `<sanitised name>-<id>`, e.g. `sales-report-a1b2c3d4`.
         Returns the populated `Artifact`. The folder is empty other
         than the two metadata files — the agent writes its own
         files into it.
+
+        The id is IN the folder name, not just in metadata.json, because
+        the name alone does not identify an artifact:
+
+        * `_sanitize_slug`'s whitelist is ASCII, so every artifact named
+          in a non-Latin script collapses to the same `untitled-artifact`
+          base;
+        * `_unique_slug`'s `-2`/`-3` counter only sees the store it is
+          rooted at, and on the cloud deployment each conversation gets
+          its own store (the agent's workspace is a conversation, not a
+          project), so the counter restarts per conversation and two
+          conversations happily produce the same folder name.
+
+        Together those made `project + slug` — which is how cowork-server
+        addresses an artifact once paths stop being usable — ambiguous in
+        the common case rather than the rare one.
+
+        Only NEW artifacts get the suffix; existing folders keep their
+        slugs, so consumers still cannot assume every slug carries one.
 
         `primary` (optional) is the relative path of the artifact's
         entry-point file. The renderer reads this to decide what to
@@ -171,16 +208,22 @@ class ArtifactStore:
         the file in the next scratchpad cell.
         """
         self.ensure_root()
-        slug_base = _sanitize_slug(name)
-        slug = self._unique_slug(slug_base)
+        # The id is part of the slug, so it has to exist before it.
+        artifact_id = _new_id()
+        slug_base = _sanitize_slug(name, max_len=_NAME_MAX_LEN - _ID_SUFFIX_LEN)
+        slug = self._unique_slug(f"{slug_base}-{artifact_id}")
         now = _utc_now()
         artifact = Artifact(
             schemaVersion=METADATA_SCHEMA_VERSION,
-            id=_new_id(),
+            id=artifact_id,
             slug=slug,
             createdAt=now,
             updatedAt=now,
-            name=name.strip() or slug,
+            # `slug_base`, not `slug`: this is the human-facing name, and it
+            # surfaces as the card title wherever the UI falls back to it
+            # (cowork-server's card_for_folder, the chat stream adapter). The
+            # id belongs in the folder name, not on screen.
+            name=name.strip() or slug_base,
             description=description.strip(),
             type=type,
             primary=(primary.strip() if isinstance(primary, str) and primary.strip() else None),

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -54,7 +54,7 @@ def test_create_writes_metadata_and_readme(store: ArtifactStore):
         description="Compares NVDA and BTC.",
         type="html-app",
     )
-    assert artifact.slug == "nvda-btc-dashboard"
+    assert artifact.slug == f"nvda-btc-dashboard-{artifact.id}"
     assert len(artifact.id) == 8
     folder = store.folder_for(artifact.slug)
     assert folder.is_dir()
@@ -83,24 +83,58 @@ def test_create_persists_round_trip(store: ArtifactStore):
 # ─── Slug uniqueness ────────────────────────────────────────────────────────
 
 
-def test_slug_collision_appends_suffix(store: ArtifactStore):
-    a = store.create(name="Dashboard", description="x", type="html-app")
-    b = store.create(name="Dashboard", description="x", type="html-app")
-    c = store.create(name="Dashboard", description="x", type="html-app")
-    assert a.slug == "dashboard"
-    assert b.slug == "dashboard-2"
-    assert c.slug == "dashboard-3"
+def test_same_name_yields_distinct_slugs(store: ArtifactStore):
+    """The id, not the `-2`/`-3` counter, is what separates them now. The
+    counter only ever saw one store, and on the cloud each conversation has its
+    own — so identical names in two conversations used to collide."""
+    slugs = {
+        store.create(name="Dashboard", description="x", type="html-app").slug
+        for _ in range(3)
+    }
+    assert len(slugs) == 3
+    assert all(s.startswith("dashboard-") for s in slugs)
 
 
 def test_slug_lowercases_and_sanitizes(store: ArtifactStore):
     artifact = store.create(name="Hello, World!", description="x", type="document")
     # Punctuation collapses to hyphens; runs deduped; lowercased.
-    assert artifact.slug == "hello-world"
+    assert artifact.slug == f"hello-world-{artifact.id}"
 
 
 def test_slug_falls_back_when_name_is_garbage(store: ArtifactStore):
     artifact = store.create(name="!!!", description="x", type="document")
-    assert artifact.slug == "untitled-artifact"
+    assert artifact.slug == f"untitled-artifact-{artifact.id}"
+
+
+def test_non_latin_names_still_get_distinct_folders(store: ArtifactStore):
+    """The character whitelist is ASCII, so a Cyrillic name sanitises to
+    nothing and every such artifact shares the `untitled-artifact` base. Before
+    the id suffix that made same-base collisions the NORM for a non-English
+    user, not an edge case."""
+    a = store.create(name="Текущее время", description="x", type="html-app")
+    b = store.create(name="Другой отчёт", description="x", type="html-app")
+
+    assert a.slug != b.slug
+    assert a.slug.startswith("untitled-artifact-")
+    assert b.slug.startswith("untitled-artifact-")
+
+
+def test_display_name_carries_no_id(store: ArtifactStore):
+    """The id belongs in the folder name, not on screen: `name` is what the UI
+    falls back to for a title when the caller supplied none."""
+    artifact = store.create(name="", description="x", type="document")
+
+    assert artifact.name == "untitled-artifact"
+    assert artifact.slug == f"untitled-artifact-{artifact.id}"
+
+
+def test_slug_stays_within_the_length_budget(store: ArtifactStore):
+    """The name is trimmed by the suffix width, so a long name plus the id
+    still respects the same 64-char ceiling folders had before."""
+    artifact = store.create(name="x" * 200, description="x", type="document")
+
+    assert len(artifact.slug) <= 64
+    assert artifact.slug.endswith(f"-{artifact.id}")
 
 
 # ─── List + open ────────────────────────────────────────────────────────────
@@ -124,8 +158,8 @@ def test_list_returns_artifacts_newest_first(store: ArtifactStore):
     record.updatedAt = "2099-01-01T00:00:00+00:00"
     store._save(record)  # type: ignore[attr-defined]
     listing = store.list()
-    assert listing[0].slug == "second"
-    assert {x.slug for x in listing} == {"first", "second"}
+    assert listing[0].slug == b.slug
+    assert {x.slug for x in listing} == {a.slug, b.slug}
 
 
 def test_open_returns_none_for_missing_slug(store: ArtifactStore):


### PR DESCRIPTION
## What

Artifact folder slugs become `<sanitised name>-<id>`, e.g. `sales-report-a1b2c3d4`.
The id is the same 8-hex-char value already stored in `metadata.json`.

## Why

The name alone does not identify an artifact, and both reasons bite in the common
case rather than a rare one.

**The collision counter cannot see across stores.** `_unique_slug`'s `-2`/`-3`
suffix only inspects the store it is rooted at. On the cloud deployment the
agent's workspace is a *conversation*, not a project
(`scratchpad-controller`'s `live_pod.py` mounts
`<project>/conversations/<conversation_id>` at the pod's workspace root), so
each conversation gets its own store and the counter restarts in each one. Two
conversations then produce the same folder name with nothing to notice.

Together those make `project + slug` ambiguous — and that pair is how
cowork-server addresses an artifact once absolute paths stop being usable, since
an org deployment cannot tell which tenant a filesystem path belongs to.

Found while testing ENG-1680 (artifact autopublish on the multi-tenant
deployment): two different artifacts in one project were both sitting at
`untitled-artifact`.

## Notes for review

* The id is generated before the slug now, because it feeds into it.
* The name budget is trimmed by the suffix width, so the whole slug still
  respects the same 64-character ceiling folders had before. Covered by a test.
* `name` falls back to the sanitised base **without** the id. It is the
  human-facing title wherever the UI has nothing better — cowork-server's
  `card_for_folder` does `meta.get("name") or folder.name`, and cowork's chat
  stream adapter does `art.title || art.slug` — so putting the id there would
  surface it on screen. The id belongs in the folder name.
* `_unique_slug` stays as a backstop for an id collision within one store.

## Blast radius

Traced across anton, cowork-server and cowork before writing this:

* Nothing parses the slug — no regex, no splitting, no length assumptions, no
  suffix stripping. It is an opaque string everywhere.
* `.published.json` is keyed by the primary filename, not the slug, and a
  published URL is `/view/<user_dir>/<report_id>`. No publish record is
  affected.
* `TaskObject.ref` (cowork-server) stores the slug at `max_length=255`; a
  64-char slug fits with room to spare.
* In anton the slug doubles as a runtime identifier for fullstack artifacts —
  `scratchpad_pool.venv_python(slug)`, `tracked_backends[slug]` — which is
  naming only, no format assumption.
* The one place a user could see it is the title fallback described above,
  which this PR keeps clean.

## Not retroactive

Existing folders keep their slugs, so consumers still cannot assume every slug
carries an id. Addressing an artifact by its `metadata.json` id remains the
robust option for cowork-server; this change removes the cause rather than
repairing what already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
