### PR TITLE
[ENG-1635] scratchpad auto install any module

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -174,7 +174,9 @@ _pending_lock = threading.Lock()
 #
 # An event NOT listed here keeps the collector path, so moving one is an
 # explicit decision rather than something that happens by default.
-_POSTHOG_EVENTS = frozenset({"turn_completed", "rule_retrieval"})
+_POSTHOG_EVENTS = frozenset(
+    {"turn_completed", "rule_retrieval", "scratchpad_package_installed"}
+)
 
 # `$lib` names the sender, matching the convention the other emitters follow
 # (`cowork-desktop`, `mindshub-site-beacon`), so a per-emitter breakdown in

--- a/anton/core/artifacts/backend_launcher.py
+++ b/anton/core/artifacts/backend_launcher.py
@@ -115,8 +115,8 @@ async def launch_artifact_backend(
                 install_log.write(banner.encode("utf-8"))
                 install_log.write(install_result.encode("utf-8"))
                 install_log.write(b"\n")
-            if install_result.startswith("Install failed") or install_result.startswith(
-                "Install timed out"
+            if install_result.startswith(
+                ("Install failed", "Install timed out", "Install refused")
             ):
                 return (
                     "Error: dependency install failed for `requirements.txt`.\n"

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -1248,6 +1248,16 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         needed = [p for p in packages if p.lower() not in self._installed_packages]
         if not needed:
             return "All packages already installed."
+        # Belt for every caller (the tool paths reject earlier, with a typed
+        # reason): nothing flag-, URL- or path-shaped may reach pip's argv
+        # (ENG-1635 — a single "--index-url=…" entry redirects resolution for
+        # the whole call). Lazy import: this module must stay importable
+        # without the tools layer.
+        from anton.core.utils.scratchpad import reject_invalid_packages
+
+        refused = reject_invalid_packages(needed)
+        if refused:
+            return refused
         self._ensure_venv()
 
         uv = self._find_uv()

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -656,10 +656,9 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         if uv:
             env["ANTON_UV_PATH"] = uv
 
-        # The in-cell auto-installer (scratchpad_boot) runs pip/uv under this
-        # budget. Pass the resolved setting so the worker's timer and the
-        # parent's kill windows in _read_result run off one number — they
-        # used to be independent constants that drifted apart (ENG-1275).
+        # scratchpad_boot no longer auto-installs on ModuleNotFoundError, so
+        # this var (and _read_result's install-span handling below) is dead;
+        # left wired rather than reworking the kill-window logic in one pass.
         env["ANTON_CELL_INSTALL_TIMEOUT"] = str(CoreSettings().cell_install_timeout)
 
         # Namespace snapshot path (ENG-1124). The boot script reads
@@ -1050,12 +1049,9 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         last_notice = 0.0
         last_output = 0.0
 
-        # In-cell auto-install span (ENG-1275). While the worker's installer
-        # runs, both kill windows defer to the install budget — the same
-        # cell_install_timeout the worker was handed at spawn — plus a grace
-        # margin, so the worker's own named install error wins the race
-        # against a parent kill. The cell's budget resumes, install time
-        # excluded, when the end marker arrives.
+        # Dead since scratchpad_boot dropped its in-cell auto-installer: the
+        # markers this deferral watches for are never emitted anymore. Left
+        # in place rather than unpicking it from the kill-window logic below.
         install_budget = float(s.cell_install_timeout)
         installing: str | None = None
         install_started = 0.0

--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -9,6 +9,7 @@ import dill
 
 from anton.core.backends.wire import (
     CELL_DELIM,
+    MISSING_MODULE_HINT,
     RESULT_START,
     RESULT_END,
     heal_surrogate_source,
@@ -1187,12 +1188,7 @@ while True:
             # Hint goes before the traceback: callers key off its last line.
             hint = ""
             if _mnf.name:
-                hint = (
-                    f"'{_mnf.name}' was not auto-installed. If your code "
-                    "deliberately needs it, list it in the exec call's "
-                    "'packages' array (or use the scratchpad's install "
-                    "action) and retry.\n"
-                )
+                hint = MISSING_MODULE_HINT.format(name=_mnf.name)
             error = hint + traceback.format_exc()
         except Exception:
             error = traceback.format_exc()

--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -822,8 +822,6 @@ import threading
 
 from anton.core.backends.wire import (
     HEARTBEAT_MARKER,
-    INSTALL_END_MARKER,
-    INSTALL_START_MARKER,
     PROGRESS_MARKER,
     STDOUT_CHUNK_MARKER,
 )
@@ -842,19 +840,6 @@ try:
     )
 except ValueError:
     _HEARTBEAT_INTERVAL = 10.0
-
-# Budget for the in-cell auto-installer. The parent resolves
-# CoreSettings.cell_install_timeout and passes it through at spawn (see
-# LocalScratchpadRuntime.start), so the installer and the parent's kill
-# windows run off one number instead of two constants that can drift apart
-# (ENG-1275); the fallback mirrors that setting's default. Same
-# malformed-override guard as the heartbeat interval above.
-try:
-    _INSTALL_TIMEOUT = float(os.environ.get("ANTON_CELL_INSTALL_TIMEOUT", "120"))
-except ValueError:
-    _INSTALL_TIMEOUT = 120.0
-if _INSTALL_TIMEOUT <= 0:
-    _INSTALL_TIMEOUT = 120.0
 
 # Per-tick cap on salvage chunk size: bounds a single wire line even when a
 # cell floods stdout between ticks; the remainder ships on later ticks.
@@ -1195,91 +1180,20 @@ while True:
 
         sys.stdout = out_buf
         sys.stderr = err_buf
-        _auto_installed = []
         try:
             compiled = compile(code, "<scratchpad>", "exec")
             exec(compiled, namespace)
         except ModuleNotFoundError as _mnf:
-            # Auto-install the missing module and retry the cell once
-            _missing = _mnf.name
-            if _missing:
-                sys.stdout = _real_stdout
-                sys.stderr = sys.__stderr__
-                _cell_log_handler.buf = None
-                # The parent turns this marker into the visible "Installing
-                # X..." progress line and defers its kill windows to the
-                # install budget while the install runs (ENG-1275).
-                with _wire_lock:
-                    _real_stdout.write(INSTALL_START_MARKER + " " + _missing + "\n")
-                    _real_stdout.flush()
-                import subprocess as _sp
-
-                _uv_path = os.environ.get("ANTON_UV_PATH", "")
-                _pip = None
-                _install_error = None
-                try:
-                    if _uv_path:
-                        _pip = _sp.run(
-                            [_uv_path, "pip", "install", "--python", sys.executable, _missing],
-                            capture_output=True,
-                            timeout=_INSTALL_TIMEOUT,
-                        )
-                    else:
-                        _pip = _sp.run(
-                            [sys.executable, "-m", "pip", "install", _missing],
-                            capture_output=True,
-                            timeout=_INSTALL_TIMEOUT,
-                        )
-                except _sp.TimeoutExpired:
-                    # An uncaught raise here used to take down the whole
-                    # worker, and the parent reported a generic process death
-                    # with no mention of the install (ENG-1275).
-                    _install_error = (
-                        f"ModuleNotFoundError: No module named '{_missing}'\n"
-                        f"Auto-install of '{_missing}' was killed after "
-                        f"{_INSTALL_TIMEOUT:.0f}s (cell_install_timeout) without "
-                        "finishing — the package is not installed. Retrying may "
-                        "complete it (downloads are cached); for a large package, "
-                        "run the scratchpad's install action first."
-                    )
-                except OSError as _exc:
-                    _install_error = (
-                        f"ModuleNotFoundError: No module named '{_missing}'\n"
-                        f"Auto-install of '{_missing}' could not run: {_exc}"
-                    )
-                # Deliberately not in a finally: if the install failed in a
-                # way not handled above the worker is going down, and the
-                # missing end marker is what lets the parent name the install
-                # in the death report.
-                with _wire_lock:
-                    _real_stdout.write(INSTALL_END_MARKER + " " + _missing + "\n")
-                    _real_stdout.flush()
-                # Reset buffers and retry
-                out_buf = io.StringIO()
-                err_buf = io.StringIO()
-                log_buf = io.StringIO()
-                # Same ordering rule as the first cell setup: shipped first,
-                # so the swap can only duplicate a chunk, never skip one.
-                _cell_out["shipped"] = 0
-                _cell_out["buf"] = out_buf
-                _cell_log_handler.buf = log_buf
-                sys.stdout = out_buf
-                sys.stderr = err_buf
-                if _pip is not None and _pip.returncode == 0:
-                    _auto_installed.append(_missing)
-                    try:
-                        exec(compiled, namespace)
-                    except Exception:
-                        error = traceback.format_exc()
-                elif _install_error is not None:
-                    error = _install_error
-                else:
-                    error = (
-                        f"ModuleNotFoundError: No module named '{_missing}'\n"
-                        f"Auto-install failed:\n{_pip.stderr.decode()}"
-                    )
-            else:
-                error = traceback.format_exc()
+            # Don't pip-install a name pulled from an exception — it may be a
+            # hallucinated import, and the string is attacker-controllable.
+            error = traceback.format_exc()
+            if _mnf.name:
+                error += (
+                    f"\n'{_mnf.name}' was not auto-installed. If your code "
+                    "deliberately needs it, list it in the exec call's "
+                    "'packages' array (or use the scratchpad's install "
+                    "action) and retry."
+                )
         except Exception:
             error = traceback.format_exc()
         finally:
@@ -1338,8 +1252,6 @@ while True:
         "error": error,
         "explainability_queries": list(namespace.get("_anton_explainability_queries", [])),
     }
-    if _auto_installed:
-        result["auto_installed"] = _auto_installed
     with _wire_lock:
         _real_stdout.write(RESULT_START + "\n")
         _real_stdout.write(json.dumps(result) + "\n")

--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -1155,8 +1155,6 @@ while True:
     # Liveness heartbeat: a daemon thread pings the real pipe while this cell
     # runs, so the parent's inactivity watchdog sees activity through a
     # deliberate sleep or a blocking call, not just through stdout/progress().
-    # Span covers the auto-install retry below too (ENG-1275: a silent
-    # in-cell install used to be indistinguishable from a wedged process).
     _hb_stop = threading.Event()
     _hb_thread = None
     if _HEARTBEAT_INTERVAL > 0:
@@ -1186,14 +1184,16 @@ while True:
         except ModuleNotFoundError as _mnf:
             # Don't pip-install a name pulled from an exception — it may be a
             # hallucinated import, and the string is attacker-controllable.
-            error = traceback.format_exc()
+            # Hint goes before the traceback: callers key off its last line.
+            hint = ""
             if _mnf.name:
-                error += (
-                    f"\n'{_mnf.name}' was not auto-installed. If your code "
+                hint = (
+                    f"'{_mnf.name}' was not auto-installed. If your code "
                     "deliberately needs it, list it in the exec call's "
                     "'packages' array (or use the scratchpad's install "
-                    "action) and retry."
+                    "action) and retry.\n"
                 )
+            error = hint + traceback.format_exc()
         except Exception:
             error = traceback.format_exc()
         finally:

--- a/anton/core/backends/wire.py
+++ b/anton/core/backends/wire.py
@@ -10,9 +10,8 @@ RESULT_END = "__ANTON_RESULT_END__"
 PROGRESS_MARKER = "__ANTON_PROGRESS__"
 HEARTBEAT_MARKER = "__ANTON_HEARTBEAT__"
 STDOUT_CHUNK_MARKER = "__ANTON_STDOUT_CHUNK__"
-# In-cell auto-install span (ENG-1275): the worker brackets its pip/uv run
-# with these so the parent can defer its kill windows to the install budget
-# and name the install if the cell dies anyway. Payload is the package name.
+# Dead: the worker no longer auto-installs on a missing import, so nothing
+# emits these anymore. local.py still parses for them defensively.
 INSTALL_START_MARKER = "__ANTON_INSTALL_START__"
 INSTALL_END_MARKER = "__ANTON_INSTALL_END__"
 

--- a/anton/core/backends/wire.py
+++ b/anton/core/backends/wire.py
@@ -15,6 +15,19 @@ STDOUT_CHUNK_MARKER = "__ANTON_STDOUT_CHUNK__"
 INSTALL_START_MARKER = "__ANTON_INSTALL_START__"
 INSTALL_END_MARKER = "__ANTON_INSTALL_END__"
 
+# The hint the worker prepends to a ModuleNotFoundError traceback (ENG-1635).
+# Lives here so the session side (nudge tests, and anything that needs the
+# exact shape) shares one definition with the boot script. Deliberately does
+# NOT tell the model to declare the failed name in 'packages' — that would
+# route the same hallucinated package through the surviving install path one
+# turn later, which is the attack this ticket closes.
+MISSING_MODULE_HINT = (
+    "'{name}' is not installed, and imports never install anything. Check "
+    "the import itself first — a missing module is often a wrong or invented "
+    "name, not a missing package. Only a real PyPI distribution this task "
+    "genuinely needs should ever be installed.\n"
+)
+
 
 def heal_surrogate_source(code: str) -> str:
     """Return ``code`` with any lone surrogates resolved to valid UTF-8.

--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -452,17 +452,16 @@ SCRATCHPAD_STUCK_NUDGE = (
     "native call may be hanging — give that call its own timeout. Reuse the "
     "SAME scratchpad; do not rename it."
 )
-# An install failure is neither a size nor a liveness problem — shrinking the
-# cell cannot make a package install, and a reset throws away a venv that may
-# already hold most of the download (ENG-1275). Routed on "auto-install" in
-# the error text, ahead of the other scratchpad branches.
+# A missing package is neither a size nor a liveness problem — shrinking the
+# cell cannot conjure an import. Routed on "auto-install" in the error text,
+# ahead of the other scratchpad branches.
 SCRATCHPAD_INSTALL_NUDGE = (
-    "\n\nSYSTEM: This scratchpad cell keeps failing on a package install, not "
-    "on its logic. Do not shrink or split the cell — that cannot make a "
-    "package install. Install the package explicitly with the scratchpad's "
-    "install action (double-check the PyPI name), then rerun the same cell. "
-    "If the explicit install also fails or times out, tell the user instead "
-    "of retrying."
+    "\n\nSYSTEM: This scratchpad cell keeps failing on a missing package, not "
+    "on its logic — cells no longer auto-install on ModuleNotFoundError. Do "
+    "not shrink or split the cell. Declare the package explicitly, either in "
+    "the exec call's 'packages' array or via the scratchpad's install action "
+    "(double-check the PyPI name), then rerun the same cell. If the explicit "
+    "install also fails or times out, tell the user instead of retrying."
 )
 # A budget kill with zero output is ambiguous — a stuck call and silent heavy
 # work look identical from outside. Say so, rather than confidently claiming

--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -97,6 +97,8 @@ multi-step AI workflows like classification, extraction, or analysis with struct
 the configured LLM's native web search and returns the model's narrative answer with source \
 links as a string. Use it for current/real-time information from within scratchpad code. The \
 call is synchronous.
+- get_llm, agentic_loop, and web_search are already available as globals inside \
+scratchpad code — do not import them.
 - All .anton/.env variables are available as environment variables (os.environ).
 - Connected data source credentials are injected as namespaced environment \
 variables in the form DS_<ENGINE>_<NAME>__<FIELD> \

--- a/anton/core/llm/prompts.py
+++ b/anton/core/llm/prompts.py
@@ -455,13 +455,18 @@ SCRATCHPAD_STUCK_NUDGE = (
 # A missing package is neither a size nor a liveness problem — shrinking the
 # cell cannot conjure an import. Routed on "auto-install" in the error text,
 # ahead of the other scratchpad branches.
+# Must not coach re-declaring the failed name (ENG-1635): a hallucinated
+# import that gets echoed into 'packages' is the same unattended install one
+# turn later, with the agent as the only approver.
 SCRATCHPAD_INSTALL_NUDGE = (
-    "\n\nSYSTEM: This scratchpad cell keeps failing on a missing package, not "
-    "on its logic — cells no longer auto-install on ModuleNotFoundError. Do "
-    "not shrink or split the cell. Declare the package explicitly, either in "
-    "the exec call's 'packages' array or via the scratchpad's install action "
-    "(double-check the PyPI name), then rerun the same cell. If the explicit "
-    "install also fails or times out, tell the user instead of retrying."
+    "\n\nSYSTEM: This scratchpad cell keeps failing on a missing module, not "
+    "on its logic — imports never install anything. Do not shrink or split "
+    "the cell. Question the import itself first: get_llm, agentic_loop, "
+    "web_search, sample and progress are already globals (no import), and a "
+    "name recovered from a failing import may not be a real package at all. "
+    "Install a package only when you can name the real PyPI distribution "
+    "this task needs; if an install fails or times out, tell the user "
+    "instead of retrying."
 )
 # A budget kill with zero output is ambiguous — a stuck call and silent heavy
 # work look identical from outside. Say so, rather than confidently claiming

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -122,6 +122,9 @@ _SENTINEL_REASONS = {
     "invalid_port": (TIER_SELF, "invalid_argument"),
     "invalid_health_timeout": (TIER_SELF, "invalid_argument"),
     "invalid_datasources": (TIER_SELF, "invalid_argument"),
+    # A refused package spec (flag/URL/path-shaped entry) is the agent's own
+    # bad argument, not an environment wall (ENG-1635).
+    "package_install_rejected": (TIER_SELF, "invalid_argument"),
     # The agent named something that does not exist. Ambiguous — it could be a
     # genuinely absent resource — but the agent chose the identifier and can
     # list the real ones, so it resolves to the non-tripping side.

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1295,11 +1295,18 @@ class ChatSession:
         if tool_name != "scratchpad":
             return RESILIENCE_NUDGE
         low = result_text.lower()
-        # An install failure/kill is neither a size nor a liveness problem —
-        # checked before both: the mid-install kill wording also contains
-        # "liveness", and the worker's install errors contain "killed"/
-        # "timed out"-adjacent words (ENG-1275).
-        if "auto-install" in low:
+        # An install/missing-module failure is neither a size nor a liveness
+        # problem — checked before both: the legacy mid-install kill wording
+        # also contains "liveness", and install errors contain "killed"/
+        # "timed out"-adjacent words (ENG-1275). Keyed on the interpreter's
+        # own exception name and install_packages' message prefixes, never on
+        # the hint text — a hint reword must not silently kill this route
+        # (ENG-1635). "auto-install" keeps matching old-version workers.
+        if (
+            "modulenotfounderror" in low
+            or low.startswith(("install failed", "install timed out", "install refused"))
+            or "auto-install" in low
+        ):
             return SCRATCHPAD_INSTALL_NUDGE
         # A silence/liveness kill means the worker looked dead — "make the
         # cell smaller" is exactly the wrong advice there (ENG-578: it taught

--- a/anton/core/tools/tool_defs.py
+++ b/anton/core/tools/tool_defs.py
@@ -80,6 +80,8 @@ SCRATCHPAD_TOOL = ToolDef(
         "sample(var) inspects any variable with type-aware formatting — DataFrames get "
         "shape/dtypes/head, dicts get keys/values, lists get length/items. "
         "Defaults to 'preview' mode (compact); use sample(var, mode='full') for complete dump.\n"
+        "get_llm, agentic_loop, web_search, sample, and progress are already available "
+        "as globals in the scratchpad — do not import them.\n"
         "All .anton/.env secrets are available as environment variables (os.environ)."
     ),
     input_schema={

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -13,6 +13,7 @@ from anton.core.utils.scratchpad import (
     prepare_scratchpad_exec,
     format_cell_result,
     observe_scratchpad_cell,
+    send_package_install_event,
 )
 
 if TYPE_CHECKING:
@@ -577,7 +578,12 @@ async def handle_scratchpad(
         if not packages:
             return "No packages specified."
         pad = await session._scratchpads.get_or_create(name)
-        return await pad.install_packages(packages)
+        result = await pad.install_packages(packages)
+        if result not in ("No packages specified.", "All packages already installed.") and (
+            "Install failed" not in result and "timed out" not in result
+        ):
+            send_package_install_event(session, packages)
+        return result
 
     else:
         return f"Unknown scratchpad action: {action}"

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -13,7 +13,9 @@ from anton.core.utils.scratchpad import (
     prepare_scratchpad_exec,
     format_cell_result,
     observe_scratchpad_cell,
+    cell_failure_reason,
     install_call_installed_something,
+    reject_invalid_packages,
     send_package_install_event,
 )
 
@@ -538,7 +540,7 @@ async def handle_scratchpad(
         return ToolOutcome(
             content=format_cell_result(cell),
             ok=not error,
-            reason=error.splitlines()[-1][:160] if error else "",
+            reason=cell_failure_reason(error),
         )
 
     elif action == "view":
@@ -578,6 +580,11 @@ async def handle_scratchpad(
         packages = tc_input.get("packages", [])
         if not packages:
             return "No packages specified."
+        refused = reject_invalid_packages(packages)
+        if refused:
+            return ToolOutcome(
+                content=refused, ok=False, reason="package_install_rejected"
+            )
         pad = await session._scratchpads.get_or_create(name)
         result = await pad.install_packages(packages)
         if install_call_installed_something(result):

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -13,6 +13,7 @@ from anton.core.utils.scratchpad import (
     prepare_scratchpad_exec,
     format_cell_result,
     observe_scratchpad_cell,
+    install_call_installed_something,
     send_package_install_event,
 )
 
@@ -579,9 +580,7 @@ async def handle_scratchpad(
             return "No packages specified."
         pad = await session._scratchpads.get_or_create(name)
         result = await pad.install_packages(packages)
-        if result not in ("No packages specified.", "All packages already installed.") and (
-            "Install failed" not in result and "timed out" not in result
-        ):
+        if install_call_installed_something(result):
             send_package_install_event(session, packages)
         return result
 

--- a/anton/core/utils/scratchpad.py
+++ b/anton/core/utils/scratchpad.py
@@ -18,15 +18,62 @@ def _acc_observe(session, kind: str, detail: dict, *, severity: int = 1) -> None
 
 # install_packages' own return shape — no structured success/failure value,
 # so both call sites (exec+packages here, and the standalone install action
-# in tool_handlers.py) key off these same literals.
-_INSTALL_FAILURE_MARKERS = ("Install failed", "timed out")
+# in tool_handlers.py) key off these same literals. Anchored to the message
+# HEAD: failures are reported as a first-line prefix, while a SUCCESSFUL
+# pip/uv run may mention "timed out" mid-output (a retried network read
+# inside an install that then succeeded) without having failed.
+_INSTALL_FAILURE_PREFIXES = ("Install failed", "Install timed out", "Install refused")
 _INSTALL_NOOP_RESULTS = frozenset(
     {"No packages specified.", "All packages already installed."}
 )
 
 
 def install_call_failed(result: str) -> bool:
-    return any(marker in result for marker in _INSTALL_FAILURE_MARKERS)
+    return result.startswith(_INSTALL_FAILURE_PREFIXES)
+
+
+def invalid_package_spec(entry: str) -> bool:
+    """True if `entry` is not a plain PEP 508 requirement (ENG-1635).
+
+    Entries land in `pip install` argv unquoted, so a flag-shaped string
+    ("--index-url=…") would redirect resolution for every package in the
+    call — dependency confusion through the one install path this ticket
+    leaves open. Direct-URL requirements ("name @ https://…") are refused
+    for the same reason: installs come from the configured index or not
+    at all.
+    """
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    try:
+        return Requirement(str(entry)).url is not None
+    except InvalidRequirement:
+        return True
+
+
+def reject_invalid_packages(packages: list[str]) -> str | None:
+    """The shared "Install refused" message, or None when every entry parses.
+
+    Called before install_packages at the model-facing call sites (exec's
+    'packages' array and the install action), and again inside the local
+    runtime as the belt for every other caller (requirements.txt launches).
+    """
+    bad = [str(p) for p in packages if invalid_package_spec(p)]
+    if not bad:
+        return None
+    return (
+        "Install refused: not a plain PyPI package specifier: "
+        + ", ".join(repr(p) for p in bad)
+        + ". Use requirement syntax like 'requests' or 'requests==2.32.0' — "
+        "flags, URLs, and local paths are never passed to pip."
+    )
+
+
+def cell_failure_reason(error: str | None) -> str:
+    """The machine-comparable failure key (ENG-1286/ENG-1492): the traceback's
+    LAST line — the cause — never a hint prepended above it. Tests call this
+    rather than restating the extraction (ENG-1635 review)."""
+    error = (error or "").strip()
+    return error.splitlines()[-1][:160] if error else ""
 
 
 def install_call_installed_something(result: str) -> bool:
@@ -277,9 +324,14 @@ async def prepare_scratchpad_exec(session: ChatSession, tc_input: dict):
 
     pad = await session._scratchpads.get_or_create(name)
 
-    # Auto-install packages before running the cell
+    # Install explicitly declared packages before running the cell
     packages = tc_input.get("packages", [])
     if packages:
+        refused = reject_invalid_packages(packages)
+        if refused:
+            return ToolOutcome(
+                content=refused, ok=False, reason="package_install_rejected"
+            )
         install_result = await pad.install_packages(packages)
         # The substring check against install_packages' message is this
         # handler's own protocol with the runtime (its return shape predates

--- a/anton/core/utils/scratchpad.py
+++ b/anton/core/utils/scratchpad.py
@@ -16,6 +16,22 @@ def _acc_observe(session, kind: str, detail: dict, *, severity: int = 1) -> None
         fn(kind, detail, severity=severity)
 
 
+def send_package_install_event(session, packages: list[str]) -> None:
+    """Fire one telemetry event per installed package — name only, never code."""
+    try:
+        settings = getattr(session, "_settings", None)
+        if settings is None or not hasattr(settings, "analytics_enabled"):
+            from anton.config.settings import AntonSettings
+
+            settings = AntonSettings()
+        from anton.analytics import send_event
+
+        for package in packages:
+            send_event(settings, "scratchpad_package_installed", package=package)
+    except Exception:
+        pass
+
+
 _DISCOVERY_MAX_PADS = 10
 _DISCOVERY_MAX_ROOT_ENTRIES = 30
 
@@ -249,6 +265,8 @@ async def prepare_scratchpad_exec(session: ChatSession, tc_input: dict):
             return ToolOutcome(
                 content=install_result, ok=False, reason="package_install_failed"
             )
+        if install_result not in ("No packages specified.", "All packages already installed."):
+            send_package_install_event(session, packages)
 
     description = tc_input.get("one_line_description", "")
     estimated_seconds = tc_input.get("estimated_execution_time_seconds", 0)

--- a/anton/core/utils/scratchpad.py
+++ b/anton/core/utils/scratchpad.py
@@ -16,8 +16,31 @@ def _acc_observe(session, kind: str, detail: dict, *, severity: int = 1) -> None
         fn(kind, detail, severity=severity)
 
 
-def send_package_install_event(session, packages: list[str]) -> None:
-    """Fire one telemetry event per installed package — name only, never code."""
+# install_packages' own return shape — no structured success/failure value,
+# so both call sites (exec+packages here, and the standalone install action
+# in tool_handlers.py) key off these same literals.
+_INSTALL_FAILURE_MARKERS = ("Install failed", "timed out")
+_INSTALL_NOOP_RESULTS = frozenset(
+    {"No packages specified.", "All packages already installed."}
+)
+
+
+def install_call_failed(result: str) -> bool:
+    return any(marker in result for marker in _INSTALL_FAILURE_MARKERS)
+
+
+def install_call_installed_something(result: str) -> bool:
+    """True if install_packages ran pip and it succeeded.
+
+    Package-level, not request-level: a request naming one cached and one new
+    package still counts as "installed" for every name in it (install_packages
+    doesn't report which of the requested names were actually new).
+    """
+    return result not in _INSTALL_NOOP_RESULTS and not install_call_failed(result)
+
+
+def send_package_install_event(session: ChatSession, packages: list[str]) -> None:
+    """Fire one telemetry event per package named in the call — name only, never code."""
     try:
         settings = getattr(session, "_settings", None)
         if settings is None or not hasattr(settings, "analytics_enabled"):
@@ -261,11 +284,11 @@ async def prepare_scratchpad_exec(session: ChatSession, tc_input: dict):
         # The substring check against install_packages' message is this
         # handler's own protocol with the runtime (its return shape predates
         # ToolOutcome); the verdict it produces is explicit from here on out.
-        if "Install failed" in install_result or "timed out" in install_result:
+        if install_call_failed(install_result):
             return ToolOutcome(
                 content=install_result, ok=False, reason="package_install_failed"
             )
-        if install_result not in ("No packages specified.", "All packages already installed."):
+        if install_call_installed_something(install_result):
             send_package_install_event(session, packages)
 
     description = tc_input.get("one_line_description", "")

--- a/docs/docs/configure/analytics.md
+++ b/docs/docs/configure/analytics.md
@@ -17,9 +17,10 @@ Every event carries:
 - an anonymous installation ID.
 
 Some events also carry **anonymous measurements of that action** — for example
-a datasource event names the engine (`postgres`), and the **measurement
-events** carry token counts, model names, durations and an opaque conversation
-id. These are numbers, names and identifiers only.
+a datasource event names the engine (`postgres`), a scratchpad install event
+names the package (`numpy`), and the **measurement events** carry token
+counts, model names, durations and an opaque conversation id. These are
+numbers, names and identifiers only.
 
 The measurement events are the two that report on Anton's own work rather than
 on something you did: what a turn cost, and how the memory-retrieval step
@@ -47,9 +48,10 @@ Two transports, depending on the event:
 
 - **Most events** are a single HTTP GET to a MindsDB-operated collector, at
   `ANTON_ANALYTICS_URL`. That collector forwards them to PostHog.
-- **The measurement events** are an HTTPS POST directly to **PostHog Inc.**
-  (`us.i.posthog.com`), a US analytics processor. A body rather than a query
-  string, so the values do not end up in intermediate access logs.
+- **The measurement events, and the scratchpad package-install event,** are
+  an HTTPS POST directly to **PostHog Inc.** (`us.i.posthog.com`), a US
+  analytics processor. A body rather than a query string, so the values do
+  not end up in intermediate access logs.
 
 Either way the data ends up in PostHog; the difference is whether it passes
 through MindsDB's collector on the way.
@@ -73,8 +75,8 @@ That switch covers every event on every transport.
 ### Turning off one transport only
 
 `ANTON_ANALYTICS_URL` set empty stops **every** event. Re-pointing it moves only
-the collector-path events; the measurement events still go to PostHog. To
-disable just those, set an empty key:
+the collector-path events; the measurement and package-install events still
+go to PostHog. To disable just those, set an empty key:
 
 ```text
 ANTON_POSTHOG_KEY=

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -178,6 +178,20 @@ def test_turn_completed_goes_to_posthog_not_the_collector(monkeypatch):
     assert body["event"] == "turn_completed"
 
 
+def test_scratchpad_package_installed_goes_to_posthog_not_the_collector(monkeypatch):
+    """The collector allowlists only five property names — 'package' would be
+    dropped there, so this event must take the direct path to survive."""
+    _clear_ci(monkeypatch)
+    captured = _capture_posthog(monkeypatch)
+
+    analytics.send_event(_PosthogSettings(), "scratchpad_package_installed", package="numpy")
+
+    assert len(captured) == 1
+    _, body = captured[0]
+    assert body["event"] == "scratchpad_package_installed"
+    assert body["properties"]["package"] == "numpy"
+
+
 def test_unregistered_events_still_use_the_collector(monkeypatch):
     """Scope guard. Only names in `_POSTHOG_EVENTS` move; nothing else does.
 

--- a/tests/test_root_cause.py
+++ b/tests/test_root_cause.py
@@ -64,6 +64,19 @@ def test_a_submodule_counts_as_its_top_level_package():
     assert a.key == b.key == "missing_dependency:pandas"
 
 
+def test_a_hint_prefixed_before_the_traceback_still_classifies():
+    """A hint prepended before the traceback must not become the LAST line
+    tool_handlers.py reads as `reason` — that has to stay the exception."""
+    error = (
+        "'somepkg' was not auto-installed. Declare it explicitly and retry.\n"
+        "Traceback (most recent call last):\n"
+        '  File "<scratchpad>", line 1, in <module>\n'
+        "ModuleNotFoundError: No module named 'somepkg'"
+    )
+    reason = error.splitlines()[-1][:160]
+    assert classify(reason).cls == "missing_dependency"
+
+
 # ── The safety property ────────────────────────────────────────────────────
 
 

--- a/tests/test_root_cause.py
+++ b/tests/test_root_cause.py
@@ -66,15 +66,19 @@ def test_a_submodule_counts_as_its_top_level_package():
 
 def test_a_hint_prefixed_before_the_traceback_still_classifies():
     """A hint prepended before the traceback must not become the LAST line
-    tool_handlers.py reads as `reason` — that has to stay the exception."""
+    read as `reason` — that has to stay the exception. Uses the production
+    hint and the production extractor, so a change to either is exercised
+    here rather than shadowed by a stale copy (ENG-1635 review)."""
+    from anton.core.backends.wire import MISSING_MODULE_HINT
+    from anton.core.utils.scratchpad import cell_failure_reason
+
     error = (
-        "'somepkg' was not auto-installed. Declare it explicitly and retry.\n"
-        "Traceback (most recent call last):\n"
+        MISSING_MODULE_HINT.format(name="somepkg")
+        + "Traceback (most recent call last):\n"
         '  File "<scratchpad>", line 1, in <module>\n'
         "ModuleNotFoundError: No module named 'somepkg'"
     )
-    reason = error.splitlines()[-1][:160]
-    assert classify(reason).cls == "missing_dependency"
+    assert classify(cell_failure_reason(error)).cls == "missing_dependency"
 
 
 # ── The safety property ────────────────────────────────────────────────────
@@ -333,7 +337,7 @@ def test_ambiguous_sentinels_resolve_away_from_tripping():
     from anton.core.root_cause import classify
 
     for reason in ("artifact_not_found", "unknown_datasource", "launch_failed",
-                   "missing_name", "invalid_port"):
+                   "missing_name", "invalid_port", "package_install_rejected"):
         assert not classify(reason).trip_eligible, reason
     # …while the unambiguous walls stay trip-eligible.
     for reason in ("package_install_failed", "store_unavailable"):

--- a/tests/test_scratchpad_watchdog_contracts.py
+++ b/tests/test_scratchpad_watchdog_contracts.py
@@ -13,6 +13,7 @@ import pytest
 
 from anton.core.backends import local as local_backend
 from anton.core.backends.local import LocalScratchpadRuntime
+from anton.core.backends.wire import MISSING_MODULE_HINT
 from anton.core.llm.prompts import (
     RESILIENCE_NUDGE,
     SCRATCHPAD_INSTALL_NUDGE,
@@ -534,31 +535,24 @@ class TestNudgeRouting:
             == RESILIENCE_NUDGE
         )
 
-    def test_install_timeout_error_routes_to_install_nudge(self):
-        """An install that ran out of its budget is neither a size nor a
-        liveness problem — 'make the cell smaller' cannot make a package
-        install (ENG-1275)."""
-        nudge = ChatSession._select_resilience_nudge(
-            "scratchpad",
-            "ModuleNotFoundError: No module named 'torch'\n"
-            "Auto-install of 'torch' was killed after 120s (cell_install_timeout) "
-            "without finishing — the package is not installed.",
-        )
-        assert nudge == SCRATCHPAD_INSTALL_NUDGE
-        assert "too heavy" not in nudge
-        assert "smaller" not in nudge
+    def test_explicit_install_failure_routes_to_install_nudge(self):
+        """install_packages' own failure shapes — the only install messages
+        the code still emits. Before ENG-1635's review these misrouted:
+        'Install timed out …' fell through to the too-heavy nudge and
+        'Install failed …' to the generic one."""
+        for text in (
+            "Install failed (exit 1):\nERROR: No matching distribution found for torhc",
+            "Install timed out after 120s.",
+            "Install refused: not a plain PyPI package specifier: '--index-url=x'.",
+        ):
+            nudge = ChatSession._select_resilience_nudge("scratchpad", text)
+            assert nudge == SCRATCHPAD_INSTALL_NUDGE, text
+            assert "too heavy" not in nudge
 
-    def test_install_failure_routes_to_install_nudge(self):
-        nudge = ChatSession._select_resilience_nudge(
-            "scratchpad",
-            "ModuleNotFoundError: No module named 'torhc'\n"
-            "Auto-install failed:\nERROR: No matching distribution found for torhc",
-        )
-        assert nudge == SCRATCHPAD_INSTALL_NUDGE
-
-    def test_kill_during_install_routes_to_install_nudge(self):
-        """The kill wording also contains 'liveness' — the install cause must
-        win over the stuck diagnosis."""
+    def test_legacy_worker_kill_during_install_routes_to_install_nudge(self):
+        """Old-version workers still emit the auto-install kill wording, which
+        also contains 'liveness' — the install cause must keep winning over
+        the stuck diagnosis for them."""
         nudge = ChatSession._select_resilience_nudge(
             "scratchpad",
             "Cell killed during auto-install of 'torch' — no liveness signal "
@@ -568,16 +562,31 @@ class TestNudgeRouting:
         assert nudge == SCRATCHPAD_INSTALL_NUDGE
 
     def test_undeclared_import_routes_to_install_nudge(self):
-        """The real shape scratchpad_boot.py now produces: a hint before the
-        traceback, no install ever attempted."""
+        """The real shape scratchpad_boot.py produces: the shared hint before
+        the traceback, no install ever attempted. Routing keys on the
+        interpreter's exception name, so the hint constant is free to change
+        wording without silently killing this route."""
         nudge = ChatSession._select_resilience_nudge(
             "scratchpad",
-            "'somepkg' was not auto-installed. If your code deliberately "
-            "needs it, list it in the exec call's 'packages' array (or use "
-            "the scratchpad's install action) and retry.\n"
+            MISSING_MODULE_HINT.format(name="somepkg")
+            + "Traceback (most recent call last):\n"
+            '  File "<scratchpad>", line 1, in <module>\n'
             "ModuleNotFoundError: No module named 'somepkg'",
         )
         assert nudge == SCRATCHPAD_INSTALL_NUDGE
+
+    def test_hint_and_nudge_do_not_coach_redeclaring_the_name(self):
+        """ENG-1635 finding 1: neither the hint nor the nudge may instruct the
+        model to re-declare the failed name — that routes the same
+        hallucinated package through the surviving install path one turn
+        later, with the agent as the only approver."""
+        hint = MISSING_MODULE_HINT.format(name="functions").lower()
+        assert "'packages'" not in hint
+        assert "install action" not in hint
+        assert "retry" not in hint
+        low = SCRATCHPAD_INSTALL_NUDGE.lower()
+        assert "'packages' array" not in low
+        assert "declare the package" not in low
 
 
 from anton.core.memory.acc import Event, detect_kill_loop

--- a/tests/test_scratchpad_watchdog_contracts.py
+++ b/tests/test_scratchpad_watchdog_contracts.py
@@ -40,8 +40,8 @@ def shrink_timers(monkeypatch, *, heartbeat: str = "0.2") -> None:
     Also shrinks the post-progress() grace window to 1s: left at its 60s
     default, a single "Installing {module}..." progress line would widen the
     silence window enough to survive a several-second silent auto-install on
-    its own, making test_silent_auto_install_survives pass with or without
-    the heartbeat and pin nothing.
+    its own, making tests relying on the inactivity window pass with or
+    without the heartbeat and pin nothing.
     """
     monkeypatch.setenv("ANTON_CELL_INACTIVITY_TIMEOUT", "1")
     monkeypatch.setenv("ANTON_CELL_INACTIVITY_MAX", "1")
@@ -140,21 +140,17 @@ class TestLivenessHeartbeat:
         finally:
             await pad.close()
 
-    async def test_silent_auto_install_survives(self, monkeypatch, tmp_path):
-        """The ENG-1275 shape: in-cell auto-install silent past the window.
-        ANTON_UV_PATH is pointed at a stub that sleeps then fails, so the cell
-        must survive the silent install attempt and report the install error
-        (not an inactivity kill).
+    async def test_module_not_found_does_not_auto_install(self, monkeypatch, tmp_path):
+        """A missing import must never trigger an unattended install — the
+        stub installer touches a sentinel file if it's ever invoked.
 
-        _find_uv is patched to return None: LocalScratchpadRuntime.start()
-        otherwise always overwrites ANTON_UV_PATH with a real `uv` found on
-        PATH (near-universal on a dev/CI box that runs `uv run pytest`),
-        silently discarding this test's stub and making it install-fail in
-        well under a second instead of exercising the slow, silent path.
+        _find_uv is patched to None so start() doesn't overwrite the stub
+        path with a real uv found on PATH.
         """
         shrink_timers(monkeypatch)
+        sentinel = tmp_path / "installer_ran"
         stub = tmp_path / "slow_uv.sh"
-        stub.write_text("#!/bin/sh\nsleep 3\nexit 1\n")
+        stub.write_text(f"#!/bin/sh\ntouch {sentinel}\nsleep 3\nexit 1\n")
         stub.chmod(0o755)
         monkeypatch.setenv("ANTON_UV_PATH", str(stub))
         monkeypatch.setattr(
@@ -165,8 +161,9 @@ class TestLivenessHeartbeat:
         try:
             cell = await pad.execute("import definitely_not_a_real_module_xyz")
             assert cell.error is not None
-            assert "auto-install failed" in cell.error.lower()
-            assert "liveness" not in cell.error.lower()
+            assert "ModuleNotFoundError" in cell.error
+            assert "definitely_not_a_real_module_xyz" in cell.error
+            assert not sentinel.exists(), "an undeclared import must never trigger an install"
         finally:
             await pad.close()
 
@@ -225,139 +222,6 @@ class TestQuietCellNotice:
             assert not any(m.startswith("still running") for m in messages)
         finally:
             await pad.close()
-
-    async def test_quiet_notice_during_install_names_the_install(
-        self, monkeypatch, tmp_path
-    ):
-        """A notice firing mid-install must name the install (ENG-1275's span
-        temporarily inflates the budget the notice quotes, so a bare 'still
-        running' would read as the cell's own progress instead of the
-        install's)."""
-        monkeypatch.setenv("ANTON_CELL_INACTIVITY_TIMEOUT", "1")
-        monkeypatch.setenv("ANTON_CELL_INACTIVITY_MAX", "1")
-        monkeypatch.setenv("ANTON_CELL_TIMEOUT_DEFAULT", "2")
-        monkeypatch.setenv("ANTON_SCRATCHPAD_HEARTBEAT_INTERVAL", "0.1")
-        monkeypatch.setattr(local_backend, "_QUIET_NOTICE_AFTER", 0.3)
-        monkeypatch.setattr(local_backend, "_QUIET_NOTICE_EVERY", 0.1)
-        fake_mod = tmp_path / "eng1324_fake_mod.py"
-        stub = tmp_path / "slow_ok_uv.sh"
-        stub.write_text(
-            f"#!/bin/sh\nsleep 1\necho 'VALUE = 1' > '{fake_mod}'\nexit 0\n"
-        )
-        stub.chmod(0o755)
-        monkeypatch.setenv("ANTON_UV_PATH", str(stub))
-        monkeypatch.setattr(
-            LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: None)
-        )
-        pad = make_pad()
-        await pad.start()
-        try:
-            messages: list[str] = []
-            code = (
-                f"import sys\nsys.path.insert(0, {str(tmp_path)!r})\n"
-                "import eng1324_fake_mod\nprint(eng1324_fake_mod.VALUE)\n"
-            )
-            async for item in pad.execute_streaming(code):
-                if isinstance(item, str):
-                    messages.append(item)
-            notices = [m for m in messages if m.startswith("still running")]
-            assert notices, "expected a quiet notice during the slow install"
-            assert all("eng1324_fake_mod" in m for m in notices)
-        finally:
-            await pad.close()
-
-
-class TestAutoInstallBudget:
-    """ENG-1275: the in-cell auto-installer must run under a budget derived
-    from CoreSettings.cell_install_timeout (one number, both sides), fail with
-    an error naming the install as the cause, and never take the pad down."""
-
-    async def test_install_past_install_timeout_fails_named_and_pad_survives(
-        self, monkeypatch, tmp_path
-    ):
-        """An install running past cell_install_timeout must produce a cell
-        error naming the auto-install and the module — and the worker must
-        survive it (no crash, next cell runs)."""
-        shrink_timers(monkeypatch)
-        monkeypatch.setenv("ANTON_CELL_INSTALL_TIMEOUT", "1")
-        stub = tmp_path / "hung_uv.sh"
-        stub.write_text("#!/bin/sh\nexec sleep 5\n")
-        stub.chmod(0o755)
-        monkeypatch.setenv("ANTON_UV_PATH", str(stub))
-        monkeypatch.setattr(
-            LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: None)
-        )
-        pad = make_pad()
-        await pad.start()
-        try:
-            cell = await pad.execute("import module_that_installs_slowly_eng1275")
-            assert cell.error is not None
-            low = cell.error.lower()
-            assert "auto-install" in low
-            assert "module_that_installs_slowly_eng1275" in cell.error
-            assert "liveness" not in low
-            follow_up = await pad.execute("print('pad-still-alive')")
-            assert follow_up.error is None
-            assert "pad-still-alive" in follow_up.stdout
-        finally:
-            await pad.close()
-
-    async def test_install_outlasting_total_budget_completes(
-        self, monkeypatch, tmp_path
-    ):
-        """The `import torch` shape: an install longer than the cell's total
-        budget must not be killed — the budget defers to the install's own
-        allowance while it runs, and the retried cell completes."""
-        monkeypatch.setenv("ANTON_CELL_INACTIVITY_TIMEOUT", "1")
-        monkeypatch.setenv("ANTON_CELL_INACTIVITY_MAX", "1")
-        monkeypatch.setenv("ANTON_CELL_INACTIVITY_AFTER_PROGRESS", "1")
-        monkeypatch.setenv("ANTON_CELL_TIMEOUT_DEFAULT", "2")
-        monkeypatch.setenv("ANTON_SCRATCHPAD_HEARTBEAT_INTERVAL", "0.2")
-        fake_mod = tmp_path / "eng1275_fake_mod.py"
-        stub = tmp_path / "slow_ok_uv.sh"
-        stub.write_text(
-            f"#!/bin/sh\nsleep 3\necho 'VALUE = 42' > '{fake_mod}'\nexit 0\n"
-        )
-        stub.chmod(0o755)
-        monkeypatch.setenv("ANTON_UV_PATH", str(stub))
-        monkeypatch.setattr(
-            LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: None)
-        )
-        pad = make_pad()
-        await pad.start()
-        try:
-            cell = await pad.execute(
-                f"import sys\nsys.path.insert(0, {str(tmp_path)!r})\n"
-                "import eng1275_fake_mod\nprint(eng1275_fake_mod.VALUE)\n"
-            )
-            assert cell.error is None
-            assert "42" in cell.stdout
-        finally:
-            await pad.close()
-
-    async def test_worker_death_mid_install_names_install(
-        self, monkeypatch, tmp_path
-    ):
-        """A worker that dies while installing must not report the generic
-        'Process exited unexpectedly.' — the error names the install."""
-        shrink_timers(monkeypatch)
-        stub = tmp_path / "killer_uv.sh"
-        stub.write_text("#!/bin/sh\nkill -9 $PPID\n")
-        stub.chmod(0o755)
-        monkeypatch.setenv("ANTON_UV_PATH", str(stub))
-        monkeypatch.setattr(
-            LocalScratchpadRuntime, "_find_uv", staticmethod(lambda: None)
-        )
-        pad = make_pad()
-        await pad.start()
-        try:
-            cell = await pad.execute("import module_whose_install_crashes_eng1275")
-            assert cell.error is not None
-            assert "auto-install" in cell.error.lower()
-            assert "module_whose_install_crashes_eng1275" in cell.error
-        finally:
-            await pad.close()
-
 
 class TestPartialStdoutSalvage:
     async def test_killed_cell_reports_partial_stdout(self, monkeypatch):

--- a/tests/test_scratchpad_watchdog_contracts.py
+++ b/tests/test_scratchpad_watchdog_contracts.py
@@ -567,6 +567,18 @@ class TestNudgeRouting:
         )
         assert nudge == SCRATCHPAD_INSTALL_NUDGE
 
+    def test_undeclared_import_routes_to_install_nudge(self):
+        """The real shape scratchpad_boot.py now produces: a hint before the
+        traceback, no install ever attempted."""
+        nudge = ChatSession._select_resilience_nudge(
+            "scratchpad",
+            "'somepkg' was not auto-installed. If your code deliberately "
+            "needs it, list it in the exec call's 'packages' array (or use "
+            "the scratchpad's install action) and retry.\n"
+            "ModuleNotFoundError: No module named 'somepkg'",
+        )
+        assert nudge == SCRATCHPAD_INSTALL_NUDGE
+
 
 from anton.core.memory.acc import Event, detect_kill_loop
 

--- a/tests/test_tool_outcome_tracking.py
+++ b/tests/test_tool_outcome_tracking.py
@@ -257,6 +257,100 @@ class TestPackageInstallTelemetry:
         assert sent == []
 
     @pytest.mark.asyncio
+    async def test_install_success_with_retry_warning_is_not_a_failure(self, monkeypatch):
+        """A network hiccup pip retried through must not fail the call: the
+        old markers matched 'timed out' ANYWHERE, so a successful install
+        whose output mentioned a retried read was classified as failed — the
+        cell never ran despite the package being present, and the install
+        event was suppressed (ENG-1635 review, finding 3)."""
+        sent = []
+        monkeypatch.setattr(
+            "anton.analytics.send_event",
+            lambda settings, action, **extra: sent.append((action, extra)),
+        )
+        pad = SimpleNamespace(
+            install_packages=AsyncMock(
+                return_value=(
+                    "WARNING: Retrying (Retry(total=4)) after connection broken by "
+                    "'ReadTimeoutError(\"HTTPSConnectionPool: Read timed out.\")'\n"
+                    "Successfully installed numpy-2.1.0"
+                )
+            )
+        )
+        result = await prepare_scratchpad_exec(
+            _install_session(pad),
+            {"action": "exec", "name": "main", "code": "import numpy", "packages": ["numpy"]},
+        )
+        assert not isinstance(result, ToolOutcome), "install succeeded — the cell must run"
+        assert sent == [("scratchpad_package_installed", {"package": "numpy"})]
+
+    @pytest.mark.asyncio
+    async def test_flag_shaped_package_entry_is_refused_before_any_install(self, monkeypatch):
+        """ENG-1635 finding 2: 'packages' entries land in pip's argv, so a
+        flag-shaped entry ('--index-url=…') would redirect resolution for
+        every package in the call. It must be refused before install_packages
+        runs, with a self-inflicted (non-wall) reason."""
+        sent = []
+        monkeypatch.setattr(
+            "anton.analytics.send_event",
+            lambda settings, action, **extra: sent.append((action, extra)),
+        )
+        pad = SimpleNamespace(install_packages=AsyncMock())
+        for bad in (
+            "--index-url=http://127.0.0.1:9/simple",
+            "-e .",
+            "requests @ https://evil.example/requests.whl",
+            "../local/path",
+        ):
+            result = await prepare_scratchpad_exec(
+                _install_session(pad),
+                {"action": "exec", "name": "main", "code": "import requests",
+                 "packages": [bad, "requests"]},
+            )
+            assert isinstance(result, ToolOutcome), bad
+            assert result.ok is False
+            assert result.reason == "package_install_rejected"
+            assert "Install refused" in result.content
+        pad.install_packages.assert_not_called()
+        assert sent == []
+
+    @pytest.mark.asyncio
+    async def test_install_action_also_refuses_flag_shaped_entries(self):
+        from anton.core.tools.tool_handlers import handle_scratchpad
+
+        pad = SimpleNamespace(install_packages=AsyncMock())
+        session = _install_session(pad)
+        result = await handle_scratchpad(
+            session,
+            {"action": "install", "name": "main",
+             "packages": ["--extra-index-url=http://evil/simple"]},
+        )
+        assert isinstance(result, ToolOutcome)
+        assert result.ok is False
+        assert result.reason == "package_install_rejected"
+        pad.install_packages.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_specifiers_still_install(self, monkeypatch):
+        """The gate must not over-reject: plain names, pins, and extras are
+        the legitimate traffic."""
+        sent = []
+        monkeypatch.setattr(
+            "anton.analytics.send_event",
+            lambda settings, action, **extra: sent.append((action, extra)),
+        )
+        pad = SimpleNamespace(
+            install_packages=AsyncMock(return_value="Successfully installed x")
+        )
+        result = await prepare_scratchpad_exec(
+            _install_session(pad),
+            {"action": "exec", "name": "main", "code": "import requests",
+             "packages": ["requests==2.32.0", "uvicorn[standard]", "numpy>=2,<3"]},
+        )
+        assert not isinstance(result, ToolOutcome)
+        pad.install_packages.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_install_action_also_sends_the_event(self, monkeypatch):
         from anton.core.tools.tool_handlers import handle_scratchpad
 

--- a/tests/test_tool_outcome_tracking.py
+++ b/tests/test_tool_outcome_tracking.py
@@ -201,3 +201,76 @@ class TestScratchpadOutcomes:
         )
         assert isinstance(outcome, ToolOutcome)
         assert outcome.ok is True
