### PR TITLE
ENG-1689: record that the install-id format is depended on cross-repo

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -238,9 +238,25 @@ def get_installation_id() -> str:
     moving off lowercase hex is not, and would silently drop the key rather
     than fail loudly.
 
-    The ``"unknown"`` return below is filtered by those consumers too: every
-    unfingerprintable machine reports the same string, so a join on it would
-    merge them into one identity.
+    Two limits worth knowing before changing either, since both are the change
+    someone would plausibly make:
+
+    - **The width freedom stops at 64.** The consumer bound is ``{8,64}``, so
+      anything up to a full SHA-256 hexdigest is fine, including dropping the
+      truncation entirely. A longer digest left untruncated is not — SHA-512 is
+      128 hex characters and would be rejected.
+    - **A replacement sentinel must stay NON-HEX.** cowork-server filters
+      ``"unknown"`` by name, but cowork's renderer rejects it only because it
+      fails the hex test — and the renderer is the side that mints the join
+      key. So a hex-shaped sentinel (``"0000000000000000"`` being the obvious
+      accident) would pass validation and stamp every unfingerprintable machine
+      with the *same* key, merging them into one identity. That is the exact
+      over-merge this value is guarded against, arriving through the door the
+      guard is assumed to cover.
+
+    The ``"unknown"`` return below exists for that reason: every
+    unfingerprintable machine reports the same string, so it must never be
+    usable as a join key.
 
     Returns:
         A 16-character hex string (64 bits of entropy), or ``"unknown"`` when

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -230,8 +230,21 @@ def get_installation_id() -> str:
     networking), a random UUID is persisted to ``~/.anton/.installation_id``
     as a one-time fallback. Computed once per process and cached.
 
+    **The format is depended on outside this repo.** cowork-server serves this
+    value on ``/health`` and cowork's renderer validates it as **lowercase
+    hex** before stamping it as the join key that connects anton's per-turn
+    cost events to an identified user (ENG-1689). Those consumers deliberately
+    do *not* pin the width, so widening the ``[:16]`` truncation is safe —
+    moving off lowercase hex is not, and would silently drop the key rather
+    than fail loudly.
+
+    The ``"unknown"`` return below is filtered by those consumers too: every
+    unfingerprintable machine reports the same string, so a join on it would
+    merge them into one identity.
+
     Returns:
-        A 16-character hex string (64 bits of entropy).
+        A 16-character hex string (64 bits of entropy), or ``"unknown"`` when
+        the machine cannot be fingerprinted at all.
     """
     global _cached_aid
     if _cached_aid is not None:


### PR DESCRIPTION
Docstring only. Follow-up to review feedback on [cowork#707](https://github.com/mindsdb/cowork/pull/707), doing the *"or vice versa"* half so the coupling is discoverable from the **producer** as well as the consumer.

## Why

`get_installation_id()` is now read across three repos, and **the format matters, not just the value**:

- `cowork-server` serves it on `/health` ([#374](https://github.com/mindsdb/cowork-server/pull/374))
- `cowork`'s renderer validates it as **lowercase hex** before stamping it as the join key that connects anton's per-turn cost events to an identified user ([#707](https://github.com/mindsdb/cowork/pull/707))

Nothing in this repo hinted that anyone depends on the encoding. The review put it well — a format change here would break a consumer that has no shared source of truth for it, and the symptom would be **every join returning zero rows**, which reads as *"no data"* rather than *"the key was discarded"*.

## What the note records

**Widening is safe; leaving hex is not.** The consumers deliberately do *not* pin the width (`{8,64}`, not `16`), precisely so this side stays free to change `[:16]`. What they cannot absorb is a move off lowercase hex.

**`"unknown"` is filtered downstream, and why.** Every unfingerprintable machine returns that same string, so a join on it would merge them all into one identity — ENG-713's over-merge outcome without an alias.

**`"unknown"` is now in the `Returns:` section.** It previously promised only *"a 16-character hex string"* while the `except` branch returns `"unknown"`. That gap is not academic: it is exactly why the first draft of cowork-server#374 passed the sentinel through as a join key. The docstring under-described the contract, and the code downstream believed it.

## Verification

Docstring only — no executable change. Full suite **2361 passed / 31 skipped** on this head.

## Merge notes

Independent of everything. Safe in any order relative to anton#381, cowork-server#374 and cowork#707; it documents a contract those PRs rely on rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)