### PR TITLE
Let Workspace's artifacts root be overridden by the caller

### DIFF
--- a/anton/workspace.py
+++ b/anton/workspace.py
@@ -27,15 +27,21 @@ Created: {date}
 class Workspace:
     """Manages the .anton/ workspace directory and its files."""
 
-    def __init__(self, base: Path) -> None:
+    def __init__(self, base: Path, artifacts_dir: Path | None = None) -> None:
         self._base = base
         self._anton_dir = base / ".anton"
         self._anton_md = self._anton_dir / "anton.md"
         self._env_file = self._anton_dir / ".env"
         self._anton_md_last_read: datetime | None = None
 
-        settings = AntonSettings()
-        self._artifacts_dir = self._anton_dir / settings.artifacts_dir
+        if artifacts_dir is not None:
+            # Caller (e.g. a host embedding multiple conversations against one
+            # workspace) owns where artifacts live; secrets/anton.md/memory
+            # still resolve under `base` regardless.
+            self._artifacts_dir = artifacts_dir
+        else:
+            settings = AntonSettings()
+            self._artifacts_dir = self._anton_dir / settings.artifacts_dir
 
     @property
     def base(self) -> Path:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -84,6 +84,26 @@ class TestInitialization:
     def test_artifacts_dir_property(self, ws, tmp_path):
         assert ws.artifacts_dir == tmp_path / ".anton" / "artifacts"
 
+    def test_artifacts_dir_override(self, tmp_path):
+        override = tmp_path / "conversations" / "abc123" / ".anton" / "artifacts"
+        ws = Workspace(tmp_path, artifacts_dir=override)
+        assert ws.artifacts_dir == override
+
+    def test_artifacts_dir_override_created_by_initialize(self, tmp_path):
+        override = tmp_path / "conversations" / "abc123" / ".anton" / "artifacts"
+        ws = Workspace(tmp_path, artifacts_dir=override)
+        ws.initialize()
+        assert override.is_dir()
+        # The default project-level artifacts dir is NOT created when overridden.
+        assert not (tmp_path / ".anton" / "artifacts").exists()
+
+    def test_artifacts_dir_override_does_not_affect_anton_md(self, tmp_path):
+        override = tmp_path / "conversations" / "abc123" / ".anton" / "artifacts"
+        ws = Workspace(tmp_path, artifacts_dir=override)
+        ws.initialize()
+        # anton.md/.env still resolve under `base`, not the override.
+        assert (tmp_path / ".anton" / "anton.md").is_file()
+
 
 class TestAntonMd:
     def test_read_none_when_missing(self, ws):


### PR DESCRIPTION
## Summary

Part of the fix for [ENG-1933](https://linear.app/mindsdb/issue/ENG-1933) — artifact cards leaking across concurrent sibling conversations in the same project on desktop.

`Workspace` always derived `artifacts_dir` from a fresh `AntonSettings()`, ignoring any conversation-scoped root the embedding host process might want to use instead. This is the hook `cowork-server` needs so each desktop conversation can get its own artifacts folder (matching how org mode already isolates a pod's artifacts per conversation), instead of every conversation in a project sharing one folder.

- `Workspace(base, artifacts_dir=...)` — new optional param, defaults to the existing behavior when omitted.
- `anton.md`/`.env`/memory are unaffected — they still resolve under `base`.
- `tool_handlers.py`'s `_artifact_store()` already reads `workspace.artifacts_dir`, so no tool-handler changes are needed.

## Test plan

- [x] `uv run pytest tests/test_workspace.py` — 38 passed (3 new: override sets `artifacts_dir`, override is created by `initialize()` without also creating the default path, override doesn't affect `anton.md`).