### PR TITLE
ENG-1808: emit a cloud turn's tool block-rows for cowork to persist

### DIFF
--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -24,6 +24,7 @@ import sys
 import time
 
 from anton.cloud_turn.contract import TurnRequestV1
+from anton.cloud_turn.history_rows import split_turn_into_rows
 from anton.cloud_turn.session import (
     build_cloud_chat_session,
     build_turn_content,
@@ -191,6 +192,14 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
     try:
         req = TurnRequestV1.from_json(raw_line)
         session = builder(req)
+        # Length of the seeded history — everything anton appends past this
+        # index belongs to this turn. Captured BEFORE turn_stream, so the
+        # current turn's user input lands inside the slice and is trimmed off
+        # below. Guarded: a session double without `.history` skips capture and
+        # the turn degrades to text-only replay (mirrors cowork-server's
+        # in-process harness).
+        seed_len = len(session.history) if hasattr(session, "history") else None
+        compacted = False  # set if anton summarizes history mid-turn
         # Fold in any attachments cowork-server staged into the workspace (read
         # off the mount, so image bytes never crossed the stdin wire). Plain
         # string when there are none. Never fail the turn over this — degrade to
@@ -258,6 +267,7 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
                       "content": _clip_result_content(event.content or "")})
             elif isinstance(event, StreamContextCompacted):
                 logger.info("context compacted: %s", event.message)
+                compacted = True
                 emit({"kind": "compacted", "message": event.message})
             elif isinstance(event, StreamComplete):
                 logger.info("model response complete")
@@ -279,6 +289,28 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
             logger.info("emitting %d skill draft(s): %s",
                         len(drafts), ", ".join(d["slug"] for d in drafts))
             emit({"kind": "skill", "entries": drafts})
+        # Pre-terminal for the same reason as memory and skills: cowork stops
+        # reading the stream at the terminal event.
+        #
+        # Skipped after a mid-turn compaction: session.history was reassigned,
+        # so seed_len no longer marks this turn's start and slicing could drop
+        # rows or surface an orphan tool_result whose tool_use was summarized
+        # away — an invalid replay. Text-only replay stays valid, so degrade to
+        # it. The failure paths below never reach this line, so a failed or
+        # torn-down turn degrades the same way.
+        if seed_len is not None and not compacted:
+            turn_slice = session.history[seed_len:]
+            # Drop this turn's user input (and anything before the first
+            # assistant message) so the slice starts where the model replied.
+            while turn_slice and (
+                not isinstance(turn_slice[0], dict)
+                or turn_slice[0].get("role") != "assistant"
+            ):
+                turn_slice = turn_slice[1:]
+            rows = split_turn_into_rows(turn_slice)
+            if rows:
+                logger.info("emitting %d turn-history row(s)", len(rows))
+                emit({"kind": "history", "rows": rows})
         logger.info("cloud turn completed")
         emit({"kind": "turn_completed"})
         terminal_emitted = True

