### PR TITLE
ENG-1486: emit a per-tool-call tool_completed analytics event

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -180,6 +180,9 @@ _pending_lock = threading.Lock()
 #                    never the message, which carries paths and user input).
 #                    One event per executed tool call; tool arguments and
 #                    result content are deliberately absent (ENG-1486).
+#                    conversation_id + turn_index mirror turn_completed's
+#                    values, so a tool row joins to its parent turn row and,
+#                    via Langfuse sessionId, to the gateway trace.
 #                    (anton/core/session.py::_emit_tool_completed)
 #
 # An event NOT listed here keeps the collector path, so moving one is an

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -172,10 +172,25 @@ _pending_lock = threading.Lock()
 #                    stop_reason, input_tokens, output_tokens, duration_ms
 #                    (anton/core/memory/cortex.py::_emit_rule_retrieval)
 #
+#   tool_completed   name, ok ("true"/"false"/"unknown" — the dispatch loop's
+#                    definitive verdict, never a prose guess; "unknown" is an
+#                    unmigrated handler or a cancelled exec), duration_ms
+#                    (human wait already subtracted), error_type (exception
+#                    CLASS name when the failure was a raise, "" otherwise —
+#                    never the message, which carries paths and user input).
+#                    One event per executed tool call; tool arguments and
+#                    result content are deliberately absent (ENG-1486).
+#                    (anton/core/session.py::_emit_tool_completed)
+#
 # An event NOT listed here keeps the collector path, so moving one is an
 # explicit decision rather than something that happens by default.
 _POSTHOG_EVENTS = frozenset(
-    {"turn_completed", "rule_retrieval", "scratchpad_package_installed"}
+    {
+        "turn_completed",
+        "rule_retrieval",
+        "scratchpad_package_installed",
+        "tool_completed",
+    }
 )
 
 # `$lib` names the sender, matching the convention the other emitters follow

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -4763,6 +4763,26 @@ class ChatSession:
                     # would make the booked duration disagree with the
                     # displayed one (#390 review). Branches that never stopped
                     # the clock fall back to reading it now.
