### PR TITLE
ENG-1852: require user confirmation for a model-supplied single select_path candidate

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1797,9 +1797,10 @@ class ChatSession:
         # prompt AND by the host's file-access policy, guessing forbidden. It
         # fabricated the data and reported a forecast from it (ENG-1357).
         #
-        # PICK mode does still work here — one match auto-resolves, and ≥2
-        # comes back with the candidate list to ask about — so this is a
-        # narrowing, not a removal.
+        # PICK mode does still work here — one pattern match auto-resolves, a
+        # single model-supplied candidate is confirmed with the user via a
+        # choice card (ENG-1852), and ≥2 comes back with the candidate list to
+        # ask about — so this is a narrowing, not a removal.
         if self.elicitor is not None and "path" in self.elicitor.supported_kinds:
             self.tool_registry.register_tool(SELECT_PATH_TOOL)
         else:

--- a/anton/core/tools/tool_defs.py
+++ b/anton/core/tools/tool_defs.py
@@ -464,11 +464,15 @@ SELECT_PATH_TOOL = ToolDef(
         "`start_dir` to seed the starting folder.\n"
         "• PICK — you already found several matches and need the user to disambiguate. "
         "Pass an explicit `candidates` list, OR a glob `pattern` (optionally under "
-        "`base_dir`) to find matches within the project. Exactly one match resolves "
-        "immediately with no prompt; zero matches tells you to refine.\n\n"
+        "`base_dir`) to find matches within the project. Exactly one `pattern` match "
+        "resolves immediately with no prompt; zero matches tells you to refine. A "
+        "single explicit candidate is NOT accepted silently — it is your guess, not "
+        "the user's choice, so the user is asked to confirm it first.\n\n"
         'On selection the tool returns {"status":"resolved","path":"<absolute path>"} '
         "— use that path directly and keep going. Other statuses: 'cancelled' (user "
-        "dismissed), 'no_matches', 'invalid', and 'picker_unavailable' (this host "
+        "dismissed or declined), 'no_matches', 'invalid', 'needs_confirmation' (confirm "
+        "the named candidate with the user before using it — never present it as "
+        "chosen until they agree), and 'picker_unavailable' (this host "
         "cannot render a picker). On 'picker_unavailable' follow the `message` in the "
         "result: in PICK mode it carries the `candidates` it found, so ask which of "
         "those the user meant; in BROWSE mode the file is somewhere you cannot reach, "
@@ -536,27 +540,38 @@ SELECT_PATH_TOOL = ToolDef(
 # forbidden here and by the harness file-access policy, guessing is forbidden.
 # The model resolved it by inventing the data (ENG-1357).
 #
-# PICK mode still earns its place without an elicitor: exactly one match
+# PICK mode still earns its place without an elicitor: a lone pattern match
 # auto-resolves with no user interaction, and ≥2 returns the candidate list so
 # the agent can ask in plain text — legitimate, because those paths are ones it
 # already found inside the project, not a path the user must type from memory.
+# A lone *explicit* candidate is the exception (ENG-1852): it is the model's
+# own guess echoed back, so it needs the user's confirmation (a choice card
+# where one renders, else 'needs_confirmation').
 SELECT_PATH_TOOL_PICK_ONLY = replace(
     SELECT_PATH_TOOL,
     description=(
         "Disambiguate between file/folder paths you have ALREADY located inside "
         "the project. Pass an explicit `candidates` list, OR a glob `pattern` "
         "(optionally under `base_dir`).\n\n"
-        "Exactly one match resolves immediately and you get the path back. Zero "
-        "matches tells you to refine. Two or more comes back as "
+        "Exactly one `pattern` match resolves immediately and you get the path "
+        "back. Zero matches tells you to refine. Two or more comes back as "
         "'picker_unavailable' WITH the candidates it found — ask the user which "
-        "of those they meant.\n\n"
+        "of those they meant. A single explicit candidate is NOT accepted "
+        "silently: it is your guess, not the user's choice, so the user is shown "
+        "a confirmation card first (or you get 'needs_confirmation' back — "
+        "confirm with the user before using it).\n\n"
         "This host cannot render an interactive file browser, so there is no "
         "BROWSE mode: you cannot ask the user to navigate to a file whose "
         "location you do not know. If the file is not in the project, ask the "
-        "user to attach it to the conversation.\n\n"
+        "user to attach it to the conversation. Never offer a path inside the "
+        "project as a substitute for a file or folder the user asked for "
+        "outside it — say plainly that this host cannot reach it, and ask them "
+        "to attach the files instead.\n\n"
         'Returns {"status":"resolved","path":"<absolute path>"} on success. '
-        "Other statuses: 'no_matches', 'invalid', 'picker_unavailable'. Never "
-        "re-ask in plain text after a resolved selection."
+        "Other statuses: 'no_matches', 'invalid', 'cancelled' (the user declined "
+        "or dismissed the confirmation), 'needs_confirmation', "
+        "'picker_unavailable'. Never re-ask in plain text after a resolved "
+        "selection."
     ),
     prompt=(
         "When the user refers to a file or folder without giving a path you can "
@@ -565,7 +580,9 @@ SELECT_PATH_TOOL_PICK_ONLY = replace(
         "between the matches. Do not guess which one they meant. If the file is "
         "not in the project at all, ask the user to attach it to the "
         "conversation; this host has no file browser, so do not ask them to "
-        "navigate to it and do not ask them to type or paste a path."
+        "navigate to it and do not ask them to type or paste a path. Never "
+        "offer a folder inside the project as a substitute for one the user "
+        "asked for outside it."
     ),
     # `replace()` copies input_schema by reference, so the schema must be
     # overridden too — otherwise the model is told two different things by the

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -829,6 +829,94 @@ def _status(status: str, message: str = "", **extra) -> str:
     return json.dumps({"status": status, **({"message": message} if message else {}), **extra})
 
 
+def _needs_confirmation(candidate: "Path", label: str) -> str:
+    """The model-supplied candidate cannot be silently accepted and no
+    confirmation card can render on this host: hand the decision back."""
+    return _status(
+        "needs_confirmation",
+        f"You supplied '{label}' as the only candidate — that is your guess, not "
+        "the user's choice, so it was not accepted. Ask the user to confirm it "
+        "before using it, and do not present it as chosen or connected until "
+        "they do. If they asked for a file or folder outside the project, no "
+        "path inside the project is an answer: tell them plainly that this host "
+        "cannot reach paths outside the project, and ask them to attach the "
+        "relevant files to the conversation.",
+        candidates=[str(candidate)],
+    )
+
+
+async def _confirm_single_candidate(
+    session: "ChatSession", candidate: "Path", root: "Path", timeout_s: "int | None"
+) -> str:
+    """Confirm a model-supplied single candidate with the user (ENG-1852).
+
+    A lone entry in ``candidates`` is the model's own guess echoed back, not a
+    discovery: in a fresh project exactly one directory exists (``skills``), so
+    silently resolving it reported folders nobody chose as connected — to the
+    first-run prompt "give you access to a folder on my computer", no less.
+    Confirmation is enforced here rather than in the prompt, because the model
+    already narrates such guesses as decisions ("I'll use it as the folder").
+
+    Renders a yes/no choice card (supported on every cowork host, which has no
+    path picker). Where no card can render either, returns
+    ``needs_confirmation`` so the model must ask in plain text.
+    """
+    from anton.core.interaction.elicit import AskOption, AskRequest, elicit
+
+    try:
+        label = str(candidate.relative_to(root))
+    except ValueError:
+        label = str(candidate)
+    noun = "folder" if candidate.is_dir() else "file"
+    request = AskRequest(
+        prompt=f"Only one candidate was found — use this {noun}?",
+        kind="choice",
+        timeout_s=timeout_s,
+        options=(
+            AskOption(value="yes", label=f"Yes — use {label}", kind=noun, style="primary"),
+            AskOption(value="no", label="No — that's not it"),
+        ),
+    )
+    try:
+        answer = await elicit(session, f"path:{uuid.uuid4().hex}", request)
+    except Exception as exc:  # noqa: BLE001 — the card is host code
+        _log.warning("select_path confirmation elicitor failed: %s", exc, exc_info=True)
+        return _status("error", f"Selection failed: {exc}")
+    if answer.status == "unavailable":
+        return _needs_confirmation(candidate, label)
+    if answer.status == "cancelled":
+        return _status(
+            "cancelled",
+            "The user dismissed the confirmation without choosing. Ask how they "
+            "would like to proceed.",
+        )
+    if answer.status == "limit":
+        return _status(
+            "error",
+            "Too many questions this turn; do not use the candidate without the "
+            "user's confirmation — ask in plain text.",
+        )
+    if answer.status != "answered":
+        return _status("error", f"The confirmation did not return an answer ({answer.status}).")
+    typed = (answer.text or "").strip()
+    if "yes" in answer.values:
+        # Deliberately NOT auto_resolved: the user confirmed this path.
+        return _status(
+            "resolved",
+            f'The user added: "{typed}"' if typed else "",
+            path=str(candidate),
+        )
+    return _status(
+        "cancelled",
+        f"The user declined '{label}'. Do not use this path and do not present "
+        "it as connected. Ask what they actually meant — and if it is a file or "
+        "folder outside the project, tell them plainly that this host cannot "
+        "reach paths outside the project, and ask them to attach the relevant "
+        "files to the conversation."
+        + (f' The user said: "{typed}"' if typed else ""),
+    )
+
+
 def _finalize_browse_choice(chosen: "str | None", kind: str, root: "Path") -> str:
     """Validate a browse-mode pick: any existing path of the requested kind."""
     if chosen is None:
@@ -858,9 +946,11 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
       is not offered browse at all, because ``session.py`` registers
       ``SELECT_PATH_TOOL_PICK_ONLY`` there (ENG-1357).
     * **pick** — ``candidates`` or ``pattern`` given: disambiguate concrete
-      matches within the project. Auto-resolves a single match and reports
-      "no matches" for none, so the picker appears only for a genuine (≥2)
-      ambiguity.
+      matches within the project. A single *pattern* match auto-resolves and
+      zero matches reports "no matches"; a single model-supplied candidate is
+      confirmed with the user first (ENG-1852) — via the path picker where one
+      renders, a yes/no choice card elsewhere, or ``needs_confirmation`` when
+      neither can.
 
     The result is fed back as the tool result, so the agent continues without a
     separate user message.
@@ -940,7 +1030,16 @@ async def handle_select_path(session: "ChatSession", tc_input: dict) -> str:
             ),
         )
     if len(candidates) == 1:
-        return _status("resolved", auto_resolved=True, path=str(candidates[0]))
+        if not has_candidates:
+            # A lone *pattern* match is a genuine discovery — the glob searched
+            # the project and found exactly one thing — so resolving it without
+            # a prompt is safe. A lone *explicit* candidate is not (ENG-1852):
+            # it is the model's own guess echoed back, so it must be confirmed
+            # by the user — via the confirmation card below, or by picking it
+            # in the path picker where one renders.
+            return _status("resolved", auto_resolved=True, path=str(candidates[0]))
+        if not can_pick:
+            return await _confirm_single_candidate(session, candidates[0], root, timeout_s)
     if not can_pick:
         return _status(
             "picker_unavailable",

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -906,6 +906,20 @@ async def _confirm_single_candidate(
             f'The user added: "{typed}"' if typed else "",
             path=str(candidate),
         )
+    if typed and "no" not in answer.values:
+        # A free-typed reply is not a decline the user made — it may even be
+        # the word "yes" — so assert nothing; hand it over verbatim. Parsing
+        # typed affirmations here would be a worse failure than one re-ask.
+        return _status(
+            "cancelled",
+            f'The user typed a reply instead of choosing an option: "{typed}". '
+            f"'{label}' is not confirmed — do not use it or present it as "
+            "connected; act on their reply. If it reads as agreement, call "
+            "select_path again for an explicit confirmation. If they want a "
+            "file or folder outside the project, tell them plainly that this "
+            "host cannot reach it and ask them to attach the relevant files "
+            "to the conversation.",
+        )
     return _status(
         "cancelled",
         f"The user declined '{label}'. Do not use this path and do not present "

--- a/tests/test_select_path.py
+++ b/tests/test_select_path.py
@@ -4,6 +4,10 @@ migration so the refactor cannot change observable behaviour silently.
 The tool's JSON result is a contract with the LLM: statuses resolved /
 invalid / no_matches / cancelled / picker_unavailable / error, plus the
 auto_resolved and path fields. Nothing here may change in Task 7.
+
+ENG-1852 later extended the contract deliberately: needs_confirmation was
+added, and auto_resolved narrowed to pattern matches only — a lone
+model-supplied candidate is confirmed with the user instead.
 """
 
 from __future__ import annotations
@@ -422,6 +426,191 @@ def test_picker_unavailable_is_a_documented_status_in_both_definitions():
     assert "picker_unavailable" in SELECT_PATH_TOOL_PICK_ONLY.description
     # The full definition must say what to do in each mode.
     assert "attach" in SELECT_PATH_TOOL.description.lower()
+
+
+# ─── ENG-1852: a model-supplied single candidate is not the user's choice ──
+#
+# In a fresh cowork project exactly one directory exists (`skills`), so the
+# model enumerates the project, offers it as the lone candidate, and the old
+# `len(candidates) == 1` shortcut confirmed it — reporting a folder nobody
+# chose as connected, in answer to "give you access to a folder on my
+# computer". A lone PATTERN match stays auto-resolved (the glob searched and
+# found exactly one thing); a lone EXPLICIT candidate now needs the user.
+
+
+class _TextAnswerElicitor(_PathlessElicitor):
+    """Answers a choice card with free-typed text instead of an option."""
+
+    def __init__(self, text: str) -> None:
+        super().__init__(None)
+        self.text = text
+
+    async def ask(self, question_id, request):
+        self.requests.append(request)
+        return AskAnswer(status="answered", text=self.text)
+
+
+def _choice_session(tmp_path, elicitor):
+    """A session whose host can render choice cards (non-None emitter):
+    elicit() refuses to publish kind="choice" into a void."""
+    session = _session(tmp_path, elicitor)
+    session.emitter = object()
+    return session
+
+
+async def test_single_explicit_candidate_needs_confirmation_without_any_elicitor(tmp_path):
+    (tmp_path / "skills").mkdir()
+    result = json.loads(
+        await handle_select_path(
+            _session(tmp_path),
+            {"prompt": "Choose the folder to connect", "kind": "folder", "candidates": ["skills"]},
+        )
+    )
+    assert result["status"] == "needs_confirmation"
+    assert "auto_resolved" not in result
+    assert result["candidates"] == [str((tmp_path / "skills").resolve())]
+    # The two remedies: confirm before using, attach for anything outside.
+    assert "confirm" in result["message"].lower()
+    assert "attach" in result["message"].lower()
+
+
+async def test_single_explicit_candidate_confirmed_through_choice_card(tmp_path):
+    (tmp_path / "skills").mkdir()
+    elicitor = _PathlessElicitor("yes")
+    result = json.loads(
+        await handle_select_path(
+            _choice_session(tmp_path, elicitor),
+            {"prompt": "Choose the folder to connect", "kind": "folder", "candidates": ["skills"]},
+        )
+    )
+    assert result["status"] == "resolved"
+    assert result["path"] == str((tmp_path / "skills").resolve())
+    # Confirmed by the user — the opposite of auto-resolved.
+    assert "auto_resolved" not in result
+    card = elicitor.requests[0]
+    assert card.kind == "choice"
+    assert [option.value for option in card.options] == ["yes", "no"]
+
+
+async def test_single_explicit_candidate_declined_is_cancelled_with_attach_guidance(tmp_path):
+    (tmp_path / "skills").mkdir()
+    result = json.loads(
+        await handle_select_path(
+            _choice_session(tmp_path, _PathlessElicitor("no")),
+            {"prompt": "Choose the folder to connect", "kind": "folder", "candidates": ["skills"]},
+        )
+    )
+    assert result["status"] == "cancelled"
+    assert "path" not in result
+    assert "declined" in result["message"].lower()
+    assert "attach" in result["message"].lower()
+
+
+async def test_single_explicit_candidate_decline_carries_the_typed_answer(tmp_path):
+    """A user who types what they actually meant must be heard — the words
+    reach the model verbatim, not as a bare 'cancelled'."""
+    (tmp_path / "skills").mkdir()
+    result = json.loads(
+        await handle_select_path(
+            _choice_session(tmp_path, _TextAnswerElicitor("I meant /Users/me/dev/tenantguard")),
+            {"prompt": "Choose the folder to connect", "kind": "folder", "candidates": ["skills"]},
+        )
+    )
+    assert result["status"] == "cancelled"
+    assert "/Users/me/dev/tenantguard" in result["message"]
+
+
+async def test_single_explicit_candidate_card_dismissed_is_cancelled(tmp_path):
+    (tmp_path / "skills").mkdir()
+    result = json.loads(
+        await handle_select_path(
+            _choice_session(tmp_path, _PathlessElicitor(None)),
+            {"prompt": "Choose the folder to connect", "kind": "folder", "candidates": ["skills"]},
+        )
+    )
+    assert result["status"] == "cancelled"
+    assert "path" not in result
+
+
+async def test_single_explicit_candidate_without_emitter_needs_confirmation(tmp_path):
+    """kind="choice" cannot publish without an emitter (the non-streaming
+    turn() path): elicit answers unavailable, which must not become resolved."""
+    (tmp_path / "skills").mkdir()
+    result = json.loads(
+        await handle_select_path(
+            _session(tmp_path, _PathlessElicitor("yes")),
+            {"prompt": "Choose the folder to connect", "kind": "folder", "candidates": ["skills"]},
+        )
+    )
+    assert result["status"] == "needs_confirmation"
+
+
+async def test_single_explicit_candidate_budget_exhausted_is_not_resolved(tmp_path):
+    (tmp_path / "skills").mkdir()
+    session = _choice_session(tmp_path, _PathlessElicitor("yes"))
+    session.question_count = MAX_QUESTIONS_PER_TURN
+    result = json.loads(
+        await handle_select_path(
+            session,
+            {"prompt": "Choose the folder to connect", "kind": "folder", "candidates": ["skills"]},
+        )
+    )
+    assert result["status"] == "error"
+    assert "confirmation" in result["message"].lower()
+
+
+async def test_single_explicit_candidate_goes_through_the_path_picker_where_one_renders(tmp_path):
+    (tmp_path / "skills").mkdir()
+    chosen = str((tmp_path / "skills").resolve())
+    elicitor = _FakeElicitor(chosen)
+    result = json.loads(
+        await handle_select_path(
+            _session(tmp_path, elicitor),
+            {"prompt": "Choose the folder to connect", "kind": "folder", "candidates": ["skills"]},
+        )
+    )
+    # Picking it in the picker IS the confirmation.
+    assert result == {"status": "resolved", "path": chosen}
+    assert len(elicitor.requests[0].options) == 1
+
+
+async def test_single_explicit_candidate_path_picker_can_be_cancelled(tmp_path):
+    (tmp_path / "skills").mkdir()
+    result = json.loads(
+        await handle_select_path(
+            _session(tmp_path, _FakeElicitor(None)),
+            {"prompt": "Choose the folder to connect", "kind": "folder", "candidates": ["skills"]},
+        )
+    )
+    assert result["status"] == "cancelled"
+
+
+async def test_single_pattern_match_still_auto_resolves_with_a_choice_host(tmp_path):
+    """The ENG-1852 guard must not widen: a lone pattern match is a genuine
+    discovery and keeps resolving with no prompt, even where a card could
+    render."""
+    (tmp_path / "report.csv").write_text("a,b\n")
+    elicitor = _PathlessElicitor("yes")
+    result = json.loads(
+        await handle_select_path(
+            _choice_session(tmp_path, elicitor),
+            {"prompt": "Which one?", "pattern": "*.csv"},
+        )
+    )
+    assert result["status"] == "resolved"
+    assert result["auto_resolved"] is True
+    assert elicitor.requests == []
+
+
+def test_needs_confirmation_is_a_documented_status_in_both_definitions():
+    from anton.core.tools.tool_defs import SELECT_PATH_TOOL, SELECT_PATH_TOOL_PICK_ONLY
+
+    assert "needs_confirmation" in SELECT_PATH_TOOL.description
+    assert "needs_confirmation" in SELECT_PATH_TOOL_PICK_ONLY.description
+    # The pick-only host is where the failure lived: its definition must also
+    # forbid substituting an in-project path for an out-of-project request.
+    assert "substitute" in SELECT_PATH_TOOL_PICK_ONLY.description
+    assert "substitute" in SELECT_PATH_TOOL_PICK_ONLY.prompt
 
 
 def test_module_singletons_are_not_mutated(make_session):

--- a/tests/test_select_path.py
+++ b/tests/test_select_path.py
@@ -506,9 +506,11 @@ async def test_single_explicit_candidate_declined_is_cancelled_with_attach_guida
     assert "attach" in result["message"].lower()
 
 
-async def test_single_explicit_candidate_decline_carries_the_typed_answer(tmp_path):
+async def test_single_explicit_candidate_typed_reply_is_relayed_not_asserted_as_decline(tmp_path):
     """A user who types what they actually meant must be heard — the words
-    reach the model verbatim, not as a bare 'cancelled'."""
+    reach the model verbatim, and the result must not claim the user
+    'declined': a free-typed reply (possibly the literal word 'yes') is not a
+    decline they made (review nit on #392)."""
     (tmp_path / "skills").mkdir()
     result = json.loads(
         await handle_select_path(
@@ -517,7 +519,10 @@ async def test_single_explicit_candidate_decline_carries_the_typed_answer(tmp_pa
         )
     )
     assert result["status"] == "cancelled"
+    assert "path" not in result
     assert "/Users/me/dev/tenantguard" in result["message"]
+    assert "declined" not in result["message"].lower()
+    assert "not confirmed" in result["message"]
 
 
 async def test_single_explicit_candidate_card_dismissed_is_cancelled(tmp_path):


### PR DESCRIPTION
## What

`select_path`'s PICK mode auto-resolved whenever exactly one candidate survived filtering — including when that one candidate came from the model's own `candidates` list. In a fresh cowork project exactly one directory exists (`skills`), so "I'd like to give you access to a folder on my computer" reliably ended with the agent's own `skills` subdirectory reported as connected, and the turn marked COMPLETE. Across 348 users in the 2026-08-14 → 08-21 window, not one connected a folder they chose.

Closes [ENG-1852](https://linear.app/mindsdb/issue/ENG-1852).

## How

- **A lone `pattern` match keeps auto-resolving** — a glob search is a genuine discovery, so `auto_resolved: true` is unchanged there.
- **A lone explicit candidate is never accepted silently.** It is the model's guess echoed back, so the user confirms it — enforced in the handler, not the prompt:
  - **Choice-capable hosts (every cowork session today):** a yes/no confirmation card ("Only one candidate was found — use this folder?"). Yes → `resolved` (no `auto_resolved` flag). No / free-typed answer → `cancelled`, with the user's typed words passed through verbatim and a message telling the model a project path is never an answer to a request for one outside it — say so plainly and point at attachment.
  - **Path-picker hosts (CLI):** falls through to the existing picker with the single option — picking it is the confirmation.
  - **Neither (e.g. non-streaming `turn()`, question budget spent):** new `needs_confirmation` status carrying the candidate and the same guidance; never `resolved`.
- Both tool definitions (`SELECT_PATH_TOOL`, `SELECT_PATH_TOOL_PICK_ONLY`) document the new behaviour and status, and the pick-only variant's description + injected prompt now forbid offering an in-project path as a substitute for an out-of-project request.

## Notes / tradeoffs

- The confirmation card draws on the shared 3-questions-per-turn budget. On exhaustion the result is an `error` instructing the model not to use the candidate unconfirmed — deliberately not `resolved`.
- The chip half of ENG-1852 (the first-run "Point it at a folder" promise) is a separate cowork PR — independent, no merge-order constraint.
- The verifier half ("a turn whose only outcome is auto_resolved isn't the task") mostly dissolves with this change, since `auto_resolved` can no longer fire on the first-run path; anything further belongs to ENG-1204.

## Tests

- 10 new tests in `tests/test_select_path.py` covering: no-elicitor → `needs_confirmation`; card confirmed → `resolved` without `auto_resolved`; declined / dismissed → `cancelled` with attach guidance; free-typed decline carries the user's words; no-emitter → `needs_confirmation`; budget exhausted → `error`; path-picker fall-through (1 option) + cancel; pattern single match still auto-resolves even on a choice host; both definitions document `needs_confirmation`.
- **Mutation-verified:** with the handler guard reverted to unconditional auto-resolve, all 9 behavioural tests fail; with the fix, the full suite is green (2423 passed, 31 skipped).

## Security pass

Reviewed the changed surface: candidate paths remain confined to the project root by the untouched `_is_within` guard; the only new data flow is the user's typed card answer being quoted back into the tool result (model-visible text, same trust level as any user message — no shell/log/exec sink); no credentials, no new endpoints, no deserialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)