+
+
+def _install_session(pad) -> SimpleNamespace:
+    return SimpleNamespace(
+        _acc_observe=None,
+        _agent_scratchpad_names=set(),
+        _scratchpads=MagicMock(
+            agent_pads=MagicMock(return_value=set()),
+            get_or_create=AsyncMock(return_value=pad),
+        ),
+        _scratchpad_challenged=False,
+        _settings=SimpleNamespace(analytics_enabled=True),
+    )
+
+
+class TestPackageInstallTelemetry:
+    @pytest.mark.asyncio
+    async def test_successful_install_sends_package_name_only(self, monkeypatch):
+        # Visibility into what gets installed — package name, never the cell.
+        sent = []
+        monkeypatch.setattr(
+            "anton.analytics.send_event",
+            lambda settings, action, **extra: sent.append((action, extra)),
+        )
+        pad = SimpleNamespace(
+            install_packages=AsyncMock(return_value="Successfully installed numpy")
+        )
+        result = await prepare_scratchpad_exec(
+            _install_session(pad),
+            {
+                "action": "exec",
+                "name": "main",
+                "code": "import numpy; print('secret sauce')",
+                "packages": ["numpy"],
+            },
+        )
+        assert not isinstance(result, ToolOutcome)
+        assert sent == [("scratchpad_package_installed", {"package": "numpy"})]
+
+    @pytest.mark.asyncio
+    async def test_already_installed_sends_no_event(self, monkeypatch):
+        sent = []
+        monkeypatch.setattr(
+            "anton.analytics.send_event",
+            lambda settings, action, **extra: sent.append((action, extra)),
+        )
+        pad = SimpleNamespace(
+            install_packages=AsyncMock(return_value="All packages already installed.")
+        )
+        await prepare_scratchpad_exec(
+            _install_session(pad),
+            {"action": "exec", "name": "main", "code": "import numpy", "packages": ["numpy"]},
+        )
+        assert sent == []
+
+    @pytest.mark.asyncio
+    async def test_install_action_also_sends_the_event(self, monkeypatch):
+        from anton.core.tools.tool_handlers import handle_scratchpad
+
+        sent = []
+        monkeypatch.setattr(
+            "anton.analytics.send_event",
+            lambda settings, action, **extra: sent.append((action, extra)),
+        )
+        pad = SimpleNamespace(
+            install_packages=AsyncMock(return_value="Successfully installed cowsay")
+        )
+        session = _install_session(pad)
+        result = await handle_scratchpad(
+            session, {"action": "install", "name": "main", "packages": ["cowsay"]}
+        )
+        assert result == "Successfully installed cowsay"
+        assert sent == [("scratchpad_package_installed", {"package": "cowsay"})]


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-1635/security-the-scratchpad-auto-installs-any-module-name-the-model


- Removed the exception-triggered pip-install-and-retry in scratchpad_boot.py — a missing import now surfaces as a normal error with a hint, no install attempt
- Only install path left is the pre-existing explicit packages array
- Added telemetry (scratchpad_package_installed, package name only) for installs that do happen
- Clarified in tool description/system prompt that get_llm/agentic_loop/web_search/sample/progress are already globals, no import needed
- Updated docs/configure/analytics.md to disclose the new event
- Fixed the hint ordering so it doesn't break root-cause classification (traceback's last line)
- Reworded SCRATCHPAD_INSTALL_NUDGE to stop claiming an install was attempted
- Deduped the install-success/failure check into shared helpers
- Marked the now-dead ENG-1275 install-span code as dead in comments
