### PR TITLE
ENG-1689: stamp endpoint_class and error_type on turn_completed

### DIFF
--- a/anton/core/llm/endpoints.py
+++ b/anton/core/llm/endpoints.py
@@ -1,0 +1,175 @@
+"""Where a turn's tokens actually went — MindsHub, a third party, or on-box.
+
+ENG-1689. ``turn_completed`` could report *how much* a turn cost but not
+*where it went*, and every available proxy for that is wrong:
+
+- ``llm_provider`` names the **client shape**, not the destination. Our own
+  gateway arrives under two different values — ``minds-cloud`` from the desktop
+  DB overlay and ``openai-compatible`` from anything constructed through
+  ``AntonSettings`` (the ``_map_minds_cloud_to_openai_compatible`` validator
+  rewrites it, and cowork-server's ``setattr`` overlay bypasses the validator;
+  ENG-1695). Measured 2026-08-20: counting the gateway as ``minds-cloud`` alone
+  undercounts it by 18% — 382 turns, 146 people, 25.2M tokens over 14 days.
+- ``planning_model`` needs a live ``/v1/models`` allowlist to interpret (73
+  distinct models in two days) and can never be authoritative anyway, since
+  nothing stops a user naming a local model ``sonnet``.
+
+Only anton knows the base URL it resolved, so only anton can answer this.
+
+**The values are a partition over the observed host, not over who pays.** That
+distinction is what makes them mutually exclusive: "is this loopback" and "is
+this our domain" are facts about a string we hold, whereas "whose money paid"
+depends on a server-side gate verdict anton cannot see (that lives on
+``usage_events``; see ENG-1611). A rule keyed on intent would put a loopback
+proxy forwarding to our gateway in two buckets at once.
+
+Consequences of reading the host and nothing else, both deliberate:
+
+- A local proxy forwarding to our gateway reports ``local``, because that is
+  genuinely all anton observes. ``local`` therefore means "the endpoint was on
+  this machine or LAN", NOT "definitely not our gateway".
+- A private/LAN address counts as ``local``, not only loopback — Ollama and
+  LM Studio are routinely reached across the network, and a loopback-only rule
+  would file those as ``third-party`` and understate on-box use, which is the
+  population this exists to measure.
+
+The raw base URL is **never** emitted: those carry internal corporate
+hostnames. Only the three labels below leave the process.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from anton.config.settings import AntonSettings
+
+#: The endpoint was on this machine or its local network.
+ENDPOINT_LOCAL = "local"
+#: The endpoint was the MindsHub gateway (any of its host/path shapes).
+ENDPOINT_MINDSHUB = "mindshub"
+#: The endpoint was somebody else's — OpenRouter, Databricks, a vendor API.
+ENDPOINT_THIRD_PARTY = "third-party"
+#: Unrecognised provider. Absent beats wrong: a value here would be a guess.
+ENDPOINT_UNKNOWN = ""
+
+VALID_ENDPOINT_CLASSES = frozenset(
+    {ENDPOINT_LOCAL, ENDPOINT_MINDSHUB, ENDPOINT_THIRD_PARTY}
+)
+
+# Registrable domains we serve the gateway from. `mdb.ai` is the legacy host
+# and still live. Matched as an exact host or a dot-delimited subdomain —
+# never as a substring, which `mindshub.ai.attacker.example` would satisfy.
+_MINDSHUB_DOMAINS = ("mindshub.ai", "mdb.ai")
+
+# Hostname suffixes that mean "this machine / this network" without being IPs.
+# `.local` is mDNS (Bonjour), how an Ollama box on the LAN is usually named.
+_LOCAL_SUFFIXES = (".localhost", ".local", ".internal", ".lan", ".home.arpa")
+
+# Providers whose destination is fixed by the provider itself, so the base URL
+# is irrelevant (and, for `anthropic`, not even passed — see
+# `LLMClient.from_settings`). `gemini` is absent from AntonSettings entirely
+# and only ever arrives via cowork-server's overlay (ENG-1695).
+_VENDOR_FIXED = {
+    "anthropic": ENDPOINT_THIRD_PARTY,
+    "gemini": ENDPOINT_THIRD_PARTY,
+    "minds-cloud": ENDPOINT_MINDSHUB,
+}
+
+# Providers that DO read `openai_base_url`, so the URL decides. Both are in
+# `from_settings`' dispatch dict with `base_url=settings.openai_base_url`;
+# omitting plain `openai` here would misfile a user who points it at us.
+_URL_DECIDED = frozenset({"openai", "openai-compatible"})
+
+
+def _host_of(base_url: str) -> str:
+    """Lowercased hostname from a base URL, tolerant of a missing scheme.
+
+    ``urlsplit`` only populates ``hostname`` when it sees an authority, so a
+    bare ``127.0.0.1:11434`` (which users do paste) parses as a *path* and
+    yields nothing. Prefixing ``//`` when there is no ``//`` already recovers
+    that case. Also strips any IPv6 brackets, which ``hostname`` already does.
+    """
+    raw = (base_url or "").strip()
+    if not raw:
+        return ""
+    try:
+        parts = urlsplit(raw if "//" in raw else f"//{raw}")
+        return (parts.hostname or "").strip().lower().rstrip(".")
+    except Exception:  # pragma: no cover - defensive; urlsplit is lenient
+        return ""
+
+
+def _is_local_host(host: str) -> bool:
+    """True for loopback, private, link-local, or a local-only name suffix."""
+    if host == "localhost" or host.endswith(_LOCAL_SUFFIXES):
+        return True
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return bool(
+        addr.is_loopback
+        or addr.is_private
+        or addr.is_link_local
+        or addr.is_unspecified
+    )
+
+
+def _is_mindshub_host(host: str) -> bool:
+    """Exact-or-subdomain match on our domains — deliberately not a substring.
+
+    ``LLMClient``'s vision gate uses ``"mindshub.ai" in host``, which a
+    hostile host like ``mindshub.ai.example.com`` satisfies. Unifying those
+    call sites onto this helper is ENG-1695; this one is written correctly from
+    the start so the new property is not spoofable.
+    """
+    return any(
+        host == domain or host.endswith(f".{domain}") for domain in _MINDSHUB_DOMAINS
+    )
+
+
+def classify_base_url(base_url: str) -> str:
+    """Classify a base URL by host alone.
+
+    An empty or unparseable URL is ``third-party``, not unknown: the OpenAI
+    SDK falls back to ``api.openai.com`` when handed no base URL, so "nothing
+    configured" genuinely does reach a third party.
+    """
+    host = _host_of(base_url)
+    if not host:
+        return ENDPOINT_THIRD_PARTY
+    if _is_local_host(host):
+        return ENDPOINT_LOCAL
+    if _is_mindshub_host(host):
+        return ENDPOINT_MINDSHUB
+    return ENDPOINT_THIRD_PARTY
+
+
+def classify_endpoint(settings: AntonSettings) -> str:
+    """``local`` | ``mindshub`` | ``third-party``, or ``""`` when unrecognised.
+
+    Provider-aware on purpose. ``openai_base_url`` is derived from
+    ``minds_url`` by ``AntonSettings.model_post_init`` — but *only* when a
+    provider is ``openai-compatible``. So for a vendor-fixed provider the
+    field can be set, stale, and pointed at us while the turn never went near
+    us; consulting it there would invent gateway traffic. Reading
+    ``planning_provider`` first is what prevents that.
+
+    Never raises: this is called from the analytics path, where a failure must
+    not disturb the turn that just ran.
+    """
+    try:
+        provider = str(getattr(settings, "planning_provider", "") or "").strip().lower()
+        fixed = _VENDOR_FIXED.get(provider)
+        if fixed is not None:
+            return fixed
+        if provider in _URL_DECIDED:
+            return classify_base_url(
+                str(getattr(settings, "openai_base_url", "") or "")
+            )
+        return ENDPOINT_UNKNOWN
+    except Exception:  # pragma: no cover - defensive
+        return ENDPOINT_UNKNOWN

--- a/anton/core/llm/endpoints.py
+++ b/anton/core/llm/endpoints.py
@@ -16,6 +16,17 @@ ENG-1689. ``turn_completed`` could report *how much* a turn cost but not
 
 Only anton knows the base URL it resolved, so only anton can answer this.
 
+**Scope: this is the PLANNING role's endpoint.** A turn has independent
+``planning_provider``, ``coding_provider`` and ``router_provider`` settings, so
+roles CAN reach different destinations — and this reports one label, matching
+``llm_provider``, which is also planning-only. The exposure is small because
+there is a single ``openai_base_url``: two roles both on ``openai-compatible``
+share an endpoint, so they diverge only when the provider *types* differ.
+Measured 14d: 12.9% of real turns ran a different coding model, but only 0.5%
+of tokens, and most of those pairs sit on the same endpoint (``sonnet`` with
+``haiku``, both ours). Read this as "where the planning role went", not as a
+guarantee that every token in the turn went there.
+
 **The values are a partition over the observed host, not over who pays.** That
 distinction is what makes them mutually exclusive: "is this loopback" and "is
 this our domain" are facts about a string we hold, whereas "whose money paid"

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 from anton.core.backends.base import Cell, ScratchpadRuntimeFactory
 from anton.core.backends.local import local_scratchpad_runtime_factory
 from anton.core.datasources.data_vault import DataVault
+from anton.core.llm.endpoints import classify_endpoint
 from anton.core.llm.prompt_builder import ChatSystemPromptBuilder, SystemPromptContext
 from anton.core.memory.acc import AnteriorCingulate
 from anton.core.root_cause import RootCauseLedger
@@ -509,6 +510,26 @@ def _safe_error_detail(exc: BaseException) -> str:
         # and never the message.
         pass
     return name
+
+
+def _safe_error_type(exc: BaseException) -> str:
+    """The exception's class name, and nothing else, for analytics.
+
+    Deliberately narrower than its sibling `_safe_error_detail`, which appends
+    a status code or the offending pydantic field paths. That extra detail is
+    right for a log line a human reads and wrong for a PostHog property: the
+    point of `error_type` is to resolve one opaque bucket into a *groupable*
+    distribution, and a compound value would spread a single failure mode
+    across many rows. Both are content-free; they differ only in cardinality.
+
+    Never raises, for the same reason as `_safe_error_detail`: it runs inside
+    an `except` handler, where an escape would turn a handled failure into a
+    dead turn.
+    """
+    try:
+        return type(exc).__name__
+    except Exception:  # pragma: no cover - defensive
+        return "unavailable"
 
 
 def _is_provider_auth_error(exc: BaseException) -> bool:
@@ -2426,6 +2447,10 @@ class ChatSession:
             tc.ended_by = "cancelled"
         elif exc is not None:
             tc.ended_by = "error"
+            # The exception was in scope here and thrown away until ENG-1689,
+            # so "error" covered a parse failure, a tool crash, a bad config
+            # and an anton bug alike — indistinguishable in any query.
+            tc.error_type = _safe_error_type(exc)
 
         # Stamped at books-open; the live lookup remains only for bare-session
         # tests and the legacy non-streaming path.
@@ -2485,6 +2510,9 @@ class ChatSession:
                 # classification is broken.
                 **_root_cause_fields,
                 ended_by=tc.ended_by,
+                # Empty unless the turn ended on an exception — see
+                # `TurnCost.error_type`.
+                error_type=tc.error_type,
                 # A completed-but-unverified turn (denied/latched verifier,
                 # ENG-1632) must be excludable from the honest-stop
                 # denominator without a per-conversation Langfuse hop.
@@ -2525,10 +2553,26 @@ class ChatSession:
                 # value is the alarm that some caller invented a role.
                 unknown_tokens=_role_tokens(tc, UNKNOWN_ROLE),
                 unknown_calls=_role_calls(tc, UNKNOWN_ROLE),
-                # Configured provider name (anthropic / openai /
-                # openai-compatible): separates gateway traffic from BYOK in
-                # queries. The finer per-model provider split is a follow-up.
+                # The provider label in the EMITTING HOST's own vocabulary,
+                # drawn from one of two registries that do not share a value
+                # space: anton's CLI dispatch has three values (anthropic /
+                # openai / openai-compatible), cowork-server's has five (plus
+                # gemini / minds-cloud). The same configuration therefore
+                # reports differently depending on which host wrote it, because
+                # a `@field_validator` rewrites `minds-cloud` on construction
+                # while cowork-server's `setattr` overlay bypasses validation
+                # (ENG-1695). An earlier comment here claimed this field
+                # "separates gateway traffic from BYOK in queries" — it cannot,
+                # and doing so undercounted the gateway by 18%. `endpoint_class`
+                # below is the field that answers that; this one is left
+                # deliberately un-normalised, since flattening the two
+                # vocabularies would destroy `minds-cloud`, the one label that
+                # is correct today.
                 llm_provider=str(getattr(settings, "planning_provider", "") or ""),
+                # Where the tokens actually went, from the resolved base-URL
+                # host: local / mindshub / third-party (ENG-1689). Never the
+                # URL itself — those carry internal corporate hostnames.
+                endpoint_class=classify_endpoint(settings),
                 harness=str(self._harness or ""),
                 anton_version=_anton_version,
                 # Join keys: the same session/turn identity the MindsHub
@@ -3729,6 +3773,10 @@ class ChatSession:
                         # mode in any error-rate query (#309 review).
                         if self._turn_cost is not None:
                             self._turn_cost.ended_by = "retry_exhausted"
+                            # Same exception the SYSTEM message below shows the
+                            # model and the user; it just never reached
+                            # telemetry (ENG-1689).
+                            self._turn_cost.error_type = _safe_error_type(_agent_exc)
                         self._append_history(
                             {
                                 "role": "user",

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2445,6 +2445,13 @@ class ChatSession:
         # narrower case where the cancel lands exactly at a yield boundary.
         if isinstance(exc, (GeneratorExit, asyncio.CancelledError)) or cancelled:
             tc.ended_by = "cancelled"
+            # Clear any error_type an earlier terminal already stamped. The
+            # retry-exhausted site stamps one and then keeps going to produce
+            # its apology — and a user who has sat through failed retries is
+            # exactly the user who then presses Stop, so this path is ordinary,
+            # not exotic. Leaving the stale value would let plain Stops appear
+            # in an error-cause breakdown, which is the opposite of the point.
+            tc.error_type = ""
         elif exc is not None:
             tc.ended_by = "error"
             # The exception was in scope here and thrown away until ENG-1689,
@@ -2493,6 +2500,19 @@ class ChatSession:
         # never conversation content (ENG-1288).
         try:
             settings = getattr(self, "_settings", None)
+            # Held separately from the fallback below. `endpoint_class` must
+            # describe THIS TURN's endpoint, and the fallback describes the
+            # process environment — which is not the same thing on any host
+            # that builds a session without passing settings (cowork-server's
+            # connector probe does exactly that, and it is a live path). Where
+            # the turn's own settings are absent, or are a `CoreSettings` that
+            # has no provider fields at all, the honest answer is "unknown",
+            # and `classify_endpoint` returns that for both.
+            #
+            # `llm_provider` below deliberately keeps reading the fallback:
+            # changing an existing field's source is ENG-1695's call, not a
+            # side effect of adding a new one.
+            _turn_settings = settings
             if settings is None or not hasattr(settings, "analytics_enabled"):
                 from anton.config.settings import AntonSettings
 
@@ -2572,7 +2592,7 @@ class ChatSession:
                 # Where the tokens actually went, from the resolved base-URL
                 # host: local / mindshub / third-party (ENG-1689). Never the
                 # URL itself — those carry internal corporate hostnames.
-                endpoint_class=classify_endpoint(settings),
+                endpoint_class=classify_endpoint(_turn_settings),
                 harness=str(self._harness or ""),
                 anton_version=_anton_version,
                 # Join keys: the same session/turn identity the MindsHub

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -105,6 +105,13 @@ class TurnCost:
     # specific exit; ``_emit_turn_cost`` overrides with cancelled/error when
     # the turn didn't end on its own terms.
     ended_by: str = "completed"
+    # Exception class that ended the turn. `ended_by` alone cannot say WHY:
+    # `error` is a catch-all and `retry_exhausted` discards the exception it
+    # already formats into chat history, so together ~12% of real turns booked
+    # a failure with no diagnosis (ENG-1689). Empty for every terminal that is
+    # not an exception — `completed`, `cancelled`, `spend_ceiling`, and
+    # `handback_verifier_failure`, which is a verdict rather than a raise.
+    error_type: str = ""
     # The completion verifier was applicable but produced no verdict this turn
     # (denied by billing/model access, or suppressed by the verifier latch —
     # ENG-1632). Such turns deliberately book ended_by="completed" (the work

--- a/tests/test_endpoint_class.py
+++ b/tests/test_endpoint_class.py
@@ -1,0 +1,285 @@
+"""`endpoint_class` — where a turn's tokens actually went (ENG-1689).
+
+The defect these cover is not arithmetic, it is *which field gets consulted*.
+`llm_provider` reported the emitting host's vocabulary rather than the
+destination, so our own gateway arrived under two labels and a gateway-share
+query ran 18% low. The tests therefore pin three things: the host partition,
+the provider gate in front of it (a vendor-fixed provider must never be
+classified from a base URL it does not read), and the emit-site seam.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from anton.core.llm.endpoints import (
+    ENDPOINT_LOCAL,
+    ENDPOINT_MINDSHUB,
+    ENDPOINT_THIRD_PARTY,
+    ENDPOINT_UNKNOWN,
+    VALID_ENDPOINT_CLASSES,
+    classify_base_url,
+    classify_endpoint,
+)
+
+
+def _settings(provider: str, base_url: str = "") -> SimpleNamespace:
+    """Only the two attributes `classify_endpoint` reads."""
+    return SimpleNamespace(planning_provider=provider, openai_base_url=base_url)
+
+
+# ─── the host partition ──────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "base_url, expected",
+    [
+        # Loopback, in the shapes people actually paste.
+        ("http://localhost:11434/v1", ENDPOINT_LOCAL),
+        ("http://127.0.0.1:1234/v1", ENDPOINT_LOCAL),
+        ("http://[::1]:8080/v1", ENDPOINT_LOCAL),
+        ("http://0.0.0.0:11434/v1", ENDPOINT_LOCAL),
+        # No scheme — `urlsplit` parses this as a path and finds no host
+        # unless `//` is prepended, which is why `_host_of` does that.
+        ("127.0.0.1:11434", ENDPOINT_LOCAL),
+        # Private / LAN. An Ollama box on the network is still local, and
+        # calling it `third-party` would understate exactly what we measure.
+        ("http://192.168.1.40:11434/v1", ENDPOINT_LOCAL),
+        ("http://10.0.0.7:8000/v1", ENDPOINT_LOCAL),
+        ("http://172.16.5.5:8000/v1", ENDPOINT_LOCAL),
+        ("http://169.254.10.1:8000/v1", ENDPOINT_LOCAL),
+        ("http://mac-studio.local:11434/v1", ENDPOINT_LOCAL),
+        # Our gateway, in all three shapes `model_post_init` can build.
+        ("https://api.mindshub.ai/v1", ENDPOINT_MINDSHUB),
+        ("https://mdb.ai/api/v1", ENDPOINT_MINDSHUB),
+        ("https://mindshub.ai", ENDPOINT_MINDSHUB),
+        ("https://api.mindshub.ai/v1/", ENDPOINT_MINDSHUB),
+        ("HTTPS://API.MINDSHUB.AI/v1", ENDPOINT_MINDSHUB),
+        # Somebody else's.
+        ("https://openrouter.ai/api/v1", ENDPOINT_THIRD_PARTY),
+        ("https://api.openai.com/v1", ENDPOINT_THIRD_PARTY),
+        ("https://acme-corp.databricks.com/serving-endpoints", ENDPOINT_THIRD_PARTY),
+        # Nothing configured still reaches a third party: the OpenAI SDK
+        # defaults to api.openai.com, so `third-party` is the true answer
+        # here rather than a fallback.
+        ("", ENDPOINT_THIRD_PARTY),
+        ("   ", ENDPOINT_THIRD_PARTY),
+        ("not a url at all", ENDPOINT_THIRD_PARTY),
+    ],
+)
+def test_host_partition(base_url, expected):
+    assert classify_base_url(base_url) == expected
+
+
+def test_api_mindshub_v1_is_recognised_the_shape_the_old_helper_missed():
+    """`cli.py`'s `_looks_like_mdb_ai` matches `{minds_url}` and
+    `{minds_url}/api/v1` but not `{minds_url}/v1` — which is precisely what
+    `model_post_init` builds for `https://api.mindshub.ai`, our production
+    gateway. Building this property on that helper would have reproduced the
+    bug in a new field (ENG-1695).
+    """
+    assert classify_base_url("https://api.mindshub.ai/v1") == ENDPOINT_MINDSHUB
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "https://mindshub.ai.attacker.example/v1",
+        "https://notmindshub.ai/v1",
+        "https://mdb.ai.evil.test/v1",
+        "https://fake-mdb.ai.co/v1",
+    ],
+)
+def test_domain_match_is_not_a_substring(hostile):
+    """`LLMClient`'s vision gate uses `"mindshub.ai" in host`, which these
+    satisfy. This property matches on exact host or dot-delimited subdomain,
+    so a lookalike cannot inflate gateway share.
+    """
+    assert classify_base_url(hostile) == ENDPOINT_THIRD_PARTY
+
+
+# ─── the provider gate in front of the host partition ────────────────────────
+
+def test_minds_cloud_is_the_gateway_whatever_the_base_url_says():
+    """The desktop DB overlay writes `minds-cloud` via `setattr`, bypassing
+    the validator. It means the gateway by definition, so the URL is not
+    consulted.
+    """
+    assert classify_endpoint(_settings("minds-cloud", "")) == ENDPOINT_MINDSHUB
+    assert (
+        classify_endpoint(_settings("minds-cloud", "http://localhost:1234/v1"))
+        == ENDPOINT_MINDSHUB
+    )
+
+
+def test_vendor_fixed_provider_is_never_classified_from_a_stale_base_url():
+    """The trap this gate exists for. `model_post_init` derives
+    `openai_base_url` from `minds_url` — so the field can be set and pointed
+    at us while an `anthropic` turn goes to api.anthropic.com and never
+    touches our gateway. Reading the URL here would invent gateway traffic.
+    """
+    stale = _settings("anthropic", "https://api.mindshub.ai/v1")
+    assert classify_endpoint(stale) == ENDPOINT_THIRD_PARTY
+    assert classify_endpoint(_settings("gemini", "https://api.mindshub.ai/v1")) == (
+        ENDPOINT_THIRD_PARTY
+    )
+
+
+@pytest.mark.parametrize("provider", ["openai", "openai-compatible"])
+def test_url_reading_providers_are_classified_from_the_url(provider):
+    """Both of these are constructed with `base_url=settings.openai_base_url`
+    in `LLMClient.from_settings`, so both can legitimately point at us.
+    Omitting plain `openai` would misfile a user who does.
+    """
+    assert classify_endpoint(_settings(provider, "https://api.mindshub.ai/v1")) == (
+        ENDPOINT_MINDSHUB
+    )
+    assert classify_endpoint(_settings(provider, "http://localhost:11434/v1")) == (
+        ENDPOINT_LOCAL
+    )
+    assert classify_endpoint(_settings(provider, "https://openrouter.ai/api/v1")) == (
+        ENDPOINT_THIRD_PARTY
+    )
+
+
+def test_unrecognised_provider_is_absent_not_guessed():
+    """A provider nobody has taught this module about must not be assigned a
+    value: absent is queryable as absent, a wrong label is not.
+    """
+    assert classify_endpoint(_settings("some-future-provider", "")) == ENDPOINT_UNKNOWN
+    assert classify_endpoint(_settings("", "")) == ENDPOINT_UNKNOWN
+
+
+def test_case_and_whitespace_in_the_provider_do_not_defeat_the_gate():
+    assert classify_endpoint(_settings("  Minds-Cloud  ", "")) == ENDPOINT_MINDSHUB
+
+
+def test_never_raises_on_a_hostile_settings_object():
+    """Called from the analytics path, which must never disturb the turn."""
+
+    class _Exploding:
+        @property
+        def planning_provider(self):  # pragma: no cover - raises by design
+            raise RuntimeError("settings blew up")
+
+    assert classify_endpoint(_Exploding()) == ENDPOINT_UNKNOWN
+
+
+# ─── the privacy constraint ──────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://llm.internal.acme-corp.example/v1",
+        "http://gpu-box-7.eng.acme.internal:8000/v1",
+        "https://api.mindshub.ai/v1",
+        "http://192.168.1.40:11434/v1",
+    ],
+)
+def test_no_hostname_ever_leaves_the_classifier(base_url):
+    """Internal corporate hostnames must not land in analytics — the reason
+    this is a class rather than the raw URL.
+    """
+    result = classify_base_url(base_url)
+    # The label is one of a closed set of three, so nothing host-derived can
+    # ride along. Checked structurally rather than by forbidden substrings:
+    # the label "mindshub" legitimately contains a domain fragment, so a
+    # substring blocklist would either fail on it or have to special-case it.
+    assert result in VALID_ENDPOINT_CLASSES
+    assert not any(ch.isdigit() for ch in result), "no address octet survives"
+    for structural in (".", ":", "/", "acme", "gpu-box", "internal", "example"):
+        assert structural not in result
+
+
+# ─── the real settings object, not a stub ────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "minds_url, expected",
+    [
+        ("https://api.mindshub.ai", ENDPOINT_MINDSHUB),  # derives /v1
+        ("https://mdb.ai", ENDPOINT_MINDSHUB),           # derives /api/v1
+        ("https://api.mindshub.ai/v1", ENDPOINT_MINDSHUB),  # kept as-is
+    ],
+)
+def test_all_three_derived_url_shapes_classify_as_the_gateway(minds_url, expected):
+    """Exercised through the real `AntonSettings.model_post_init` derivation
+    rather than hand-written URLs, so a change to that derivation surfaces
+    here instead of silently reclassifying gateway traffic.
+    """
+    from anton.config.settings import AntonSettings
+
+    settings = AntonSettings(
+        minds_url=minds_url,
+        minds_api_key="mdb_test_key",
+        openai_api_key=None,
+        planning_provider="openai-compatible",
+        coding_provider="openai-compatible",
+    )
+    assert settings.openai_base_url, "derivation did not run — test is vacuous"
+    assert classify_endpoint(settings) == expected
+
+
+# ─── the emit-site seam ──────────────────────────────────────────────────────
+
+def test_emit_site_actually_sends_both_new_properties():
+    """A call-site guard, not a helper test. Deleting the emit-site argument
+    for a comparable property once passed the entire 1,448-test suite, because
+    no test drove that path — so the seam is pinned structurally.
+
+    AST rather than a substring search: a mention in a comment or a stale
+    import must not satisfy it. The keywords have to be on the `send_event`
+    call inside `_emit_turn_cost`.
+    """
+    src = Path(
+        __import__("anton.core.session", fromlist=["session"]).__file__
+    ).read_text()
+    emit = next(
+        (
+            n
+            for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.FunctionDef) and n.name == "_emit_turn_cost"
+        ),
+        None,
+    )
+    assert emit is not None, "_emit_turn_cost not found — rename?"
+
+    send_calls = [
+        n
+        for n in ast.walk(emit)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "send_event"
+    ]
+    assert send_calls, "no send_event call inside _emit_turn_cost"
+    keywords = {kw.arg for call in send_calls for kw in call.keywords}
+    assert "endpoint_class" in keywords, "endpoint_class is not emitted"
+    assert "error_type" in keywords, "error_type is not emitted"
+
+
+def test_the_seam_guard_can_fail():
+    """Positive control for the guard above: the same AST predicate run
+    against a source that omits the keyword must report absence. Without this
+    a bug in the predicate would make the guard silently vacuous.
+    """
+    src = (
+        "def _emit_turn_cost(self):\n"
+        "    send_event(settings, 'turn_completed', ended_by='x')\n"
+    )
+    emit = next(
+        n
+        for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.FunctionDef) and n.name == "_emit_turn_cost"
+    )
+    keywords = {
+        kw.arg
+        for n in ast.walk(emit)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "send_event"
+        for kw in n.keywords
+    }
+    assert "endpoint_class" not in keywords
+    assert "ended_by" in keywords

