### PR TITLE
fix(scratchpad): never persist file handles in namespace snapshots (ENG-1726)

### DIFF
--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -91,6 +91,17 @@ def _inject_helper(name: str, fn) -> None:
 # rebind to something picklable is retried rather than excluded forever.
 _UNPICKLABLE: dict = {}
 
+# Byte marker of dill's file-handle reconstructor inside a pickle stream. A pickled
+# file object is stored as a CALL to `dill._dill._create_filehandle(name, mode, …)`,
+# and that call runs `open(name, mode)` at LOAD time — for a `'w'` handle (even an
+# already-closed one, e.g. `f` surviving a `with open(path, 'w') as f:` block) the
+# open() itself truncates the file on disk. In cloud mode the snapshot is reloaded on
+# every turn, so one leftover handle wiped artifact files turn after turn (ENG-1726).
+# Scanning the serialised bytes instead of isinstance-checking the value catches
+# handles nested inside containers too, and leaves harmless io.StringIO/io.BytesIO
+# (which pickle by contents, not by reconstructor) alone.
+_FILEHANDLE_MARKER = b"_create_filehandle"
+
 # Persistence notes for the next cell's `logs`. Deliberately NOT `error` — a snapshot
 # problem must not make the cell look failed, or it would feed the consecutive-error
 # circuit breaker and the resilience nudge.
@@ -169,6 +180,12 @@ def _decode_values(blobs: dict) -> tuple[dict, dict]:
     ns: dict = {}
     dropped: dict = {}
     for name, blob in blobs.items():
+        if _FILEHANDLE_MARKER in blob:
+            # Snapshots written before ENG-1726 can still hold pickled file handles;
+            # materialising one re-opens the file in its original mode, truncating it
+            # when that mode is 'w'. Refuse to load rather than damage workspace files.
+            dropped[name] = "file handle: restoring would re-open (and truncate) the file"
+            continue
         try:
             ns[name] = dill.loads(blob)
         except Exception as exc:
@@ -315,6 +332,14 @@ def _encode_values(payload: dict) -> tuple[dict, list]:
             _UNPICKLABLE[key] = id(value)
             dropped.append(key)
             continue
+        if _FILEHANDLE_MARKER in blob:
+            # File handles pickle without error but must never be persisted: loading
+            # them re-runs open() and truncates 'w'-mode files (ENG-1726). Registered
+            # in _UNPICKLABLE like any live resource, so the warning fires once and a
+            # rebind to real data is retried.
+            _UNPICKLABLE[key] = id(value)
+            dropped.append(key)
+            continue
         total += len(blob)
         if total > SESSION_MAX_BYTES:
             raise _TooBig()
@@ -370,8 +395,8 @@ def _dump_namespace(ns: dict) -> str | None:
             "will be undefined if this scratchpad restarts: "
             + ", ".join(sorted(dropped))
             + ". Objects holding live resources (database connections, sockets, "
-            "generators) cannot be saved — recreate them rather than relying on them "
-            "persisting."
+            "generators, open or closed file handles) cannot be saved — recreate "
+            "them rather than relying on them persisting."
         )
     return None
 

--- a/tests/test_scratchpad.py
+++ b/tests/test_scratchpad.py
@@ -1424,6 +1424,116 @@ class TestSessionPersistence:
         finally:
             await pad2.cleanup()
 
