### PR TITLE
fix(cloud): don't create anton.md from template in cloud turns (ENG-1817)

### DIFF
--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -570,7 +570,11 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
     settings.skill_drafts_root.mkdir(parents=True, exist_ok=True)
 
     workspace = Workspace(base, settings=settings)
-    workspace.initialize()
+    # create_anton_md=False: in the cloud, .anton/anton.md is cowork-server's
+    # staged copy of the project instructions. A pod-written template gets
+    # deleted by the next staging pass, and the pod's cached NFS handle then
+    # fails every stat with ESTALE under gVisor (ENG-1817).
+    workspace.initialize(create_anton_md=False)
     # No apply_env_to_process(): loading workspace .env into the process env
     # would expose tenant secrets to cell code.
 

--- a/anton/workspace.py
+++ b/anton/workspace.py
@@ -83,7 +83,7 @@ class Workspace:
 
     # ── Initialization ───────────────────────────────────────────
 
-    def initialize(self) -> list[str]:
+    def initialize(self, *, create_anton_md: bool = True) -> list[str]:
         """Create the workspace structure. Returns list of actions taken.
 
         Retries once on ESTALE: on a shared NFS/EFS workspace another
@@ -91,15 +91,25 @@ class Workspace:
         wipe) can delete an inode this pod still has cached, so the first
         stat fails with a stale handle. That failed stat drops the cached
         dentry, so a second pass does a fresh lookup and succeeds.
+
+        ``create_anton_md=False`` is the cloud mode (ENG-1817): there
+        ``.anton/anton.md`` is owned by cowork-server, which stages the
+        project's instructions into it before every turn and clears it when
+        they are removed. A template written by the pod would be treated as
+        a stale staged copy and deleted — and under gVisor the pod then
+        keeps hitting the dead inode via its cached handle (ESTALE), which
+        the retry above cannot recover. Not creating the file removes the
+        ownership fight entirely; skipping the stat also removes the one
+        ESTALE-prone call from the cloud turn's critical path.
         """
         try:
-            return self._initialize_once()
+            return self._initialize_once(create_anton_md=create_anton_md)
         except OSError as exc:
             if exc.errno != errno.ESTALE:
                 raise
-            return self._initialize_once()
+            return self._initialize_once(create_anton_md=create_anton_md)
 
-    def _initialize_once(self) -> list[str]:
+    def _initialize_once(self, *, create_anton_md: bool = True) -> list[str]:
         actions: list[str] = []
 
         # Create .anton/ directory and memory subdirectory
@@ -108,7 +118,7 @@ class Workspace:
         actions.append(f"Created {self._anton_dir}")
 
         # Create anton.md if it doesn't exist
