### PR TITLE
ENG-1945: stamp surface on turn_completed and tool_completed

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -165,7 +165,9 @@ _pending_lock = threading.Lock()
 #                    cache_read_tokens, cache_creation_tokens, llm_calls,
 #                    rounds, continuations, peak_context_tokens, duration_ms,
 #                    {planning,coding,router}_{model,tokens,calls},
-#                    unknown_{tokens,calls}, llm_provider, harness,
+#                    unknown_{tokens,calls}, llm_provider, endpoint_class,
+#                    error_type, harness, surface (desktop / web / cli — WHERE
+#                    the user was, "" when the host did not say; ENG-1945),
 #                    anton_version, conversation_id, turn_index
 #
 #   rule_retrieval   outcome, when_rules, kept_rules, rules_chars,
@@ -180,6 +182,7 @@ _pending_lock = threading.Lock()
 #                    never the message, which carries paths and user input).
 #                    One event per executed tool call; tool arguments and
 #                    result content are deliberately absent (ENG-1486).
+#                    surface mirrors turn_completed's (ENG-1945).
 #                    conversation_id + turn_index mirror turn_completed's
 #                    values, so a tool row joins to its parent turn row and,
 #                    via Langfuse sessionId, to the gateway trace.

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2871,9 +2871,10 @@ class ChatSession:
         is reported as ``"unknown"`` rather than coerced either way.
 
         Payload is deliberately name + verdict + duration + exception CLASS
-        plus the two join keys, and nothing else. Arguments, result content
-        and ``str(exc)`` routinely carry file paths, user data and
-        credentials-adjacent strings — none of them may ever appear here.
+        + surface (a closed enum, ENG-1945) plus the two join keys, and
+        nothing else. Arguments, result content and ``str(exc)`` routinely
+        carry file paths, user data and credentials-adjacent strings — none
+        of them may ever appear here.
 
         ``conversation_id`` / ``turn_index`` mirror ``turn_completed``'s
         values exactly (same names, same derivation), so a tool failure spotted

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2828,6 +2828,15 @@ class ChatSession:
                 # URL itself — those carry internal corporate hostnames.
                 endpoint_class=classify_endpoint(_turn_settings),
                 harness=str(self._harness or ""),
+                # WHERE the user was (desktop / web / cli), as opposed to which
+                # agent ran (`harness`). Same value the Langfuse `surface:` tag
+                # carries (ENG-1459); it was deliberately left off this event
+                # then, on the grounds that PostHog's renderer events already
+                # had it — but those ride a different distinct_id and cannot
+                # split this row, and this row is where cost and outcome live
+                # (ENG-1945). "" when the host did not say; never a guess —
+                # `_validated_surface` already rejected anything unrecognised.
+                surface=str(getattr(self, "_surface", None) or ""),
                 anton_version=_anton_version,
                 # Join keys: the same session/turn identity the MindsHub
                 # trace headers carry, so an analytics row links back to
@@ -2906,6 +2915,10 @@ class ChatSession:
                 ok="unknown" if ok is None else str(ok).lower(),
                 duration_ms=str(int(duration_ms)),
                 error_type=error_type,
+                # Same derivation as `turn_completed`'s `surface` (ENG-1945),
+                # so a tool row can be split by desktop / web without joining
+                # to its parent turn first.
+                surface=str(getattr(self, "_surface", None) or ""),
                 conversation_id=str(self._session_id or ""),
                 turn_index=str(turn_index),
             )

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -163,17 +163,32 @@ async def test_unmigrated_handler_verdict_is_unknown_not_a_guess(workspace):
 # ── Payload contract ─────────────────────────────────────────────────
 
 
-async def test_payload_is_exactly_the_six_keys_all_strings(workspace):
+async def test_payload_is_exactly_the_seven_keys_all_strings(workspace):
     """No arguments, no result content, no surprise keys — and str values only,
     because send_event's extras are wire parameters (tests/test_ask_user.py:496).
     """
     session = _session(workspace, [ToolOutcome(content="secret result body", ok=True)])
     events = await _tool_completed_calls(session)
     assert set(events[0]) == {"name", "ok", "duration_ms", "error_type",
-                              "conversation_id", "turn_index"}
+                              "surface", "conversation_id", "turn_index"}
     assert all(isinstance(v, str) for v in events[0].values())
     assert "secret result body" not in json.dumps(events[0])
     int(events[0]["duration_ms"])  # numeric string, parseable
+
+
+async def test_surface_rides_the_tool_row_and_is_empty_when_the_host_did_not_say(workspace):
+    """ENG-1945: `surface` on the tool row, same derivation as turn_completed.
+
+    Two assertions on purpose: the unset case must be "" (never a guess —
+    `_validated_surface` already dropped anything unrecognised), and a host
+    that declared one must see it on every tool row, not just the turn row.
+    """
+    session = _session(workspace, [ToolOutcome(content="x", ok=True)])
+    assert (await _tool_completed_calls(session))[0]["surface"] == ""
+
+    session = _session(workspace, [ToolOutcome(content="x", ok=True)])
+    session._surface = "desktop"
+    assert (await _tool_completed_calls(session))[0]["surface"] == "desktop"
 
 
 async def test_join_keys_match_the_same_turns_turn_completed_row(workspace):