+    async def test_file_handle_does_not_truncate_its_file_on_restart(
+        self, tmp_path, monkeypatch
+    ):
+        """ENG-1726: a leftover `'w'` handle must never reach the snapshot.
+
+        dill reconstructs a pickled file object by re-calling `open()` with the
+        original mode — even for an already-closed handle — so loading a snapshot
+        holding `fh` from `with open(path, 'w') as fh:` truncated the file on disk.
+        In cloud mode the snapshot is reloaded on every turn, which wiped artifact
+        files turn after turn (empty index.html published to S3).
+        """
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PERSIST_SESSION", "true")
+        venvs_base = tmp_path / "venvs"
+        target = tmp_path / "index.html"
+        pad = make_scratchpad(name="writer", _venvs_base=venvs_base, session_id="c")
+        await pad.start()
+        cell = await pad.execute(
+            f"with open({str(target)!r}, 'w') as fh:\n"
+            "    fh.write('<html>content</html>')\n"
+            "kept = 'alive'\n"
+        )
+        assert cell.error is None, cell.error
+        # The casualty is reported by name, on `logs`, never on `error`.
+        assert "fh" in cell.logs and "could not be preserved" in cell.logs
+        assert target.read_text() == "<html>content</html>"
+        await pad.close()
+
+        pad2 = make_scratchpad(name="writer", _venvs_base=venvs_base, session_id="c")
+        await pad2.start()
+        try:
+            cell = await pad2.execute("print(kept, 'fh' in dir())")
+            assert cell.error is None, cell.error
+            assert cell.stdout.strip() == "alive False"
+            # The point of the ticket: the file the handle pointed at is intact.
+            assert target.read_text() == "<html>content</html>"
+        finally:
+            await pad2.cleanup()
+
+    async def test_file_handle_nested_in_a_container_is_not_persisted(
+        self, tmp_path, monkeypatch
+    ):
+        """A handle hidden inside a container pickles without error too.
+
+        An isinstance check on the value would miss it; the byte-scan of the
+        serialised blob is what catches the nested case.
+        """
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PERSIST_SESSION", "true")
+        venvs_base = tmp_path / "venvs"
+        target = tmp_path / "log.txt"
+        target.write_text("first line\n")
+        pad = make_scratchpad(name="nested", _venvs_base=venvs_base, session_id="c")
+        await pad.start()
+        cell = await pad.execute(
+            f"box = {{'sink': open({str(target)!r}, 'w')}}\n"
+            "box['sink'].write('rewritten')\n"
+            "box['sink'].close()\n"
+            "safe = 7\n"
+        )
+        assert cell.error is None, cell.error
+        assert "box" in cell.logs and "could not be preserved" in cell.logs
+        await pad.close()
+
+        pad2 = make_scratchpad(name="nested", _venvs_base=venvs_base, session_id="c")
+        await pad2.start()
+        try:
+            cell = await pad2.execute("print(safe, 'box' in dir())")
+            assert cell.error is None, cell.error
+            assert cell.stdout.strip() == "7 False"
+            assert target.read_text() == "rewritten"
+        finally:
+            await pad2.cleanup()
+
+    async def test_legacy_snapshot_with_a_file_handle_is_not_materialised(
+        self, tmp_path, monkeypatch
+    ):
+        """Snapshots written before the dump-side filter can still hold handles.
+
+        Loading such a snapshot must drop the handle instead of re-opening (and
+        truncating) its file — the load-side guard is what protects conversations
+        that carried a snapshot across the deploy of the fix.
+        """
+        import dill
+
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PERSIST_SESSION", "true")
+        venvs_base = tmp_path / "venvs"
+        target = tmp_path / "victim.html"
+        legacy = open(target, "w")
+        legacy.write("precious")
+        legacy.close()
+        blob = dill.dumps(legacy)  # pickles fine: a closed 'w' handle
+
+        pad = make_scratchpad(name="legacy", _venvs_base=venvs_base, session_id="c")
+        snapshot = pad._session_snapshot_path(create=True)
+        assert snapshot is not None
+        # The on-disk envelope format of scratchpad_boot (magic, version, blobs).
+        envelope = ("__anton_snapshot__", 2, {"legacy": blob, "ok": dill.dumps(42)})
+        with open(snapshot, "wb") as f:
+            dill.dump(envelope, f)
+
+        await pad.start()
+        try:
+            cell = await pad.execute("print(ok, 'legacy' in dir())")
+            assert cell.error is None, cell.error
+            assert cell.stdout.strip() == "42 False"
+            # The handle was refused, so its file was not truncated by the load.
+            assert target.read_text() == "precious"
+            assert "legacy" in cell.logs and "file handle" in cell.logs
+        finally:
+            await pad.cleanup()
+
     async def test_unpicklable_warning_is_not_repeated_every_cell(self, tmp_path, monkeypatch):
         """Told once, not on every cell — and the per-key scan runs once, not per cell."""
         monkeypatch.setenv("ANTON_SCRATCHPAD_PERSIST_SESSION", "true")


### PR DESCRIPTION
Fixes ENG-1726 (https://linear.app/mindsdb/issue/ENG-1726/scratchpad-namespace-snapshot-truncates-artifact-files-on-restore)

## Problem

The scratchpad namespace snapshot pickles every namespace value with dill, including file handles left over from cells (e.g. `f` after `with open(path, 'w') as f:` — the variable survives the `with` block, closed).

A pickled file object is stored as a call to `dill._dill._create_filehandle(name, mode, …)`, and unpickling executes it: it re-runs `open(name, mode)`. With dill 0.3.8's default `fmode=0` (HANDLE_FMODE) that open **truncates the file to 0 bytes when the mode is `'w'` — even for an already-closed handle**.

In cloud multitenant mode every turn runs in a fresh pad process, so the snapshot is reloaded each turn — any file previously written by a cell gets wiped on the next turn. Observed live on staging (2026-08-19): an artifact's `index.html` was truncated at pad boot and autopublish faithfully shipped the empty file to S3. On desktop the pad lives for the whole session, so it only manifests on session resume.

## Fix

Detect file handles by scanning the serialised blob for the `_create_filehandle` reconstructor. Compared to an `isinstance` check on the value, the byte-scan also catches handles nested inside containers, and leaves harmless `io.StringIO`/`io.BytesIO` alone (they pickle by contents, not by reconstructor).

Applied on both sides:

- **Dump (`_encode_values`)**: the value is dropped and registered in `_UNPICKLABLE`, so the "could not be preserved" note names it once and a rebind to real data is retried — same semantics as sockets/DB connections.
- **Load (`_decode_values`)**: snapshots written before this fix can still hold pickled handles; they are dropped with a reason instead of being materialised, so carrying a pre-fix snapshot across the deploy cannot truncate files either.

## Tests

Three end-to-end regression tests in `TestSessionPersistence` (real pad restart round-trip):

- a leftover `'w'` handle: file intact after restart, handle undefined, other variables restored, casualty reported on `logs`;
- a handle nested inside a dict — the case an `isinstance` check would miss;
- a hand-crafted legacy snapshot already containing a pickled handle: load drops it, file untouched.

`tests/test_scratchpad.py`, `tests/test_verifier_truncation.py`, `tests/test_scratchpad_watchdog_contracts.py`: **174 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)