+                    #
+                    # The fallback's `- answer_wait_s` is inert TODAY and kept
+                    # for the day it isn't: `elicit()` is the only writer of
+                    # that counter, and its only callers (`handle_select_path`,
+                    # `handle_ask_user`) both route to the branch above, which
+                    # never reaches this fallback. Verified dynamically too —
+                    # asserting the counter is 0.0 here passes the whole suite,
+                    # across the 29 tests that do reach this line.
+                    #
+                    # KNOWN LIMIT, not covered by that subtraction: the
+                    # interactive branch's tools (`connect_new_datasource`,
+                    # `publish_or_preview` publish) collect human input via
+                    # `prompt_or_cancel`, which does NOT feed `answer_wait_s`.
+                    # Their duration therefore includes however long the human
+                    # spent typing — measured at 401ms for a 0.4s stand-in, so
+                    # minutes of real credential entry. Read p95 for those two
+                    # names as "wall-clock of an interactive flow", never as
+                    # tool performance. Fixing it needs a session-scoped
+                    # accumulator behind `prompt_or_cancel`, which is a change
+                    # to the CLI prompt path rather than to this event.
                     self._emit_tool_completed(
                         name=tc.name,
                         ok=tool_ok,

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2768,7 +2768,11 @@ class ChatSession:
             send_event(
                 settings,
                 "tool_completed",
-                name=name,
+                # `tc.name` is model-generated: a hallucinated tool name is
+                # real signal and SHOULD emit, but unbounded model output has
+                # no business being a property value verbatim. Same idiom as
+                # the dispatch loop's args_summary[:120].
+                name=name[:200],
                 ok="unknown" if ok is None else str(ok).lower(),
                 duration_ms=str(int(duration_ms)),
                 error_type=error_type,
@@ -3427,6 +3431,10 @@ class ChatSession:
                     tool_results.append(damaged)
                     continue
 
+                import time as _time  # same local-import idiom as turn_stream
+
+                _tool_t0 = _time.monotonic()
+                _tool_error_type = ""
                 try:
                     outcome = await self.tool_registry.dispatch_tool(
                         self, tc.name, tc.input, tool_call_id=tc.id,
@@ -3439,6 +3447,19 @@ class ChatSession:
                         ok=False,
                         reason=type(exc).__name__,
                     )
+                    _tool_error_type = type(exc).__name__
+                # Same per-tool-call analytics as the streaming loop's tail
+                # (ENG-1486) — without this, a host on the non-streaming API
+                # silently undercounts. Raw elapsed, no human-wait deduction:
+                # elicitation is structurally unavailable on this path (no
+                # emitter to render a question), so there is no wait to
+                # subtract.
+                self._emit_tool_completed(
+                    name=tc.name,
+                    ok=outcome.ok,
+                    duration_ms=(_time.monotonic() - _tool_t0) * 1000.0,
+                    error_type=_tool_error_type,
+                )
                 result = outcome.content
 
                 if isinstance(result, list):
@@ -4447,12 +4468,14 @@ class ChatSession:
                         continue
 
                     _tool_t0 = _time.monotonic()
-                    # Per dispatched call, not per general-branch call: every
-                    # branch below can elicit() (which accumulates the wait),
-                    # and the duration maths at the bottom of this block runs
-                    # for all of them. Resetting only on the general branch
-                    # left a stale wait from an earlier call in the round to
-                    # be subtracted from the wrong tool's runtime.
+                    # Reset alongside the timer, before ANY branch dispatches:
+                    # the tool_completed emit at the bottom of this block is
+                    # the first reader that runs for every branch, and every
+                    # branch can elicit() (which accumulates the wait). The
+                    # reset used to live on the general branch only — correct
+                    # while that branch was also the only subtractor, but the
+                    # cross-branch emit would have deducted another call's
+                    # leftover wait from this one's runtime.
                     self.answer_wait_s = 0.0
 
                     # The handler's own failure verdict, when it gave one —

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2732,9 +2732,16 @@ class ChatSession:
         is reported as ``"unknown"`` rather than coerced either way.
 
         Payload is deliberately name + verdict + duration + exception CLASS
-        and nothing else. Arguments, result content and ``str(exc)`` routinely
-        carry file paths, user data and credentials-adjacent strings — none of
-        them may ever appear here.
+        plus the two join keys, and nothing else. Arguments, result content
+        and ``str(exc)`` routinely carry file paths, user data and
+        credentials-adjacent strings — none of them may ever appear here.
+
+        ``conversation_id`` / ``turn_index`` mirror ``turn_completed``'s
+        values exactly (same names, same derivation), so a tool failure spotted
+        in PostHog joins to its parent turn row there and, via
+        ``conversation_id`` → Langfuse ``sessionId``, to the gateway trace of
+        the turn it happened in. Both already ride ``turn_completed`` through
+        this same sink — no new privacy surface.
         """
         try:
             # Same settings resolution as `_emit_turn_cost` above: the
@@ -2750,6 +2757,14 @@ class ChatSession:
             # send_event takes STRING values only — every extra is a wire
             # parameter (tests/test_ask_user.py:496 exists because a first
             # draft assumed a (name, props) shape).
+            # The same derivation `_emit_turn_cost` uses at close-of-books:
+            # the live TurnCost carries the authoritative index (an explicit
+            # turn_id on the cloud path, the local counter otherwise), so the
+            # values here and on the turn's own row can never disagree.
+            _tc = getattr(self, "_turn_cost", None)
+            turn_index = (
+                getattr(_tc, "turn_index", 0) or (self._turn_count + 1)
+            )
             send_event(
                 settings,
                 "tool_completed",
@@ -2757,6 +2772,8 @@ class ChatSession:
                 ok="unknown" if ok is None else str(ok).lower(),
                 duration_ms=str(int(duration_ms)),
                 error_type=error_type,
+                conversation_id=str(self._session_id or ""),
+                turn_index=str(turn_index),
             )
         except Exception:
             # Analytics must never affect the tool call that just ran.

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2710,6 +2710,58 @@ class ChatSession:
             # Reporting must never affect the turn that just ran.
             pass
 
+    def _emit_tool_completed(
+        self,
+        name: str,
+        ok: bool | None,
+        duration_ms: float,
+        error_type: str,
+    ) -> None:
+        """Per-tool-call analytics event (ENG-1486).
+
+        The verdict the dispatch loop already computes for the UI's
+        ``tool_done`` marker, sent where it can be aggregated: without this,
+        "which tools fail, how often, how slowly" is unanswerable — the
+        gateway's vantage point is structurally wrong (67% of its tool spans
+        are structured-output schemas that never return by design, and anton's
+        own retries hide failures from it).
+
+        ``ok`` is the definitive verdict, never a prose guess: ``True``/
+        ``False`` from a caught exception or the handler's own
+        ``ToolOutcome.ok``; ``None`` (an unmigrated handler, a cancelled exec)
+        is reported as ``"unknown"`` rather than coerced either way.
+
+        Payload is deliberately name + verdict + duration + exception CLASS
+        and nothing else. Arguments, result content and ``str(exc)`` routinely
+        carry file paths, user data and credentials-adjacent strings — none of
+        them may ever appear here.
+        """
+        try:
+            # Same settings resolution as `_emit_turn_cost` above: the
+            # session's settings when the host provided AntonSettings, else a
+            # fresh resolve so analytics_enabled / the CI drop still apply.
+            settings = getattr(self, "_settings", None)
+            if settings is None or not hasattr(settings, "analytics_enabled"):
+                from anton.config.settings import AntonSettings
+
+                settings = AntonSettings()
+            from anton.analytics import send_event
+
+            # send_event takes STRING values only — every extra is a wire
+            # parameter (tests/test_ask_user.py:496 exists because a first
+            # draft assumed a (name, props) shape).
+            send_event(
+                settings,
+                "tool_completed",
+                name=name,
+                ok="unknown" if ok is None else str(ok).lower(),
+                duration_ms=str(int(duration_ms)),
+                error_type=error_type,
+            )
+        except Exception:
+            # Analytics must never affect the tool call that just ran.
+            pass
+
     def _spend_ceiling_reached(self) -> bool:
         """True when this turn has spent enough that it must stop and ask.
 
@@ -4378,6 +4430,13 @@ class ChatSession:
                         continue
 
                     _tool_t0 = _time.monotonic()
+                    # Per dispatched call, not per general-branch call: every
+                    # branch below can elicit() (which accumulates the wait),
+                    # and the duration maths at the bottom of this block runs
+                    # for all of them. Resetting only on the general branch
+                    # left a stale wait from an earlier call in the round to
+                    # be subtracted from the wrong tool's runtime.
+                    self.answer_wait_s = 0.0
 
                     # The handler's own failure verdict, when it gave one —
                     # drives the error streak instead of text matching
@@ -4386,6 +4445,12 @@ class ChatSession:
                     # ENG-1276 populated this and nothing ever read it; ENG-1492
                     # is what reads it.
                     tool_reason: str = ""
+                    # Exception class name when the verdict came from a raise,
+                    # "" otherwise. Kept apart from `tool_reason`, which on the
+                    # ToolOutcome path is prose (a traceback line, a handler
+                    # message) and so can carry paths and user input — this one
+                    # is the only failure detail analytics may see (ENG-1486).
+                    _tool_error_type: str = ""
                     try:
                         if tc.name == "scratchpad" and tc.input.get("action") == "exec":
                             # Inline streaming exec — yields progress events
@@ -4547,7 +4612,7 @@ class ChatSession:
                             # itself via session.emitter — _dispatch_draining
                             # forwards them here as ordinary ("event", ev)
                             # tuples, no different from an ask_user event.
-                            self.answer_wait_s = 0.0
+                            # (answer_wait_s was reset with _tool_t0 above.)
                             _tool_error: Exception | None = None
                             agen = self._dispatch_draining(tc)
                             try:
@@ -4632,6 +4697,27 @@ class ChatSession:
                         result_text = f"Tool '{tc.name}' failed: {exc}"
                         tool_ok = False
                         tool_reason = type(exc).__name__
+                        _tool_error_type = type(exc).__name__
+
+                    # Per-tool-call analytics (ENG-1486): the verdict computed
+                    # for the UI stream, finally aggregable. This is the one
+                    # point every EXECUTED call flows through — all three
+                    # dispatch branches, both the raise and the
+                    # ToolOutcome.ok=False failure shapes — and only executed
+                    # calls: discarded/damaged calls `continue` before
+                    # `_tool_t0`, and structured-output extractions
+                    # (`generate_object_code`) never enter tool dispatch at
+                    # all. Human wait is subtracted so an ask_user answered
+                    # after four minutes is not booked as a slow tool.
+                    self._emit_tool_completed(
+                        name=tc.name,
+                        ok=tool_ok,
+                        duration_ms=max(
+                            _time.monotonic() - _tool_t0 - self.answer_wait_s,
+                            0.0,
+                        ) * 1000.0,
+                        error_type=_tool_error_type,
+                    )
 
                     if isinstance(result_text, list):
                         # Multimodal tool result — scrub credentials from text

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3447,7 +3447,7 @@ class ChatSession:
                         ok=False,
                         reason=type(exc).__name__,
                     )
