### PR TITLE
ENG-1694: harness names which agent ran, not where

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -20,7 +20,7 @@ from anton.clipboard import (
     replace_at_image_paths,
     save_clipboard_image,
 )
-from anton.core.llm.tracing import SURFACE_CLI
+from anton.core.llm.tracing import HARNESS_ANTON, SURFACE_CLI
 from anton.core.session import ChatSession, ChatSessionConfig, _is_provider_auth_error
 from anton.core.llm.prompt_builder import SystemPromptContext
 from anton.core.llm.provider import (
@@ -1396,10 +1396,11 @@ async def _chat_loop(
         session_id=current_session_id,
         # ENG-1495: see the note on the same field in chat_session.py — an unset
         # `harness` is indistinguishable from a host that forgot to set one.
-        harness="cli",
-        # WHERE this ran, as opposed to which agent ran (ENG-1459).
-        # ENG-1694 will move the host meaning out of `harness` entirely,
-        # at which point this becomes the only place "cli" is stated.
+        # WHICH AGENT: the CLI runs anton, so that is what it reports
+        # (ENG-1694). It said "cli" until then, which described the host and
+        # left "did this run anton or hermes?" unanswerable.
+        harness=HARNESS_ANTON,
+        # WHERE it ran — the other axis, and now the only place "cli" appears.
         surface=SURFACE_CLI,
         proactive_dashboards=settings.proactive_dashboards,
         act_first=settings.act_first,

--- a/anton/chat_session.py
+++ b/anton/chat_session.py
@@ -88,7 +88,7 @@ def rebuild_session(
     """Rebuild LLMClient + ChatSession after settings change."""
     from anton.core.llm.client import LLMClient
     from anton.chat import ChatSession
-    from anton.core.llm.tracing import SURFACE_CLI
+    from anton.core.llm.tracing import HARNESS_ANTON, SURFACE_CLI
     from anton.core.session import ChatSessionConfig
     from anton.tools import DEFAULT_SESSION_TOOLS
 
@@ -121,10 +121,11 @@ def rebuild_session(
         # telemetry as "" — which meant BOTH "this is the CLI" and "the host
         # didn't identify itself", so the two could never be told apart and the
         # ambiguity got worse with every new host.
-        harness="cli",
-        # WHERE this ran, as opposed to which agent ran (ENG-1459).
-        # ENG-1694 will move the host meaning out of `harness` entirely,
-        # at which point this becomes the only place "cli" is stated.
+        # WHICH AGENT: the CLI runs anton, so that is what it reports
+        # (ENG-1694). It said "cli" until then, which described the host and
+        # left "did this run anton or hermes?" unanswerable.
+        harness=HARNESS_ANTON,
+        # WHERE it ran — the other axis, and now the only place "cli" appears.
         surface=SURFACE_CLI,
         proactive_dashboards=settings.proactive_dashboards,
         act_first=settings.act_first,

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -26,6 +26,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from anton.cloud_turn.contract import TurnRequestV1
+from anton.core.llm.tracing import HARNESS_ANTON
 from anton.core.tools.skill_format import SKILL_FILE
 
 if TYPE_CHECKING:
@@ -587,7 +588,12 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
         settings=settings,
         workspace=workspace,
         session_id=request.conversation_id,
-        harness="cloud",
+        # WHICH AGENT: this pod image is "anton + boot" — the agent running here
+        # IS anton, so "cloud" was factually wrong, not merely overloaded
+        # (ENG-1694). Where it ran comes from `surface` below, which cowork
+        # sends; every web turn executes in a pod and only web turns do, so
+        # "ran in a pod" needs no field of its own today.
+        harness=HARNESS_ANTON,
         # WHERE the user was, which this pod cannot know on its own — only the
         # deployment does, so cowork sends it (ENG-1459). Absent when the pod is
         # driven directly rather than by cowork; an unset surface reads as

--- a/anton/core/llm/tracing.py
+++ b/anton/core/llm/tracing.py
@@ -23,6 +23,26 @@ from contextvars import ContextVar, Token
 from dataclasses import dataclass, replace
 
 
+# WHICH AGENT ran the turn (ENG-1694). The canonical definition, alongside the
+# surface vocabulary below — the two are orthogonal and must stay so.
+#
+#   HARNESS_ANTON   the anton agent. Every first-party caller today: the CLI,
+#                   cowork-server (desktop and web), and the cloud pod.
+#   HARNESS_HERMES  cowork-server's other harness. Emits no langfuse traces yet
+#                   (`hermes_harness/harness.py` accepts trace_tags/metadata and
+#                   ignores them), so this value has NO volume — a query showing
+#                   100% anton is not evidence hermes is unused.
+#
+# Until ENG-1694 this field also held "cli" and "cloud", which name *places*.
+# One field with two vocabularies could answer neither question: a "cli" trace
+# could not say which agent ran, and an "anton" trace could not say where. If a
+# value answers "where", it belongs in `surface`; a third question gets a third
+# field rather than a third meaning here.
+HARNESS_ANTON = "anton"
+HARNESS_HERMES = "hermes"
+VALID_HARNESSES = frozenset({HARNESS_ANTON, HARNESS_HERMES})
+
+
 # Where the user was when the turn happened (ENG-1459). This is the CANONICAL
 # definition; cowork-server imports these rather than repeating the strings, so
 # the field cannot pick up a second vocabulary the way ``harness`` did.

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -865,20 +865,27 @@ class ChatSessionConfig:
     initial_history: list[dict] | None = None
     history_store: HistoryStore | None = None
     session_id: str | None = None
-    # Identifier for the host driving this session. Surfaced on telemetry /
-    # langfuse traces so the host that produced a given trace is filterable.
+    # WHICH AGENT ran this session. Surfaced on telemetry / langfuse traces, and
+    # the gateway composes the trace's display name from it as
+    # "{harness}:turn-{turn_id}".
     #
-    # The values actually in use, which are NOT what this field's name suggests:
-    #   "cli"     — anton's own interactive chat (chat_session.py, chat.py)
-    #   "anton"   — cowork-server, which passes its *agent harness* id here;
-    #               this — see `surface` below, which is how they are now told
-    #               apart (ENG-1459)
-    #   "cloud"   — the one-turn-per-pod cloud path
-    #   None      — a host that did not identify itself
+    #   "anton"   — the anton agent. Every first-party caller today: the CLI,
+    #               cowork-server (desktop and web), and the cloud pod.
+    #   "hermes"  — the hermes agent (cowork-server's other harness). Note it
+    #               emits no langfuse traces yet, so this value has no volume —
+    #               a query showing 100% anton is NOT evidence hermes is unused.
+    #   None      — a host that did not identify itself.
     #
     # None must stay reserved for that last case: until ENG-1495 the CLI left it
     # unset, so "" meant both "CLI" and "unidentified" and nothing could tell
     # them apart.
+    #
+    # WHERE it ran is `surface`, below — a separate axis. Until ENG-1694 this one
+    # field carried both, holding "cli" and "cloud" (places) alongside "anton"
+    # and "hermes" (agents), so it could answer neither question: a "cli" trace
+    # could not say which agent ran, and an "anton" trace could not say where.
+    # Keep the vocabularies apart. A value that answers "where" belongs in
+    # `surface`; if a third question ever needs answering, it gets a third field.
     harness: str | None = None
     # WHERE the user was, as opposed to which agent ran: one of
     # `anton.core.llm.tracing.VALID_SURFACES` (`desktop` / `web` / `cli`), or

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -67,7 +67,13 @@ def test_scratchpad_uses_local_factory_and_is_workspace_bound(tmp_path, monkeypa
     _, cfg = _build(tmp_path, monkeypatch)
     assert cfg.runtime_factory is local_scratchpad_runtime_factory
     assert cfg.workspace is not None
-    assert cfg.harness == "cloud"
+    # ENG-1694: `harness` names WHICH AGENT, and this pod image is "anton +
+    # boot" — so the agent here IS anton. It said "cloud" until then, which
+    # described the execution and left "anton or hermes?" unanswerable. Where
+    # it ran is `surface`, sent by cowork (see the surface tests below); unset
+    # here because this fixture builds a request with no trace block.
+    assert cfg.harness == "anton"
+    assert cfg.surface is None
     assert cfg.session_id == "conv_1"
 
 

--- a/tests/test_harness_is_the_agent.py
+++ b/tests/test_harness_is_the_agent.py
@@ -1,0 +1,110 @@
+"""`harness` names WHICH AGENT ran, never where (ENG-1694).
+
+Until this change one field held both vocabularies — "anton"/"hermes" (agents)
+alongside "cli"/"cloud" (places) — so it could answer neither question: a "cli"
+trace could not say which agent ran, and an "anton" trace could not say where.
+
+`surface` (ENG-1459) owns the "where" axis. This pins the split so the field
+cannot quietly reacquire a second meaning, which is how it got here.
+"""
+
+import inspect
+
+from anton.core.llm.tracing import (
+    HARNESS_ANTON,
+    HARNESS_HERMES,
+    SURFACE_CLI,
+    VALID_HARNESSES,
+    VALID_SURFACES,
+    TraceContext,
+)
+
+
+class TestTheTwoVocabulariesAreDisjoint:
+    def test_no_value_means_both_an_agent_and_a_place(self):
+        # The actual defect, as an assertion. `cli` was in both worlds.
+        assert not (VALID_HARNESSES & VALID_SURFACES), (
+            "a value that is both an agent and a surface reintroduces the "
+            f"ambiguity this split removed: {VALID_HARNESSES & VALID_SURFACES}"
+        )
+
+    def test_places_are_not_harness_values(self):
+        for place in ("cli", "cloud", "desktop", "web", "cowork"):
+            assert place not in VALID_HARNESSES, f"{place!r} names a place, not an agent"
+
+    def test_agents_are_not_surface_values(self):
+        for agent in (HARNESS_ANTON, HARNESS_HERMES):
+            assert agent not in VALID_SURFACES
+
+
+class TestEveryFirstPartyCallerReportsAnAgent:
+    """All three call sites named a place before this change."""
+
+    def test_the_cli_entrypoints_report_anton_and_the_cli_surface(self):
+        from anton import chat, chat_session
+
+        for mod in (chat, chat_session):
+            src = inspect.getsource(mod)
+            assert "harness=HARNESS_ANTON" in src, f"{mod.__name__} does not report its agent"
+            assert "surface=SURFACE_CLI" in src, f"{mod.__name__} lost its surface"
+            assert 'harness="cli"' not in src, f"{mod.__name__} still names a place as its harness"
+
+    def test_the_cloud_pod_reports_anton(self):
+        # The pod image is "anton + boot" — the agent running there IS anton, so
+        # "cloud" was factually wrong rather than merely overloaded.
+        from anton.cloud_turn import session as cloud_session
+
+        src = inspect.getsource(cloud_session)
+        assert "harness=HARNESS_ANTON" in src
+        assert 'harness="cloud"' not in src
+
+
+class TestTheTraceNameIsRestored:
+    """The gateway composes the display name from `harness` alone.
+
+    So a CLI turn arrived as `cli:turn-N` while every other anton turn was
+    `anton:turn-N`, splitting name-based grouping. Fixing the value fixes the
+    name with no gateway change — assert it rather than assuming.
+    """
+
+    def _name_the_gateway_would_build(self, ctx: TraceContext) -> str:
+        import json
+
+        from anton.core.llm.openai import OpenAIProvider
+        from anton.core.llm.tracing import reset_trace_context, set_trace_context
+
+        provider = OpenAIProvider.__new__(OpenAIProvider)
+        provider._emit_trace_headers = True
+        token = set_trace_context(ctx)
+        try:
+            md = json.loads(provider._build_trace_headers()["Langfuse-Metadata"])
+        finally:
+            reset_trace_context(token)
+        # mindshub_inference/minds/requests/context.py: f"{harness}:turn-{turn_id}"
+        return f"{md['harness']}:turn-{md['turn_id']}"
+
+    def test_a_cli_turn_is_named_anton_again(self):
+        name = self._name_the_gateway_would_build(
+            TraceContext(turn_id=7, harness=HARNESS_ANTON, surface=SURFACE_CLI)
+        )
+        assert name == "anton:turn-7", "CLI turns must rejoin the anton:turn-N family"
+
+    def test_a_cli_turn_stays_distinguishable_despite_the_shared_name(self):
+        # Sharing the trace NAME with desktop is the point — grouping works
+        # again — but the surface tag is what keeps them apart.
+        import json
+
+        from anton.core.llm.openai import OpenAIProvider
+        from anton.core.llm.tracing import reset_trace_context, set_trace_context
+
+        provider = OpenAIProvider.__new__(OpenAIProvider)
+        provider._emit_trace_headers = True
+        token = set_trace_context(
+            TraceContext(turn_id=1, harness=HARNESS_ANTON, surface=SURFACE_CLI)
+        )
+        try:
+            headers = provider._build_trace_headers()
+        finally:
+            reset_trace_context(token)
+        assert "surface:cli" in headers["Langfuse-Tags"]
+        assert json.loads(headers["Langfuse-Metadata"])["harness"] == HARNESS_ANTON

--- a/tests/test_session_tools.py
+++ b/tests/test_session_tools.py
@@ -37,27 +37,42 @@ def test_both_session_builders_use_the_shared_tool_list():
 def test_both_session_builders_identify_the_host_as_cli():
     """Same drift class as the tool list above, one field over.
 
-    `ChatSessionConfig.harness` reserves `None` for "a host that did not
-    identify itself". The CLI leaving it unset is what made `""` mean both
-    "this is the CLI" and "nobody said", so the two could never be told apart —
-    and that value reaches PostHog and Langfuse tags, not just a log line.
+    ENG-1495's property, unchanged: a host that does not identify itself is
+    indistinguishable from the CLI, because `None` is reserved for exactly that
+    case. The CLI leaving it unset is what made `""` mean both "this is the CLI"
+    and "nobody said", and that value reaches PostHog and Langfuse tags, not
+    just a log line.
+
+    **ENG-1694 moved which field carries it.** `harness` now names the AGENT
+    (`anton` / `hermes`) and `surface` names the HOST (`cli` / `desktop` /
+    `web`) — one field could not answer both, which is why a `cli` trace could
+    not say whether anton or hermes ran. So the CLI identifies itself via
+    `surface=SURFACE_CLI` now, and additionally reports `harness=HARNESS_ANTON`
+    because the CLI does run the anton agent. Both must be present: dropping
+    the surface reintroduces exactly the ENG-1495 ambiguity, and dropping the
+    harness makes the agent unknowable.
 
     Source inspection rather than a behavioural test, for the same reason the
     test above gives: exercising `rebuild_session` means standing up an
     LLMClient, a Cortex and a knowledge refresh. The property being guarded is
-    structural — both builders must pass the argument — so asserting on the
+    structural — both builders must pass the arguments — so asserting on the
     call site is the honest check rather than a weaker substitute.
 
-    Verified to be needed: deleting `harness="cli"` from both files leaves the
-    entire suite green.
+    Verified to be needed: deleting either kwarg from both files leaves the
+    rest of the suite green.
     """
     fresh = (_ANTON_DIR / "chat.py").read_text()
     rebuild = (_ANTON_DIR / "chat_session.py").read_text()
-    assert 'harness="cli"' in fresh, (
-        "fresh session builder (chat.py) must identify the host, or telemetry "
-        "and Langfuse tags cannot tell the CLI from an unidentified host"
-    )
-    assert 'harness="cli"' in rebuild, (
-        "rebuild_session (chat_session.py) must identify the host — a resumed "
-        "session that drops it reintroduces the ambiguity mid-session"
-    )
+    for name, src in (("chat.py", fresh), ("chat_session.py", rebuild)):
+        assert "surface=SURFACE_CLI" in src, (
+            f"{name} must identify the host, or telemetry and Langfuse tags "
+            "cannot tell the CLI from an unidentified host (ENG-1495)"
+        )
+        assert "harness=HARNESS_ANTON" in src, (
+            f"{name} must name the agent it runs, or a CLI trace cannot say "
+            "whether anton or hermes produced it (ENG-1694)"
+        )
+        assert 'harness="cli"' not in src, (
+            f"{name} still names a PLACE as its harness — that is the "
+            "two-vocabularies bug ENG-1694 removed"
+        )


### PR DESCRIPTION
> [!NOTE]
> **The gate is SATISFIED as of 2026-08-26. This is now mergeable on the merits.**
>
> All three conditions verified against production, not inferred:
>
> 1. ✅ **ENG-1459 merged** — anton `695dcee7`, cowork-server `06c9a4b9`, scratchpad-controller `d21a0e1a` (21 Aug).
> 2. ✅ **Pod image pin moved past it.** scratchpad-controller [#32](https://github.com/mindsdb/scratchpad-controller/pull/32) merged 26 Aug 08:53 UTC (`b6b55ce9`), released as `v2.26.8.26.1`. It splits the pins rather than letting prod inherit staging: `values.yaml` → `17dc5b57`, `values-prod.yaml` → `2a3ad8ea`. **Both contain ENG-1459's anton half** (verified by content — `695dcee7` is not an *ancestor* of `anton/main`, because the release squashes, so an ancestry check misleads here).
> 3. ✅ **Production web turns carry `surface=web`** — **49 traces in 72h** on prod Langfuse. A real one:
>
> ```
> ['cloud', 'origin:harness', 'prod', 'surface:web',
>  'organization_id:…', 'user_id:7d8022d3-…', '<user email>']
> ```
>
> So `harness="cloud"` can be retired without losing the web/desktop split — `surface:web` has replaced it on live traffic. Companion tags also confirmed live: `surface:desktop` 3,155, `surface:cli` 145.
>
> **Note for anyone querying across the changeover:** historical traces keep `harness=cloud`, so a window spanning 26 Aug needs `harness=cloud OR surface=web`, not one or the other.
>
> **Also re-verified after the gate cleared:** merges cleanly into `staging` across the 15 commits added since this branch was rebased, and the **full suite passes at 2,653** on the merged result — including ENG-1486's `tool_completed`, which landed in the same emit path.

Closes ENG-1694 (pending the gate above).

## What

`harness` becomes a pure agent identity. `surface` (ENG-1459) owns "where".

```
chat.py / chat_session.py    harness="cli"    →  HARNESS_ANTON + surface=cli
cloud_turn/session.py        harness="cloud"  →  HARNESS_ANTON
```

Adds `HARNESS_ANTON` / `HARNESS_HERMES` / `VALID_HARNESSES` beside the surface vocabulary, so both live in one place and disjointness is assertable — `test_no_value_means_both_an_agent_and_a_place` fails if any value ever appears in both.

## Why `cloud` was wrong, not just overloaded

The pod image is `minds-anton-scratchpad` — *"anton + boot"*. **The agent running there IS anton.** And the web path can only ever run anton: `turnqueue/producer.py` hardcodes `op="anton_turn"`, the controller's only turn op.

Nothing is lost by removing it: every web turn runs in a pod and only web turns do, so *"ran in a pod"* is fully determined by `surface=web`. It earns its own axis only if that 1:1 breaks.

## The trace-name fix is free

The gateway composes the display name from `harness`, so CLI turns arrived as `cli:turn-1` while every other anton turn was `anton:turn-N` — splitting name-based grouping, which is the most natural thing to group on in a dashboard. Verified: a CLI context now yields `anton:turn-1`, **no gateway change**.

## Two existing tests updated deliberately, not flipped

Both pinned the old contract:

- `test_cloud_turn_session.py` asserted `cfg.harness == "cloud"` → now `anton` plus `surface is None` (that fixture sends no trace block).
- `test_session_tools.py::test_both_session_builders_identify_the_host_as_cli` was **ENG-1495's guard**. Its property is unchanged — a host that doesn't identify itself must stay distinguishable from the CLI — but the field carrying it moved. It now requires **both** `surface=SURFACE_CLI` and `harness=HARNESS_ANTON`, and rejects `harness="cli"`.

> Process note, since it bit twice: I found both by running the **full** suite (one first surfaced by a mutation run), not my own new file. New tests passing says nothing about existing tests that pinned the old contract.

## ENG-1540's inherited criterion — discharged

Audited every in-repo query keying on `harness`. **None filters on harness absence.** One keys on the trace-*name* prefix and this change moves traffic into its population:

`harness-measure/scripts/measure.py:460` — `startswith('anton:turn')`

CLI (`cli:turn-N`) and pod (`cloud:turn-N`) turns are excluded today and will now **join**. Direction is right — they *are* harness-identified anton turns — but it is a **discontinuity**: the scoped denominator grows by ≈5 CLI traces plus every pod turn (68 prod / 506 staging). No fix needed there; recorded so the jump is explained rather than investigated.

## Tests

7 new in `tests/test_harness_is_the_agent.py`. **Mutation-verified — 5 mutations, all caught:** reverting either call site, readmitting `cloud` *or* `cli` into `VALID_HARNESSES` (the latter recreates the exact agent/place overlap), and dropping the CLI's surface.

## Security check

Performed. Read-only observability. Both fields are closed low-cardinality enums set by first-party code — no user content, hostnames, credentials, endpoints or auth surface. Values narrow rather than widen (`cli`/`cloud` leave the harness vocabulary), so nothing new reaches a header; tag sanitisation is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Self-review findings (2026-08-20)

Three, all recorded rather than code-fixed — the change itself held up.

**1. A vintage boundary this PR creates, and my body didn't mention.** Historical traces keep their old values: a `harness=cloud` trace stays `cloud` forever. So *after* this ships, "which turns were web?" is `harness=cloud` **before** the boundary UNION `surface=web` **after** it. A single-predicate query spanning the change undercounts one side silently. Same class as ENG-1289's tagging-era boundary. Scale: 68 prod / 506 staging `cloud` traces over recent windows.

**2. ENG-1540's inherited criterion is only PARTIALLY dischargeable by me, and the ticket overstated it.** Verified programmatically: no in-repo query filters on harness absence, and **0 of 93 saved PostHog insights** (projects 424726 + 355390) reference `harness` at all. **Not verifiable from here:** saved *Langfuse* views — the public API doesn't expose them (`/api/public/{dashboards,saved-views,views,widgets}` all 404). **A human must check the Langfuse UI** for views keyed on `harness = cli` / `= cloud` / absence. Ticket corrected from "DISCHARGED" to "partially".

**3. A measurement discontinuity in our own tooling.** `harness-measure/scripts/measure.py:460` scopes on `startswith('anton:turn')`. CLI (`cli:turn-N`) and pod (`cloud:turn-N`) turns are excluded today and will **join** that population — correct in direction, but the scoped denominator jumps with no code change behind it.

### Refuted during the review

- **Other consumers of the harness value.** The gateway's only use is the trace name (`context.py:380-384`) — no allowlist, no branching, so `anton` passes cleanly and produces the intended name. Grepped anton, cowork-server, anton_services and mdb-ai: nothing branches on `harness == "cli"` or `"cloud"`.
- **PostHog breakage.** `turn_completed` carries `harness`, and the value distribution shifts (cli 9 + cloud 108 fold into anton) — but no saved insight or skill keys on it, so nothing breaks.
- **`Message.harness`** (cowork-server DB column, values like `cowork-direct`) — untouched; different field, confirmed out of scope.

### Known weakness in the tests

The call-site assertions are **source inspection** (`inspect.getsource`), matching the existing ENG-1495 guard and for the reason its docstring gives — exercising `rebuild_session` means standing up an LLMClient, Cortex and knowledge refresh. They catch removal and the wrong value, but would be fooled by the string appearing in a comment. The trace-name test is genuinely behavioural (builds real headers via the real provider).


