### PR TITLE
[ENG-1893] Agent stops mid session

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -166,10 +166,13 @@ _pending_lock = threading.Lock()
 #                    rounds, continuations, peak_context_tokens, duration_ms,
 #                    {planning,coding,router}_{model,tokens,calls},
 #                    unknown_{tokens,calls}, llm_provider, endpoint_class,
-#                    error_type, verifier_failure + verifier_error_type (WHY
-#                    the completion verifier produced no verdict — the loop's
-#                    truncated/transient/hard/denied class and the content-
-#                    free exception type; "" on verified turns; ENG-1858),
+#                    error_type, grace_granted + grace_tokens ("", "round",
+#                    "ceiling", or "ceiling,round" — the one-time round-cap /
+#                    spend-ceiling extensions granted this turn, and the
+#                    ceiling one's size), verifier_failure + verifier_error_type
+#                    (WHY the completion verifier produced no verdict — the
+#                    loop's truncated/transient/hard/denied class and the
+#                    content-free exception type; "" on verified turns; ENG-1858),
 #                    harness, surface (desktop / web / cli — WHERE
 #                    the user was, "" when the host did not say; ENG-1945),
 #                    anton_version, conversation_id, turn_index

--- a/anton/core/memory/acc.py
+++ b/anton/core/memory/acc.py
@@ -141,7 +141,7 @@ EVENT_KINDS = frozenset({
     "tool_result",              # detail: {name, success, error}
     # Session-level
     "history_repair",           # detail: {reason} — tool_use/result mismatch repair fired
-    "cap_exhausted",            # detail: {} — terminal: hit max_rounds
+    "cap_exhausted",            # detail: {cap, configured_cap} — terminal: hit max_rounds
 })
 
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -14,7 +14,7 @@ import sys
 from typing import TYPE_CHECKING, List, Literal
 import os
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from anton.core.backends.base import Cell, ScratchpadRuntimeFactory
 from anton.core.backends.local import local_scratchpad_runtime_factory
@@ -363,6 +363,13 @@ class _VerifierVerdict(BaseModel):
             "than assuming it's almost done."
         ),
     )
+
+    @field_validator("close_to_done", mode="before")
+    @classmethod
+    def _null_falls_back_to_default(cls, v: object) -> object:
+        # An explicit `null` here otherwise fails validation for the WHOLE
+        # verdict, not just this field — fall back to the field default.
+        return False if v is None else v
 
 
 # Output budgets for the verdict call: first attempt, then the retry used when
@@ -878,14 +885,15 @@ def _role_calls(tc: TurnCost, role: str) -> str:
 
 
 def _record_grace(turn_cost: TurnCost | None, tag: str) -> None:
-    """Append `tag` ("round" or "ceiling") to `turn_cost.grace_granted`,
-    comma-joined and deduplicated."""
+    """Add `tag` ("round" or "ceiling") to `turn_cost.grace_granted`,
+    comma-joined, deduplicated, and sorted — alphabetical rather than
+    firing order, so the two-grace value is one fixed string either way."""
     if turn_cost is None:
         return
     tags = turn_cost.grace_granted.split(",") if turn_cost.grace_granted else []
     if tag not in tags:
         tags.append(tag)