--- a/anton/cloud_turn/contract.py
+++ b/anton/cloud_turn/contract.py
@@ -4,12 +4,18 @@ Matches what the controller sends (`scratchpad_controller.anton_turn.request_lin
 and what cowork-server consumes off the reply stream. Intentionally minimal and
 data-only: the entrypoint reads ONE newline-terminated JSON line on stdin.
 
-Events written back on stdout (JSONL) are the five the controller translates:
+Events written back on stdout (JSONL) are the six the controller translates:
   {"kind": "delta", "text": "..."}   - streamed assistant text, one per chunk
   {"kind": "memory", "entries": [...]}  - pre-terminal; cowork persists these
   {"kind": "skill", "entries": [...]}   - pre-terminal; skill drafts the agent
       built this turn, as [{"slug", "files": {name: text}}]. Staged only: cowork
       surfaces a card and the user saves it, so nothing reaches the skill store.
+  {"kind": "history", "rows": [...]}  - pre-terminal; this turn's tool
+      block-rows as [{"role", "content"}], where content holds only tool_use
+      (assistant) or tool_result (user) blocks. cowork persists them as their
+      own hidden `messages` rows so the NEXT turn's history replays a valid
+      tool_use -> tool_result sequence. Omitted after a mid-turn compaction or
+      on failure, in which case that turn replays text-only.
   {"kind": "turn_completed"}          - terminal success (no payload)
   {"kind": "turn_failed", "error": "..."}  - terminal failure (scrubbed string)
 """

--- a/anton/cloud_turn/history_rows.py
+++ b/anton/cloud_turn/history_rows.py
@@ -1,0 +1,64 @@
+"""Extract one turn's tool block-rows from a raw anton history slice.
+
+Shared by both consumers of that shape, which is why it lives in anton rather
+than in either caller:
+
+  * the pod entrypoint (`anton.cloud_turn.__main__`) builds the wire payload
+    cowork-server persists for a remote turn;
+  * cowork-server's in-process harness builds the same rows on the desktop path.
+
+Keeping one implementation matters because the two paths must produce
+byte-identical rows: a conversation can move between them (desktop and SaaS read
+the same `messages` table), and a divergence would only surface as an invalid
+tool_use/tool_result sequence many turns later.
+"""
+
+from __future__ import annotations
+
+REPLAY_IMAGE_PLACEHOLDER = "[an image was returned here; omitted from replayed history]"
+
+
+def sanitize_tool_result(block: dict) -> dict:
+    """Replace image parts inside a tool_result with a text marker.
+
+    Base64 image payloads would bloat the JSON column and add nothing to the
+    replayed history. The marker states the removal happened at replay time
+    (not that the tool returned it) so the model doesn't misread it.
+    """
+    content = block.get("content")
+    if not isinstance(content, list):
+        return block
+    scrubbed = [
+        {"type": "text", "text": REPLAY_IMAGE_PLACEHOLDER}
+        if isinstance(part, dict) and part.get("type") == "image"
+        else part
+        for part in content
+    ]
+    return {**block, "content": scrubbed}
+
+
+def split_turn_into_rows(history_slice: list) -> list[dict]:
+    """Extract the tool block-rows of one turn from anton's raw history slice.
+
+    Keeps only `tool_use` (assistant) / `tool_result` (user) blocks as
+    `{role, content}` rows. Text blocks are dropped — the assistant's visible
+    text is persisted once in the display row — so a pure-text message yields
+    no row. Images inside tool_result are replaced with a replay marker.
+    """
+    rows: list[dict] = []
+    for msg in history_slice:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        keep_type = "tool_use" if role == "assistant" else "tool_result"
+        blocks = [
+            sanitize_tool_result(b) if keep_type == "tool_result" else b
+            for b in content
+            if isinstance(b, dict) and b.get("type") == keep_type
+        ]
+        if blocks:
+            rows.append({"role": role, "content": blocks})
+    return rows

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -414,3 +414,107 @@ def test_entrypoint_wires_attachment_augmentation(tmp_path, monkeypatch):
     _drive(_S())
     assert isinstance(captured["input"], list)            # augmented, not the bare "hi"
     assert any(b.get("type") == "text" and "notes.txt" in b.get("text", "") for b in captured["input"])
+
+
+# ── turn-history rows ────────────────────────────────────────────────────────
+
+_HISTORY_TURN = [
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": [
+        {"type": "text", "text": "looking"},
+        {"type": "tool_use", "id": "t1", "name": "recall_skill", "input": {"name": "pdf"}},
+    ]},
+    {"role": "user", "content": [
+        {"type": "tool_result", "tool_use_id": "t1", "content": "BODY"}]},
+    {"role": "assistant", "content": [{"type": "text", "text": "done"}]},
+]
+
+_EXPECTED_ROWS = [
+    {"role": "assistant", "content": [
+        {"type": "tool_use", "id": "t1", "name": "recall_skill", "input": {"name": "pdf"}}]},
+    {"role": "user", "content": [
+        {"type": "tool_result", "tool_use_id": "t1", "content": "BODY"}]},
+]
+
+
+class _HistorySession(_FakeSession):
+    """Grows `history` while the turn streams, like a real ChatSession.
+
+    `seed` is what the constructor would have loaded from `initial_history`;
+    `appended` is what `turn_stream` adds — including the current turn's user
+    input, which lands INSIDE the slice and must be trimmed away.
+    """
+
+    def __init__(self, seed, appended, deltas=("ok",), raise_on_stream=None,
+                 compact=False):
+        super().__init__(deltas=deltas, raise_on_stream=raise_on_stream)
+        self.history = list(seed)
+        self._appended = list(appended)
+        self._compact = compact
+
+    async def turn_stream(self, user_input, **kwargs):
+        self.history.extend(self._appended)
+        if self._compact:
+            yield StreamContextCompacted(message="squeezed")
+        if self._raise:
+            raise self._raise
+        for d in self._deltas:
+            yield StreamTextDelta(text=d)
+
+
+def _history_events(events):
+    return [e for e in events if e.get("kind") == "history"]
+
+
+def test_history_rows_emitted_before_the_terminal_event():
+    events = _drive(_HistorySession(seed=[], appended=_HISTORY_TURN))
+    assert events == [
+        {"kind": "delta", "text": "ok"},
+        {"kind": "history", "rows": _EXPECTED_ROWS},
+        {"kind": "turn_completed"},
+    ]
+
+
+def test_history_slice_starts_after_the_seeded_history():
+    """Rows from PREVIOUS turns (already in the DB) must not be re-sent."""
+    prior = [
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "old", "name": "x", "input": {}}]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "old", "content": "B"}]},
+    ]
+    events = _drive(_HistorySession(seed=prior, appended=_HISTORY_TURN))
+    assert _history_events(events) == [{"kind": "history", "rows": _EXPECTED_ROWS}]
+
+
+def test_history_rows_not_emitted_after_a_mid_turn_compaction():
+    """Compaction reassigns session.history, so seed_len no longer marks this
+    turn's start — slicing could surface an orphan tool_result."""
+    events = _drive(_HistorySession(seed=[], appended=_HISTORY_TURN, compact=True))
+    assert _history_events(events) == []
+    assert events[-1] == {"kind": "turn_completed"}
+
+
+def test_history_rows_not_emitted_when_the_turn_fails():
+    session = _HistorySession(
+        seed=[], appended=_HISTORY_TURN, raise_on_stream=RuntimeError("boom"),
+    )
+    events = _drive(session)
+    assert _history_events(events) == []
+    assert events[-1]["kind"] == "turn_failed"
+
+
+def test_no_history_event_when_the_turn_used_no_tools():
+    text_only = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": [{"type": "text", "text": "done"}]},
+    ]
+    events = _drive(_HistorySession(seed=[], appended=text_only))
+    assert _history_events(events) == []
+
+
+def test_a_session_without_history_still_completes():
+    """Test doubles and older anton builds have no `.history`; capture is
+    skipped rather than raising."""
+    events = _drive(_FakeSession(deltas=["ok"]))
+    assert events == [{"kind": "delta", "text": "ok"}, {"kind": "turn_completed"}]

--- a/tests/test_cloud_turn_history_rows.py
+++ b/tests/test_cloud_turn_history_rows.py
@@ -1,0 +1,89 @@
+"""Turn-history row extraction (ENG-1808).
+
+These helpers live here rather than in cowork-server because both consumers
+need them: the pod entrypoint (to build the wire payload) and cowork-server's
+in-process harness (to build the same rows on the desktop path).
+"""
+
+from __future__ import annotations
+
+from anton.cloud_turn.history_rows import (
+    REPLAY_IMAGE_PLACEHOLDER,
+    sanitize_tool_result,
+    split_turn_into_rows,
+)
+
+
+def _turn_slice():
+    """A realistic anton history slice: narration + tool call, its result,
+    then the final answer."""
+    return [
+        {"role": "assistant", "content": [
+            {"type": "text", "text": "let me look it up"},
+            {"type": "tool_use", "id": "t1", "name": "recall_skill", "input": {"name": "pdf"}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "SKILL BODY"},
+        ]},
+        {"role": "assistant", "content": [{"type": "text", "text": "final answer"}]},
+    ]
+
+
+def test_split_strips_text_and_keeps_tool_blocks():
+    rows = split_turn_into_rows(_turn_slice())
+    assert len(rows) == 2
+    assert rows[0]["role"] == "assistant"
+    assert [b["type"] for b in rows[0]["content"]] == ["tool_use"]
+    assert rows[0]["content"][0]["input"] == {"name": "pdf"}
+    assert rows[1]["role"] == "user"
+    assert rows[1]["content"][0]["type"] == "tool_result"
+    assert rows[1]["content"][0]["tool_use_id"] == "t1"
+
+
+def test_split_drops_a_pure_text_message():
+    # The trailing "final answer" message carries no tool block -> no row.
+    rows = split_turn_into_rows(_turn_slice())
+    assert all(
+        b["type"] in ("tool_use", "tool_result")
+        for row in rows for b in row["content"]
+    )
+
+
+def test_split_ignores_non_dict_entries_and_string_content():
+    slice_ = ["junk", {"role": "assistant", "content": "plain text"}]
+    assert split_turn_into_rows(slice_) == []
+
+
+def test_split_of_an_empty_slice_is_empty():
+    assert split_turn_into_rows([]) == []
+
+
+def test_sanitize_replaces_an_image_with_the_replay_marker():
+    block = {"type": "tool_result", "tool_use_id": "x", "content": [
+        {"type": "image", "source": {"data": "AAAA"}},
+        {"type": "text", "text": "kept"},
+    ]}
+    out = sanitize_tool_result(block)
+    assert out["content"][0] == {"type": "text", "text": REPLAY_IMAGE_PLACEHOLDER}
+    assert out["content"][1] == {"type": "text", "text": "kept"}
+    # The input block is not mutated in place.
+    assert block["content"][0]["type"] == "image"
+
+
+def test_sanitize_leaves_a_string_result_untouched():
+    block = {"type": "tool_result", "tool_use_id": "x", "content": "plain string"}
+    assert sanitize_tool_result(block) == block
+
+
+def test_split_sanitizes_images_inside_tool_results():
+    slice_ = [
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "screenshot", "input": {}}]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": [
+                {"type": "image", "source": {"data": "AAAA"}}]}]},
+    ]
+    rows = split_turn_into_rows(slice_)
+    assert rows[1]["content"][0]["content"] == [
+        {"type": "text", "text": REPLAY_IMAGE_PLACEHOLDER}
+    ]


### PR DESCRIPTION
Pod side of [ENG-1808](https://linear.app/mindsdb/issue/ENG-1808).

## Problem

In SaaS (multitenant) cowork the agent does not remember its own tool calls from previous turns. Asked "which tools did you use", it answers that there were none. On desktop the same scenario works.

In org mode a turn runs in a pod and the session is rebuilt from DB history every turn, so only what cowork persisted survives. cowork's in-process path has extracted a turn's `tool_use` / `tool_result` blocks from `session.history` and persisted them as their own hidden rows since ENG-742. The pod emitted no equivalent event, so there was nothing to persist.

This PR makes the pod send them. cowork's side is mindsdb/cowork-server#372, the relay is mindsdb/scratchpad-controller#30.

## What changed

**`anton/cloud_turn/history_rows.py` (new)** — `split_turn_into_rows` and `sanitize_tool_result`, ported verbatim from the private copies in cowork-server's `anton_harness/harness.py`, with the names made public.

It lives here rather than in either caller because both need it: the pod entrypoint builds the wire payload, and cowork-server's in-process harness builds the same rows for desktop. They must agree byte for byte — a conversation reads the same `messages` table from either path, so a divergence would surface as an invalid `tool_use` → `tool_result` sequence many turns later rather than at the point of the mistake. cowork-server switches its harness over to this module in a follow-up (see below).

**`anton/cloud_turn/__main__.py`** — capture `seed_len = len(session.history)` right after the session is built, track a `compacted` flag, and after the existing `memory` / `skill` emits (so still pre-terminal, since cowork stops reading at the terminal event) slice `session.history[seed_len:]`, trim to the first assistant message, split, and emit `{"kind": "history", "rows": [...]}`.

Three details that are not obvious:

- `seed_len` is captured **before** `turn_stream`, so this turn's user input lands *inside* the slice. The trim to the first assistant message is what removes it — same as `harness.py` does. It is not dead code even though `split_turn_into_rows` would filter a plain user message anyway; it keeps the two implementations equivalent, and a divergence here would be invisible until some edge case.
- Capture is guarded by `hasattr(session, "history")`. Session doubles in the existing entrypoint tests have no `history`, and older builds may not either; the harness carries the same guard. Without it every existing entrypoint test breaks.
- Rows are **not** emitted after a mid-turn compaction: `session.history` is reassigned, so `seed_len` no longer marks this turn's start and slicing could drop rows or surface an orphan `tool_result` whose `tool_use` was summarized away. Text-only replay stays valid, so it degrades to that. The failure and teardown paths never reach the emit at all, so they degrade the same way.

`contract.py`'s event list is updated to document the new event.

## Tests

`2359 passed, 30 skipped` on the full suite.

- 7 unit tests on `history_rows`: tool blocks kept, text dropped, a pure-text message yields no row, images inside a `tool_result` replaced with the replay marker, and the input block not mutated in place.
- 6 entrypoint tests: rows emitted between `skill` and `turn_completed`; rows from *previous* turns (already in the DB, so already in `initial_history`) not re-sent; **no** rows after a compaction; **no** rows on `turn_failed`; no event at all for a tool-free turn; and a session without `.history` still completing normally.

## Merge & deploy order

Three repos, and the order is **not** free — though this PR is the flexible one.

`kind` is a `Literal` in two mirrored pydantic models on the other two sides, and cowork-server's reply loop validates every entry unguarded, so a kind it does not know **fails the whole turn** rather than being ignored.

1. **mindsdb/cowork-server#372 → `staging`. First**, and rolled out, not merely merged.
2. **This PR → `staging`.** Safe at any point, before or after step 1: the pod image pin is not bumped here, and even with a bumped pin the current controller maps the unknown `history` event to `None` and drops the frame. So merging this alone changes nothing observable.
3. **mindsdb/scratchpad-controller#30 → `main`. Last.** A push to that `main` fires `staging-build-deploy.yml` immediately, so merging *is* deploying.

**This PR must be merged before the pin bump can be prepared.** The controller pins the pod image as `development-head-<sha of anton/staging>`, so that bump needs this commit on `staging` first. It is added to mindsdb/scratchpad-controller#30 once this lands.

## Follow-up, deliberately not here

cowork-server keeps its private copy of the splitter for now. It pins anton as a library from `branch = "main"`, and `main` is the weekly-ish release branch — `history_rows` will not be importable there until a `staging → main` promotion. Note this repo is consumed **twice, from different branches**: cowork-server takes the library from `main`, while the pod image is built from `staging`. Once the promotion happens, a small cowork-server follow-up relocks `uv.lock` and deletes the duplicate. Readiness check:

```
git cat-file -e origin/main:anton/cloud_turn/history_rows.py && echo READY
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
