### PR TITLE
Guarantee terminal event

### DIFF
--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -184,6 +184,10 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
             return
 
     hb = asyncio.create_task(_heartbeat())
+    # A teardown crash / CancelledError escapes `except Exception`, so guarantee
+    # a terminal event in `finally` — else the turn dies with no terminal and
+    # the controller reports a silent "unexpected error".
+    terminal_emitted = False
     try:
         req = TurnRequestV1.from_json(raw_line)
         session = builder(req)
@@ -277,11 +281,19 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
             emit({"kind": "skill", "entries": drafts})
         logger.info("cloud turn completed")
         emit({"kind": "turn_completed"})
+        terminal_emitted = True
     except Exception as exc:
         # Full traceback -> stderr only; wire carries a short scrubbed string.
         logger.exception("cloud turn failed")
         emit({"kind": "turn_failed", "error": _scrub(exc)})
+        terminal_emitted = True
     finally:
+        # No terminal yet = BaseException/teardown path; emit one (guarded — a
+        # broken pipe here must not mask the original error).
+        if not terminal_emitted:
+            logger.warning("cloud turn ended without a terminal event; emitting turn_failed")
+            with contextlib.suppress(Exception):
+                emit({"kind": "turn_failed", "error": "The turn ended unexpectedly. Please try again."})
         hb.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await hb

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -224,6 +224,29 @@ def test_turn_failure_is_terminal_and_scrubbed():
     assert session.closed is True  # closed even on failure
 
 
+class _BaseBoom(BaseException):
+    """A non-Exception failure, like the httpcore GeneratorExit->RuntimeError
+    teardown or a CancelledError, that escapes `except Exception`."""
+
+
+def test_baseexception_teardown_still_emits_a_terminal_event():
+    """Regression: a teardown crash after the turn body must not close the
+    stream with no terminal event (controller reports 'stream ended without a
+    terminal event' -> cowork shows a bare 'unexpected error'). The finally
+    guarantee emits turn_failed, then the BaseException re-propagates."""
+    session = _FakeSession(raise_on_stream=_BaseBoom("teardown"))
+    events = []
+    try:
+        asyncio.run(stream_turn(
+            '{"protocol_version":1,"conversation_id":"c","input":"hi"}',
+            events.append, session_builder=lambda r: session,
+        ))
+    except _BaseBoom:
+        pass  # re-propagates after finally emitted the terminal event
+    assert events and events[-1]["kind"] == "turn_failed"
+    assert session.closed is True
+
+
 def test_bad_request_is_a_single_turn_failed():
     events = []
     asyncio.run(stream_turn("{not valid json", events.append))


### PR DESCRIPTION
Some cloud turns were ending as a bare "An unexpected error occurred" with no detail. The cause: a teardown crash (an httpcore GeneratorExit → RuntimeError during stream close, or a CancelledError) unwinds past except Exception, so stream_turn exits without emitting turn_completed or turn_failed. The controller then sees a stream that closed with no terminal event and reports the generic error — and the turn isn't cleanly retry-able.

This adds a finally guard that emits a turn_failed if no terminal event went out, so a turn can never end silently. It turns those silent deaths into a normal, retry-able failure.