--- a/tests/test_turn_cost.py
+++ b/tests/test_turn_cost.py
@@ -161,6 +161,7 @@ def _bare_session(**overrides) -> ChatSession:
     s._llm.coding_model = "coder"
     s._session_id = "conv-123"
     s._harness = "cowork"
+    s._surface = "desktop"
     s._turn_count = 4
     s._cancel_event = overrides.pop("cancel_event", MagicMock(is_set=lambda: False))
     s._settings = overrides.pop("settings", None)
@@ -187,6 +188,22 @@ class TestEmitTurnCost:
         # Numbers, names, and IDs only — nothing that could carry content.
         for value in kwargs.values():
             assert isinstance(value, str) and len(value) < 200
+
+    def test_surface_is_stamped_and_empty_when_the_host_did_not_say(self):
+        """ENG-1945: WHERE the user was rides the cost row. It was left off
+        deliberately in ENG-1459 (renderer events "already had it") — but those
+        ride a different distinct_id and cannot split this row. Unset must be
+        "", never a guess, matching `harness`'s rule."""
+        s = _bare_session()
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        assert send.call_args.kwargs["surface"] == "desktop"
+        assert send.call_args.kwargs["harness"] == "cowork"
+
+        s = _bare_session(_surface=None)
+        with patch("anton.analytics.send_event") as send:
+            s._emit_turn_cost()
+        assert send.call_args.kwargs["surface"] == ""
 
     def test_books_close_and_listener_disarms(self):
         s = _bare_session()


### PR DESCRIPTION
Closes [ENG-1945](https://linear.app/mindsdb/issue/ENG-1945/turn-completed-cant-say-which-surface-a-turn-ran-on-surface-exists-on).

## What

`surface` (`desktop` / `web` / `cli`) has ridden Langfuse traces since ENG-1459 (#373) but was **deliberately left off anton's PostHog events** — ENG-1459's Out-of-scope reads *"PostHog's renderer events already stamp surface … do not redo it."* Those renderer events ride a different `distinct_id` (Keycloak sub) from anton's `aid`, so they cannot split `turn_completed` — and `turn_completed` is where per-turn cost and outcome live. Measured 2026-08-25: `surface` is `None` on **100%** of `turn_completed` rows, desktop included.

Two emit sites, one line each, beside the existing `harness=`:

- `_emit_turn_cost` → `turn_completed`
- `_emit_tool_completed` → `tool_completed` (same derivation, so a tool row splits by surface without joining to its parent turn)

`""` when the host did not say — never a guess; `_validated_surface` already dropped anything unrecognised at config time. `getattr(self, "_surface", None)` rather than the bare attribute so a host that builds a session unusually can never turn a telemetry field into a swallowed emit.

Also registers `endpoint_class` / `error_type` in `analytics.py`'s event register — #381 shipped them without adding the doc entries.

## Why this and not the ENG-1459 reasoning

ENG-1459 gave two reasons for leaving it off. Neither holds for this event: (1) the renderer's `surface` can't join to `aid`-keyed rows; (2) "web pods collapse users into one `aid`" is true of **every** field on a web `turn_completed`, not this one, and is irrelevant on desktop where all real traffic is. Recorded on the ticket so the decision isn't re-litigated from the old text. Web rows will carry `surface=web` under a shared `aid` until ENG-1459/ENG-1694 resolve pod identity — noted so nobody reads per-user web numbers off this event.

## Verification

- `test_turn_cost.py::test_surface_is_stamped_and_empty_when_the_host_did_not_say` — `"desktop"` when set, `""` when `None`.
- `test_tool_completed.py::test_payload_is_exactly_the_seven_keys_all_strings` (was six) + `test_surface_rides_the_tool_row_and_is_empty_when_the_host_did_not_say`.
- **Mutation-verified:** with both `surface=` kwargs deleted, exactly those three tests fail (3 failed / 53 passed); restored, all pass.
- Full suite (`uv sync --frozen --all-groups`, macOS): **2,501 passed, 31 skipped, 5 failed** — all five in `tests/test_cloud_turn_process.py`, and **identical on pure `origin/staging`** (stashed check: 5 failed / 1 passed). CI on `staging` at the same base `17dc5b5` is green, so those are local-environment failures, not this branch.

## Delivery / QA note

anton changes reach desktop users only after this lands on anton `main` and cowork-server picks it up — verify on the released build, not this PR. After it ships: `turn_completed` on the new `anton_version` shows `surface=desktop` on desktop rows; `.claude/skills/turn-cost` can then group by it (follow-up on the analytics side, not this repo). No wire change — `turn_completed` posts direct to PostHog (ENG-1495), so no collector allowlist to update.

## Security check

Observability-only. `surface` is a closed enum validated at config time (`_validated_surface`); the value is never user-supplied text, never a URL or path. No new endpoints, no new inputs. Same sink, same opt-out (`analytics_enabled`) and CI drop as the existing properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
