### PR TITLE
ENG-1459: declare which surface a turn came from, on every path

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -20,6 +20,7 @@ from anton.clipboard import (
     replace_at_image_paths,
     save_clipboard_image,
 )
+from anton.core.llm.tracing import SURFACE_CLI
 from anton.core.session import ChatSession, ChatSessionConfig, _is_provider_auth_error
 from anton.core.llm.prompt_builder import SystemPromptContext
 from anton.core.llm.provider import (
@@ -1396,6 +1397,10 @@ async def _chat_loop(
         # ENG-1495: see the note on the same field in chat_session.py — an unset
         # `harness` is indistinguishable from a host that forgot to set one.
         harness="cli",
+        # WHERE this ran, as opposed to which agent ran (ENG-1459).
+        # ENG-1694 will move the host meaning out of `harness` entirely,
+        # at which point this becomes the only place "cli" is stated.
+        surface=SURFACE_CLI,
         proactive_dashboards=settings.proactive_dashboards,
         act_first=settings.act_first,
         output_dir=settings.artifacts_dir,

--- a/anton/chat_session.py
+++ b/anton/chat_session.py
@@ -88,6 +88,7 @@ def rebuild_session(
     """Rebuild LLMClient + ChatSession after settings change."""
     from anton.core.llm.client import LLMClient
     from anton.chat import ChatSession
+    from anton.core.llm.tracing import SURFACE_CLI
     from anton.core.session import ChatSessionConfig
     from anton.tools import DEFAULT_SESSION_TOOLS
 
@@ -121,6 +122,10 @@ def rebuild_session(
         # didn't identify itself", so the two could never be told apart and the
         # ambiguity got worse with every new host.
         harness="cli",
+        # WHERE this ran, as opposed to which agent ran (ENG-1459).
+        # ENG-1694 will move the host meaning out of `harness` entirely,
+        # at which point this becomes the only place "cli" is stated.
+        surface=SURFACE_CLI,
         proactive_dashboards=settings.proactive_dashboards,
         act_first=settings.act_first,
         output_dir=settings.artifacts_dir,

--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -204,7 +204,17 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
         tool_args_len: dict[str, int] = {}
         seen_tool_progress: set[str] = set()
         last_progress_wire = 0.0
-        async for event in session.turn_stream(turn_content):
+        # Build attribution rides the turn, not the session: cowork resolved it
+        # per turn and only it knows the server version / install channel (this
+        # image has no cowork-server). `surface` is handled on the session
+        # config instead, so it is dropped here to avoid stamping it twice.
+        # Observability only — a malformed block must never affect the turn.
+        _trace_md = {
+            str(k): str(v)
+            for k, v in (req.trace or {}).items()
+            if k != "surface" and v is not None
+        } or None
+        async for event in session.turn_stream(turn_content, trace_metadata=_trace_md):
             if isinstance(event, StreamTextDelta):
                 emit({"kind": "delta", "text": event.text or ""})
             # Step events go on the wire for cowork's thinking/steps UI;

--- a/anton/cloud_turn/contract.py
+++ b/anton/cloud_turn/contract.py
@@ -45,6 +45,19 @@ class TurnRequestV1:
     #: {slug: {"files": {relpath: text}}}. Staged read-only in the pod; the pod
     #: never writes skills back (agent-built skills are a desktop draft flow).
     skills: dict | None = None
+    #: Optional trace-attribution block cowork resolved for this turn:
+    #: ``{"surface": "web", "cowork_server_version": ..., "install_channel": ...}``.
+    #: Observability only — nothing here may affect what the turn DOES.
+    #:
+    #: It has to travel because the pod cannot derive any of it: cowork-server is
+    #: not installed in this image, and only the deployment knows which surface it
+    #: serves. Without it a web turn is indistinguishable from a desktop one
+    #: (ENG-1459), and ENG-1279's server version + install channel are absent too.
+    #:
+    #: Deliberately one open dict rather than N typed fields: every key otherwise
+    #: needs declaring in three repos (cowork-server -> scratchpad-controller's
+    #: allowlist -> here), so a block keeps the next key to two.
+    trace: dict | None = None
 
     @staticmethod
     def from_json(raw: str) -> "TurnRequestV1":
@@ -59,4 +72,7 @@ class TurnRequestV1:
             llm=d.get("llm"),
             memory=d.get("memory"),
             skills=d.get("skills"),
+            # A controller too old to forward it simply yields None, which reads
+            # as "no attribution" rather than failing the turn.
+            trace=d.get("trace") if isinstance(d.get("trace"), dict) else None,
         )

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -584,6 +584,11 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
         workspace=workspace,
         session_id=request.conversation_id,
         harness="cloud",
+        # WHERE the user was, which this pod cannot know on its own — only the
+        # deployment does, so cowork sends it (ENG-1459). Absent when the pod is
+        # driven directly rather than by cowork; an unset surface reads as
+        # "nobody declared one", which is the honest answer for a standalone run.
+        surface=(request.trace or {}).get("surface"),
         # DB-authoritative history; the pod never loads its own.
         initial_history=list(request.history) if request.history else None,
         console=None,                       # headless

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -913,7 +913,7 @@ class OpenAIProvider(LLMProvider):
         """
         if not self._emit_trace_headers:
             return None
-        from .tracing import get_trace_context
+        from .tracing import get_trace_context, surface_tag
 
         ctx = get_trace_context()
         if ctx is None:
@@ -929,6 +929,12 @@ class OpenAIProvider(LLMProvider):
         tags: list[str] = []
         if ctx.harness:
             tags.append(ctx.harness)
+        # Where the user was (ENG-1459), prefixed so it cannot be confused with
+        # the bare `harness` tag — `cli` is currently a legal value of BOTH
+        # fields while ENG-1694 is in flight, and an unprefixed tag would make
+        # the two indistinguishable in a filter.
+        if ctx.surface:
+            tags.append(surface_tag(ctx.surface))
         tags.extend(ctx.tags)
         tags = [t for t in (self._sanitize_langfuse_tag(s) for s in tags) if t]
         if tags:
@@ -940,6 +946,11 @@ class OpenAIProvider(LLMProvider):
             extra["turn_id"] = ctx.turn_id
         if ctx.harness:
             extra["harness"] = ctx.harness
+        # Also in metadata, unprefixed: a human reading one trace sees the
+        # plain value, and a metadata filter can reach it without knowing the
+        # tag convention. The tag is what a cheap population count uses.
+        if ctx.surface:
+            extra["surface"] = ctx.surface
         # Our own build (ENG-1279). The router lifts this onto the trace's
         # native `version` field, the only form the Langfuse metrics API can
         # group by — so "did this fix change behaviour in production?" becomes

--- a/anton/core/llm/tracing.py
+++ b/anton/core/llm/tracing.py
@@ -23,6 +23,47 @@ from contextvars import ContextVar, Token
 from dataclasses import dataclass, replace
 
 
+# Where the user was when the turn happened (ENG-1459). This is the CANONICAL
+# definition; cowork-server imports these rather than repeating the strings, so
+# the field cannot pick up a second vocabulary the way ``harness`` did.
+#
+# `surface` answers WHERE, `harness` answers WHICH AGENT. They are orthogonal:
+# a `web` turn and a `desktop` turn can both run the anton agent, and after
+# ENG-1694 `harness` will carry only the agent identity (`anton` / `hermes`).
+#
+#   SURFACE_DESKTOP  the Electron app
+#   SURFACE_WEB      the SaaS build (cowork-server derives it from org tenancy)
+#   SURFACE_CLI      anton's own interactive chat
+#
+# Deliberately NOT a value here: the cloud one-turn-per-pod path. That is an
+# *execution mode*, not a place a user sits — cowork is its caller, so one web
+# turn could legitimately be both — and folding it in would recreate exactly
+# the two-vocabularies-in-one-field problem this pair of fields is undoing.
+SURFACE_DESKTOP = "desktop"
+SURFACE_WEB = "web"
+SURFACE_CLI = "cli"
+VALID_SURFACES = frozenset({SURFACE_DESKTOP, SURFACE_WEB, SURFACE_CLI})
+
+# Tags are the only Langfuse dimension a filter can reach cheaply, but they are
+# a flat namespace shared with caller-supplied tags — so the value is prefixed.
+# Two reasons it is not emitted bare: an unprefixed `cli` would be
+# indistinguishable from the `harness` tag of the same name while ENG-1694 is
+# still in flight, and `origin:` (ENG-1289) already set this convention one
+# change earlier.
+#
+# NOTE for anyone querying it: tags are FILTERABLE, not groupable.
+# ``dimensions: [{field: "tags"}]`` keys on the whole tag array as a tuple and
+# returns roughly one row per trace. Use
+# ``filters: [{column: "tags", operator: "any of", value: ["surface:web"], type: "arrayOptions"}]``
+# and count, one query per surface.
+SURFACE_TAG_PREFIX = "surface:"
+
+
+def surface_tag(surface: str) -> str:
+    """Render a surface as its Langfuse tag (``web`` -> ``surface:web``)."""
+    return f"{SURFACE_TAG_PREFIX}{surface}"
+
+
 @dataclass(frozen=True)
 class TraceContext:
     """Identifiers attached to outbound LLM calls during a turn."""
@@ -30,6 +71,11 @@ class TraceContext:
     session_id: str | None = None
     turn_id: int | None = None
     harness: str | None = None
+    # Where the user was: one of VALID_SURFACES, or None when the host did not
+    # say. None is a real answer ("unknown host"), not a default to be guessed
+    # at — the same reservation ``harness`` makes, and the reason ENG-1495 had
+    # to stop the CLI reporting an empty string.
+    surface: str | None = None
     # Optional, caller-supplied trace annotations forwarded verbatim to the
     # langfuse-style headers (see ``OpenAIProvider._build_trace_headers``).
     # `tags` are appended to ``Langfuse-Tags``; `metadata` is merged into

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -63,6 +63,7 @@ from anton.core.llm.thalamus import (
     gate_turn,
 )
 from anton.core.llm.tracing import (
+    VALID_SURFACES,
     TraceContext,
     reset_trace_context,
     set_trace_context,
@@ -790,6 +791,36 @@ def _build_verify_request(
     return verifier_system, verify_messages
 
 
+def _validated_surface(value: str | None) -> str | None:
+    """Keep only a recognised surface; drop anything else with a warning.
+
+    Hosts supply this string, so it is treated as untrusted (ENG-1459). An
+    unrecognised value is dropped rather than forwarded for two reasons: it
+    would appear as a junk row in every surface breakdown, and a *wrong*
+    surface is worse than an absent one — an absent one is visibly unknown,
+    while a wrong one silently moves a turn into the population it is being
+    compared against.
+
+    Never raises. Telemetry must not be able to fail a turn.
+    """
+    if value is None:
+        return None
+    try:
+        cleaned = str(value).strip().lower()
+    except Exception:  # pragma: no cover - defensive: a pathological __str__
+        return None
+    if not cleaned:
+        return None
+    if cleaned not in VALID_SURFACES:
+        logger.warning(
+            "ignoring unrecognised surface %r (expected one of %s)",
+            value,
+            sorted(VALID_SURFACES),
+        )
+        return None
+    return cleaned
+
+
 @dataclass
 class ChatSessionConfig:
     """All construction parameters for a ChatSession.
@@ -819,8 +850,8 @@ class ChatSessionConfig:
     # The values actually in use, which are NOT what this field's name suggests:
     #   "cli"     — anton's own interactive chat (chat_session.py, chat.py)
     #   "anton"   — cowork-server, which passes its *agent harness* id here;
-    #               desktop and hosted web are indistinguishable, both send
-    #               this (ENG-1459 is where that gets split)
+    #               this — see `surface` below, which is how they are now told
+    #               apart (ENG-1459)
     #   "cloud"   — the one-turn-per-pod cloud path
     #   None      — a host that did not identify itself
     #
@@ -828,6 +859,18 @@ class ChatSessionConfig:
     # unset, so "" meant both "CLI" and "unidentified" and nothing could tell
     # them apart.
     harness: str | None = None
+    # WHERE the user was, as opposed to which agent ran: one of
+    # `anton.core.llm.tracing.VALID_SURFACES` (`desktop` / `web` / `cli`), or
+    # None when the host did not say. Surfaced on langfuse traces as the
+    # `surface:<value>` tag plus a `surface` metadata key (ENG-1459).
+    #
+    # Hosts that serve more than one surface must resolve it themselves —
+    # cowork-server derives `web` from org tenancy and `desktop` otherwise,
+    # because only the host knows how it was deployed. An unrecognised value is
+    # dropped with a warning rather than forwarded: it would become a junk row
+    # in every surface breakdown, and a wrong surface is worse than an absent
+    # one.
+    surface: str | None = None
     proactive_dashboards: bool = False
     # When True (default), Anton acts on reasonable defaults and surfaces its
     # assumptions inline instead of stopping to ask ("do first, ask later").
@@ -986,6 +1029,7 @@ class ChatSession:
         self._history_store = config.history_store
         self._session_id = config.session_id
         self._harness = config.harness
+        self._surface = _validated_surface(config.surface)
         # Per-turn token cost books (ENG-1288). Created and armed at each
         # turn's start; emitted and disarmed in the turn's finally. None
         # outside a turn.
@@ -3494,6 +3538,7 @@ class ChatSession:
                 session_id=self._session_id,
                 turn_id=turn_id if turn_id is not None else self._turn_count + 1,
                 harness=self._harness,
+                surface=self._surface,
                 tags=tuple(trace_tags or ()),
                 metadata=trace_metadata or None,
             )

--- a/tests/cloud_turn/test_heartbeat.py
+++ b/tests/cloud_turn/test_heartbeat.py
@@ -15,7 +15,9 @@ async def test_stream_turn_emits_heartbeat_during_slow_turn(monkeypatch):
     from anton.core.llm.provider import StreamTextDelta
 
     class SlowSession:
-        async def turn_stream(self, user_input):
+        # `**kwargs` as every other fake in tests/ does: the entrypoint passes
+        # trace_metadata (ENG-1459) and may pass more later.
+        async def turn_stream(self, user_input, **kwargs):
             await asyncio.sleep(0.25)  # quiet period longer than the heartbeat interval
             yield StreamTextDelta(text="done")
 

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -391,3 +391,59 @@ def test_entrypoint_wires_attachment_augmentation(tmp_path, monkeypatch):
     _drive(_S())
     assert isinstance(captured["input"], list)            # augmented, not the bare "hi"
     assert any(b.get("type") == "text" and "notes.txt" in b.get("text", "") for b in captured["input"])
+
+
+# ── build attribution rides the turn (ENG-1459 / ENG-1279) ───────────────────
+
+
+class _KwargCapturingSession(_FakeSession):
+    """Records the kwargs the entrypoint passes to turn_stream."""
+
+    def __init__(self):
+        super().__init__(deltas=["ok"])
+        self.turn_kwargs = None
+
+    async def turn_stream(self, user_input, **kwargs):
+        self.turn_kwargs = kwargs
+        for d in self._deltas:
+            yield StreamTextDelta(text=d)
+
+
+def _drive_with_trace(trace_json: str):
+    session = _KwargCapturingSession()
+    _drive(
+        session,
+        req_json='{"protocol_version":1,"conversation_id":"c","input":"hi",'
+                 f'"trace":{trace_json}}}',
+    )
+    return session.turn_kwargs
+
+
+def test_build_attribution_is_forwarded_onto_the_turn():
+    # `cowork_server_version` / `install_channel` are ENG-1279 fields the pod
+    # cannot self-report — 0 of 68 prod cloud traces carried them before this.
+    kwargs = _drive_with_trace(
+        '{"surface":"web","cowork_server_version":"0.26.8.17.1","install_channel":"hosted"}'
+    )
+    assert kwargs["trace_metadata"] == {
+        "cowork_server_version": "0.26.8.17.1",
+        "install_channel": "hosted",
+    }
+
+
+def test_surface_is_not_duplicated_into_the_turn_metadata():
+    # It rides the session config instead; stamping both would put two sources
+    # of truth for one value on the same trace.
+    kwargs = _drive_with_trace('{"surface":"web","install_channel":"hosted"}')
+    assert "surface" not in kwargs["trace_metadata"]
+
+
+def test_a_surface_only_block_forwards_no_metadata():
+    kwargs = _drive_with_trace('{"surface":"web"}')
+    assert kwargs["trace_metadata"] is None
+
+
+def test_no_trace_block_forwards_no_metadata():
+    session = _KwargCapturingSession()
+    _drive(session)
+    assert session.turn_kwargs["trace_metadata"] is None

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -737,3 +737,30 @@ def test_conflicting_paths_do_not_fail_the_turn(tmp_path, monkeypatch, skills_tm
     }}}
     _, cfg = _build(tmp_path, monkeypatch, skills=skills)
     assert (cfg.settings.skills_root / "ok-skill" / "SKILL.md").is_file()
