### PR TITLE
fix(cli): name the endpoint that actually serves requests (ENG-1634)

### DIFF
--- a/anton/cli.py
+++ b/anton/cli.py
@@ -72,6 +72,11 @@ def is_minds_host(base: str, minds_url: str = "") -> bool:
     Judged from the endpoint, never from whether a MindsHub key or URL happens to
     be configured: signing in sets those, so a user running a local model has
     them too. *minds_url* covers self-hosted gateways on a private host.
+
+    A schemeless base ("api.mindshub.ai/v1") names no host to ``urlparse`` and
+    so reads as not-MindsHub. Deliberate: this only picks a display label, and
+    declining to claim MindsHub is the safe direction. Cowork's equivalent
+    assumes a scheme, because there the answer decides routing.
     """
     from urllib.parse import urlparse
 
@@ -92,6 +97,30 @@ def is_minds_host(base: str, minds_url: str = "") -> bool:
     return host in ("mindshub.ai", "mdb.ai") or host.endswith(
         (".mindshub.ai", ".mdb.ai")
     )
+
+
+def openai_compatible_label(settings) -> str:
+    """Display label for an ``openai-compatible`` provider.
+
+    Names the endpoint that will actually serve requests, read from
+    ``openai_base_url``. Not from ``minds_url``: signing in to MindsHub sets
+    that, so a user pointed at a local model has it too and would be told their
+    prompts go to MindsHub when they do not.
+
+    Shared with the ``/setup`` summary so the two surfaces cannot disagree
+    about where requests go.
+    """
+    base = settings.openai_base_url or ""
+    if is_minds_host(base, settings.minds_url or ""):
+        return "MindsHub"
+    host = url_hostname(base)
+    if host == "generativelanguage.googleapis.com" or host.endswith(
+        ".generativelanguage.googleapis.com"
+    ):
+        return "Google Gemini"
+    if base:
+        return f"OpenAI-compatible ({base})"
+    return "OpenAI-compatible"
 
 
 def _reexec() -> None:
@@ -615,18 +644,7 @@ async def _animate_onboard(
     provider_label = settings.planning_provider
     model_label = settings.planning_model
     if provider_label == "openai-compatible":
-        base = settings.openai_base_url or ""
-        # The base URL decides, not minds_url: that is set for anyone signed in,
-        # so testing it labelled a local endpoint "MindsHub" — telling a user
-        # their prompts stayed on their machine when they did not.
-        if is_minds_host(base, settings.minds_url or ""):
-            provider_label = "MindsHub"
-        elif url_hostname(base) == "generativelanguage.googleapis.com":
-            provider_label = "Google Gemini"
-        elif base:
-            provider_label = f"OpenAI-compatible ({base})"
-        else:
-            provider_label = "OpenAI-compatible"
+        provider_label = openai_compatible_label(settings)
     console.print(f"  [anton.muted]Provider:[/] [anton.cyan]{provider_label}[/]")
     console.print(f"  [anton.muted]Model:[/]    [anton.cyan]{model_label}[/]")
     console.print()

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -66,6 +66,34 @@ def url_hostname(url: str) -> str:
         return ""
 
 
+def is_minds_host(base: str, minds_url: str = "") -> bool:
+    """Whether *base* points at MindsHub rather than an endpoint of the user's own.
+
+    Judged from the endpoint, never from whether a MindsHub key or URL happens to
+    be configured: signing in sets those, so a user running a local model has
+    them too. *minds_url* covers self-hosted gateways on a private host.
+    """
+    from urllib.parse import urlparse
+
+    def _origin(url: str) -> tuple[str, int | None]:
+        try:
+            parsed = urlparse(url)
+            return (parsed.hostname or "", parsed.port)
+        except Exception:
+            return ("", None)
+
+    host, port = _origin(base)
+    if not host:
+        return False
+    # Host AND port: a self-hosted gateway and a local model server often share
+    # a machine and differ only by port.
+    if minds_url and (host, port) == _origin(minds_url):
+        return True
+    return host in ("mindshub.ai", "mdb.ai") or host.endswith(
+        (".mindshub.ai", ".mdb.ai")
+    )
+
+
 def _reexec() -> None:
     """Re-execute the current process from scratch using the original binary."""
     # Prefer the installed `anton` binary so the uv tool wrapper re-runs correctly.
@@ -588,9 +616,10 @@ async def _animate_onboard(
     model_label = settings.planning_model
     if provider_label == "openai-compatible":
         base = settings.openai_base_url or ""
-        if settings.minds_url and (
-            "mindshub.ai" in settings.minds_url or "mdb.ai" in settings.minds_url
-        ):
+        # The base URL decides, not minds_url: that is set for anyone signed in,
+        # so testing it labelled a local endpoint "MindsHub" — telling a user
+        # their prompts stayed on their machine when they did not.
+        if is_minds_host(base, settings.minds_url or ""):
             provider_label = "MindsHub"
         elif url_hostname(base) == "generativelanguage.googleapis.com":
             provider_label = "Google Gemini"

--- a/anton/commands/setup.py
+++ b/anton/commands/setup.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
 
 from rich.console import Console
 
@@ -40,25 +39,12 @@ async def handle_setup_models(
     global_ws = _Workspace(Path.home())
 
     def _provider_label(provider: str) -> str:
+        # Shared with the startup summary so both surfaces name the endpoint
+        # that actually serves requests.
+        from anton.cli import openai_compatible_label
+
         if provider == "openai-compatible":
-            base = settings.openai_base_url or ""
-            if settings.minds_url and (
-                "mindshub.ai" in settings.minds_url or "mdb.ai" in settings.minds_url
-            ):
-                return "MindsHub"
-            else:
-                hostname = None
-                if base:
-                    parsed = urlparse(base)
-                    hostname = parsed.hostname
-                if hostname and (
-                    hostname == "generativelanguage.googleapis.com"
-                    or hostname.endswith(".generativelanguage.googleapis.com")
-                ):
-                    return "Google Gemini"
-                elif base:
-                    return f"OpenAI-compatible ({base})"
-            return "OpenAI-compatible"
+            return openai_compatible_label(settings)
         return provider.capitalize()
 
     provider_display = _provider_label(settings.planning_provider)

--- a/tests/test_provider_label_host.py
+++ b/tests/test_provider_label_host.py
@@ -1,0 +1,35 @@
+"""The setup summary must name the endpoint that will actually serve requests.
+
+A MindsHub key and URL are set for anyone signed in, so deciding the label from
+`minds_url` told a user pointed at a local model that they were on MindsHub —
+the claim they installed a local model to be able to trust.
+"""
+from anton.cli import is_minds_host
+
+
+def test_local_endpoint_is_not_minds_even_when_signed_in():
+    assert (
+        is_minds_host("http://192.168.1.100:1234/v1", "https://api.mindshub.ai")
+        is False
+    )
+
+
+def test_public_minds_hosts():
+    assert is_minds_host("https://api.mindshub.ai/v1") is True
+    assert is_minds_host("https://llm.mdb.ai/api/v1") is True
+
+
+def test_self_hosted_gateway_matches_by_minds_url():
+    assert is_minds_host("http://gateway.internal:8080/v1", "http://gateway.internal:8080") is True
+
+
+def test_same_host_different_port_is_not_the_gateway():
+    assert is_minds_host("http://gateway.internal:1234/v1", "http://gateway.internal:8080") is False
+
+
+def test_lookalike_host_is_not_minds():
+    assert is_minds_host("https://notmindshub.ai/v1") is False
+
+
+def test_unset_base_is_not_minds():
+    assert is_minds_host("", "https://api.mindshub.ai") is False

--- a/tests/test_provider_label_host.py
+++ b/tests/test_provider_label_host.py
@@ -33,3 +33,61 @@ def test_lookalike_host_is_not_minds():
 
 def test_unset_base_is_not_minds():
     assert is_minds_host("", "https://api.mindshub.ai") is False
+
+
+# ── The label itself ────────────────────────────────────────────────────
+#
+# The helper tests above pin the host comparison. These pin the thing the bug
+# was actually about: WHICH setting the label is read from. Reverting the call
+# site to the old `minds_url` substring check turns these red.
+
+from types import SimpleNamespace
+
+from anton.cli import openai_compatible_label
+
+
+def _cfg(base: str, minds_url: str = ""):
+    return SimpleNamespace(openai_base_url=base, minds_url=minds_url)
+
+
+def test_label_names_the_local_endpoint_not_mindshub():
+    label = openai_compatible_label(
+        _cfg("http://192.168.1.100:1234/v1", "https://api.mindshub.ai")
+    )
+    assert label != "MindsHub"
+    assert "192.168.1.100:1234" in label
+
+
+def test_label_says_mindshub_for_the_gateway():
+    assert (
+        openai_compatible_label(_cfg("https://api.mindshub.ai/v1", "https://api.mindshub.ai"))
+        == "MindsHub"
+    )
+
+
+def test_label_never_claims_mindshub_without_an_endpoint_to_point_to():
+    """No base URL names no endpoint, so the label must not assert one.
+
+    A real MindsHub config does not reach here with an empty base: settings
+    derive it from ``minds_url``. So this shape means the endpoint is unknown,
+    and the old check answered "MindsHub" for it purely because a MindsHub URL
+    was configured — the over-claim this label exists to stop.
+    """
+    assert openai_compatible_label(_cfg("", "https://api.mindshub.ai")) == "OpenAI-compatible"
+
+
+def test_label_recognises_gemini():
+    base = "https://generativelanguage.googleapis.com/v1beta/openai/"
+    assert openai_compatible_label(_cfg(base, "https://api.mindshub.ai")) == "Google Gemini"
+
+
+def test_setup_summary_uses_the_same_label():
+    """/setup must not disagree with the startup summary about the endpoint."""
+    import inspect
+
+    from anton.commands import setup
+
+    src = inspect.getsource(setup.handle_setup_models)
+    assert "openai_compatible_label" in src
+    # The old substring check must not survive anywhere in this module.
+    assert "mindshub.ai\" in" not in inspect.getsource(setup)


### PR DESCRIPTION
## Description

The setup summary decided the provider label from `minds_url`:

```python
if settings.minds_url and ("mindshub.ai" in settings.minds_url or "mdb.ai" in settings.minds_url):
    provider_label = "MindsHub"
```

`minds_url` is set for anyone signed in, so this labelled the provider "MindsHub" regardless of where requests actually go. A user pointed at a local model was told they were running on MindsHub — the one claim a local model is installed to be able to trust.

`is_minds_host` now judges from the base URL, the value that decides routing. It matches host **and** port, so a self-hosted gateway and a local model server sharing a machine stay distinct, and the `mindshub.ai` / `mdb.ai` suffixes are dot-anchored so a lookalike host misses.

This is the self-report half of ENG-1634; the routing half is in cowork (mindsdb/cowork#688) and cowork-server (mindsdb/cowork-server#356).

Related to ENG-1634

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing

New `tests/test_provider_label_host.py` covers each branch: a LAN endpoint while signed in, the public hosts, a self-hosted gateway matched via `minds_url`, same host with a different port, a lookalike host, and an unset base.

Full suite: 2341 passed, 17 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)