### PR TITLE
[ENG-1795] Artifact publishing TLS certificate verification failure

### DIFF
--- a/anton/minds_client.py
+++ b/anton/minds_client.py
@@ -16,6 +16,8 @@ import urllib.request
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import truststore
+
 from anton.core.llm.openai import build_chat_completion_kwargs
 
 if TYPE_CHECKING:
@@ -82,9 +84,13 @@ def minds_request(
     req.add_header("Accept-Encoding", "identity")
     req.add_header("Connection", "keep-alive")
 
-    ctx = None
+    # truststore delegates verification to the OS-native trust APIs
+    # (SChannel on Windows, Security framework on macOS) instead of
+    # CPython's own cert-store enumeration, which some Windows machines
+    # behind a TLS-inspecting corporate proxy/AV don't pick up even though
+    # the injected root CA is trusted by the OS (and thus the browser).
+    ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     if not verify:
-        ctx = ssl.create_default_context()
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pyyaml>=6.0",
     "dill==0.3.8",
     "aiohttp>=3.9",
+    "truststore>=0.10.4",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_minds_client_ssl_context.py
+++ b/tests/test_minds_client_ssl_context.py
@@ -1,0 +1,43 @@
+"""Tests for minds_request()'s TLS trust source.
+
+On some Windows machines (typically behind a TLS-inspecting corporate
+proxy/AV whose root CA is trusted by the OS but not picked up by CPython's
+own Windows cert-store enumeration), verified Minds Hub requests fail with
+SSLCertVerificationError even though the browser trusts the same proxy.
+minds_request() must build its SSL context via `truststore`, which delegates
+verification to the OS-native trust APIs, instead of relying on urllib's
+implicit ssl.create_default_context() fallback.
+"""
+from __future__ import annotations
+
+import ssl
+from unittest.mock import MagicMock, patch
+
+import truststore
+
+from anton.minds_client import minds_request
+
+
+def test_verified_request_uses_truststore_context():
+    """verify=True (the default) must build a truststore.SSLContext, not
+    rely on the implicit default context urllib would otherwise use."""
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"{}"
+        minds_request("https://view.mindshub.ai/upload", "key")
+
+    _, kwargs = mock_urlopen.call_args
+    assert isinstance(kwargs["context"], truststore.SSLContext)
+    assert kwargs["context"].verify_mode == ssl.CERT_REQUIRED
+    assert kwargs["context"].check_hostname is True
+
+
+def test_unverified_request_disables_hostname_and_cert_checks():
+    """verify=False must still fully disable verification (used only for
+    explicit user opt-out via ANTON_MINDS_SSL_VERIFY=false)."""
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value.read.return_value = b"{}"
+        minds_request("https://view.mindshub.ai/upload", "key", verify=False)
+
+    _, kwargs = mock_urlopen.call_args
+    assert kwargs["context"].check_hostname is False
+    assert kwargs["context"].verify_mode == ssl.CERT_NONE

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "truststore" },
     { name = "typer" },
 ]
 
@@ -204,6 +205,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0,<15" },
+    { name = "truststore", specifier = ">=0.10.4" },
     { name = "typer", specifier = ">=0.12.4" },
 ]
 provides-extras = ["clipboard"]
@@ -1178,6 +1180,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-1795/artifact-publishing-not-possible-in-cowork-desktop-tls-certificate

- Artifact publishing ("Share to the Web") failed on Windows with "Connection failed during TLS certificate verification", most likely behind a TLS-inspecting corporate proxy/AV whose root CA is trusted by the OS but not picked up by CPython's own Windows cert-store enumeration.
- minds_request() now builds its SSL context via truststore instead of relying on urllib's default context.
- This makes it use OS-native certificate verification (SChannel on Windows), same as the browser.
- Applies to every call that shares this transport: publish, list_published, unpublish, list_versions, activate_version, and the Minds product API calls.
- The existing ANTON_MINDS_SSL_VERIFY=false opt-out is unchanged.
- Same fix pattern as #705. Related to ENG-1819.

Root cause not confirmed against the reporter's actual machine — no raw traceback was available, only the generic UI error message.