+
+
+# ── surface attribution (ENG-1459) ───────────────────────────────────────────
+#
+# The pod cannot derive any of this: cowork-server is not installed in the
+# `minds-anton-scratchpad` image, and only the deployment knows which surface it
+# serves. So it arrives on `TurnRequestV1.trace` and must reach the config —
+# mutation-testing showed the contract tests alone did NOT cover that hop.
+
+
+def test_the_surface_from_the_trace_block_reaches_the_config(tmp_path, monkeypatch):
+    _, cfg = _build(tmp_path, monkeypatch, trace={"surface": "web"})
+    assert cfg.surface == "web"
+
+
+def test_no_trace_block_leaves_the_surface_unset(tmp_path, monkeypatch):
+    # A pod driven directly rather than by cowork: nobody declared a surface,
+    # and unset is the honest answer rather than a guess.
+    _, cfg = _build(tmp_path, monkeypatch)
+    assert cfg.surface is None
+
+
+def test_a_trace_block_without_a_surface_leaves_it_unset(tmp_path, monkeypatch):
+    # cowork may send build attribution and no surface (an override it could not
+    # resolve). That must not become a junk value.
+    _, cfg = _build(tmp_path, monkeypatch, trace={"install_channel": "hosted"})
+    assert cfg.surface is None

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -123,3 +123,47 @@ class TestItReachesTheWireFromTheConfig:
         # value must not reach the wire, and a sloppy one must be normalised.
         assert make_session(surface=" WEB ")._surface == SURFACE_WEB
         assert make_session(surface="cowork")._surface is None