-        turn_cost.grace_granted = ",".join(tags)
+        turn_cost.grace_granted = ",".join(sorted(tags))
 
 
 def _build_verify_request(
@@ -3132,9 +3140,12 @@ class ChatSession:
 
         `_spend_ceiling_grace_tokens` adds on top of that bound, not inside it:
         the reserve term above cancels out of the gate-plus-reserve landing
-        point, so a granted grace overshoots the ceiling by (approximately)
-        its own size, once per turn. See `_grant_spend_ceiling_grace` for why
-        that term is kept well under the reserve's own size.
+        point, so a granted grace overshoots the ceiling by roughly one more
+        call, once per turn. Known gap: the grace is capped at
+        `max_turn_tokens // 4`, so a single call costing more than that share
+        overshoots past this bound — see `test_total_is_bounded_by_the_ceiling`.
+        See `_grant_spend_ceiling_grace` for why the grace stays well under
+        the reserve's own size otherwise.
         """
         peak = self._turn_cost.peak_context_tokens if self._turn_cost else 0
         reserve = min(
@@ -3658,18 +3669,22 @@ class ChatSession:
         resilience_nudged: set[str] = set()
         # Mirrors turn_stream's one-time grants, the same way the round-cap
         # and spend-ceiling checks below already mirror it. This path has no
-        # continuation loop, so each grant is simply spent once for the
-        # whole call rather than once per continuation.
-        _round_cap_grace_active = False
-
+        # continuation loop — unlike `_stream_and_handle_tools`, which needs
+        # its own per-continuation flag — so `_round_cap_grace_used` alone
+        # already tracks whether THIS call earned the wider cap.
         while response.tool_calls:
             tool_round += 1
-            if tool_round > self._max_tool_rounds and not self._round_cap_grace_used:
+            # `> 0` excludes a configured 0 (or misconfigured negative) cap:
+            # that means "no tool rounds", not "one round of free grace".
+            if (
+                tool_round > self._max_tool_rounds
+                and not self._round_cap_grace_used
+                and self._max_tool_rounds > 0
+            ):
                 self._round_cap_grace_used = True
-                _round_cap_grace_active = True
                 _record_grace(self._turn_cost, "round")
             effective_round_cap = self._max_tool_rounds + (
-                _ROUND_CAP_GRACE_ROUNDS if _round_cap_grace_active else 0
+                _ROUND_CAP_GRACE_ROUNDS if self._round_cap_grace_used else 0
             )
             if self._turn_cost is not None and tool_round <= effective_round_cap:
                 self._turn_cost.rounds += 1
@@ -4046,6 +4061,11 @@ class ChatSession:
         assistant_text_parts: list[str] = []
         _max_auto_retries = 2
         _retry_count = 0
+        # One-time cap grace, reset once per turn_stream() call rather than in
+        # `_stream_and_handle_tools`, which retries re-enter and would re-arm.
+        self._spend_ceiling_grace_used = False
+        self._spend_ceiling_grace_tokens = 0
+        self._round_cap_grace_used = False
         # ENG-673: a mid-stream provider failure that had NO prior retry (an
         # overload smuggled into an HTTP-200 stream) gets budget-bounded
         # backoff-and-retry — separate from the instant, count-bounded recovery
@@ -4583,10 +4603,6 @@ class ChatSession:
         system = await self._build_system_prompt(user_message)
         self._compacted_this_turn = False
         self._compaction_failed_this_turn = False
-        # One-time cap grace (ENG-1893), reset per turn like the flags above.
-        self._spend_ceiling_grace_used = False
-        self._spend_ceiling_grace_tokens = 0
-        self._round_cap_grace_used = False
 
         response: StreamComplete | None = None
 
@@ -4674,8 +4690,14 @@ class ChatSession:
                 # mid-loop spend-ceiling grace — no verdict exists yet at
                 # this point, so the grant is a single small window rather
                 # than a self-report. Decided before the accounting below so
-                # the granted round is counted like any other.
-                if tool_round > self._max_tool_rounds and not self._round_cap_grace_used:
+                # the granted round is counted like any other. `> 0` excludes
+                # a configured 0 (or negative) cap — "no tool rounds", not
+                # "one round of free grace".
+                if (
+                    tool_round > self._max_tool_rounds
+                    and not self._round_cap_grace_used
+                    and self._max_tool_rounds > 0
+                ):
                     self._round_cap_grace_used = True
                     _round_cap_grace_active = True
                     _record_grace(self._turn_cost, "round")

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -449,6 +449,13 @@ _VERIFIER_LATCH_REPROBE_TURNS = 10
 # call has reported usage.
 _SPEND_CEILING_RESERVE = 200_000
 
+# Floor for the one-time spend-ceiling grace — deliberately lower
+# than `_SPEND_CEILING_RESERVE`'s own floor. That reserve is sized to cover
+# TWO calls guaranteed to land after the gate trips; the grace is sized for
+# roughly ONE more, so granting it does not cancel the reserve outright and
+# put the turn back up near the ceiling. See `_grant_spend_ceiling_grace`.
+_SPEND_CEILING_GRACE_FLOOR = 100_000
+
 # One-time round-cap extension (ENG-1893), granted the first time a turn
 # breaches max_tool_rounds. Sized to the "2-3 more tool calls" this exists
 # for — add a closing step, save, verify — not a way to talk past the cap
@@ -847,6 +854,17 @@ def _role_tokens(tc: TurnCost, role: str) -> str:
 def _role_calls(tc: TurnCost, role: str) -> str:
     slice_ = tc.by_role.get(role)
     return str(slice_.calls if slice_ else 0)
+
+
+def _record_grace(turn_cost: TurnCost | None, tag: str) -> None:
+    """Append `tag` ("round" or "ceiling") to `turn_cost.grace_granted`,
+    comma-joined and deduplicated."""
+    if turn_cost is None:
+        return
+    tags = turn_cost.grace_granted.split(",") if turn_cost.grace_granted else []
+    if tag not in tags:
+        tags.append(tag)
+        turn_cost.grace_granted = ",".join(tags)
 
 
 def _build_verify_request(
@@ -2676,12 +2694,14 @@ class ChatSession:
             _root_cause_fields = {}
         logger.info(
             "turn_cost session=%s turn=%d ended_by=%s verification_skipped=%s "
+            "grace_granted=%s grace_tokens=%d "
             "tokens_total=%d "
             "input=%d output=%d cache_read=%d cache_creation=%d "
             "llm_calls=%d rounds=%d continuations=%d peak_context=%d duration_ms=%d "
             "by_role=%s %s",
             self._session_id, turn_index, tc.ended_by,
-            str(tc.verification_skipped).lower(), tc.total_tokens,
+            str(tc.verification_skipped).lower(),
+            tc.grace_granted or "-", tc.grace_tokens, tc.total_tokens,
             tc.input_tokens, tc.output_tokens, tc.cache_read_tokens,
             tc.cache_creation_tokens, tc.llm_calls, tc.rounds,
             tc.continuations, tc.peak_context_tokens, tc.duration_ms,
@@ -2795,6 +2815,11 @@ class ChatSession:
                 # ENG-1632) must be excludable from the honest-stop
                 # denominator without a per-conversation Langfuse hop.
                 verification_skipped=str(tc.verification_skipped).lower(),
+                # One-time grace(s) granted this turn — see
+                # `TurnCost.grace_granted`. Empty string, not "-", to stay
+                # consistent with how other unset string properties go out.
+                grace_granted=tc.grace_granted,
+                grace_tokens=str(tc.grace_tokens),
                 tokens_total=str(tc.total_tokens),
                 input_tokens=str(tc.input_tokens),
                 output_tokens=str(tc.output_tokens),
@@ -3012,6 +3037,12 @@ class ChatSession:
         against `total_tokens`, which also counts output, so a turn can land
         over the ceiling by roughly two output budgets. See
         `test_total_is_bounded_by_the_ceiling` for the asserted form.
+
+        `_spend_ceiling_grace_tokens` adds on top of that bound, not inside it:
+        the reserve term above cancels out of the gate-plus-reserve landing
+        point, so a granted grace overshoots the ceiling by (approximately)
+        its own size, once per turn. See `_grant_spend_ceiling_grace` for why
+        that term is kept well under the reserve's own size.
         """
         peak = self._turn_cost.peak_context_tokens if self._turn_cost else 0
         reserve = min(
@@ -3023,20 +3054,30 @@ class ChatSession:
         )
 
     def _grant_spend_ceiling_grace(self) -> None:
-        """Raise the gate once this turn (ENG-1893), sized like one more call.
+        """Raise the gate once this turn, sized like ONE more call.
 
-        Reuses the reserve's own formula rather than a flat constant, for the
-        same reason the reserve does: a turn with a big context needs a bigger
-        exception to actually cover 1-3 more calls. Idempotent — a caller that
-        checks `_spend_ceiling_grace_used` first never calls this twice, but a
-        stray second call would just recompute the same amount, not stack it.
+        Deliberately smaller than the reserve `_spend_ceiling_gate` nets this
+        against: that reserve is sized for the TWO calls guaranteed to land
+        after the gate trips (the crossing call, the hand-back). Reusing that
+        same size for the grace cancelled the reserve outright and let a
+        granted turn land back up near the ceiling — measured up to 1.5x the
+        configured ceiling. Scaled by `peak_context_tokens` for the same
+        reason the reserve is (a big-context turn's next call costs more),
+        but at 1x peak and a lower floor, not 2x and the
+        reserve's own floor, so the grant stays closer to "a bit more room"
+        than "the reserve, again". Idempotent — a caller that checks
+        `_spend_ceiling_grace_used` first never calls this twice, but a stray
+        second call would just recompute the same amount, not stack it.
         """
         peak = self._turn_cost.peak_context_tokens if self._turn_cost else 0
         self._spend_ceiling_grace_tokens = min(
-            max(_SPEND_CEILING_RESERVE, 2 * peak),
-            max(self._max_turn_tokens // 2, 1),
+            max(_SPEND_CEILING_GRACE_FLOOR, peak),
+            max(self._max_turn_tokens // 4, 1),
         )
         self._spend_ceiling_grace_used = True
+        if self._turn_cost is not None:
+            self._turn_cost.grace_tokens = self._spend_ceiling_grace_tokens
+        _record_grace(self._turn_cost, "ceiling")
 
     def _spend_ceiling_notice(self) -> str:
         """The SYSTEM injection for a ceiling stop.
@@ -3496,6 +3537,12 @@ class ChatSession:
         system = await self._build_system_prompt(user_msg_str)
         self._compacted_this_turn = False
         self._compaction_failed_this_turn = False
+        # Same reset turn_stream does — without it a grace granted in an
+        # earlier turn_stream call leaks into every later turn() call on
+        # this session, permanently widening its round cap / spend ceiling.
+        self._spend_ceiling_grace_used = False
+        self._spend_ceiling_grace_tokens = 0
+        self._round_cap_grace_used = False
 
         response = await self.plan_with_recovery(system=system, tools=tools)
 
@@ -3517,12 +3564,24 @@ class ChatSession:
         tool_round = 0
         error_streak: dict[str, int] = {}
         resilience_nudged: set[str] = set()
+        # Mirrors turn_stream's one-time grants, the same way the round-cap
+        # and spend-ceiling checks below already mirror it. This path has no
+        # continuation loop, so each grant is simply spent once for the
+        # whole call rather than once per continuation.
+        _round_cap_grace_active = False
 
         while response.tool_calls:
             tool_round += 1
-            if self._turn_cost is not None and tool_round <= self._max_tool_rounds:
+            if tool_round > self._max_tool_rounds and not self._round_cap_grace_used:
+                self._round_cap_grace_used = True
+                _round_cap_grace_active = True
+                _record_grace(self._turn_cost, "round")
+            effective_round_cap = self._max_tool_rounds + (
+                _ROUND_CAP_GRACE_ROUNDS if _round_cap_grace_active else 0
+            )
+            if self._turn_cost is not None and tool_round <= effective_round_cap:
                 self._turn_cost.rounds += 1
-            if tool_round > self._max_tool_rounds:
+            if tool_round > effective_round_cap:
                 # Mirror turn_stream's cap mark (#309 review) — this path is
                 # public API even without in-repo callers, and the books are
                 # wired here too.
@@ -3535,7 +3594,7 @@ class ChatSession:
                     {
                         "role": "user",
                         "content": (
-                            f"SYSTEM: You have used {self._max_tool_rounds} tool-call rounds on this turn. "
+                            f"SYSTEM: You have used {effective_round_cap} tool-call rounds on this turn. "
                             "Pause here. Summarize what you have accomplished so far and what remains. "
                             "If you believe you are on a good track and can finish the task with more steps, "
                             "tell the user and ask if they'd like you to continue. "
@@ -3558,22 +3617,28 @@ class ChatSession:
             # all, so this path is exactly where a tiny ceiling would break the
             # loop on round 1 having run nothing (#344 review).
             if self._spend_ceiling_stops_the_tool_loop():
-                if self._turn_cost is not None:
-                    self._turn_cost.ended_by = "spend_ceiling"
-                logger.info(
-                    "spend ceiling reached (turn): tokens=%d ceiling=%d "
-                    "tool_round=%d — pausing to ask the user",
-                    self._turn_cost.total_tokens if self._turn_cost else 0,
-                    self._max_turn_tokens, tool_round,
-                )
-                self._append_history(
-                    {"role": "assistant", "content": response.content or ""}
-                )
-                self._append_history(
-                    {"role": "user", "content": self._spend_ceiling_notice()}
-                )
-                response = await self.plan_with_recovery(system=system)
-                break
+                # One-time, unconditional extension, mirroring turn_stream's
+                # mid-loop grant — no verdict exists on this verifier-less
+                # path either, so the grant is unconditional here too.
+                if not self._spend_ceiling_grace_used:
+                    self._grant_spend_ceiling_grace()
+                if self._spend_ceiling_stops_the_tool_loop():
+                    if self._turn_cost is not None:
+                        self._turn_cost.ended_by = "spend_ceiling"
+                    logger.info(
+                        "spend ceiling reached (turn): tokens=%d ceiling=%d "
+                        "tool_round=%d — pausing to ask the user",
+                        self._turn_cost.total_tokens if self._turn_cost else 0,
+                        self._max_turn_tokens, tool_round,
+                    )
+                    self._append_history(
+                        {"role": "assistant", "content": response.content or ""}
+                    )
+                    self._append_history(
+                        {"role": "user", "content": self._spend_ceiling_notice()}
+                    )
+                    response = await self.plan_with_recovery(system=system)
+                    break
 
             # Build assistant message with content blocks
             assistant_content: list[dict] = []
@@ -4499,6 +4564,13 @@ class ChatSession:
             tool_round = 0
             error_streak: dict[str, int] = {}
             resilience_nudged: set[str] = set()
+            # Per-continuation, unlike `_round_cap_grace_used`: only the
+            # continuation that actually earns the grant (the first ever
+            # breach this turn) gets the wider cap. Without this,
+            # `_round_cap_grace_used` staying True for the rest of the turn
+            # let EVERY later continuation start pre-extended to M+3, turning
+            # a one-shot +3 into +3 per continuation.
+            _round_cap_grace_active = False
 
             while llm_response.tool_calls:
                 tool_round += 1
@@ -4509,8 +4581,10 @@ class ChatSession:
                 # the granted round is counted like any other.
                 if tool_round > self._max_tool_rounds and not self._round_cap_grace_used:
                     self._round_cap_grace_used = True
+                    _round_cap_grace_active = True
+                    _record_grace(self._turn_cost, "round")
                 effective_round_cap = self._max_tool_rounds + (
-                    _ROUND_CAP_GRACE_ROUNDS if self._round_cap_grace_used else 0
+                    _ROUND_CAP_GRACE_ROUNDS if _round_cap_grace_active else 0
                 )
                 # Accumulate, don't assign: `tool_round` is loop-local and
                 # resets to 0 on every verifier-forced continuation, so
@@ -4527,7 +4601,7 @@ class ChatSession:
                         self._turn_cost.ended_by = "round_cap"
                     self._acc_observe(
                         "cap_exhausted",
-                        {"cap": self._max_tool_rounds},
+                        {"cap": effective_round_cap, "configured_cap": self._max_tool_rounds},
                         severity=9,
                         round_idx=tool_round,
                     )

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -351,6 +351,17 @@ class _VerifierVerdict(BaseModel):
         )
     )
     reason: str = Field(description="One brief sentence explaining the verdict.")
+    close_to_done: bool = Field(
+        default=False,
+        description=(
+            "Only meaningful when status is INCOMPLETE: true if the "
+            "remaining work is small — roughly 1-3 more tool calls — with "
+            "nothing blocking or uncertain. False for anything that needs "
+            "substantially more work, or where you aren't sure. Defaults to "
+            "false, so an unsure model errs toward asking the user rather "
+            "than assuming it's almost done."
+        ),
+    )
 
 
 # Output budgets for the verdict call: first attempt, then the retry used when
@@ -437,6 +448,12 @@ _VERIFIER_LATCH_REPROBE_TURNS = 10
 # will cost, and ENG-1288 already tracks it. This floor only applies before any
 # call has reported usage.
 _SPEND_CEILING_RESERVE = 200_000
+
+# One-time round-cap extension (ENG-1893), granted the first time a turn
+# breaches max_tool_rounds. Sized to the "2-3 more tool calls" this exists
+# for — add a closing step, save, verify — not a way to talk past the cap
+# repeatedly: see the grant sites for the one-shot guard.
+_ROUND_CAP_GRACE_ROUNDS = 3
 
 # Appended to the verifier system prompt. Shortens the preamble on narrating
 # models but is not sufficient alone (0/3 at 256 with it), so it pairs with the
@@ -1039,6 +1056,13 @@ class ChatSession:
         # older settings object doesn't break — absent means "no ceiling",
         # matching the pre-ENG-1286 behaviour rather than silently applying one.
         self._max_turn_tokens = getattr(s, "max_turn_tokens", 0)
+        # One-time exception to the always-ask ceiling (ENG-1893): granted at
+        # most once per turn, and only when the verifier reports the
+        # remaining work as small. Reset per turn in turn_stream, not here —
+        # this is __init__ so a long CLI session gets it too.
+        self._spend_ceiling_grace_used = False
+        self._spend_ceiling_grace_tokens = 0
+        self._round_cap_grace_used = False
         # Tally of classified tool failures (ENG-1492). MEASUREMENT ONLY —
         # nothing reads this to change behaviour. The control that will
         # (ENG-1531) is deliberately unbuilt until this has reported real
@@ -2994,7 +3018,25 @@ class ChatSession:
             max(_SPEND_CEILING_RESERVE, 2 * peak),
             max(self._max_turn_tokens // 2, 1),
         )
-        return max(self._max_turn_tokens - reserve, 1)
+        return max(
+            self._max_turn_tokens + self._spend_ceiling_grace_tokens - reserve, 1
+        )
+
+    def _grant_spend_ceiling_grace(self) -> None:
+        """Raise the gate once this turn (ENG-1893), sized like one more call.
+
+        Reuses the reserve's own formula rather than a flat constant, for the
+        same reason the reserve does: a turn with a big context needs a bigger
+        exception to actually cover 1-3 more calls. Idempotent — a caller that
+        checks `_spend_ceiling_grace_used` first never calls this twice, but a
+        stray second call would just recompute the same amount, not stack it.
+        """
+        peak = self._turn_cost.peak_context_tokens if self._turn_cost else 0
+        self._spend_ceiling_grace_tokens = min(
+            max(_SPEND_CEILING_RESERVE, 2 * peak),
+            max(self._max_turn_tokens // 2, 1),
+        )
+        self._spend_ceiling_grace_used = True
 
     def _spend_ceiling_notice(self) -> str:
         """The SYSTEM injection for a ceiling stop.
@@ -4380,6 +4422,10 @@ class ChatSession:
         system = await self._build_system_prompt(user_message)
         self._compacted_this_turn = False
         self._compaction_failed_this_turn = False
+        # One-time cap grace (ENG-1893), reset per turn like the flags above.
+        self._spend_ceiling_grace_used = False
+        self._spend_ceiling_grace_tokens = 0
+        self._round_cap_grace_used = False
 
         response: StreamComplete | None = None
 
@@ -4456,15 +4502,26 @@ class ChatSession:
 
             while llm_response.tool_calls:
                 tool_round += 1
+                # One-time extension (ENG-1893), unconditional like the
+                # mid-loop spend-ceiling grace — no verdict exists yet at
+                # this point, so the grant is a single small window rather
+                # than a self-report. Decided before the accounting below so
+                # the granted round is counted like any other.
+                if tool_round > self._max_tool_rounds and not self._round_cap_grace_used:
+                    self._round_cap_grace_used = True
+                effective_round_cap = self._max_tool_rounds + (
+                    _ROUND_CAP_GRACE_ROUNDS if self._round_cap_grace_used else 0
+                )
                 # Accumulate, don't assign: `tool_round` is loop-local and
                 # resets to 0 on every verifier-forced continuation, so
                 # assigning reported only the last continuation's rounds —
                 # breaking the metric for exactly the expensive shape it
                 # exists to classify. Counted before the cap check so a
-                # capped turn reports the cap, not cap+1 (#309 review).
-                if self._turn_cost is not None and tool_round <= self._max_tool_rounds:
+                # capped turn reports the (possibly grace-extended) cap, not
+                # cap+1 (#309 review).
+                if self._turn_cost is not None and tool_round <= effective_round_cap:
                     self._turn_cost.rounds += 1
-                if tool_round > self._max_tool_rounds:
+                if tool_round > effective_round_cap:
                     _max_rounds_hit = True
                     if self._turn_cost is not None:
                         self._turn_cost.ended_by = "round_cap"
@@ -4481,7 +4538,7 @@ class ChatSession:
                         {
                             "role": "user",
                             "content": (
-                                f"SYSTEM: You have used {self._max_tool_rounds} tool-call rounds on this turn. "
+                                f"SYSTEM: You have used {effective_round_cap} tool-call rounds on this turn. "
                                 "Pause here. Summarize what you have accomplished so far and what remains. "
                                 "If you believe you are on a good track and can finish the task with more steps, "
                                 "tell the user and ask if they'd like you to continue. "
@@ -4510,36 +4567,46 @@ class ChatSession:
                 # round cap so a turn that breaches both still reports
                 # `round_cap`, leaving that path's behaviour untouched.
                 if self._spend_ceiling_stops_the_tool_loop():
-                    _spend_ceiling_hit = True
-                    if self._turn_cost is not None:
-                        self._turn_cost.ended_by = "spend_ceiling"
-                    logger.info(
-                        "spend ceiling reached: tokens=%d ceiling=%d gate=%d "
-                        "tool_round=%d continuation=%d — pausing to ask the user",
-                        self._turn_cost.total_tokens if self._turn_cost else 0,
-                        self._max_turn_tokens, self._spend_ceiling_gate(),
-                        tool_round, continuation,
-                    )
-                    self._append_history(
-                        {"role": "assistant", "content": llm_response.content or ""}
-                    )
-                    self._append_history(
-                        {"role": "user", "content": self._spend_ceiling_notice()}
-                    )
-                    # Same ENG-1155 capture the other four hand-back sites need:
-                    # the reply above is already in history, so without this the
-                    # post-loop fallback appends it again and the message the user
-                    # actually read is lost.
-                    _reply_persisted = True
-                    yield StreamTaskProgress(
-                        phase="analyzing",
-                        message="Reached this task's token budget — checking in with you...",
-                    )
-                    async for event in self._stream_handback_diagnosis(
-                        system=system, label="spend-ceiling"
-                    ):
-                        yield event
-                    break
+                    # One-time, unconditional extension (ENG-1893): no verdict
+                    # exists yet at this point in the loop — the model just
+                    # asked for more tools, it hasn't stopped to produce
+                    # anything judgeable — so grace here is a single small
+                    # window rather than a self-report. Whether it wraps up
+                    # inside that window is itself the evidence; if it
+                    # hasn't, the second trip below asks same as always.
+                    if not self._spend_ceiling_grace_used:
+                        self._grant_spend_ceiling_grace()
+                    if self._spend_ceiling_stops_the_tool_loop():
+                        _spend_ceiling_hit = True
+                        if self._turn_cost is not None:
+                            self._turn_cost.ended_by = "spend_ceiling"
+                        logger.info(
+                            "spend ceiling reached: tokens=%d ceiling=%d gate=%d "
+                            "tool_round=%d continuation=%d — pausing to ask the user",
+                            self._turn_cost.total_tokens if self._turn_cost else 0,
+                            self._max_turn_tokens, self._spend_ceiling_gate(),
+                            tool_round, continuation,
+                        )
+                        self._append_history(
+                            {"role": "assistant", "content": llm_response.content or ""}
+                        )
+                        self._append_history(
+                            {"role": "user", "content": self._spend_ceiling_notice()}
+                        )
+                        # Same ENG-1155 capture the other four hand-back sites need:
+                        # the reply above is already in history, so without this the
+                        # post-loop fallback appends it again and the message the user
+                        # actually read is lost.
+                        _reply_persisted = True
+                        yield StreamTaskProgress(
+                            phase="analyzing",
+                            message="Reached this task's token budget — checking in with you...",
+                        )
+                        async for event in self._stream_handback_diagnosis(
+                            system=system, label="spend-ceiling"
+                        ):
+                            yield event
+                        break
 
                 # Build assistant message with content blocks
                 assistant_content: list[dict] = []
@@ -5453,31 +5520,40 @@ class ChatSession:
             # reached and the turn would end `completed` with no hand-back at
             # all, however much it had spent (ENG-1286).
             if self._spend_ceiling_reached():
-                _spend_ceiling_hit = True
-                if self._turn_cost is not None:
-                    self._turn_cost.ended_by = "spend_ceiling"
-                logger.info(
-                    "spend ceiling reached at the continuation gate: tokens=%d "
-                    "ceiling=%d continuation=%d — pausing to ask the user",
-                    self._turn_cost.total_tokens if self._turn_cost else 0,
-                    self._max_turn_tokens, continuation,
-                )
-                self._append_history(
-                    {"role": "user", "content": self._spend_ceiling_notice()}
-                )
-                # `_reply_persisted` is already True here — the verification block
-                # appends the assistant reply before requesting a verdict — so the
-                # post-loop fallback is already suppressed and only the diagnosis
-                # needs capturing.
-                yield StreamTaskProgress(
-                    phase="analyzing",
-                    message="Reached this task's token budget — checking in with you...",
-                )
-                async for event in self._stream_handback_diagnosis(
-                    system=system, label="spend-ceiling"
-                ):
-                    yield event
-                break
+                # One-time exception (ENG-1893): the verifier we just ran
+                # already judged this INCOMPLETE, and it also said the
+                # remaining work is small — take that at its word once per
+                # turn and keep going instead of asking. A verdict that
+                # isn't confident (the default) falls straight through to
+                # the ask below, unchanged from before this existed.
+                if verdict.close_to_done and not self._spend_ceiling_grace_used:
+                    self._grant_spend_ceiling_grace()
+                if self._spend_ceiling_reached():
+                    _spend_ceiling_hit = True
+                    if self._turn_cost is not None:
+                        self._turn_cost.ended_by = "spend_ceiling"
+                    logger.info(
+                        "spend ceiling reached at the continuation gate: tokens=%d "
+                        "ceiling=%d continuation=%d — pausing to ask the user",
+                        self._turn_cost.total_tokens if self._turn_cost else 0,
+                        self._max_turn_tokens, continuation,
+                    )
+                    self._append_history(
+                        {"role": "user", "content": self._spend_ceiling_notice()}
+                    )
+                    # `_reply_persisted` is already True here — the verification block
+                    # appends the assistant reply before requesting a verdict — so the
+                    # post-loop fallback is already suppressed and only the diagnosis
+                    # needs capturing.
+                    yield StreamTaskProgress(
+                        phase="analyzing",
+                        message="Reached this task's token budget — checking in with you...",
+                    )
+                    async for event in self._stream_handback_diagnosis(
+                        system=system, label="spend-ceiling"
+                    ):
+                        yield event
+                    break
 
             continuation += 1
             if self._turn_cost is not None:

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -127,7 +127,8 @@ class TurnCost:
     # their ended_by already distinguishes them.
     verification_skipped: bool = False
     # One-time grace(s) granted this turn: "", "round", "ceiling", or
-    # "round,ceiling". Without this a turn that used a grace and finished is
+    # "ceiling,round" — alphabetical, not firing order (see `_record_grace`).
+    # Without this a turn that used a grace and finished is
     # byte-identical in `turn_completed` to one that never neared a limit —
     # `ended_by=round_cap`/`spend_ceiling` counts drop while actual spend
     # rises, unmeasurably.

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -124,6 +124,15 @@ class TurnCost:
     # note below on stamped-at-open fields). Handback terminals don't need it:
     # their ended_by already distinguishes them.
     verification_skipped: bool = False
+    # One-time grace(s) granted this turn: "", "round", "ceiling", or
+    # "round,ceiling". Without this a turn that used a grace and finished is
+    # byte-identical in `turn_completed` to one that never neared a limit —
+    # `ended_by=round_cap`/`spend_ceiling` counts drop while actual spend
+    # rises, unmeasurably.
+    grace_granted: str = ""
+    # Size of the spend-ceiling grace actually granted, 0 if none. Queryable
+    # alongside `grace_granted` so the size of the concession is visible.
+    grace_tokens: int = 0
     started_monotonic: float = field(default_factory=time.monotonic)
     # Set when these books have been reported. Replaces "the shared slot is
     # None" as the double-emit guard, because a late finalizer now emits the

--- a/tests/e2e/scenarios/test_circuit_breaker_evasion.py
+++ b/tests/e2e/scenarios/test_circuit_breaker_evasion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import pytest
 
+from anton.core.session import _ROUND_CAP_GRACE_ROUNDS
 from tests.e2e.harness import (
     assert_exit_ok, assert_not_output, assert_output, base_env, run_anton,
 )
@@ -12,16 +13,24 @@ from tests.e2e.harness import (
 
 _BAD_CODE = "def broken(:\n    pass\n"
 _GOOD_CODE = "print('ok')\n"
+_MAX_TOOL_ROUNDS = 25
+_EFFECTIVE_CAP = _MAX_TOOL_ROUNDS + _ROUND_CAP_GRACE_ROUNDS  # ENG-1893 grace
 
 
 @pytest.mark.stub_only
 def test_alternating_errors_evade_circuit_breaker(cfg, stub, tmp_path):
     """Alternating error/success keeps streak <=1 — MAX_TOOL_ROUNDS is the only backstop."""
-    # _MAX_TOOL_ROUNDS = 25; backstop fires at round 26 (> 25).
-    # 13 bad+good pairs = 26 tool-call slots, keeping the error streak at ≤1 per tool.
-    for i in range(13):
+    # Backstop fires at effective_cap + 1 (the one-time grace extension counts
+    # too, see _EFFECTIVE_CAP) — exactly that many tool-call slots, or the
+    # extra queued response gets consumed by the hand-back diagnosis call
+    # instead of the text reply below. Pairs keep the error streak at ≤1 per
+    # tool; a trailing odd slot rounds up to effective_cap + 1.
+    pairs, odd_one = divmod(_EFFECTIVE_CAP + 1, 2)
+    for i in range(pairs):
         stub.queue_tool_call("scratchpad", {"action": "exec", "name": f"bad_{i}", "code": _BAD_CODE})
         stub.queue_tool_call("scratchpad", {"action": "exec", "name": f"good_{i}", "code": _GOOD_CODE})
+    if odd_one:
+        stub.queue_tool_call("scratchpad", {"action": "exec", "name": f"bad_{pairs}", "code": _BAD_CODE})
     stub.queue_text("Max rounds hit. ROUNDS_EXHAUSTED")
     result = run_anton(["--folder", str(tmp_path)], ["keep trying", "exit"],
                        env=base_env(stub), timeout=cfg.timeout(60))
@@ -31,7 +40,7 @@ def test_alternating_errors_evade_circuit_breaker(cfg, stub, tmp_path):
     assert_output(result, "ROUNDS_EXHAUSTED")
 
     all_messages = json.dumps([r.get("messages", []) for r in stub.requests])
-    assert "You have used 25 tool-call rounds" in all_messages, \
+    assert f"You have used {_EFFECTIVE_CAP} tool-call rounds" in all_messages, \
         f"Max-rounds message not found. Request count: {stub.request_count}"
     assert "has failed 5 times in a row" not in all_messages, \
         "Circuit breaker fired unexpectedly"

--- a/tests/e2e/scenarios/test_loop_safety.py
+++ b/tests/e2e/scenarios/test_loop_safety.py
@@ -5,15 +5,22 @@ from __future__ import annotations
 import json
 import pytest
 
+from anton.core.session import _ROUND_CAP_GRACE_ROUNDS
 from tests.e2e.harness import (
     assert_exit_ok, assert_not_output, assert_output, base_env, run_anton,
 )
 
 
+_MAX_TOOL_ROUNDS = 25
+_EFFECTIVE_CAP = _MAX_TOOL_ROUNDS + _ROUND_CAP_GRACE_ROUNDS  # ENG-1893 grace
+
+
 @pytest.mark.stub_only
 def test_max_tool_rounds_circuit_breaker_fires(cfg, stub, tmp_path):
-    # _MAX_TOOL_ROUNDS = 25; backstop fires at round 26 (> 25) — need 26 queued tool calls.
-    for i in range(26):
+    # Backstop fires at effective_cap + 1 — the one-time grace extension
+    # (ENG-1893) runs first, so it takes effective_cap + 1 queued tool calls
+    # to actually reach the ask.
+    for i in range(_EFFECTIVE_CAP + 1):
         stub.queue_tool_call("scratchpad", {"action": "exec", "name": f"loop_{i}", "code": f"print({i})"})
     stub.queue_text("Summarising. CIRCUIT_FIRED")
     result = run_anton(["--folder", str(tmp_path)], ["run forever", "exit"],
@@ -23,7 +30,7 @@ def test_max_tool_rounds_circuit_breaker_fires(cfg, stub, tmp_path):
     assert_not_output(result, "Traceback (most recent call last)")
     assert_output(result, "CIRCUIT_FIRED")
     assert any(
-        "You have used 25 tool-call rounds" in json.dumps(r.get("messages", []))
+        f"You have used {_EFFECTIVE_CAP} tool-call rounds" in json.dumps(r.get("messages", []))
         for r in stub.requests
     ), f"Max-rounds message not found. Request count: {stub.request_count}"
 

--- a/tests/test_round_cap_grace.py
+++ b/tests/test_round_cap_grace.py
@@ -1,0 +1,135 @@
+"""Round-cap grace (ENG-1893).
+
+Exercises `max_tool_rounds`'s "always ask" hand-back in isolation: `per_call`
+usage is kept tiny relative to the default 1.25M `max_turn_tokens` so the
+spend ceiling never interferes, and `max_tool_rounds` is set directly on the
+session (not through settings) so these stay cheap to script.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_mock_llm
+
+from anton.core.llm.provider import LLMResponse, StreamComplete, ToolCall, Usage
+from anton.core.session import ChatSession, ChatSessionConfig, _ROUND_CAP_GRACE_ROUNDS
+
+
+@pytest.fixture()
+def workspace():
+    base = Path(__file__).resolve().parents[1] / ".pytest-workspace"
+    base.mkdir(parents=True, exist_ok=True)
+    return MagicMock(base=base)
+
+
+def _usage(n: int = 1_000) -> Usage:
+    q = n // 4
+    return Usage(
+        input_tokens=q, output_tokens=q,
+        cache_read_tokens=q, cache_creation_tokens=n - 3 * q,
+    )
+
+
+def _tool_call(i: int = 1) -> LLMResponse:
+    return LLMResponse(
+        content="working",
+        tool_calls=[ToolCall(id=f"tc_{i}", name="scratchpad",
+                             input={"action": "view", "name": "main"})],
+        usage=_usage(), stop_reason="tool_use",
+    )
+
+
+def _text(text: str = "done") -> LLMResponse:
+    return LLMResponse(content=text, tool_calls=[], usage=_usage(), stop_reason="end_turn")
+
+
+def _session(workspace, *, max_tool_rounds: int, responses=None) -> ChatSession:
+    """Session whose LLM emits `responses` in order, falling back to a text
+    reply once the script runs out — a test that fails to trip the cap
+    terminates instead of looping.
+    """
+    mock_llm = make_mock_llm()
+    script = list(responses or [])
+
+    def _plan_stream(**kwargs):
+        async def _gen():
+            resp = script.pop(0) if script else _text()
+            if mock_llm.usage_listener is not None:
+                mock_llm.usage_listener("planning", "test-model", _usage())
+            yield StreamComplete(response=resp)
+        return _gen()
+
+    async def _plan(**kwargs):
+        resp = script.pop(0) if script else _text()
+        if mock_llm.usage_listener is not None:
+            mock_llm.usage_listener("planning", "test-model", _usage())
+        return resp
+
+    mock_llm.usage_listener = None
+    mock_llm.plan_stream = _plan_stream
+    mock_llm.plan = _plan
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session._max_tool_rounds = max_tool_rounds
+    from anton.core.tools.registry import ToolOutcome
+    session.tool_registry.dispatch_tool = AsyncMock(
+        return_value=ToolOutcome(content="stubbed tool result", ok=True)
+    )
+    return session
+
+
+def _history_text(session) -> str:
+    out = []
+    for m in session._history:
+        c = m.get("content")
+        if isinstance(c, str):
+            out.append(c)
+    return "\n".join(out)
+
+
+async def _run(session, prompt="do the thing"):
+    async for _ in session.turn_stream(prompt):
+        pass
+
+
+async def test_round_cap_grants_one_time_grace_then_stops(workspace):
+    """The first breach is silent; running through the whole grace window
+    still asks, same as today past that point."""
+    max_rounds = 5
+    session = _session(
+        workspace, max_tool_rounds=max_rounds,
+        responses=[_tool_call(i) for i in range(1, max_rounds + _ROUND_CAP_GRACE_ROUNDS + 3)],
+    )
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    assert send.call_args.kwargs["ended_by"] == "round_cap"
+    assert session._round_cap_grace_used
+    assert int(send.call_args.kwargs["rounds"]) == max_rounds + _ROUND_CAP_GRACE_ROUNDS
+
+
+async def test_round_cap_grace_lets_a_near_finish_wrap_up_without_asking(workspace):
+    """A task that actually finishes inside the grace window never asks at all."""
+    max_rounds = 5
+    session = _session(
+        workspace, max_tool_rounds=max_rounds,
+        responses=[_tool_call(i) for i in range(1, max_rounds + _ROUND_CAP_GRACE_ROUNDS + 1)]
+        + [_text("done")],
+    )
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    assert send.call_args.kwargs["ended_by"] != "round_cap"
+    text = _history_text(session)
+    assert "ask if they'd like you to continue" not in text
+
+
+async def test_round_under_the_cap_is_untouched(workspace):
+    """No behaviour change for a turn that never reaches the cap."""
+    session = _session(workspace, max_tool_rounds=5,
+                       responses=[_tool_call(1), _text("done")])
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    assert send.call_args.kwargs["ended_by"] == "completed"
+    assert not session._round_cap_grace_used

--- a/tests/test_round_cap_grace.py
+++ b/tests/test_round_cap_grace.py
@@ -16,7 +16,12 @@ import pytest
 from tests.conftest import make_mock_llm
 
 from anton.core.llm.provider import LLMResponse, StreamComplete, ToolCall, Usage
-from anton.core.session import ChatSession, ChatSessionConfig, _ROUND_CAP_GRACE_ROUNDS
+from anton.core.session import (
+    ChatSession,
+    ChatSessionConfig,
+    _ROUND_CAP_GRACE_ROUNDS,
+    _VerifierVerdict,
+)
 
 
 @pytest.fixture()
@@ -137,9 +142,14 @@ async def test_round_cap_grace_lets_a_near_finish_wrap_up_without_asking(workspa
         responses=[_tool_call(i) for i in range(1, max_rounds + _ROUND_CAP_GRACE_ROUNDS + 1)]
         + [_text("done")],
     )
+    # A finished turn reaches the completion verifier; give it a real verdict
+    # instead of an unconfigured MagicMock, which the INCOMPLETE branch treats
+    # as neither COMPLETE/WAITING/STUCK and force-continues on regardless.
+    verdict = _VerifierVerdict(status="COMPLETE", reason="done", close_to_done=False)
+    session._llm.generate_object_code = AsyncMock(return_value=verdict)
     with patch("anton.analytics.send_event") as send:
         await _run(session)
-    assert send.call_args.kwargs["ended_by"] != "round_cap"
+    assert send.call_args.kwargs["ended_by"] == "completed"
     text = _history_text(session)
     assert "ask if they'd like you to continue" not in text
 
@@ -148,10 +158,137 @@ async def test_round_under_the_cap_is_untouched(workspace):
     """No behaviour change for a turn that never reaches the cap."""
     session = _session(workspace, max_tool_rounds=5,
                        responses=[_tool_call(1), _text("done")])
+    verdict = _VerifierVerdict(status="COMPLETE", reason="done", close_to_done=False)
+    session._llm.generate_object_code = AsyncMock(return_value=verdict)
     with patch("anton.analytics.send_event") as send:
         await _run(session)
     assert send.call_args.kwargs["ended_by"] == "completed"
     assert not session._round_cap_grace_used
+
+
+async def test_a_zero_cap_denies_the_first_round_instead_of_granting_one(workspace):
+    """`max_tool_rounds=0` means "no tool rounds", not "one free grace round".
+
+    The grant condition used to fire on the very first round whenever the cap
+    was non-positive (`1 > 0` is true the moment anyone breaches nothing),
+    silently handing out `_ROUND_CAP_GRACE_ROUNDS` the operator explicitly
+    tried to disallow.
+    """
+    session = _session(workspace, max_tool_rounds=0, responses=[_tool_call(1)])
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    kwargs = send.call_args.kwargs
+    assert kwargs["ended_by"] == "round_cap"
+    assert kwargs["rounds"] == "0"
+    assert not session._round_cap_grace_used
+    assert kwargs["grace_granted"] == ""
+
+
+async def test_both_graces_can_fire_in_the_same_turn(workspace):
+    """The round-cap and spend-ceiling graces are independent one-shot flags;
+    nothing stops both firing in one turn, and `grace_granted` must report
+    both — alphabetically, not firing order (see `_record_grace`).
+
+    Needs a real per-call token cost to trip the ceiling, which `_session`'s
+    `usage_listener` stub ignores (always reports the fixed default `_usage()`
+    regardless of the scripted response) — so this builds its own session
+    rather than growing that shared helper's surface for one test.
+    """
+    per_call = 50_000
+    mock_llm = make_mock_llm()
+    script = [
+        LLMResponse(
+            content="working",
+            tool_calls=[ToolCall(id=f"tc_{i}", name="scratchpad",
+                                 input={"action": "view", "name": "main"})],
+            usage=_usage(per_call), stop_reason="tool_use",
+        ) for i in range(1, 16)
+    ]
+
+    def _plan_stream(**kwargs):
+        async def _gen():
+            resp = script.pop(0) if script else _text()
+            if mock_llm.usage_listener is not None:
+                mock_llm.usage_listener("planning", "test-model", _usage(per_call))
+            yield StreamComplete(response=resp)
+        return _gen()
+
+    mock_llm.usage_listener = None
+    mock_llm.plan_stream = _plan_stream
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session._max_tool_rounds = 3
+    session._max_turn_tokens = 300_000
+    from anton.core.tools.registry import ToolOutcome
+    session.tool_registry.dispatch_tool = AsyncMock(
+        return_value=ToolOutcome(content="stubbed tool result", ok=True)
+    )
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    kwargs = send.call_args.kwargs
+    assert kwargs["grace_granted"] == "ceiling,round"
+    assert session._round_cap_grace_used
+    assert session._spend_ceiling_grace_used
+
+
+def _session_with_faults(workspace, *, max_tool_rounds: int, script) -> ChatSession:
+    """Like `_session`, but a `script` item may be an `Exception`: raised when
+    that call's `plan_stream` is iterated, so it can model a mid-loop provider
+    blip that triggers `_turn_stream_inner`'s auto-retry.
+    """
+    mock_llm = make_mock_llm()
+    calls = list(script)
+
+    def _plan_stream(**kwargs):
+        async def _gen():
+            item = calls.pop(0) if calls else _text()
+            if isinstance(item, Exception):
+                raise item
+            if mock_llm.usage_listener is not None:
+                mock_llm.usage_listener("planning", "test-model", _usage())
+            yield StreamComplete(response=item)
+        return _gen()
+
+    mock_llm.usage_listener = None
+    mock_llm.plan_stream = _plan_stream
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    session._max_tool_rounds = max_tool_rounds
+    from anton.core.tools.registry import ToolOutcome
+    session.tool_registry.dispatch_tool = AsyncMock(
+        return_value=ToolOutcome(content="stubbed tool result", ok=True)
+    )
+    return session
+
+
+async def test_round_cap_grace_survives_a_mid_loop_retry(workspace):
+    """A retryable provider blip after the grace already fired must not
+    re-arm it — `_stream_and_handle_tools` used to reset the one-shot flags
+    on every entry, including the auto-retry's `continue`, so a blip landing
+    inside the grace window bought a second +3 window for free.
+
+    Round 6 breaches M=5 and earns the one grace (effective cap 8); round 7's
+    call raises instead of answering, triggering the count-based auto-retry.
+    The retry's fresh loop breaches the (un-graced) cap again at round 6 —
+    with the flag correctly staying spent, that second breach gets no bonus
+    and ends the turn at the bare cap.
+    """
+    max_rounds = 5
+    session = _session_with_faults(
+        workspace, max_tool_rounds=max_rounds,
+        script=(
+            [_tool_call(i) for i in range(1, 7)]  # rounds 1-6 of the first call
+            + [RuntimeError("provider blip")]  # round 7 errors, triggers retry
+            + [_tool_call(i) for i in range(1, 11)]  # the retried call
+        ),
+    )
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    kwargs = send.call_args.kwargs
+    assert kwargs["ended_by"] == "round_cap"
+    # One grant total: 6 (first call — breaches and grants, then errors before
+    # using the rest of the window) + 5 (retry, capped at the bare 5 with no
+    # second grant) = 11. A re-armed grace would instead let the retry run
+    # its own +3 window before capping, for 14 or more.
+    assert int(kwargs["rounds"]) == (max_rounds + 1) + max_rounds
 
 
 async def test_round_cap_grace_does_not_multiply_across_continuations(workspace):
@@ -171,8 +308,6 @@ async def test_round_cap_grace_does_not_multiply_across_continuations(workspace)
     same as it would with no grace at all. That bounds the turn at
     2M + grace, not `max_continuations * (M + grace)`.
     """
-    from anton.core.session import _ROUND_CAP_GRACE_ROUNDS, _VerifierVerdict
-
     max_rounds = 5
     per_continuation = max_rounds + 1  # exceeds M, comfortably inside M + grace
     session = _session(

--- a/tests/test_round_cap_grace.py
+++ b/tests/test_round_cap_grace.py
@@ -110,6 +110,25 @@ async def test_round_cap_grants_one_time_grace_then_stops(workspace):
     assert int(send.call_args.kwargs["rounds"]) == max_rounds + _ROUND_CAP_GRACE_ROUNDS
 
 
+async def test_round_cap_grace_also_applies_to_the_non_streaming_turn(workspace):
+    """`turn()` mirrors turn_stream's grace, like it already mirrors the
+    plain round cap and spend ceiling.
+
+    Public API with no in-tree caller, but its cost books are wired, so an
+    unmirrored grace here would under-report every host that uses it.
+    """
+    max_rounds = 5
+    session = _session(
+        workspace, max_tool_rounds=max_rounds,
+        responses=[_tool_call(i) for i in range(1, max_rounds + _ROUND_CAP_GRACE_ROUNDS + 3)],
+    )
+    with patch("anton.analytics.send_event") as send:
+        await session.turn("do the thing")
+    assert send.call_args.kwargs["ended_by"] == "round_cap"
+    assert session._round_cap_grace_used
+    assert int(send.call_args.kwargs["rounds"]) == max_rounds + _ROUND_CAP_GRACE_ROUNDS
+
+
 async def test_round_cap_grace_lets_a_near_finish_wrap_up_without_asking(workspace):
     """A task that actually finishes inside the grace window never asks at all."""
     max_rounds = 5
@@ -133,3 +152,44 @@ async def test_round_under_the_cap_is_untouched(workspace):
         await _run(session)
     assert send.call_args.kwargs["ended_by"] == "completed"
     assert not session._round_cap_grace_used
+
+
+async def test_round_cap_grace_does_not_multiply_across_continuations(workspace):
+    """A one-shot grace must not become the ambient cap for every continuation.
+
+    `_round_cap_grace_used` used to gate the effective cap directly, so once
+    ANY continuation exceeded the base cap it stayed extended to M+3 for the
+    rest of the turn — every later continuation got the +3 window for free.
+    Here every continuation's
+    scripted work (6 tool calls) exceeds M=5, so before the fix none of them
+    ever actually hit the cap and the turn ran all 3 continuations to
+    completion (24 rounds, ended_by=handback_budget).
+
+    With the grant gated on a per-continuation `_round_cap_grace_active`
+    flag, only the FIRST continuation to breach gets the wider cap; the next
+    continuation that also breaches ends the turn outright at the base cap,
+    same as it would with no grace at all. That bounds the turn at
+    2M + grace, not `max_continuations * (M + grace)`.
+    """
+    from anton.core.session import _ROUND_CAP_GRACE_ROUNDS, _VerifierVerdict
+
+    max_rounds = 5
+    per_continuation = max_rounds + 1  # exceeds M, comfortably inside M + grace
+    session = _session(
+        workspace, max_tool_rounds=max_rounds,
+        responses=(
+            [_tool_call(i) for i in range(1, per_continuation + 1)] + [_text("partial")]
+        )
+        * 3,
+    )
+    verdict = _VerifierVerdict(status="INCOMPLETE", reason="not done", close_to_done=False)
+    session._llm.generate_object_code = AsyncMock(return_value=verdict)
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    kwargs = send.call_args.kwargs
+    assert kwargs["ended_by"] == "round_cap"
+    assert int(kwargs["continuations"]) <= 1, (
+        "the grace must not let a second continuation also breach for free"
+    )
+    assert int(kwargs["rounds"]) <= 2 * max_rounds + _ROUND_CAP_GRACE_ROUNDS
+    assert session._round_cap_grace_used

--- a/tests/test_spend_ceiling.py
+++ b/tests/test_spend_ceiling.py
@@ -136,7 +136,8 @@ async def test_ceiling_stops_the_turn_and_marks_the_exit(workspace):
 
 
 async def test_total_is_bounded_by_the_ceiling(workspace):
-    """The turn's spend lands at the ceiling, give or take two output budgets.
+    """The turn's spend lands at the ceiling, give or take two output budgets
+    and one grace allotment.
 
     The reserve is what makes this hold at all: the hand-back diagnosis is
     itself an LLM call, so gating AT the ceiling would overshoot by that call.
@@ -148,13 +149,21 @@ async def test_total_is_bounded_by_the_ceiling(workspace):
     Asserting `<= CEILING` exactly passed only because the old fixture happened
     to land on 1,000,000 with zero margin; it reddened as soon as `per_call`
     moved. State the real bound instead of a knife-edge one.
+
+    The grace term is new (ENG-1893): this run's all-tool-calls shape trips
+    the mid-loop gate, and the first trip buys one silent extension sized like
+    the reserve itself (see `_grant_spend_ceiling_grace`) before the turn
+    actually stops.
     """
     session = _session(workspace, responses=[_tool_call(i) for i in range(1, 40)])
     with patch("anton.analytics.send_event") as send:
         await _run(session)
     slack = 2 * (PER_CALL // 4)  # `_usage` puts a quarter of each call in output
     # Analytics properties go over the wire as strings.
-    assert int(send.call_args.kwargs["tokens_total"]) <= CEILING + slack
+    assert (
+        int(send.call_args.kwargs["tokens_total"])
+        <= CEILING + slack + _SPEND_CEILING_RESERVE
+    )
 
 
 async def test_trips_inside_one_tool_loop_with_no_continuation(workspace):
@@ -391,6 +400,109 @@ async def test_ceiling_trips_at_the_continuation_gate(workspace):
     with patch("anton.analytics.send_event") as send:
         await _run(session)
     assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
+
+
+# ── Judgment-gated grace at the ceiling (ENG-1893) ──────────────────────────
+#
+# The ceiling above is a deliberate "always ask" design (see
+# test_handback_asks_the_user_and_is_persisted_as_streamed). But the verifier
+# that runs right before this gate already carries a signal about how much
+# work is left — `close_to_done` — and today that signal is thrown away: the
+# ask fires the same whether the task is one tool call from finished or
+# nowhere close. These tests pin a small, one-time exception: a verdict that
+# says the remaining work is small lets the turn keep going seamlessly
+# instead of stopping to ask, exactly once per turn.
+
+
+async def test_close_to_done_verdict_skips_the_ask_and_keeps_going(workspace):
+    """An INCOMPLETE verdict with close_to_done=True continues past the gate.
+
+    Same shape as test_ceiling_trips_at_the_continuation_gate — one tool
+    round, then a text reply that trips the gate on the first verifier call —
+    but this verdict reports the remaining work as small.
+    """
+    from anton.core.session import _VerifierVerdict
+
+    session = _session(workspace, per_call=300_000,
+                       responses=[_tool_call(1), _text("partial")])
+    verdict = _VerifierVerdict(status="INCOMPLETE", reason="almost there",
+                               close_to_done=True)
+    generate = AsyncMock(return_value=verdict)
+    session._llm.generate_object_code = generate
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    assert send.call_args.kwargs["ended_by"] != "spend_ceiling"
+    assert generate.call_count == 1, "grace must not re-verify — one call, one decision"
+    text = _history_text(session)
+    assert "ask if they'd like you to continue" not in text
+
+
+async def test_close_to_done_grace_is_granted_only_once_per_turn(workspace):
+    """A second ceiling breach in the same turn asks, even if close_to_done again.
+
+    Grace is a one-time exception, not a standing invitation to talk past the
+    ceiling — otherwise a model that always claims "almost done" would never
+    actually stop.
+    """
+    from anton.core.session import _VerifierVerdict
+
+    session = _session(workspace, per_call=300_000,
+                       responses=[_tool_call(1), _text("partial"),
+                                  _tool_call(2), _text("still going")])
+    verdict = _VerifierVerdict(status="INCOMPLETE", reason="almost there",
+                               close_to_done=True)
+    session._llm.generate_object_code = AsyncMock(return_value=verdict)
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
+
+
+# ── Mid-loop grace (ENG-1893) ────────────────────────────────────────────────
+#
+# Inside the tool loop there is no verdict to read close_to_done off — the
+# model hasn't stopped to produce a judgeable reply, it just asked for more
+# tools. So this grace is unconditional rather than judgment-gated: the first
+# trip buys one small, one-time extension; whatever happens in that window is
+# itself the evidence. If the loop is still going after it, that is grounds
+# enough to ask — no self-report needed either way.
+
+
+def test_mid_loop_grace_raises_the_gate_once(workspace):
+    """`_grant_spend_ceiling_grace` lifts the gate; spending through the grace
+    trips it again — the bump is not renewed."""
+    from anton.core.turn_cost import TurnCost
+
+    session = _session(workspace)
+    session._turn_cost = TurnCost()
+    session._turn_cost.rounds = 5  # > 1, so the never-zero-tools guard is moot here
+    # peak_context_tokens is 0 here, so both the reserve and the grace land on
+    # the flat _SPEND_CEILING_RESERVE floor — the gate before grace is exactly
+    # CEILING - reserve, and after grace it is back at CEILING.
+    session._turn_cost.input_tokens = CEILING - _SPEND_CEILING_RESERVE
+    assert session._spend_ceiling_stops_the_tool_loop()
+    session._grant_spend_ceiling_grace()
+    assert not session._spend_ceiling_stops_the_tool_loop()
+    session._turn_cost.input_tokens = CEILING
+    assert session._spend_ceiling_stops_the_tool_loop(), (
+        "the one-time bump must not renew itself on a second trip"
+    )
+
+
+async def test_mid_loop_ceiling_grants_grace_once_then_stops(workspace):
+    """A long, all-tool-calls run gets one silent extension before it asks.
+
+    Mirrors test_trips_inside_one_tool_loop_with_no_continuation's shape
+    (consecutive tool calls, no continuation involved) with more responses
+    scripted, so the run survives the first, now-silent trip and reaches a
+    second one that still asks.
+    """
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 60)])
+    with patch("anton.analytics.send_event") as send:
+        await _run(session)
+    kwargs = send.call_args.kwargs
+    assert kwargs["ended_by"] == "spend_ceiling"
+    assert session._spend_ceiling_grace_used
+    assert int(kwargs["continuations"]) == 0, "still trips inside one tool loop"
 
 
 @pytest.mark.parametrize("ceiling", [CEILING, 100_000, 1])

--- a/tests/test_spend_ceiling.py
+++ b/tests/test_spend_ceiling.py
@@ -25,7 +25,12 @@ from anton.core.llm.provider import (
     ToolCall,
     Usage,
 )
-from anton.core.session import ChatSession, ChatSessionConfig, _SPEND_CEILING_RESERVE
+from anton.core.session import (
+    ChatSession,
+    ChatSessionConfig,
+    _SPEND_CEILING_GRACE_FLOOR,
+    _SPEND_CEILING_RESERVE,
+)
 
 CEILING = 1_000_000
 # Sized so the trip needs SEVERAL rounds. The first version used 500_000, which
@@ -135,7 +140,8 @@ async def test_ceiling_stops_the_turn_and_marks_the_exit(workspace):
     assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
 
 
-async def test_total_is_bounded_by_the_ceiling(workspace):
+@pytest.mark.parametrize("per_call", [PER_CALL, 300_000])
+async def test_total_is_bounded_by_the_ceiling(workspace, per_call):
     """The turn's spend lands at the ceiling, give or take two output budgets
     and one grace allotment.
 
@@ -150,19 +156,24 @@ async def test_total_is_bounded_by_the_ceiling(workspace):
     to land on 1,000,000 with zero margin; it reddened as soon as `per_call`
     moved. State the real bound instead of a knife-edge one.
 
-    The grace term is new (ENG-1893): this run's all-tool-calls shape trips
-    the mid-loop gate, and the first trip buys one silent extension sized like
-    the reserve itself (see `_grant_spend_ceiling_grace`) before the turn
-    actually stops.
+    The grace term is new: this run's all-tool-calls shape trips the mid-loop
+    gate, and the first trip buys one silent extension before the turn
+    actually stops. Computed from the real `_grant_spend_ceiling_grace`
+    formula, not a flat constant — a flat `_SPEND_CEILING_RESERVE` slack only
+    held at this fixture's small `per_call`; parametrised over a second,
+    bigger `per_call` so the peak-scaled branch of the formula is pinned too.
     """
-    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 40)])
+    session = _session(workspace, responses=[_tool_call(i) for i in range(1, 40)],
+                       per_call=per_call)
     with patch("anton.analytics.send_event") as send:
         await _run(session)