-        if not self._anton_md.is_file():
+        if create_anton_md and not self._anton_md.is_file():
             self._anton_md.write_text(
                 ANTON_MD_TEMPLATE.format(date=datetime.now().strftime("%Y-%m-%d"))
             )

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -198,7 +198,7 @@ def test_apply_env_to_process_never_called(tmp_path, monkeypatch):
     real_apply = ws_mod.Workspace.apply_env_to_process
 
     monkeypatch.setattr(ws_mod.Workspace, "initialize",
-                        lambda self, **kw: (calls.__setitem__("init", calls["init"] + 1), real_init(self, **kw))[1])
+                        lambda self, *a, **kw: (calls.__setitem__("init", calls["init"] + 1), real_init(self, *a, **kw))[1])
     monkeypatch.setattr(ws_mod.Workspace, "apply_env_to_process",
                         lambda self: (calls.__setitem__("apply_env", calls["apply_env"] + 1), real_apply(self))[1])
 

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -71,6 +71,17 @@ def test_scratchpad_uses_local_factory_and_is_workspace_bound(tmp_path, monkeypa
     assert cfg.session_id == "conv_1"
 
 
+def test_cloud_workspace_does_not_create_anton_md(tmp_path, monkeypatch):
+    """ENG-1817: `.anton/anton.md` is cowork-server's staged copy of the project
+    instructions. If the pod creates a template there, the next staging pass
+    deletes it, and under gVisor the pod's cached NFS handle then fails every
+    stat with ESTALE. The cloud builder must set up the workspace without
+    creating that file."""
+    _build(tmp_path, monkeypatch)
+    assert (tmp_path / ".anton").is_dir()  # the rest of the workspace is set up
+    assert not (tmp_path / ".anton" / "anton.md").exists()
+
+
 def test_db_history_is_seeded_not_loaded(tmp_path, monkeypatch):
     _, cfg = _build(
         tmp_path, monkeypatch,
@@ -187,7 +198,7 @@ def test_apply_env_to_process_never_called(tmp_path, monkeypatch):
     real_apply = ws_mod.Workspace.apply_env_to_process
 
     monkeypatch.setattr(ws_mod.Workspace, "initialize",
-                        lambda self: (calls.__setitem__("init", calls["init"] + 1), real_init(self))[1])
+                        lambda self, **kw: (calls.__setitem__("init", calls["init"] + 1), real_init(self, **kw))[1])
     monkeypatch.setattr(ws_mod.Workspace, "apply_env_to_process",
                         lambda self: (calls.__setitem__("apply_env", calls["apply_env"] + 1), real_apply(self))[1])
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -117,10 +117,10 @@ class TestInitialization:
         create (or even stat) the file."""
         actions = ws.initialize(create_anton_md=False)
         assert not (tmp_path / ".anton" / "anton.md").exists()
+        assert not any("anton.md" in a for a in actions)
         # Everything else is still set up.
         assert (tmp_path / ".anton" / ".env").is_file()
         assert (tmp_path / ".anton" / "artifacts").is_dir()
-        assert len(actions) == 3  # .anton/, .env, artifacts/
 
     def test_cloud_mode_leaves_staged_instructions_alone(self, ws, tmp_path):
         (tmp_path / ".anton").mkdir()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -89,11 +89,11 @@ class TestInitialization:
         calls = {"n": 0}
         real = ws._initialize_once
 
-        def stale_then_ok():
+        def stale_then_ok(**kwargs):
             calls["n"] += 1
             if calls["n"] == 1:
                 raise OSError(errno.ESTALE, "Stale file handle")
-            return real()
+            return real(**kwargs)
 
         monkeypatch.setattr(ws, "_initialize_once", stale_then_ok)
         actions = ws.initialize()
@@ -101,13 +101,32 @@ class TestInitialization:
         assert len(actions) == 4
 
     def test_does_not_retry_other_oserrors(self, ws, monkeypatch):
-        def boom():
+        def boom(**kwargs):
             raise OSError(errno.EACCES, "Permission denied")
 
         monkeypatch.setattr(ws, "_initialize_once", boom)
         with pytest.raises(OSError) as exc_info:
             ws.initialize()
         assert exc_info.value.errno == errno.EACCES
+
+    def test_cloud_mode_skips_anton_md(self, ws, tmp_path):
+        """ENG-1817: in the cloud, `.anton/anton.md` is owned by cowork-server's
+        instruction staging. A pod-written template is treated as a stale staged
+        copy and deleted before the next turn, and under gVisor the pod's cached
+        NFS handle then fails every stat with ESTALE — so the cloud path must not
+        create (or even stat) the file."""
+        actions = ws.initialize(create_anton_md=False)
+        assert not (tmp_path / ".anton" / "anton.md").exists()
+        # Everything else is still set up.
+        assert (tmp_path / ".anton" / ".env").is_file()
+        assert (tmp_path / ".anton" / "artifacts").is_dir()
+        assert len(actions) == 3  # .anton/, .env, artifacts/
+
+    def test_cloud_mode_leaves_staged_instructions_alone(self, ws, tmp_path):
+        (tmp_path / ".anton").mkdir()
+        (tmp_path / ".anton" / "anton.md").write_text("staged by cowork-server")
+        ws.initialize(create_anton_md=False)
+        assert (tmp_path / ".anton" / "anton.md").read_text() == "staged by cowork-server"
 
 
 class TestAntonMd:


### PR DESCRIPTION
Part of ENG-1817 (https://linear.app/mindsdb/issue/ENG-1817/turn-fails-with-estale-on-antonantonmd-cowork-server-unlinks-the-pod). Companion cowork-server PR: mindsdb/cowork-server#371.

## Problem

In the cloud, `.anton/anton.md` is cowork-server's staged copy of the project instructions: staging overwrites it in place before every turn and clears it when the project has none. The pod's `workspace.initialize()` also creates that file from `ANTON_MD_TEMPLATE` when it's missing — so for projects without instructions the two sides fight: the server deletes the pod's template every turn, the pod recreates it. Under gVisor the pod then keeps hitting the dead inode via its cached NFS handle: `stat` fails with `OSError: [Errno 116] Stale file handle`, the ESTALE retry from #383 fails identically (verified on staging: 4 retries over ~70 s, all ESTALE), and the turn dies with "An unexpected error occurred".

## Change

- `Workspace.initialize()` gains a keyword-only `create_anton_md` flag (default `True` — desktop behaviour unchanged).
- `build_cloud_chat_session` calls `initialize(create_anton_md=False)`: the cloud path no longer creates the template, and no longer even stats the file on the turn's critical path.

## Tests

- `test_workspace.py`: cloud mode creates everything except `anton.md`; an already-staged file is left untouched; existing ESTALE-retry tests adapted to the new signature.
- `test_cloud_turn_session.py`: the real session builder leaves no `anton.md` in the workspace.

`tests/test_workspace.py` + `tests/test_cloud_turn_session.py` + neighbours: 115 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