+
+
+class TestThePodReceivesItsAttribution:
+    """The pod cannot derive any of this, so it has to arrive on the wire.
+
+    ENG-1459. Web turns do not run in cowork-server — they execute here, in a
+    `minds-anton-scratchpad` pod ("anton + boot", no cowork-server installed).
+    So `surface`, `cowork_server_version` and `install_channel` are all absent
+    on web unless cowork sends them, which is what `TurnRequestV1.trace` is for.
+    """
+
+    def _req(self, **over):
+        import json
+
+        from anton.cloud_turn.contract import TurnRequestV1
+
+        body = {"protocol_version": 1, "conversation_id": "c1", "input": "go"}
+        body.update(over)
+        return TurnRequestV1.from_json(json.dumps(body))
+
+    def test_the_trace_block_survives_the_wire(self):
+        req = self._req(trace={"surface": "web", "install_channel": "hosted"})
+        assert req.trace == {"surface": "web", "install_channel": "hosted"}
+
+    def test_a_controller_too_old_to_forward_it_yields_none(self):
+        # Steps land in any order, so an unforwarded block must read as
+        # "no attribution" rather than failing the turn.
+        assert self._req().trace is None
+
+    def test_a_non_dict_trace_is_rejected_rather_than_carried(self):
+        # It reaches ChatSessionConfig and a metadata dict; a string or list
+        # would explode somewhere less obvious than here.
+        assert self._req(trace="web").trace is None
+        assert self._req(trace=["web"]).trace is None
+
+    def test_the_pod_config_takes_its_surface_from_the_block(self):
+        from anton.core.llm.tracing import SURFACE_WEB
+
+        # Assert on the resolution rule rather than building a real cloud
+        # session (which needs a trusted mount + settings): the pod reads
+        # `(request.trace or {}).get("surface")`.
+        req = self._req(trace={"surface": "web"})
+        assert (req.trace or {}).get("surface") == SURFACE_WEB
+        assert (self._req().trace or {}).get("surface") is None

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -1,0 +1,125 @@
+"""`surface` says WHERE a turn happened, and only in a vocabulary we recognise.
+
+ENG-1459. The value arrives from a host (cowork-server derives it from org
+tenancy; the CLI states it directly), so it is untrusted input on a field whose
+whole purpose is to partition a population cleanly.
+"""
+
+import logging
+
+import pytest
+
+from anton.core.llm.tracing import (
+    SURFACE_CLI,
+    SURFACE_DESKTOP,
+    SURFACE_WEB,
+    VALID_SURFACES,
+    surface_tag,
+)
+from anton.core.session import _validated_surface
+
+
+class TestTheEnum:
+    def test_cloud_is_deliberately_not_a_surface(self):
+        """It is an execution mode, not a place a user sits.
+
+        `anton/cloud_turn` runs headless with cowork as its caller, so one web
+        turn could legitimately be both — folding it in would recreate the
+        two-vocabularies-in-one-field problem ENG-1694 is undoing.
+        """
+        assert "cloud" not in VALID_SURFACES
+        assert VALID_SURFACES == {SURFACE_DESKTOP, SURFACE_WEB, SURFACE_CLI}
+
+    def test_tag_is_prefixed(self):
+        assert surface_tag(SURFACE_WEB) == "surface:web"
+
+
+class TestValidation:
+    @pytest.mark.parametrize("value", sorted(VALID_SURFACES))
+    def test_recognised_values_pass_through(self, value):
+        assert _validated_surface(value) == value
+
+    def test_none_stays_none(self):
+        # "The host did not say" is a real answer, not a value to invent.
+        assert _validated_surface(None) is None
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_blank_is_treated_as_absent(self, value):
+        # ENG-1495's lesson: "" meaning both "CLI" and "unidentified" is what
+        # made the old field unusable.
+        assert _validated_surface(value) is None
+
+    def test_case_and_whitespace_are_normalised(self):
+        # A host sending "Web " must not create a second population.
+        assert _validated_surface(" Web ") == SURFACE_WEB
+
+    def test_an_unrecognised_value_is_dropped_with_a_warning(self, caplog):
+        # Dropped, not forwarded: a junk row in every breakdown is bad, but a
+        # *wrong* surface is worse — it moves a turn into the population it is
+        # being compared against.
+        with caplog.at_level(logging.WARNING):
+            assert _validated_surface("cowork") is None
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("cowork" in m for m in messages), messages
+
+    def test_validation_never_raises(self):
+        """Telemetry must not be able to fail a turn."""
+
+        class Hostile:
+            def __str__(self):
+                raise RuntimeError("boom")
+
+        assert _validated_surface(Hostile()) is None
+
+
+class TestTheCliDeclaresItself:
+    def test_cli_entrypoints_pass_the_cli_surface(self):
+        """Both CLI call sites must set it, or CLI turns look like an unknown host."""
+        import inspect
+
+        from anton import chat, chat_session
+
+        for mod in (chat, chat_session):
+            src = inspect.getsource(mod)
+            assert "surface=SURFACE_CLI" in src, f"{mod.__name__} does not declare its surface"
+
+
+class TestItReachesTheWireFromTheConfig:
+    """The seam the unit tests above cannot see.
+
+    `_validated_surface` and `_build_trace_headers` are the two ends. Between
+    them sits the session, which has to store the value and put it on the
+    per-turn `TraceContext`. Both ends can be perfect while that middle is
+    disconnected — mutation-testing confirmed exactly that: deleting
+    `surface=self._surface` from the TraceContext left every other test in this
+    file green. So this drives a real turn and reads what the provider would
+    actually send.
+    """
+
+    async def _headers_during(self, session, prompt="go"):
+        from anton.core.llm.openai import OpenAIProvider
+
+        provider = OpenAIProvider.__new__(OpenAIProvider)
+        provider._emit_trace_headers = True
+        seen = []
+        async for _ in session.turn_stream(prompt):
+            seen.append(provider._build_trace_headers())
+        return [h for h in seen if h]
+
+    async def test_a_configured_surface_reaches_the_trace_headers(self, make_session):
+        session = make_session(harness="anton", surface=SURFACE_WEB)
+        headers = await self._headers_during(session)
+        assert headers, "no trace headers were built during the turn"
+        assert all(surface_tag(SURFACE_WEB) in h["Langfuse-Tags"] for h in headers)
+
+    async def test_an_unconfigured_surface_stays_absent_end_to_end(self, make_session):
+        session = make_session(harness="anton")
+        headers = await self._headers_during(session)
+        assert headers
+        assert all("surface:" not in h["Langfuse-Tags"] for h in headers)
+
+    async def test_the_session_validates_what_the_host_supplied(self, make_session):
+        # Catches a session that stores config.surface raw: an unrecognised
+        # value must not reach the wire, and a sloppy one must be normalised.
+        assert make_session(surface=" WEB ")._surface == SURFACE_WEB
+        assert make_session(surface="cowork")._surface is None