-    slack = 2 * (PER_CALL // 4)  # `_usage` puts a quarter of each call in output
+    slack = 2 * (per_call // 4)  # `_usage` puts a quarter of each call in output
+    peak = per_call - (per_call // 4)  # `_usage`'s context share of one call
+    grace = min(max(_SPEND_CEILING_GRACE_FLOOR, peak), CEILING // 4)
     # Analytics properties go over the wire as strings.
     assert (
         int(send.call_args.kwargs["tokens_total"])
-        <= CEILING + slack + _SPEND_CEILING_RESERVE
+        <= CEILING + slack + grace
     )
 
 
@@ -420,10 +431,16 @@ async def test_close_to_done_verdict_skips_the_ask_and_keeps_going(workspace):
     Same shape as test_ceiling_trips_at_the_continuation_gate — one tool
     round, then a text reply that trips the gate on the first verifier call —
     but this verdict reports the remaining work as small.
+
+    `per_call=240_000`, not 300_000: the text reply triggers a truncation
+    retry, so 3 calls land before this gate check. That total must clear the
+    pre-grace gate but stay under the smaller post-grace one now that the
+    grace is sized off 1x peak, not 2x — 300_000 no longer leaves enough
+    room after the resize.
     """
     from anton.core.session import _VerifierVerdict
 
-    session = _session(workspace, per_call=300_000,
+    session = _session(workspace, per_call=240_000,
                        responses=[_tool_call(1), _text("partial")])
     verdict = _VerifierVerdict(status="INCOMPLETE", reason="almost there",
                                close_to_done=True)
@@ -475,9 +492,11 @@ def test_mid_loop_grace_raises_the_gate_once(workspace):
     session = _session(workspace)
     session._turn_cost = TurnCost()
     session._turn_cost.rounds = 5  # > 1, so the never-zero-tools guard is moot here
-    # peak_context_tokens is 0 here, so both the reserve and the grace land on
-    # the flat _SPEND_CEILING_RESERVE floor — the gate before grace is exactly
-    # CEILING - reserve, and after grace it is back at CEILING.
+    # peak_context_tokens is 0 here, so both floors apply: the reserve lands on
+    # _SPEND_CEILING_RESERVE and the (deliberately smaller) grace lands on
+    # _SPEND_CEILING_GRACE_FLOOR — the gate before grace is exactly
+    # CEILING - reserve, and after grace it is CEILING - reserve + grace_floor,
+    # still below CEILING since grace_floor < reserve.
     session._turn_cost.input_tokens = CEILING - _SPEND_CEILING_RESERVE
     assert session._spend_ceiling_stops_the_tool_loop()
     session._grant_spend_ceiling_grace()

--- a/tests/test_spend_ceiling.py
+++ b/tests/test_spend_ceiling.py
@@ -140,41 +140,38 @@ async def test_ceiling_stops_the_turn_and_marks_the_exit(workspace):
     assert send.call_args.kwargs["ended_by"] == "spend_ceiling"
 
 
-@pytest.mark.parametrize("per_call", [PER_CALL, 300_000])
-async def test_total_is_bounded_by_the_ceiling(workspace, per_call):
-    """The turn's spend lands at the ceiling, give or take two output budgets
-    and one grace allotment.
+@pytest.mark.parametrize(
+    "per_call,expected_total",
+    [
+        # Pinned observed totals, not re-derived from `_grant_spend_ceiling_grace`
+        # at test time — a regression in that shared formula must move the
+        # production value AWAY from a frozen expected number, not move both
+        # in lockstep with an assertion that re-computes the same formula.
+        (PER_CALL, 1_000_000),
+        (300_000, 1_200_000),
+    ],
+)
+async def test_total_is_bounded_by_the_ceiling(workspace, per_call, expected_total):
+    """The turn's spend lands at a specific, pinned total for each fixture.
 
-    The reserve is what makes this hold at all: the hand-back diagnosis is
-    itself an LLM call, so gating AT the ceiling would overshoot by that call.
+    Deterministic scripted mock, deterministic outcome — exact equality catches
+    a regression the old `<= CEILING + slack + grace` bound could not: that
+    bound re-derived the same formula the code under test uses, so a formula
+    regression moved the bound and the production value together and the
+    assertion never noticed.
 
-    The slack is not slop — it is the exact residual of the design. The reserve
-    is derived from `peak_context_tokens` (input + cache_read + cache_creation)
-    but compared against `total_tokens`, which also counts output, so the two
-    calls that land after the last passing check contribute their output on top.
-    Asserting `<= CEILING` exactly passed only because the old fixture happened
-    to land on 1,000,000 with zero margin; it reddened as soon as `per_call`
-    moved. State the real bound instead of a knife-edge one.
-
-    The grace term is new: this run's all-tool-calls shape trips the mid-loop
-    gate, and the first trip buys one silent extension before the turn
-    actually stops. Computed from the real `_grant_spend_ceiling_grace`
-    formula, not a flat constant — a flat `_SPEND_CEILING_RESERVE` slack only
-    held at this fixture's small `per_call`; parametrised over a second,
-    bigger `per_call` so the peak-scaled branch of the formula is pinned too.
+    Known gap, not asserted here: at `per_call` large enough that one call's
+    cost exceeds the grace's own `CEILING // 4` cap (roughly >25% of the
+    ceiling), the overshoot is materially larger than this formula predicts —
+    e.g. `per_call=600_000` lands at 1,800,000, not the ~1,550,000 the old
+    bound implied. Tracked as a follow-up, not fixed here.
     """
     session = _session(workspace, responses=[_tool_call(i) for i in range(1, 40)],
                        per_call=per_call)
     with patch("anton.analytics.send_event") as send:
         await _run(session)
-    slack = 2 * (per_call // 4)  # `_usage` puts a quarter of each call in output
-    peak = per_call - (per_call // 4)  # `_usage`'s context share of one call
-    grace = min(max(_SPEND_CEILING_GRACE_FLOOR, peak), CEILING // 4)
     # Analytics properties go over the wire as strings.
-    assert (
-        int(send.call_args.kwargs["tokens_total"])
-        <= CEILING + slack + grace
-    )
+    assert int(send.call_args.kwargs["tokens_total"]) == expected_total
 
 
 async def test_trips_inside_one_tool_loop_with_no_continuation(workspace):

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -277,6 +277,10 @@ async def test_rounds_accumulate_across_verifier_continuations(workspace):
 
 
 async def test_round_cap_reports_the_cap_not_cap_plus_one(workspace):
+    """Reports the *effective* cap — the configured cap plus the one-time
+    grace extension (ENG-1893) — not effective_cap + 1."""
+    from anton.core.session import _ROUND_CAP_GRACE_ROUNDS
+
     mock_llm = make_mock_llm()
     mock_llm.plan_stream = MagicMock(
         side_effect=lambda **kw: _Iter([StreamComplete(response=_tool_call())])
@@ -294,7 +298,10 @@ async def test_round_cap_reports_the_cap_not_cap_plus_one(workspace):
 
     kwargs = send.call_args.kwargs
     assert kwargs["ended_by"] == "round_cap"
-    assert kwargs["rounds"] == "2", f"cap is 2, reported {kwargs['rounds']}"
+    expected = 2 + _ROUND_CAP_GRACE_ROUNDS
+    assert kwargs["rounds"] == str(expected), (
+        f"effective cap is {expected}, reported {kwargs['rounds']}"
+    )
 
 
 async def test_non_streaming_turn_marks_round_cap(workspace):

--- a/tests/test_verifier_verdict_schema.py
+++ b/tests/test_verifier_verdict_schema.py
@@ -55,3 +55,14 @@ def test_close_to_done_defaults_false_and_is_bounded():
     assert "roughly 1-3 more tool calls" in desc
     assert "nothing blocking or uncertain" in desc
     assert "an unsure model errs toward asking the user" in desc
+
+
+def test_close_to_done_null_falls_back_to_default_not_a_validation_error():
+    # A model emitting an explicit `"close_to_done": null` alongside an
+    # otherwise-valid verdict used to fail the WHOLE verdict (non-Optional
+    # field, lax bool coercion has no null case) rather than take the
+    # field's own documented default.
+    verdict = _VerifierVerdict.model_validate(
+        {"status": "INCOMPLETE", "reason": "still working", "close_to_done": None}
+    )
+    assert verdict.close_to_done is False

--- a/tests/test_verifier_verdict_schema.py
+++ b/tests/test_verifier_verdict_schema.py
@@ -43,3 +43,15 @@ def test_recovered_error_rule_is_intact():
     desc = _status_description()
     assert "RECOVERED" in desc
     assert "do NOT mark a turn incomplete just because an earlier tool call failed" in desc
+
+
+def test_close_to_done_defaults_false_and_is_bounded():
+    # `close_to_done` unlocks extra spend on an INCOMPLETE verdict with no
+    # human in the loop, so an under-specified model self-report degrades the
+    # whole feature to a no-op: wording that stays a small, bounded claim
+    # (not "probably fine") is what keeps a model from defaulting to it.
+    desc = _VerifierVerdict.model_fields["close_to_done"].description
+    assert _VerifierVerdict.model_fields["close_to_done"].default is False
+    assert "roughly 1-3 more tool calls" in desc
+    assert "nothing blocking or uncertain" in desc
+    assert "an unsure model errs toward asking the user" in desc


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-1893/agent-stops-mid-task-near-the-per-turn-token-budget-instead-of

* agent no longer stops to ask permission just because it hit a round or token cap
* grants a small one-time extension when the completion verifier says the remaining work is close to done
* round cap and mid loop spend ceiling get the same one time extension, unconditionally, since no verdict exists yet at that point
* extension is one-shot per turn, the hard ceiling is unchanged, genuine stuck or uncertain cases still ask
* updated the round cap and spend ceiling tests whose counts were calibrated to the old always ask behavior