### PR TITLE
chore(deps): bump undici from 7.28.0 to 7.29.0 in /docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -18949,9 +18949,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/docs/package.json
+++ b/docs/package.json
@@ -45,7 +45,7 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.7",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "brace-expansion": "^5.0.8"
   }
 }


### PR DESCRIPTION
Fix for:
https://github.com/mindsdb/anton/security/dependabot/64

undici's cache interceptor mishandled malformed `Cache-Control: private` directives two ways — a shared-cache response could be stored and later served to a different caller under the same cache key (disclosing bodies/headers including `Set-Cookie`), and a header mixing an unqualified `private` with a qualified `private="..."` threw an uncaught `TypeError` during parsing. Both fixed upstream in 7.29.0.

This is a hand-opened replacement for #374 (Dependabot's own PR), which is stuck: Dependabot always targets `main`, and retargeting it to `staging` broke GitHub's CodeQL PR-annotation check (Default Setup is anchored to `main`, so it can't reconcile results against a non-default base — a platform/config issue, not something either PR's diff could fix).

| File | Change |
|---|---|
| `docs/package.json` | `overrides.undici` `^7.28.0` → `^7.29.0` — undici is pulled in transitively via `@easyops-cn/docusaurus-search-local` and pinned to the vulnerable version through this override. |
| `docs/package-lock.json` | Regenerated via `npm install` — only the `undici` entry changed (version, resolved URL, integrity hash). |

**Verification:** `npm run build` in `docs/` still produces a clean production build with no errors.