### PR TITLE
ENG-1769: explicit owner-only publish access

### DIFF
--- a/anton/publish_access.py
+++ b/anton/publish_access.py
@@ -272,10 +272,11 @@ async def prompt_access(prompt_fn, *, previous=None, allow_keep=False) -> dict |
     """Interactively collect an access spec via a prompt_or_cancel-like coro.
 
     Returns an input access dict ({"mode": ...}) or None if the user cancels
-    (Esc at any step). Empty password / empty restricted selection re-prompt
-    rather than silently degrading to public — parity with cowork's
-    isAccessDraftValid(). ``prompt_fn`` is injected so this is unit-testable
-    without a TTY.
+    (Esc at any step). An empty password re-prompts rather than silently
+    degrading to public; an empty restricted selection is an explicit
+    owner-only publish, while malformed addresses re-prompt — parity with
+    cowork's isAccessDraftValid(). ``prompt_fn`` is injected so this is
+    unit-testable without a TTY.
     """
     choices = ["public", "password", "restricted"]
     if allow_keep:
@@ -306,11 +307,20 @@ async def prompt_access(prompt_fn, *, previous=None, allow_keep=False) -> dict |
             # empty → re-prompt (do NOT degrade to public silently)
 
     if mode == "restricted":
+        hint = ""
         while True:
-            raw = await prompt_fn("  Allowed emails (comma or space separated)")
+            raw = await prompt_fn(
+                f"{hint}  Allowed emails (comma or space separated; empty = only you)"
+            )
             if raw is None:
                 return None
