### PR TITLE
fix(docker): install image deps from uv.lock, not a fresh resolve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,14 @@ WORKDIR /app
 COPY . /app
 
 # Install anton into a venv owned by UID 1000 so the non-root runtime can also `uv pip install`
-# missing packages at turn time. boto3 is imported by anton at runtime but not declared as a
-# dependency, so add it explicitly.
+# missing packages at turn time. `uv sync --frozen` installs the exact versions
+# from uv.lock; a bare `uv pip install .` re-resolves at build time, which is
+# what silently pulled anthropic 1.x (httpx2) into pods while the lockfile
+# still pinned 0.x. boto3 is imported by anton at runtime but not declared as
+# a dependency, so add it explicitly (the one unlocked package).
 RUN uv venv "$VIRTUAL_ENV" \
-    && uv pip install --no-cache . boto3 \
+    && UV_PROJECT_ENVIRONMENT="$VIRTUAL_ENV" uv sync --frozen --no-dev --no-cache \
+    && uv pip install --no-cache boto3 \
     && chown -R 1000:1000 "$VIRTUAL_ENV"
 
 # scratchpad-boot.sh: the single-cell entrypoint the controller execs (reads code + delimiter on stdin).


### PR DESCRIPTION
The scratchpad image installed with `uv pip install .`, which re-resolves dependencies from PyPI at build time and ignores `uv.lock`. `anthropic>=0.42.0` therefore resolved to the new 1.0.0 (which switched to `httpx2`/`httpcore2`) while the lockfile — and everything tested locally/CI — pins 0.83.0 on httpx 1.x.

The version skew shows up as asyncgen-finalization tracebacks in scratchpad-controller logs after every completed cloud turn (`RuntimeError: generator didn't stop after athrow()` in `httpcore2`): the 1.x SDK leaves SSE response-body generators suspended, and the event loop's shutdown finalizer trips an httpcore2 cleanup bug (present through httpcore2 2.12.0, so upgrading doesn't help).

This switches the image to `uv sync --frozen --no-dev`, making pods run exactly the locked versions. Verified in a local build: image now has anthropic 0.83.0 / httpx 0.28.1, no httpcore2, boto3 + anton import fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)