--- a/tests/test_endpoint_class.py
+++ b/tests/test_endpoint_class.py
@@ -222,6 +222,35 @@ def test_all_three_derived_url_shapes_classify_as_the_gateway(minds_url, expecte
     assert classify_endpoint(settings) == expected
 
 
+# ─── the turn's own settings, never the ambient environment ──────────────────
+
+def test_absent_settings_reports_unknown_not_the_process_environment():
+    """The gap `ENDPOINT_UNKNOWN` exists for — and it was unreachable at first.
+
+    `_emit_turn_cost` falls back to a fresh `AntonSettings()` when the session
+    carries none, which reads the *process environment*. That is fine for
+    `llm_provider` (its historical meaning) and wrong here: it would describe
+    the machine rather than the turn, confidently. cowork-server's connector
+    probe builds a `ChatSessionConfig` with no `settings=` and is a live path
+    (68 events / 4.8M tokens in 14 days), so this is not hypothetical.
+
+    A default `AntonSettings` always carries a valid provider, so the unknown
+    branch could never fire through the fallback — the same
+    unreachable-by-construction shape as ENG-1459's `surface=web`.
+    """
+    assert classify_endpoint(None) == ENDPOINT_UNKNOWN
+
+
+def test_core_settings_without_provider_fields_reports_unknown():
+    """`ChatSessionConfig.settings` is typed `CoreSettings | None`, and
+    `CoreSettings` has no `planning_provider` and no `openai_base_url`. Absent
+    is the truthful answer; guessing `third-party` from a missing field is not.
+    """
+    from anton.core.settings import CoreSettings
+
+    assert classify_endpoint(CoreSettings()) == ENDPOINT_UNKNOWN
+
+
 # ─── the emit-site seam ──────────────────────────────────────────────────────
 
 def test_emit_site_actually_sends_both_new_properties():

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -616,3 +616,121 @@ async def test_hard_latch_and_failed_reprobe_turns_also_stamp_verification_skipp
     # Every later turn — the latched skips AND the failed re-probe that falls
     # inside this window — books completed and must carry the flag.
     assert all(r == ("completed", "true") for r in rows[2:]), rows[2:]
+
+
+# ─── error_type: naming the failure, not just counting it (ENG-1689) ─────────
+
+def _error_type(send_event_mock) -> str:
+    assert send_event_mock.called, "no turn_completed event emitted"
+    return send_event_mock.call_args.kwargs["error_type"]
+
+
+async def test_retry_exhausted_names_the_exception_class(workspace):
+    """`retry_exhausted` was 6.7% of real turns with a median of ZERO LLM
+    calls — dying before the first model call — and said nothing about why.
+    The exception was already in hand: the retry loop formats it into a SYSTEM
+    message the model and the user both read, then dropped it.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.plan_stream = MagicMock(side_effect=RuntimeError("provider down"))
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("do something"):
+            pass
+
+    assert _ended_by(send) == "retry_exhausted"
+    assert _error_type(send) == "RuntimeError"
+
+
+async def test_retry_exhausted_reports_the_specific_provider_exception(workspace):
+    """The value of the field is discriminating between causes, so a second
+    exception type must produce a different label rather than a generic one.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.plan_stream = MagicMock(side_effect=TimeoutError("upstream stalled"))
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("do something"):
+            pass
+
+    assert _ended_by(send) == "retry_exhausted"
+    assert _error_type(send) == "TimeoutError"
+
+
+async def test_error_terminal_names_the_exception_class(workspace):
+    """The catch-all. `ended_by="error"` covered a parse failure, a tool
+    crash, a bad config and an anton bug alike, with the exception object in
+    scope at the assignment and discarded.
+
+    A `BaseException` is what reaches this branch — the retry loop catches
+    `Exception`, so only something outside that hierarchy escapes to the
+    outer handler. `KeyboardInterrupt` is the real-world instance of that
+    (Ctrl-C in the CLI) and is not one of the cancel shapes that would file
+    as `cancelled`.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.plan_stream = MagicMock(side_effect=KeyboardInterrupt())
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        with pytest.raises(KeyboardInterrupt):
+            async for _ in session.turn_stream("do something"):
+                pass
+
+    assert _ended_by(send) == "error"
+    assert _error_type(send) == "KeyboardInterrupt"
+
+
+async def test_completed_turn_carries_no_error_type(workspace):
+    """Empty, not "none" or "unknown" — a clean turn has no exception, and a
+    placeholder would pollute the distribution this field exists to produce.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.plan_stream = MagicMock(
+        side_effect=lambda **kw: _Iter([StreamComplete(response=_text("hi"))])
+    )
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("hello"):
+            pass
+
+    assert _ended_by(send) == "completed"
+    assert _error_type(send) == ""
+
+
+async def test_user_stop_carries_no_error_type(workspace):
+    """A user pressing Stop is not a failure. `CancelledError` takes the
+    `cancelled` branch, which deliberately does not stamp `error_type` — so
+    an error-cause breakdown cannot be inflated by ordinary stops.
+    """
+    mock_llm = make_mock_llm()
+    started = asyncio.Event()
+
+    def _hang(**kwargs):
+        async def _gen():
+            started.set()
+            await asyncio.sleep(3600)
+            yield StreamComplete(response=_text())
+
+        return _gen()
+
+    mock_llm.plan_stream = MagicMock(side_effect=_hang)
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+
+    with patch("anton.analytics.send_event") as send:
+
+        async def _run():
+            async for _ in session.turn_stream("long one"):
+                pass
+
+        task = asyncio.create_task(_run())
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert _ended_by(send) == "cancelled"
+    assert _error_type(send) == ""

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -759,3 +759,62 @@ async def test_user_stop_carries_no_error_type(workspace):
 
     assert _ended_by(send) == "cancelled"
     assert _error_type(send) == ""
+
+
+async def test_stop_after_exhausted_retries_does_not_report_an_error_type(workspace):
+    """A stale `error_type` must not survive into a `cancelled` turn.
+
+    The retry-exhausted site stamps `error_type` and then keeps going to
+    produce its apology — and a user who has sat through repeated failures is
+    precisely the one who then presses Stop. `ended_by` correctly flips to
+    `cancelled`; without clearing, `error_type` kept the old exception and
+    ordinary Stops showed up in an error-cause breakdown.
+    """
+    from anton.core.turn_cost import TurnCost
+
+    tc = TurnCost()
+    tc.ended_by = "retry_exhausted"
+    tc.error_type = "RuntimeError"
+    session = ChatSession(
+        ChatSessionConfig(
+            llm_client=make_mock_llm(), workspace=workspace, session_id="conv-t"
+        )
+    )
+    session._turn_cost = tc
+
+    with patch("anton.analytics.send_event") as send:
+        session._emit_turn_cost(expected=tc, exc=asyncio.CancelledError())
+
+    assert _ended_by(send) == "cancelled"
+    assert _error_type(send) == ""
+
+
+async def test_session_without_settings_emits_no_endpoint_class(workspace):
+    """The emit-site half of the same defect, which the helper test cannot see.
+
+    `_emit_turn_cost` resolves a fresh `AntonSettings()` when the session
+    carries none, so passing THAT to the classifier would report the machine's
+    environment as if it were the turn's endpoint — confidently, and with no
+    way to tell it apart from a real answer. cowork-server's connector probe
+    builds a session with no `settings=`, so this path carries real traffic.
+
+    Driven through the real turn rather than the helper, because the defect is
+    which object the emit site hands over.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.plan_stream = MagicMock(
+        side_effect=lambda **kw: _Iter([StreamComplete(response=_text("hi"))])
+    )
+    session = ChatSession(
+        ChatSessionConfig(
+            llm_client=mock_llm, workspace=workspace, session_id="conv-t"
+        )
+    )
+    assert session._settings is None, "fixture must have no settings for this to bite"
+
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("hello"):
+            pass
+
+    assert send.called
+    assert send.call_args.kwargs["endpoint_class"] == ""

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -620,6 +620,11 @@ async def test_hard_latch_and_failed_reprobe_turns_also_stamp_verification_skipp
 
 # ─── error_type: naming the failure, not just counting it (ENG-1689) ─────────
 
+# Every session here carries a `session_id` deliberately: ENG-1692's guard
+# suppresses `turn_completed` for a turn with no session id AND zero LLM
+# calls (script traffic), which is exactly the shape of a pre-model failure.
+# Without it these tests pass alone and fail the moment anton#379 lands —
+# a break neither PR's CI can see, since each is green on its own base.
 def _error_type(send_event_mock) -> str:
     assert send_event_mock.called, "no turn_completed event emitted"
     return send_event_mock.call_args.kwargs["error_type"]
@@ -633,7 +638,11 @@ async def test_retry_exhausted_names_the_exception_class(workspace):
     """
     mock_llm = make_mock_llm()
     mock_llm.plan_stream = MagicMock(side_effect=RuntimeError("provider down"))
-    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session = ChatSession(
+        ChatSessionConfig(
+            llm_client=mock_llm, workspace=workspace, session_id="conv-t"
+        )
+    )
 
     with patch("anton.analytics.send_event") as send:
         async for _ in session.turn_stream("do something"):
@@ -649,7 +658,11 @@ async def test_retry_exhausted_reports_the_specific_provider_exception(workspace
     """
     mock_llm = make_mock_llm()
     mock_llm.plan_stream = MagicMock(side_effect=TimeoutError("upstream stalled"))
-    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session = ChatSession(
+        ChatSessionConfig(
+            llm_client=mock_llm, workspace=workspace, session_id="conv-t"
+        )
+    )
 
     with patch("anton.analytics.send_event") as send:
         async for _ in session.turn_stream("do something"):
@@ -672,7 +685,11 @@ async def test_error_terminal_names_the_exception_class(workspace):
     """
     mock_llm = make_mock_llm()
     mock_llm.plan_stream = MagicMock(side_effect=KeyboardInterrupt())
-    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session = ChatSession(
+        ChatSessionConfig(
+            llm_client=mock_llm, workspace=workspace, session_id="conv-t"
+        )
+    )
 
     with patch("anton.analytics.send_event") as send:
         with pytest.raises(KeyboardInterrupt):
@@ -691,7 +708,11 @@ async def test_completed_turn_carries_no_error_type(workspace):
     mock_llm.plan_stream = MagicMock(
         side_effect=lambda **kw: _Iter([StreamComplete(response=_text("hi"))])
     )
-    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session = ChatSession(
+        ChatSessionConfig(
+            llm_client=mock_llm, workspace=workspace, session_id="conv-t"
+        )
+    )
 
     with patch("anton.analytics.send_event") as send:
         async for _ in session.turn_stream("hello"):
@@ -718,7 +739,11 @@ async def test_user_stop_carries_no_error_type(workspace):
         return _gen()
 
     mock_llm.plan_stream = MagicMock(side_effect=_hang)
-    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session = ChatSession(
+        ChatSessionConfig(
+            llm_client=mock_llm, workspace=workspace, session_id="conv-t"
+        )
+    )
 
     with patch("anton.analytics.send_event") as send:
 


### PR DESCRIPTION
Closes gaps 2 and 3 of ENG-1689. `turn_completed` could report *how much* a turn cost but not *where its tokens went* or *why it failed*. Two properties, both anton-only, both purely additive.

## `endpoint_class` — `local` | `mindshub` | `third-party`

**Every existing proxy for this is wrong.** `llm_provider` names the *emitting host's own vocabulary*, not the destination, so our gateway arrives under **two** values — `minds-cloud` from the desktop DB overlay (written by `setattr`, bypassing the validator) and `openai-compatible` from anything constructed through `AntonSettings` (where `_map_minds_cloud_to_openai_compatible` rewrites it). Mechanism documented on ENG-1695.

Measured 14 days, real turns only (ENG-1692's script filter), model set from the **live** prod `/v1/models` catalog rather than a hand-list:

| | turns |
|---|---:|
| `llm_provider = minds-cloud` | 1,739 |
| `llm_provider = openai-compatible`, catalog-only model | **382 — also our gateway** |
| `openai-compatible`, non-catalog | 1,363 |

**Counting the gateway as `minds-cloud` alone runs 18% low — 382 turns, 146 people, 25.2M tokens.** `planning_model` is no better: it needs a live allowlist to interpret (73 distinct models in two days) and can never be authoritative, since nothing stops a user naming a local model `sonnet`.

### The values partition the observed host, not who pays

That distinction is what makes them mutually exclusive. "Is this loopback" and "is this our domain" are facts about a string we hold; "whose money paid" depends on a server-side gate verdict anton cannot see. Keyed on intent, a loopback proxy forwarding to our gateway would land in two buckets at once.

Two consequences, both deliberate and both documented in the module:

- **A local proxy forwarding to our gateway reports `local`** — that is genuinely all anton observes. `local` means "the endpoint was on this machine or LAN", *not* "definitely not our gateway".
- **Private/LAN addresses count as `local`,** not only loopback. Ollama and LM Studio are routinely reached across the network, and a loopback-only rule would file those as `third-party` and understate the exact population this measures.

### The provider gate is the load-bearing part

`AntonSettings.model_post_init` derives `openai_base_url` from `minds_url` — but **only when a provider is `openai-compatible`**. So for a vendor-fixed provider that field can be set, stale, and pointed at us while the turn never goes near us. Consulting it there would invent gateway traffic.

| `planning_provider` | classified from |
|---|---|
| `minds-cloud` | fixed → `mindshub` |
| `anthropic`, `gemini` | fixed → `third-party` (no base URL exists for them in `AntonSettings`; `gemini` only ever arrives via cowork-server's overlay) |
| `openai`, `openai-compatible` | the base URL |
| anything else | `""` — absent beats a guess |

**Note a correction to the ticket:** its table put plain `openai` under "third-party, vendor endpoint". That is wrong — `from_settings` constructs it with `base_url=settings.openai_base_url`, so a user *can* point it at us, and fixing it at `third-party` would misfile them. Ticket updated to match; mutation-tested (dropping `openai` from the URL-decided set fails a test).

### Not built on the existing helper

`cli.py`'s `_looks_like_mdb_ai` matches `{minds_url}` and `{minds_url}/api/v1` but **not `{minds_url}/v1`** — precisely what `model_post_init` builds for `https://api.mindshub.ai`, our production gateway. Its docstring claims parity with `LLMClient.from_settings`, which was fixed while it was not. Reusing it would have reproduced a known bug in a new field (ENG-1695).

Domain matching here is **exact-or-subdomain**, not the substring form `LLMClient`'s vision gate uses — `mindshub.ai.attacker.example` satisfies `"mindshub.ai" in host` and would inflate gateway share. Pinned by test.

Unifying the three existing "is this ours?" idioms onto this helper is **left to ENG-1695 as a separate PR**, deliberately: two of them *gate real behaviour* (native web-search passthrough, Anthropic-vs-OpenAI image format), so fixing them changes what some installs do and deserves its own review rather than riding along with a telemetry change. Sequential, not stacked.

## `error_type` — the exception class at the two terminals that discarded it

Real turns, 14 days: `error` **199 (5.6%)** and `retry_exhausted` **240 (6.7%)**, both with a **median of zero LLM calls and zero rounds** — they die *before the first model call*. A failure to start, not a failure mid-work, and previously indistinguishable.

`error` is a catch-all: a parse failure, a tool crash, a bad config and an anton bug all landed there with the exception object in scope at the assignment and thrown away. `retry_exhausted` is worse — it already formats the exception into a SYSTEM message the model *and the user* read, then never attached it to telemetry.

**Class name only**, via a new `_safe_error_type` sibling to the existing `_safe_error_detail`. The existing helper appends status codes and pydantic field paths, which suit a log line a human reads and are wrong for a property whose purpose is a *groupable* distribution — a compound value spreads one failure mode across many rows. Both are content-free; they differ only in cardinality, and the docstring says so.

Not stamped on `cancelled`, so ordinary user Stops cannot inflate an error breakdown. Not stamped on `handback_verifier_failure` (221 turns, 6.2%) either — that is a verdict, not a raise, and diagnosing it is a separate problem.

## Also fixed here

The emit-site comment claiming `llm_provider` *"separates gateway traffic from BYOK in queries"*. It cannot, and that belief is what produced the 18% undercount. Corrected in place rather than deferred, since leaving a false claim on the line directly above the field that *does* answer it is worse than the one-line overlap with ENG-1695.

## What is NOT in this PR

- **`key_source` is dropped from the ticket entirely** — a layer error, not a deferral. ENG-1611's `key_source` is a column on `usage_events`, *"resolved from the gate verdict at write time and never trusted from the caller"*. The populations are disjoint (a local-Ollama turn produces no ledger row at all, so `local` is unreachable there), "BYOK" means different things in the two tickets, and anton cannot compute it regardless — both key kinds start with `mdb_`. Nothing was ever blocked on Lucas; that was my misreading, now corrected on the ticket.
- Gaps 1 and 4 (`aid`, `anton_version` on a `cowork-desktop` event) — cowork repo, and they need ENG-713's over-merge constraint honoured (property, never alias).

## Security pass

- The **raw base URL is never emitted** — a closed set of three labels, asserted by a test that also checks no digit, dot, colon or slash survives into the value. This is the whole reason it is a class rather than the URL.
- **Exception messages are never emitted**, only class names — messages carry file paths and payload fragments.
- The domain check is **not substring-spoofable** (test covers four lookalike hosts).
- Both new helpers are **exception-proof**: `classify_endpoint` runs on the analytics path, which must never disturb the turn; `_safe_error_type` runs inside an `except` handler, where an escape would turn a handled failure into a dead turn. A hostile settings object whose property raises is covered by test.
- No new input is parsed from an untrusted source: the base URL comes from the user's own settings.

## Verification

- **42 new tests** in `tests/test_endpoint_class.py` — host partition (loopback, IPv6, bare `host:port`, private ranges, link-local, `.local` mDNS, all three gateway shapes, case-insensitivity), the provider gate, four spoofing attempts, the privacy constraint, and the three real `model_post_init` derivations exercised through **actual `AntonSettings`** rather than hand-written URLs.
- **5 new tests** in `tests/test_turn_cost_terminals.py`, driving the real `turn_stream` rather than poking the classifier — matching that file's stated philosophy, since these bugs live in the wiring.
- **An AST seam guard with a positive control.** Deleting a comparable emit-site argument once passed the entire suite because no test drove that path, so the seam is pinned structurally — and the guard's own predicate is verified against a source that omits the keyword, so a bug in the predicate cannot make it vacuous.
- **Full suite: 2372 passed, 31 skipped** on Python 3.12 (pinned via `UV_PYTHON` to match CI — a local 3.14 resolve produces failures that are purely environmental).
- **Mutation-verified with `PYTHONDONTWRITEBYTECODE=1`** (a same-length edit otherwise reuses cached bytecode and reports a false pass). Nine mutations, **all nine caught**: dropping either emit-site argument; removing the provider gate; loopback-only local; substring domain match; dropping `openai` from the URL-decided set; removing the `//` prefix in `_host_of`; and removing each of the two `error_type` stamp sites.

## Merge notes

No ordering constraint against the other open Harness PRs — this adds two new property names and touches no field they read. ENG-1695's helper unification should land *after* this, from `staging`, not stacked on it.

Unblocks ENG-1690, which needed six live prod gateway probes and a Langfuse cross-check to establish only that a failure was anton-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)