--- a/tests/test_trace_headers.py
+++ b/tests/test_trace_headers.py
@@ -10,9 +10,13 @@ import json
 
 from anton.core.llm.openai import OpenAIProvider
 from anton.core.llm.tracing import (
+    SURFACE_CLI,
+    SURFACE_DESKTOP,
+    SURFACE_WEB,
     TraceContext,
     reset_trace_context,
     set_trace_context,
+    surface_tag,
 )
 
 
@@ -97,3 +101,62 @@ def test_caller_cannot_spoof_anton_version():
     )
     meta = json.loads(headers["Langfuse-Metadata"])
     assert meta["anton_version"] == __version__
+
+
+# ---------------------------------------------------------------------------
+# ENG-1459: `surface` says WHERE the user was, so web and desktop use can be
+# told apart. Orthogonal to `harness`, which says which agent ran.
+# ---------------------------------------------------------------------------
+
+
+def test_surface_rides_as_a_prefixed_tag_and_plain_metadata():
+    headers = _headers_for(
+        TraceContext(session_id="s1", turn_id=1, harness="anton", surface=SURFACE_WEB)
+    )
+    # Prefixed in tags: cheap to filter, and unambiguous next to `harness`.
+    assert headers["Langfuse-Tags"] == "anton,surface:web"
+    # Unprefixed in metadata: what a human reads on a single trace.
+    assert json.loads(headers["Langfuse-Metadata"])["surface"] == "web"
+
+
+def test_web_and_desktop_are_distinguishable():
+    """The whole point of the ticket: these two must not look alike."""
+    web = _headers_for(TraceContext(turn_id=1, harness="anton", surface=SURFACE_WEB))
+    desktop = _headers_for(TraceContext(turn_id=1, harness="anton", surface=SURFACE_DESKTOP))
+    assert web["Langfuse-Tags"] != desktop["Langfuse-Tags"]
+    assert surface_tag(SURFACE_WEB) in web["Langfuse-Tags"]
+    assert surface_tag(SURFACE_DESKTOP) in desktop["Langfuse-Tags"]
+
+
+def test_surface_is_prefixed_so_it_cannot_be_confused_with_the_harness_tag():
+    """`cli` is currently a legal value of BOTH fields (until ENG-1694).
+
+    Emitted bare, a `surface` of "cli" would be indistinguishable from a
+    `harness` of "cli" in a tag filter — which is the ambiguity this pair of
+    fields exists to remove, reintroduced one layer down.
+    """
+    headers = _headers_for(TraceContext(turn_id=1, harness="anton", surface=SURFACE_CLI))
+    tags = headers["Langfuse-Tags"].split(",")
+    assert "surface:cli" in tags
+    assert "cli" not in tags, "a bare surface tag collides with the harness vocabulary"
+
+
+def test_absent_surface_emits_nothing_rather_than_a_placeholder():
+    """An unidentified host must stay visibly unknown.
+
+    An empty-string or "unknown" surface would become a junk row in every
+    breakdown, and would repeat the ENG-1495 failure where "" meant both "CLI"
+    and "the host did not say".
+    """
+    headers = _headers_for(TraceContext(session_id="s1", turn_id=1, harness="anton"))
+    assert headers["Langfuse-Tags"] == "anton"
+    assert "surface" not in json.loads(headers["Langfuse-Metadata"])
+
+
+def test_a_caller_cannot_smuggle_a_second_surface_through_metadata():
+    """Built-in identity wins on collision, as it does for harness/turn_id."""
+    headers = _headers_for(
+        TraceContext(turn_id=1, harness="anton", surface=SURFACE_WEB,
+                     metadata={"surface": "desktop"})
+    )
+    assert json.loads(headers["Langfuse-Metadata"])["surface"] == "web"