-                    _tool_error_type = type(exc).__name__
+                    _tool_error_type = _safe_error_type(exc)
                 # Same per-tool-call analytics as the streaming loop's tail
                 # (ENG-1486) — without this, a host on the non-streaming API
                 # silently undercounts. Raw elapsed, no human-wait deduction:
@@ -4486,7 +4486,10 @@ class ChatSession:
                     # is what reads it.
                     tool_reason: str = ""
                     # Exception class name when the verdict came from a raise,
-                    # "" otherwise. Kept apart from `tool_reason`, which on the
+                    # "" otherwise, via the same `_safe_error_type` helper
+                    # `turn_completed`'s own error_type uses (ENG-1689) — one
+                    # definition of "class name only, never raises" for both
+                    # events. Kept apart from `tool_reason`, which on the
                     # ToolOutcome path is prose (a traceback line, a handler
                     # message) and so can carry paths and user input — this one
                     # is the only failure detail analytics may see (ENG-1486).
@@ -4741,7 +4744,7 @@ class ChatSession:
                         result_text = f"Tool '{tc.name}' failed: {exc}"
                         tool_ok = False
                         tool_reason = type(exc).__name__
-                        _tool_error_type = type(exc).__name__
+                        _tool_error_type = _safe_error_type(exc)
 
                     # Per-tool-call analytics (ENG-1486): the verdict computed
                     # for the UI stream, finally aggregable. This is the one

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -4491,6 +4491,10 @@ class ChatSession:
                     # message) and so can carry paths and user input — this one
                     # is the only failure detail analytics may see (ENG-1486).
                     _tool_error_type: str = ""
+                    # Set by the branch that stops the clock at the moment the
+                    # tool finished. None = that branch didn't, so the emit
+                    # falls back to reading the clock itself. See the emit.
+                    _tool_elapsed: float | None = None
                     try:
                         if tc.name == "scratchpad" and tc.input.get("action") == "exec":
                             # Inline streaming exec — yields progress events
@@ -4749,11 +4753,22 @@ class ChatSession:
                     # (`generate_object_code`) never enter tool dispatch at
                     # all. Human wait is subtracted so an ask_user answered
                     # after four minutes is not booked as a slow tool.
