### PR TITLE
fix(workspace): retry initialize once on stale NFS handle (ESTALE)

### DIFF
--- a/anton/workspace.py
+++ b/anton/workspace.py
@@ -8,6 +8,7 @@ Handles:
 
 from __future__ import annotations
 
+import errno
 import os
 from datetime import datetime
 from pathlib import Path
@@ -83,7 +84,22 @@ class Workspace:
     # ── Initialization ───────────────────────────────────────────
 
     def initialize(self) -> list[str]:
-        """Create the workspace structure. Returns list of actions taken."""
+        """Create the workspace structure. Returns list of actions taken.
+
+        Retries once on ESTALE: on a shared NFS/EFS workspace another
+        client (cowork-server re-staging `.anton/anton.md`, or a workspace
+        wipe) can delete an inode this pod still has cached, so the first
+        stat fails with a stale handle. That failed stat drops the cached
+        dentry, so a second pass does a fresh lookup and succeeds.
+        """
+        try:
+            return self._initialize_once()
+        except OSError as exc:
+            if exc.errno != errno.ESTALE:
+                raise
+            return self._initialize_once()
+
+    def _initialize_once(self) -> list[str]:
         actions: list[str] = []
 
         # Create .anton/ directory and memory subdirectory

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import os
 from pathlib import Path
 
@@ -83,6 +84,30 @@ class TestInitialization:
 
     def test_artifacts_dir_property(self, ws, tmp_path):
         assert ws.artifacts_dir == tmp_path / ".anton" / "artifacts"
+
+    def test_retries_once_on_stale_nfs_handle(self, ws, monkeypatch):
+        calls = {"n": 0}
+        real = ws._initialize_once
+
+        def stale_then_ok():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError(errno.ESTALE, "Stale file handle")
+            return real()
+
+        monkeypatch.setattr(ws, "_initialize_once", stale_then_ok)
+        actions = ws.initialize()
+        assert calls["n"] == 2
+        assert len(actions) == 4
+
+    def test_does_not_retry_other_oserrors(self, ws, monkeypatch):
+        def boom():
+            raise OSError(errno.EACCES, "Permission denied")
+
+        monkeypatch.setattr(ws, "_initialize_once", boom)
+        with pytest.raises(OSError) as exc_info:
+            ws.initialize()
+        assert exc_info.value.errno == errno.EACCES
 
 
 class TestAntonMd:


### PR DESCRIPTION
Live pods crash the turn with `OSError: [Errno 116] Stale file handle` on `<workspace>/.anton/anton.md` when another EFS client (cowork-server's per-turn `stage_project_instructions` unlink/re-copy, or a conversation-dir wipe) removes an inode the pod's NFS client still has cached. The failed stat invalidates the cached dentry, so a single retry performs a fresh lookup and succeeds.

`initialize()` now runs its body via `_initialize_once()` and retries exactly once on ESTALE; other OSErrors propagate unchanged. Unit tests cover both paths.

Base is `main` (hotfix line); needs the usual sync back into staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)