### PR DESCRIPTION
> [!NOTE]
> **Now covers the pod (web) path too**, added after the review traced where web turns actually run.
>
> Web turns don't execute in cowork-server — they run in a `minds-anton-scratchpad` pod via `anton.cloud_turn`, and that pod can't derive its own attribution (no cowork-server installed, and only the deployment knows the surface). Measured on prod: **0 of 68** `harness=cloud` traces carried `surface`, `cowork_server_version` or `install_channel`.
>
> So `TurnRequestV1` gains a `trace` block, the pod reads `surface` from it onto the session config, and the build fields ride the turn's `trace_metadata`.
>
> Siblings, **any merge order**: [cowork-server#357](https://github.com/mindsdb/cowork-server/pull/357) sends it, [scratchpad-controller#24](https://github.com/mindsdb/scratchpad-controller/pull/24) relays it.
>
> **Worth a reviewer's attention:** three mutations initially *survived* on the pod side — the pod ignoring `surface`, the entrypoint dropping `trace_metadata`, and the entrypoint leaking `surface` into the metadata as well. The contract tests covered the wire and nothing covered the two consumers. Fixed with behavioural tests driving the real `build_cloud_chat_session` and `stream_turn`. Same "tested the ends, not the middle" gap this PR already hit once on the session seam.

Part 1 of 2 for ENG-1459. **Merge this first** — cowork-server#<pr> supplies the value for desktop/web.

Adds `surface` to `TraceContext` and `ChatSessionConfig`, emitted on Langfuse traces as a `surface:<value>` tag plus a plain `surface` metadata key. Values: `desktop` | `web` | `cli`.

## Why

The SaaS web build is live (first `cowork-web` analytics events 2026-08-18) and **nothing on a trace told it apart from the desktop app** — both run this codebase and both report `harness="anton"`. So "are web users behaving differently?" had no answer.

`surface` says **where the user was**; `harness` says **which agent ran**. Orthogonal: a web turn and a desktop turn can both run anton. ENG-1694 finishes the job by moving the host meaning out of `harness` entirely, and depends on this.

## Three choices worth reviewing

**1. The tag is prefixed (`surface:cli`, not `cli`).** `cli` is currently a legal value of *both* fields while ENG-1694 is in flight, so a bare tag would make `surface=cli` and `harness=cli` indistinguishable in a filter — reintroducing the exact ambiguity this pair of fields exists to remove. `origin:` (ENG-1289) set the same convention one change earlier. Pinned by `test_surface_is_prefixed_so_it_cannot_be_confused_with_the_harness_tag`.

**2. `cloud` is deliberately not a surface value.** `anton/cloud_turn` is a *cloud-safe execution mode* — headless, pod-side — and its own docstring names cowork as the caller (*"cowork sends the tenant's slots per turn"*), so one web turn could legitimately be both. Folding it in would recreate two-vocabularies-in-one-field. It is also 42 traces / staff-only today. Pinned by `test_cloud_is_deliberately_not_a_surface`.

**3. An unrecognised value is dropped with a warning, never forwarded.** A junk row in every breakdown is bad; a **wrong** surface is worse, because it silently moves a turn into the population it is being compared against. Absent stays honestly unknown — the ENG-1495 lesson, where `""` meant both "CLI" and "the host did not say".

## For anyone querying this

**Tags are filterable, not groupable.** `dimensions: [{field: "tags"}]` keys on the whole tag array as a tuple and returns ~one row per trace (9,678 rows for 9,679 traces, measured on prod). Measure a surface with filtered counts, one query per surface:

```
filters: [{column: "tags", operator: "any of", value: ["surface:web"], type: "arrayOptions"}]
```

The metadata copy is unprefixed so a human reading one trace sees the plain value.

## Tests

17 new tests (`tests/test_surface.py`, plus 5 in `tests/test_trace_headers.py`). **Mutation-verified — 8 mutations, all caught.**

Two of them initially **SURVIVED** and are worth flagging, because it is the "tests that lie" shape: deleting `surface=self._surface` from the `TraceContext`, and dropping validation at the session seam. I had covered both *ends* — the validator and the header builder — and not the middle, so the feature could have been fully disconnected with every test green. Fixed by `TestItReachesTheWireFromTheConfig`, which drives a real turn and reads what the provider would actually send.

Full suite: **2,341 passed, 31 skipped, 0 failed.**

> Mutation runs need `PYTHONDONTWRITEBYTECODE=1` — a mutation that swaps two same-length identifiers is byte-identical in size, so Python reuses a stale `.pyc` (cache keys on mtime+size) and reports a false pass while `inspect.getsource` shows correct code.

## Security check

Performed. `surface` is a fixed low-cardinality enum, validated against a closed set before use — no user content, hostnames, credentials, endpoints or auth surface. Host-supplied, so treated as untrusted: normalised, checked, and dropped if unrecognised. Tag values are additionally run through the existing `_sanitize_langfuse_tag` (commas and control chars would corrupt the header). Validation cannot raise — telemetry must never fail a turn, covered by `test_validation_never_raises`.

## No gateway change needed

Verified against the gateway branch: client-supplied tags are merged through untouched, so `surface:web` arrives without any `mindshub_inference` change. (ENG-1289's tag strip is scoped to the `origin:` prefix only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