+                    # Prefer the duration the branch already stopped the clock
+                    # on — the same value `tool_done` displays. Re-reading the
+                    # clock here would bill the consumer's pull latency for
+                    # the events yielded in between (`tool_done`, and a
+                    # `StreamToolResult` for a scratchpad `dump`) to the tool.
+                    # Small and always upward, but it lands on exactly the
+                    # "how slowly" metric this event exists to answer, and it
+                    # would make the booked duration disagree with the
+                    # displayed one (#390 review). Branches that never stopped
+                    # the clock fall back to reading it now.
                     self._emit_tool_completed(
                         name=tc.name,
                         ok=tool_ok,
                         duration_ms=max(
-                            _time.monotonic() - _tool_t0 - self.answer_wait_s,
+                            _tool_elapsed if _tool_elapsed is not None
+                            else _time.monotonic() - _tool_t0 - self.answer_wait_s,
                             0.0,
                         ) * 1000.0,
                         error_type=_tool_error_type,

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -1,0 +1,279 @@
+"""The per-tool-call `tool_completed` analytics event (ENG-1486).
+
+Anton computes a definitive per-tool success verdict for the UI's ``tool_done``
+marker and, before this, threw it away — nothing could answer "which tools
+fail, how often, or how slowly". These drive the real ``turn_stream`` (the same
+harness shape as ``test_root_cause_wiring.py``) and assert on what
+``send_event`` was handed, because the contract under test is the seam:
+
+- both failure shapes produce ``ok="false"`` — a raised exception AND a handler
+  returning ``ToolOutcome.ok=False`` (the distinction the ``tool_done`` yield
+  exists to make; PR #304's review caught a draft where a raise rendered as
+  unconditional success);
+- ``error_type`` is the exception CLASS name and never the message —
+  ``str(exc)`` routinely embeds file paths and user input;
+- the payload is exactly {name, ok, duration_ms, error_type}, all strings —
+  no tool arguments, no result content;
+- human wait (``answer_wait_s``, accumulated by ``elicit()``) is subtracted
+  from the duration;
+- the event name is registered in ``_POSTHOG_EVENTS``, because a name the
+  collector has never heard of otherwise reaches nothing (ENG-1355/ENG-1495).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_mock_llm
+
+from anton import analytics
+from anton.core.llm.provider import LLMResponse, StreamComplete, ToolCall, Usage
+from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.tools.registry import ToolOutcome
+
+
+@pytest.fixture()
+def workspace():
+    base = Path(__file__).resolve().parents[1] / ".pytest-workspace"
+    base.mkdir(parents=True, exist_ok=True)
+    return MagicMock(base=base)
+
+
+def _usage(n: int = 1_000) -> Usage:
+    return Usage(input_tokens=n // 2, output_tokens=n // 2)
+
+
+def _tool_call(i: int) -> LLMResponse:
+    return LLMResponse(
+        content="working",
+        tool_calls=[ToolCall(id=f"tc{i}", name="scratchpad",
+                             input={"action": "view", "name": "m"})],
+        usage=_usage(), stop_reason="tool_use",
+    )
+
+
+def _text(t: str = "done") -> LLMResponse:
+    return LLMResponse(content=t, tool_calls=[], usage=_usage(), stop_reason="end_turn")
+
+
+def _session(workspace, dispatch_side_effect, n_tool_calls: int = 1):
+    """Session whose tool dispatch runs `dispatch_side_effect`."""
+    llm = make_mock_llm()
+    llm.usage_listener = None
+    seq = {"i": 0}
+
+    def plan_stream(**kw):
+        async def gen():
+            seq["i"] += 1
+            if llm.usage_listener:
+                llm.usage_listener("planning", "m", _usage())
+            yield StreamComplete(
+                response=_tool_call(seq["i"]) if seq["i"] <= n_tool_calls else _text()
+            )
+        return gen()
+
+    llm.plan_stream = plan_stream
+    s = ChatSession(ChatSessionConfig(llm_client=llm, workspace=workspace,
+                                      session_id="conv-tc"))
+    s._max_turn_tokens = 0
+    s.tool_registry.dispatch_tool = AsyncMock(side_effect=dispatch_side_effect)
+    return s
+
+
+async def _tool_completed_calls(session, prompt="go"):
+    """Run a turn; return the kwargs of every tool_completed send_event call."""
+    with patch("anton.analytics.send_event") as sent:
+        async for _ in session.turn_stream(prompt):
+            pass
+    return [c.kwargs for c in sent.call_args_list if c.args[1] == "tool_completed"]
+
+
+# ── The two failure shapes, and success ──────────────────────────────
+
+
+async def test_handler_verdict_false_emits_ok_false_and_no_error_type(workspace):
+    """`ToolOutcome.ok=False` with no raise → ok="false", error_type=""."""
+    session = _session(workspace, [ToolOutcome(
+        content="[error]\nNameError: name 'wb' is not defined",
+        ok=False, reason="NameError: name 'wb' is not defined",
+    )])
+    events = await _tool_completed_calls(session)
+    assert len(events) == 1
+    assert events[0]["ok"] == "false"
+    # No exception was raised, so there is no exception class to name — the
+    # handler's prose `reason` must NOT be smuggled in as error_type.
+    assert events[0]["error_type"] == ""
+    assert events[0]["name"] == "scratchpad"
+
+
+async def test_raising_tool_emits_ok_false_with_exception_class_only(workspace):
+    """A raise → ok="false", error_type = the CLASS name, never the message."""
+    secret = "/Users/someone/.aws/credentials leaked into the message"
+    session = _session(workspace, RuntimeError(secret))
+    events = await _tool_completed_calls(session)
+    assert len(events) == 1
+    assert events[0]["ok"] == "false"
+    assert events[0]["error_type"] == "RuntimeError"
+    # The security line this ticket draws: str(exc) — paths, user input —
+    # must appear in NO emitted property.
+    for value in events[0].values():
+        assert secret not in value
+        assert "credentials" not in value
+
+
+async def test_success_emits_ok_true(workspace):
+    session = _session(workspace, [ToolOutcome(content="fine", ok=True)])
+    events = await _tool_completed_calls(session)
+    assert len(events) == 1
+    assert events[0]["ok"] == "true"
+    assert events[0]["error_type"] == ""
+
+
+async def test_unmigrated_handler_verdict_is_unknown_not_a_guess(workspace):
+    """ok=None (unmigrated handler) is reported honestly as "unknown".
+
+    The verdict must come from the exception/ToolOutcome seam, never from
+    re-inferring intent out of the result text — even when the text contains
+    the word "failed".
+    """
+    session = _session(workspace, [ToolOutcome(content="task failed maybe", ok=None)])
+    events = await _tool_completed_calls(session)
+    assert len(events) == 1
+    assert events[0]["ok"] == "unknown"
+
+
+# ── Payload contract ─────────────────────────────────────────────────
+
+
+async def test_payload_is_exactly_name_ok_duration_error_type_all_strings(workspace):
+    """No arguments, no result content, no surprise keys — and str values only,
+    because send_event's extras are wire parameters (tests/test_ask_user.py:496).
+    """
+    session = _session(workspace, [ToolOutcome(content="secret result body", ok=True)])
+    events = await _tool_completed_calls(session)
+    assert set(events[0]) == {"name", "ok", "duration_ms", "error_type"}
+    assert all(isinstance(v, str) for v in events[0].values())
+    assert "secret result body" not in json.dumps(events[0])
+    int(events[0]["duration_ms"])  # numeric string, parseable
+
+
+async def test_one_event_per_tool_call(workspace):
+    outcomes = [ToolOutcome(content="a", ok=True),
+                ToolOutcome(content="b", ok=False, reason="x"),
+                ToolOutcome(content="c", ok=True)]
+    pending = list(outcomes)
+    session = _session(workspace, lambda *a, **k: pending.pop(0), n_tool_calls=3)
+    events = await _tool_completed_calls(session)
+    assert [e["ok"] for e in events] == ["true", "false", "true"]
+
+
+# ── Duration semantics ───────────────────────────────────────────────
+
+
+async def test_duration_excludes_human_wait(workspace):
+    """An ask_user answered after four minutes is not a four-minute tool.
+
+    The dispatch mock does what elicit() does, at real wall-clock scale:
+    it spends 0.4s waiting and credits that same 0.4s to `answer_wait_s`.
+    Only an emitted duration that actually subtracts the wait lands near
+    zero — a mutation that drops the subtraction reports ~400ms and fails.
+    """
+    import asyncio
+
+    session_holder = {}
+
+    async def slow_human(*a, **k):
+        await asyncio.sleep(0.4)
+        session_holder["s"].answer_wait_s += 0.4
+        return ToolOutcome(content="answered", ok=True)
+
+    session = _session(workspace, slow_human)
+    session_holder["s"] = session
+    events = await _tool_completed_calls(session)
+    assert len(events) == 1
+    assert int(events[0]["duration_ms"]) < 200
+
+
+async def test_wait_reset_is_per_call_not_per_general_branch(workspace):
+    """A stale wait from an earlier call must not deflate the next call's
+    duration: answer_wait_s resets with _tool_t0 for EVERY dispatched call."""
+    calls = {"n": 0}
+
+    async def first_waits(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            session_holder["s"].answer_wait_s += 240.0
+        return ToolOutcome(content="ok", ok=True)
+
+    session_holder = {}
+    session = _session(workspace, first_waits, n_tool_calls=2)
+    session_holder["s"] = session
+    events = await _tool_completed_calls(session)
+    assert len(events) == 2
+    # Both near-zero: the first because its own 240s wait is subtracted, the
+    # second because the first call's wait was NOT carried into its maths as
+    # a negative (clamped) or its own subtraction baseline.
+    assert all(int(e["duration_ms"]) < 1_000 for e in events)
+
+
+# ── Analytics resilience + routing ───────────────────────────────────
+
+
+async def test_turn_survives_send_event_raising(workspace):
+    """Analytics must never break the tool call that just ran."""
+    session = _session(workspace, [ToolOutcome(content="fine", ok=True)])
+    with patch("anton.analytics.send_event", side_effect=RuntimeError("boom")):
+        async for _ in session.turn_stream("go"):
+            pass  # completing without raising is the assertion
+
+
+def test_tool_completed_goes_to_posthog_not_the_collector(monkeypatch):
+    """`tool_completed` is a new event NAME: the collector drops names it has
+    never heard of (ENG-1355), so it must take the ENG-1495 direct route."""
+    monkeypatch.setattr(analytics, "_cached_is_ci", None)
+    for var in ("ANTON_IS_CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE",
+                "CIRCLECI", "TF_BUILD", "JENKINS_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    captured: list[tuple[str, dict]] = []
+
+    class _SyncThread:
+        def __init__(self, target=None, args=(), daemon=None):
+            self._target = target
+            self._args = args
+
+        def start(self):
+            if self._target:
+                self._target(*self._args)
+
+    monkeypatch.setattr(analytics.threading, "Thread", _SyncThread)
+    monkeypatch.setattr(
+        analytics, "_fire_posthog",
+        lambda url, body: captured.append((url, json.loads(body))),
+    )
+    monkeypatch.setattr(
+        analytics, "_fire",
+        lambda url: pytest.fail(f"took the collector path instead: {url}"),
+    )
+
+    class _PosthogSettings:
+        analytics_enabled = True
+        analytics_url = "https://example.test/collect"
+        posthog_host = "https://ph.example.test"
+        posthog_key = "phc_test"
+
+    analytics.send_event(
+        _PosthogSettings(), "tool_completed",
+        name="scratchpad", ok="false", duration_ms="1234", error_type="TimeoutError",
+    )
+
+    assert len(captured) == 1
+    url, body = captured[0]
+    assert url == "https://ph.example.test/capture/"
+    assert body["event"] == "tool_completed"
+    assert body["properties"]["name"] == "scratchpad"
+    assert body["properties"]["ok"] == "false"

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -12,10 +12,13 @@ harness shape as ``test_root_cause_wiring.py``) and assert on what
   unconditional success);
 - ``error_type`` is the exception CLASS name and never the message —
   ``str(exc)`` routinely embeds file paths and user input;
-- the payload is exactly {name, ok, duration_ms, error_type}, all strings —
-  no tool arguments, no result content;
+- the payload is exactly {name, ok, duration_ms, error_type, conversation_id,
+  turn_index}, all strings — no tool arguments, no result content;
 - human wait (``answer_wait_s``, accumulated by ``elicit()``) is subtracted
-  from the duration;
+  from the duration — which covers ``ask_user`` and ``select_path``, the only
+  tools that elicit. It does NOT cover the interactive branch, whose tools
+  prompt via ``prompt_or_cancel`` and never touch that counter; see
+  ``test_interactive_branch_emits_too`` for the pinned limit;
 - the event name is registered in ``_POSTHOG_EVENTS``, because a name the
   collector has never heard of otherwise reaches nothing (ENG-1355/ENG-1495).
 """
@@ -47,10 +50,12 @@ def _usage(n: int = 1_000) -> Usage:
     return Usage(input_tokens=n // 2, output_tokens=n // 2)
 
 
-def _tool_call(i: int) -> LLMResponse:
+def _tool_call(i: int, name: str = "scratchpad") -> LLMResponse:
+    # Default routes to the general dispatch branch (a scratchpad "view", not
+    # an "exec"); pass connect_new_datasource to route to the interactive one.
     return LLMResponse(
         content="working",
-        tool_calls=[ToolCall(id=f"tc{i}", name="scratchpad",
+        tool_calls=[ToolCall(id=f"tc{i}", name=name,
                              input={"action": "view", "name": "m"})],
         usage=_usage(), stop_reason="tool_use",
     )
@@ -60,7 +65,8 @@ def _text(t: str = "done") -> LLMResponse:
     return LLMResponse(content=t, tool_calls=[], usage=_usage(), stop_reason="end_turn")
 
 
-def _session(workspace, dispatch_side_effect, n_tool_calls: int = 1):
+def _session(workspace, dispatch_side_effect, n_tool_calls: int = 1,
+             tool_name: str = "scratchpad"):
     """Session whose tool dispatch runs `dispatch_side_effect`."""
     llm = make_mock_llm()
     llm.usage_listener = None
@@ -72,7 +78,8 @@ def _session(workspace, dispatch_side_effect, n_tool_calls: int = 1):
             if llm.usage_listener:
                 llm.usage_listener("planning", "m", _usage())
             yield StreamComplete(
-                response=_tool_call(seq["i"]) if seq["i"] <= n_tool_calls else _text()
+                response=_tool_call(seq["i"], tool_name)
+                if seq["i"] <= n_tool_calls else _text()
             )
         return gen()
 
@@ -80,7 +87,7 @@ def _session(workspace, dispatch_side_effect, n_tool_calls: int = 1):
         seq["i"] += 1
         if llm.usage_listener:
             llm.usage_listener("planning", "m", _usage())
-        return _tool_call(seq["i"]) if seq["i"] <= n_tool_calls else _text()
+        return _tool_call(seq["i"], tool_name) if seq["i"] <= n_tool_calls else _text()
 
     llm.plan_stream = plan_stream
     llm.plan = plan
@@ -276,6 +283,37 @@ async def test_slow_consumer_after_tool_done_does_not_inflate_the_duration(works
     assert len(events) == 1 and len(displayed) == 1
     assert int(events[0]["duration_ms"]) < 200
     assert int(events[0]["duration_ms"]) == int(displayed[0] * 1000)
+
+
+async def test_interactive_branch_emits_too(workspace):
+    """The interactive branch (`connect_new_datasource`, `publish_or_preview`
+    publish) reaches the shared emit — nothing else asserted this.
+
+    It also pins a known limit. This branch's tools collect human input via
+    `prompt_or_cancel`, which — unlike `elicit()` — does not feed
+    `answer_wait_s`, so the emitted duration INCLUDES the human's typing time.
+    The 0.4s stall below stands in for that and is expected in the number;
+    real credential entry takes minutes. The emit's fallback subtracts
+    `answer_wait_s`, but that counter is provably 0.0 here (only `elicit()`
+    writes it, and its callers all route to the general branch), so the
+    subtraction cannot help these two tools. Asserted as-is deliberately:
+    the value is honest wall-clock, and a silent inflation would be worse
+    than a documented one.
+    """
+    import asyncio
+
+    async def human_types_credentials(*a, **k):
+        await asyncio.sleep(0.4)
+        return ToolOutcome(content="connected", ok=True)
+
+    session = _session(workspace, human_types_credentials,
+                       tool_name="connect_new_datasource")
+    events = await _tool_completed_calls(session)
+    assert len(events) == 1
+    assert events[0]["name"] == "connect_new_datasource"
+    assert events[0]["ok"] == "true"
+    assert int(events[0]["duration_ms"]) >= 400  # human time is in there
+    assert session.answer_wait_s == 0.0  # prompt_or_cancel never fed it
 
 
 async def test_nonstreaming_turn_path_also_emits(workspace):

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -253,6 +253,31 @@ async def test_wait_from_one_call_never_leaks_into_the_next(workspace):
     assert all(int(e["duration_ms"]) < 1_000 for e in events)
 
 
+async def test_slow_consumer_after_tool_done_does_not_inflate_the_duration(workspace):
+    """The booked duration is the tool's runtime, not the consumer's pull rate.
+
+    #390 review: the emit sits a few yields past the point the branch stops
+    the clock, so re-reading `monotonic()` there would bill whatever the
+    consumer spends pulling `tool_done` (and a scratchpad `dump`'s result) to
+    the tool. Here the consumer stalls 0.4s right after `tool_done`; the
+    emitted duration must stay near zero AND equal the `eta_seconds` the UI
+    displayed, so the two sources can never disagree.
+    """
+    import asyncio
+
+    session = _session(workspace, [ToolOutcome(content="fine", ok=True)])
+    displayed: list[float] = []
+    with patch("anton.analytics.send_event") as sent:
+        async for ev in session.turn_stream("go"):
+            if getattr(ev, "phase", None) == "tool_done":
+                displayed.append(ev.eta_seconds)
+                await asyncio.sleep(0.4)
+    events = [c.kwargs for c in sent.call_args_list if c.args[1] == "tool_completed"]
+    assert len(events) == 1 and len(displayed) == 1
+    assert int(events[0]["duration_ms"]) < 200
+    assert int(events[0]["duration_ms"]) == int(displayed[0] * 1000)
+
+
 async def test_nonstreaming_turn_path_also_emits(workspace):
     """`turn()` has its own dispatch loop (session.py ~3315), separate from the
     streaming tail — self-review finding: without its own emit, any host on

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -149,16 +149,37 @@ async def test_unmigrated_handler_verdict_is_unknown_not_a_guess(workspace):
 # ── Payload contract ─────────────────────────────────────────────────
 
 
-async def test_payload_is_exactly_name_ok_duration_error_type_all_strings(workspace):
+async def test_payload_is_exactly_the_six_keys_all_strings(workspace):
     """No arguments, no result content, no surprise keys — and str values only,
     because send_event's extras are wire parameters (tests/test_ask_user.py:496).
     """
     session = _session(workspace, [ToolOutcome(content="secret result body", ok=True)])
     events = await _tool_completed_calls(session)
-    assert set(events[0]) == {"name", "ok", "duration_ms", "error_type"}
+    assert set(events[0]) == {"name", "ok", "duration_ms", "error_type",
+                              "conversation_id", "turn_index"}
     assert all(isinstance(v, str) for v in events[0].values())
     assert "secret result body" not in json.dumps(events[0])
     int(events[0]["duration_ms"])  # numeric string, parseable
+
+
+async def test_join_keys_match_the_same_turns_turn_completed_row(workspace):
+    """The reason the two keys exist: a tool row must join to its parent turn.
+
+    conversation_id and turn_index on tool_completed must equal the values the
+    SAME run's turn_completed carries — same names, same derivation — so the
+    PostHog join (and the conversation_id → Langfuse sessionId pivot) needs no
+    translation table.
+    """
+    session = _session(workspace, [ToolOutcome(content="fine", ok=True)])
+    with patch("anton.analytics.send_event") as sent:
+        async for _ in session.turn_stream("go"):
+            pass
+    tool = [c.kwargs for c in sent.call_args_list if c.args[1] == "tool_completed"]
+    turn = [c.kwargs for c in sent.call_args_list if c.args[1] == "turn_completed"]
+    assert len(tool) == 1 and len(turn) == 1
+    assert tool[0]["conversation_id"] == turn[0]["conversation_id"] == "conv-tc"
+    assert tool[0]["turn_index"] == turn[0]["turn_index"]
+    assert tool[0]["turn_index"] != ""  # a real index, not a blank join key
 
 
 async def test_one_event_per_tool_call(workspace):

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -76,7 +76,14 @@ def _session(workspace, dispatch_side_effect, n_tool_calls: int = 1):
             )
         return gen()
 
+    async def plan(**kw):
+        seq["i"] += 1
+        if llm.usage_listener:
+            llm.usage_listener("planning", "m", _usage())
+        return _tool_call(seq["i"]) if seq["i"] <= n_tool_calls else _text()
+
     llm.plan_stream = plan_stream
+    llm.plan = plan
     s = ChatSession(ChatSessionConfig(llm_client=llm, workspace=workspace,
                                       session_id="conv-tc"))
     s._max_turn_tokens = 0
@@ -219,9 +226,14 @@ async def test_duration_excludes_human_wait(workspace):
     assert int(events[0]["duration_ms"]) < 200
 
 
-async def test_wait_reset_is_per_call_not_per_general_branch(workspace):
-    """A stale wait from an earlier call must not deflate the next call's
-    duration: answer_wait_s resets with _tool_t0 for EVERY dispatched call."""
+async def test_wait_from_one_call_never_leaks_into_the_next(workspace):
+    """Consecutive calls each get a clean wait ledger and a clamped duration.
+
+    Guards the per-call reset plus the negative clamp — NOT a historical bug:
+    before the tail emit existed, the general branch was both the only
+    resetter and the only subtractor, so the old maths was self-consistent.
+    The reset's earlier position is a prerequisite of the cross-branch emit.
+    """
     calls = {"n": 0}
 
     async def first_waits(*a, **k):
@@ -239,6 +251,35 @@ async def test_wait_reset_is_per_call_not_per_general_branch(workspace):
     # second because the first call's wait was NOT carried into its maths as
     # a negative (clamped) or its own subtraction baseline.
     assert all(int(e["duration_ms"]) < 1_000 for e in events)
+
+
+async def test_nonstreaming_turn_path_also_emits(workspace):
+    """`turn()` has its own dispatch loop (session.py ~3315), separate from the
+    streaming tail — self-review finding: without its own emit, any host on
+    the non-streaming API silently undercounts. No production caller uses it
+    today; this test is the seam guard for the first one that does.
+    """
+    session = _session(workspace, RuntimeError("boom"))
+    with patch("anton.analytics.send_event") as sent:
+        await session.turn("go")
+    events = [c.kwargs for c in sent.call_args_list if c.args[1] == "tool_completed"]
+    assert len(events) == 1
+    assert events[0]["ok"] == "false"
+    assert events[0]["error_type"] == "RuntimeError"
+    assert events[0]["name"] == "scratchpad"
+
+
+async def test_model_generated_tool_name_is_bounded(workspace):
+    """`tc.name` is model output: a degenerate name must emit (it is real
+    signal) but bounded, never verbatim-unbounded into a property value."""
+    session = _session(workspace, [ToolOutcome(content="ok", ok=True)])
+    with patch("anton.analytics.send_event") as sent:
+        session._emit_tool_completed(
+            name="x" * 5000, ok=False, duration_ms=1.0, error_type="",
+        )
+    kwargs = sent.call_args.kwargs
+    assert kwargs["name"] == "x" * 200
+    assert len(kwargs["name"]) == 200
 
 
 # ── Analytics resilience + routing ───────────────────────────────────


### PR DESCRIPTION
Closes [ENG-1486](https://linear.app/mindsdb/issue/ENG-1486/anton-computes-a-per-tool-success-verdict-and-throws-it-away-nothing).

Anton computes a definitive per-tool success verdict for the UI's `tool_done` marker and threw it away — nothing could answer *which tools fail, how often, or how slowly* (the gateway is structurally the wrong vantage point: 67% of its `tool:*` spans are structured-output schemas, and anton's own handling hides failures from it).

## What

- **`session.py`** — emit `tool_completed` via `send_event` at the point every **executed** tool call flows through: the streaming dispatch loop's common tail — covering all three branches (inline scratchpad exec, interactive, general) and both failure shapes (a raise AND `ToolOutcome.ok=False` — the PR #304 distinction) — plus the non-streaming `turn()` loop's own dispatch site (zero production callers today; instrumented so the per-call contract holds on every path — self-review finding 2). `name` is bounded to 200 chars — it is model output (self-review finding 3). Discarded/damaged calls `continue` before the timer and never emit; structured-output extractions (`generate_object_code`) never enter tool dispatch at all.
  - Payload: `name`, `ok` (`"true"`/`"false"`/`"unknown"` — `None` = unmigrated handler or cancelled exec, reported honestly rather than coerced), `duration_ms` (human wait subtracted), `error_type` (exception **class name** when the failure was a raise, `""` otherwise — never the message), plus two join keys: `conversation_id` and `turn_index`, mirroring `turn_completed`'s values exactly (same names, same derivation) so a tool row joins to its parent turn row in PostHog and, via `conversation_id` → Langfuse `sessionId`, to the gateway trace. All string values, per `send_event`'s wire contract.
  - New `_tool_error_type` variable kept apart from `tool_reason`, which on the `ToolOutcome` path is prose (traceback line / handler message) and can carry paths and user input.
  - `answer_wait_s` now resets with `_tool_t0` for **every** dispatched call, not only on the general branch. This is a **prerequisite of the new cross-branch emit**, not a fix of a pre-existing bug: before this PR the general branch was both the only resetter and the only subtractor, so the old maths was self-consistent (self-review finding 1 corrected an earlier claim here).
- **`analytics.py`** — `tool_completed` registered in `_POSTHOG_EVENTS` (the ENG-1495 direct sink) with its properties documented in the register. A new event *name* through the collector would reach nothing (ENG-1355).

## Ticket decisions (as recommended in the ticket)

1. **Per-call event** (not per-turn counters) — volume checked against current ingest, see below.
2. **`error_type` included**, exception class name only.
3. **PostHog, not Langfuse** — client-side product telemetry keyed on install. The `conversation_id` join key is the bridge for trace forensics: PostHog → Langfuse `sessionId` → the turn's gateway trace.

## Relationship to ENG-1689 / #381 (no duplication)

#381's `error_type` is **turn-level** — the exception that *ended the turn*. Tool exceptions are caught by the dispatch loop and converted into a `Tool 'x' failed:` result the model reacts to; they never escape to end the turn, so they are invisible to #381 **by construction**, and a turn-ending exception never books here. Same name and semantics (class name only) on two disjoint populations. `git merge-tree` confirms the branches merge cleanly. If #381 lands first, a one-line rebase switches `type(exc).__name__` to its `_safe_error_type` helper.

## Volume check (decision 1's pre-merge condition)

Measured 2026-08-21, project 424726, last 7 days: 4,075 real turns (`llm_calls > 0`) totalling 15,506 rounds (avg 3.8/turn). At ~1–2 tool calls per round this is roughly **15–30k `tool_completed` events/week**, against a current total project ingest of ~53k events/week — a +30–60% relative increase but small in absolute terms.

## Verified end-to-end (not only unit-tested)

Ran a real turn on this branch (real LLM via the gateway, real analytics, no mocks) prompting a scratchpad exec of `raise ValueError('eng1486_e2e_probe')`. The event is visible in PostHog project 424726:

```
2026-08-21T13:46:12-07:00  distinct_id=a64c660a636b44be
{'name': 'scratchpad', 'ok': 'false', 'duration_ms': '270', 'error_type': '',
 'conversation_id': 'eng1486-e2e-probe', 'turn_index': '1'}
```

This exercised the **inline scratchpad-exec branch** (cell-error verdict, no raise → `error_type=""`), which the unit harness can't reach — so both the raise path (unit) and the `ToolOutcome`/cell path (unit + live) are confirmed, join keys included.

## Tests (all mutation-verified — each mutation flips a named test to FAIL)

`tests/test_tool_completed.py`, driving the real `turn_stream`:
- raise → `ok="false"`, `error_type="RuntimeError"`; `str(exc)` (a path-bearing message) appears in **no** property — killed by `error_type = str(exc)` mutation
- `ToolOutcome.ok=False` → `ok="false"`, `error_type=""` (the prose `reason` is not smuggled in)
- `ok=None` → `"unknown"`, never coerced — killed by coerce-to-true mutation
- payload is exactly `{name, ok, duration_ms, error_type, conversation_id, turn_index}`, all strings, result content absent — killed by extra-property mutation
- join keys equal the same run's `turn_completed` values — killed by blanking `conversation_id` and by deriving `turn_index` from a different counter on the tool side only
- duration subtracts real wall-clock human wait — killed by dropping the subtraction
- a consumer stalling 0.4s right after `tool_done` does not inflate the booked duration, which equals the `eta_seconds` the UI displayed — killed by re-reading the clock at the emit (review nit from @pnewsam; measured 401ms billed to a ~0ms tool before the fix)
- one event per call; turn survives `send_event` raising
- routing: `tool_completed` takes the PostHog path, never the collector — killed by unregistering it

Two more from self-review, both mutation-verified: the non-streaming `turn()` path emits (killed by deleting that emit) and the model-generated `name` is bounded to 200 chars (killed by dropping the truncation).

Full suite: **2336 passed, 31 skipped**.

## Security check

Performed. The payload carries tool name, verdict, duration, exception class name and the two join ids only — no tool arguments, no result content, no `str(exc)` (asserted in a test with a path-bearing message), no file paths, no credentials. `conversation_id` and `turn_index` already ride `turn_completed` through this same sink — no new privacy surface. `analytics_enabled` opt-out and the CI drop apply unchanged (the new call site goes through `send_event`, which owns both). `distinct_id` is the existing per-install `aid`. `$process_person_profile=False` as with the other direct-sink events.

## Open question the first week of data answers

Is the observed near-zero tool-failure rate real, or does anton absorb failures the gateway never sees? This event is what distinguishes the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