-            valid, _invalid = parse_emails(raw)
+            valid, invalid = parse_emails(raw)
+            if invalid:
+                # Re-prompt instead of dropping them: a typo'd address would
+                # otherwise turn into an owner-only publish the user never asked
+                # for. prompt_fn is the only output channel available here.
+                hint = f"  Invalid: {', '.join(invalid)}\n"
+                continue
             org_ans = await prompt_fn(
                 "  Allow everyone in your organization?",
                 choices=["y", "n"], choices_display="y/n", default="n",
@@ -318,8 +328,11 @@ async def prompt_access(prompt_fn, *, previous=None, allow_keep=False) -> dict |
             if org_ans is None:
                 return None
             org_allowed = org_ans.strip().lower() in ("y", "yes")
-            if valid or org_allowed:
-                return {"mode": "restricted", "emails": valid, "org_allowed": org_allowed}
-            # nothing selected → re-prompt
+            return {
+                "mode": "restricted",
+                "emails": valid,
+                "org_allowed": org_allowed,
+                "owner_only": not valid and not org_allowed,
+            }
 
     return {"mode": "public"}

--- a/anton/publish_access.py
+++ b/anton/publish_access.py
@@ -43,8 +43,9 @@ def resolve_access(
 
     Returns ``(effective_access, pwd_version, access_version, owner_side)``.
     A request with no usable selection (empty password, or restricted with no
-    emails and no org) degrades to ``public`` — a server-side safety net for
-    programmatic callers; interactive callers must gate empty input earlier.
+    emails, no org and no owner_only) degrades to ``public`` — a server-side
+    safety net for programmatic callers; interactive callers must gate empty
+    input earlier.
     NOTE: with ``access=None`` and ``password=None`` the mode defaults to
     ``public`` — the prior mode is NOT inherited (``previous`` only feeds the
     version counters). Callers that want to preserve a prior non-public mode
@@ -79,17 +80,29 @@ def resolve_access(
     if mode == "restricted":
         emails = normalize_emails((access or {}).get("emails"))
         org_allowed = bool((access or {}).get("org_allowed"))
-        if emails or org_allowed:
+        # The owner always matches (the FK condition in auth), so an explicit
+        # owner_only next to emails/org carries no information — canonicalise it
+        # away so two equivalent selections don't differ in access_version.
+        owner_only = bool((access or {}).get("owner_only")) and not emails and not org_allowed
+        if emails or org_allowed or owner_only:
             prev_restricted = prev.get("mode") == "restricted"
             prev_emails = prev.get("emails") if prev_restricted else None
             prev_org = prev.get("org_allowed") if prev_restricted else None
-            changed = (emails != prev_emails) or (org_allowed != prev_org)
+            # bool(): pre-ENG-1769 entries have no owner_only key, and a bare
+            # `False != None` would bump the version on an unchanged re-publish.
+            prev_owner_only = bool(prev.get("owner_only")) if prev_restricted else None
+            changed = (
+                (emails != prev_emails)
+                or (org_allowed != prev_org)
+                or (owner_only != prev_owner_only)
+            )
             access_version = (prev_access_version + 1) if changed else (prev_access_version or 1)
             owner_side = {
                 "mode": "restricted",
                 "requires_password": False,
                 "emails": emails,
                 "org_allowed": org_allowed,
+                "owner_only": owner_only,
                 "access_version": access_version,
             }
             return (

--- a/anton/publish_access.py
+++ b/anton/publish_access.py
@@ -160,6 +160,10 @@ def access_from_owner_side(entry: Any) -> dict:
             "mode": "restricted",
             "emails": entry.get("emails", []) or [],
             "org_allowed": bool(entry.get("org_allowed")),
+            # LOAD-BEARING: without this key a "keep" re-publish of an
+            # owner-only artifact reconstructs an empty selection, which
+            # degrades to public — silently un-privating the artifact.
+            "owner_only": bool(entry.get("owner_only")),
         }
     return {"mode": "public"}
 

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -534,9 +534,17 @@ async def handle_publish_or_preview(session: ChatSession, tc_input: dict) -> str
             req_access["password"] = pw
         elif access_mode == "restricted":
             from anton.publish_access import parse_emails
-            valid, _invalid = parse_emails(tc_input.get("emails") or [])
+            valid, invalid = parse_emails(tc_input.get("emails") or [])
+            if invalid:
+                # Silently dropping these would collapse the selection and
+                # publish PUBLICLY (or owner-only) behind the user's back.
+                return (
+                    "INVALID: these are not valid email addresses: "
+                    f"{', '.join(invalid)}. Fix them or omit them, then call the tool again."
+                )
             req_access["emails"] = valid
             req_access["org_allowed"] = bool(tc_input.get("org_allowed"))
+            req_access["owner_only"] = bool(tc_input.get("owner_only"))
     elif isinstance(prev, dict) and prev.get("report_id"):
         req_access = access_from_owner_side(prev)  # preserve previous, do NOT reset to public
     else:
@@ -667,6 +675,15 @@ PUBLISH_TOOL = ToolDef(
             "org_allowed": {
                 "type": "boolean",
                 "description": "Whether the whole organization may view (access_mode='restricted').",
+            },
+            "owner_only": {
+                "type": "boolean",
+                "description": (
+                    "For access_mode='restricted': publish so that ONLY the user themselves "
+                    "can open it. Set true ONLY when the user explicitly asked for the artifact "
+                    "to be private to them. Leaving emails empty WITHOUT this flag publishes "
+                    "PUBLICLY."
+                ),
             },
         },
         "required": ["file_path"],

--- a/tests/test_publish_access_resolve.py
+++ b/tests/test_publish_access_resolve.py
@@ -84,6 +84,69 @@ def test_resolve_restricted_empty_degrades_to_public():
     assert eff == {"mode": "public"}
 
 
+def test_resolve_restricted_owner_only_does_not_degrade():
+    """Explicit owner_only is a valid selection: empty emails + no org stays restricted."""
+    eff, _, acc_v, owner = resolve_access(
+        None, {"mode": "restricted", "emails": [], "org_allowed": False, "owner_only": True}, None
+    )
+    assert eff == {"mode": "restricted", "emails": [], "org_allowed": False}
+    assert acc_v == 1
+    assert owner["mode"] == "restricted"
+    assert owner["emails"] == []
+    assert owner["org_allowed"] is False
+    assert owner["owner_only"] is True
+
+
+def test_resolve_restricted_owner_only_canonicalized_away_when_emails_present():
+    """The owner always has access, so owner_only carries no meaning next to emails."""
+    _, _, _, owner = resolve_access(
+        None, {"mode": "restricted", "emails": ["a@x.com"], "org_allowed": False, "owner_only": True}, None
+    )
+    assert owner["owner_only"] is False
+
+
+def test_resolve_restricted_owner_only_canonicalized_away_when_org_allowed():
+    _, _, _, owner = resolve_access(
+        None, {"mode": "restricted", "emails": [], "org_allowed": True, "owner_only": True}, None
+    )
+    assert owner["owner_only"] is False
+
+
+def test_resolve_owner_only_to_emails_and_back_bumps_access_version():
+    """Each switch must invalidate viewer grants."""
+    prev = {"mode": "restricted", "emails": [], "org_allowed": False,
+            "owner_only": True, "access_version": 5}
+    _, _, acc_v, owner = resolve_access(
+        None, {"mode": "restricted", "emails": ["a@x.com"], "org_allowed": False}, prev
+    )
+    assert acc_v == 6
+
+    _, _, acc_v2, _ = resolve_access(
+        None, {"mode": "restricted", "emails": [], "org_allowed": False, "owner_only": True}, owner
+    )
+    assert acc_v2 == 7
+
+
+def test_resolve_owner_only_unchanged_keeps_access_version():
+    prev = {"mode": "restricted", "emails": [], "org_allowed": False,
+            "owner_only": True, "access_version": 4}
+    _, _, acc_v, _ = resolve_access(
+        None, {"mode": "restricted", "emails": [], "org_allowed": False, "owner_only": True}, prev
+    )
+    assert acc_v == 4
+
+
+def test_resolve_legacy_restricted_entry_without_owner_only_key_keeps_version():
+    """A pre-ENG-1769 entry has no owner_only key: prev.get() returns None and a
+    naive `False != None` comparison would bump the version on an unchanged
+    re-publish, resetting every viewer's grant."""
+    prev = {"mode": "restricted", "emails": ["a@x.com"], "org_allowed": False, "access_version": 3}
+    _, _, acc_v, _ = resolve_access(
+        None, {"mode": "restricted", "emails": ["a@x.com"], "org_allowed": False}, prev
+    )
+    assert acc_v == 3
+
+
 def test_parse_emails_splits_and_validates():
     valid, invalid = parse_emails("a@x.com, b@x.com foo@ ; c@y.io")
     assert valid == ["a@x.com", "b@x.com", "c@y.io"]

--- a/tests/test_publish_access_resolve.py
+++ b/tests/test_publish_access_resolve.py
@@ -277,7 +277,56 @@ async def test_prompt_access_restricted():
     fp = _FakePrompt(["restricted", "a@x.com, b@x.com", "y"])
     assert await prompt_access(fp) == {
         "mode": "restricted", "emails": ["a@x.com", "b@x.com"], "org_allowed": True,
+        "owner_only": False,
     }
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_restricted_empty_input_is_owner_only():
+    """Empty emails + no org is now a valid, explicit 'only me' selection."""
+    fp = _FakePrompt(["restricted", "", "n"])
+    assert await prompt_access(fp) == {
+        "mode": "restricted", "emails": [], "org_allowed": False, "owner_only": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_restricted_valid_emails_not_owner_only():
+    fp = _FakePrompt(["restricted", "a@x.com", "n"])
+    assert await prompt_access(fp) == {
+        "mode": "restricted", "emails": ["a@x.com"], "org_allowed": False, "owner_only": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_restricted_org_only_not_owner_only():
+    fp = _FakePrompt(["restricted", "", "y"])
+    assert await prompt_access(fp) == {
+        "mode": "restricted", "emails": [], "org_allowed": True, "owner_only": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_restricted_invalid_email_reprompts():
+    """A malformed address must NOT be silently dropped into an owner-only publish."""
+    fp = _FakePrompt(["restricted", "colleague@corp", "a@x.com", "n"])
+    result = await prompt_access(fp)
+    assert result == {
+        "mode": "restricted", "emails": ["a@x.com"], "org_allowed": False, "owner_only": False,
+    }
+    # The org question is asked once, after the email input finally validates.
+    assert sum("organization" in label for label in fp.asked) == 1
+    # The rejected token is echoed back in the re-prompt label.
+    assert any("colleague@corp" in label for label in fp.asked)
+
+
+@pytest.mark.asyncio
+async def test_prompt_access_restricted_mixed_input_reprompts():
+    """Valid + invalid together is still blocked: no silent 'invalid ignored'."""
+    fp = _FakePrompt(["restricted", "a@x.com bad", "a@x.com", "n"])
+    result = await prompt_access(fp)
+    assert result["emails"] == ["a@x.com"]
+    assert sum("organization" in label for label in fp.asked) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_publish_access_resolve.py
+++ b/tests/test_publish_access_resolve.py
@@ -167,8 +167,34 @@ def test_access_from_owner_side_password():
 def test_access_from_owner_side_restricted():
     entry = {"mode": "restricted", "emails": ["a@x.com"], "org_allowed": True}
     assert access_from_owner_side(entry) == {
-        "mode": "restricted", "emails": ["a@x.com"], "org_allowed": True,
+        "mode": "restricted", "emails": ["a@x.com"], "org_allowed": True, "owner_only": False,
     }
+
+
+def test_access_from_owner_side_restricted_owner_only():
+    entry = {"mode": "restricted", "emails": [], "org_allowed": False, "owner_only": True}
+    assert access_from_owner_side(entry) == {
+        "mode": "restricted", "emails": [], "org_allowed": False, "owner_only": True,
+    }
+
+
+def test_access_from_owner_side_restricted_legacy_entry_has_false_flag():
+    """Pre-ENG-1769 entries have no owner_only key — it must read as False, not None."""
+    entry = {"mode": "restricted", "emails": ["a@x.com"], "org_allowed": False}
+    assert access_from_owner_side(entry)["owner_only"] is False
+
+
+def test_keep_republish_of_owner_only_stays_restricted():
+    """The regression this exists for: without owner_only in the round-trip, a
+    'keep' re-publish reconstructs an empty selection which degrades to public,
+    silently making a private artifact world-readable."""
+    _, _, _, owner = resolve_access(
+        None, {"mode": "restricted", "emails": [], "org_allowed": False, "owner_only": True}, None
+    )
+    reconstructed = access_from_owner_side(owner)
+    eff, _, _, owner2 = resolve_access(None, reconstructed, owner)
+    assert eff["mode"] == "restricted"
+    assert owner2["owner_only"] is True
 
 
 def test_access_from_owner_side_public_and_legacy():

--- a/tests/test_publish_tool_access.py
+++ b/tests/test_publish_tool_access.py
@@ -131,3 +131,62 @@ async def test_tool_fullstack_from_inner_file_publishes_folder(tmp_path):
         )
     args, _ = fake_publish.call_args
     assert Path(args[0]) == art  # normalized up to the fullstack folder
+
+
+@pytest.mark.asyncio
+async def test_tool_owner_only_publishes_restricted(tmp_path):
+    """An explicit owner_only from the agent must NOT degrade to public."""
+    f = _artifact(tmp_path)
+    fake_publish = mock.Mock(return_value={"view_url": "u", "report_id": "r", "md5": "m", "version": 1})
+    with mock.patch("anton.publisher.publish", fake_publish), \
+         mock.patch("anton.config.settings.AntonSettings", return_value=_settings(f.parent.parent)), \
+         mock.patch("webbrowser.open"):
+        await tools.handle_publish_or_preview(
+            _session(tmp_path),
+            {"file_path": str(f), "action": "publish",
+             "access_mode": "restricted", "emails": [], "owner_only": True},
+        )
+    _, kwargs = fake_publish.call_args
+    assert kwargs["access"] == {"mode": "restricted", "emails": [], "org_allowed": False}
+    entry = json.loads((f.parent / ".published.json").read_text())[f.name]
+    assert entry["mode"] == "restricted"
+    assert entry["owner_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_tool_restricted_without_owner_only_still_degrades(tmp_path):
+    """The safety net for careless programmatic callers stays in place."""
+    f = _artifact(tmp_path)
+    fake_publish = mock.Mock(return_value={"view_url": "u", "report_id": "r", "md5": "m", "version": 1})
+    with mock.patch("anton.publisher.publish", fake_publish), \
+         mock.patch("anton.config.settings.AntonSettings", return_value=_settings(f.parent.parent)), \
+         mock.patch("webbrowser.open"):
+        await tools.handle_publish_or_preview(
+            _session(tmp_path),
+            {"file_path": str(f), "action": "publish", "access_mode": "restricted", "emails": []},
+        )
+    _, kwargs = fake_publish.call_args
+    assert kwargs["access"] == {"mode": "public"}
+
+
+@pytest.mark.asyncio
+async def test_tool_restricted_invalid_email_returns_error(tmp_path):
+    """A malformed address must not collapse into an owner-only or public publish."""
+    f = _artifact(tmp_path)
+    fake_publish = mock.Mock(return_value={"view_url": "u", "report_id": "r", "md5": "m", "version": 1})
+    with mock.patch("anton.publisher.publish", fake_publish), \
+         mock.patch("anton.config.settings.AntonSettings", return_value=_settings(f.parent.parent)), \
+         mock.patch("webbrowser.open"):
+        out = await tools.handle_publish_or_preview(
+            _session(tmp_path),
+            {"file_path": str(f), "action": "publish",
+             "access_mode": "restricted", "emails": ["colleague@corp"]},
+        )
+    assert "colleague@corp" in out
+    assert "INVALID" in out
+    fake_publish.assert_not_called()
+
+
+def test_publish_tool_schema_exposes_owner_only():
+    props = tools.PUBLISH_TOOL.input_schema["properties"]
+    assert props["owner_only"]["type"] == "boolean"


### PR DESCRIPTION
## Goal

Let a user publish an artifact only **they** can open, without listing their own email and without turning on `org_allowed`.

Today that is inexpressible: `resolve_access` treats "restricted with no emails and no org" as a caller mistake and silently degrades it to `public`. So `{"mode": "restricted", "emails": [], "org_allowed": false}` — the natural way to say "nobody but me" — produces a world-readable artifact.

The degradation is a deliberate safety net for programmatic callers and **stays**. This adds an explicit `owner_only` selector so the empty-empty case remains a mistake while the intentional case becomes expressible.

Nothing changes in `auth`'s access check: a rule with empty `allowed_emails` and `org_allowed=false` already resolves to "owner only" via the owner FK condition in `evaluate_artifact_access`. The flag therefore never reaches the publish lambda — it lives only in the input `access` and in `owner_side` (`.published.json`).

## Changes

**`publish_access.py`**

- `resolve_access` — accepts `owner_only` as a valid selection (`if emails or org_allowed or owner_only`). Canonicalised away when emails or org are set, since the owner always matches anyway; without that, two equivalent selections would differ in `access_version` and needlessly reset viewer grants.
- `access_version` — the `changed` comparison now includes `owner_only`, so switching to/from owner-only invalidates viewer caches. Read via `bool(prev.get(...))`: pre-ENG-1769 entries have no such key, and a bare `False != None` would bump the version on an unchanged re-publish of every legacy artifact.
- `access_from_owner_side` — round-trips the flag. Without this, a "keep" re-publish of an owner-only artifact reconstructs an empty selection which degrades to `public`, silently un-privating it.
- `prompt_access` — empty input is now an explicit owner-only selection; malformed addresses re-prompt with the rejected tokens echoed back instead of being dropped, which would otherwise have produced an owner-only publish behind the user's back.

**`tools.py`**

- The `restricted` branch forwards `owner_only`; without it the flag was dropped before `resolve_access` and an agent could not honour an explicit "only me" request.
- Malformed addresses now return an `INVALID:` error instead of being silently dropped into a public publish.
- `owner_only` added to the tool input schema, with copy that warns an empty list without the flag publishes publicly. `cowork-server` reuses `PUBLISH_TOOL.input_schema`, so it inherits this.

## Tests

`tests/test_publish_access_resolve.py` — non-degradation of an explicit owner-only selection, kept alongside the existing test that pins the degradation for the genuinely empty case; canonicalisation; `access_version` bumps across owner-only ↔ emails switches; no bump for a legacy entry without the key; and a test running `resolve_access` + `access_from_owner_side` in the loop where the "keep → public" regression lives.

`tests/test_publish_tool_access.py` — owner-only through the tool path, degradation preserved without the flag, invalid address returns an error and does not publish, schema exposes the property.

Full suite: 2340 passed, 30 skipped.

## Related

Part of ENG-1769 across four repos: this one, `cowork-server`, `cowork`, `auth`. Merge this first — the other three depend on `resolve_access` accepting the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)