### PR TITLE
ENG-1849: fix connect from chat

### DIFF
--- a/anton/commands/datasource/verify.py
+++ b/anton/commands/datasource/verify.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
     from rich.console import Console
     from anton.core.backends.manager import ScratchpadManager
 
+# Bounds only the connect attempt itself (pad.execute of the test_snippet).
+# A ModuleNotFoundError retry's pad.install_packages() call is not covered —
+# it has its own, separate cell_install_timeout (default 120s) — so the
+# worst-case wall clock for a full test is higher than this number suggests.
 CONNECTION_TEST_TIMEOUT_SECONDS = 30
 
 
@@ -29,11 +33,17 @@ async def run_connection_test(
     credentials: dict[str, str],
     retry_fields: "list[DatasourceField]",
     retry_edit_callback: "Callable[[], Awaitable[bool]] | None" = None,
+    *,
+    interactive: bool = True,
 ) -> bool:
     """Inject flat DS_* vars, run engine_def.test_snippet, restore env.
 
     Returns True on success, False if the user declines retry after failure.
     Mutates credentials in-place when the user re-enters secrets on retry.
+    `interactive=False` (mode (a) callers with no terminal to prompt in)
+    skips the "retry?" prompt entirely and fails closed on the first error —
+    prompt_or_cancel drives a real terminal regardless of the `console`
+    passed in, so it must never be reached without one.
     """
     while True:
         console.print()
@@ -61,12 +71,23 @@ async def run_connection_test(
 
             cell = None
             for attempt in range(3):
-                try:
-                    cell = await asyncio.wait_for(
-                        pad.execute(engine_def.test_snippet),
-                        timeout=CONNECTION_TEST_TIMEOUT_SECONDS,
-                    )
-                except asyncio.TimeoutError:
+                task = asyncio.ensure_future(pad.execute(engine_def.test_snippet))
+                done, _pending = await asyncio.wait(
+                    {task}, timeout=CONNECTION_TEST_TIMEOUT_SECONDS
+                )
+                if task not in done:
+                    # The local backend catches its own internal
+                    # CancelledError and returns a Cell instead of
+                    # re-raising, so `await task` here would silently hand
+                    # back that Cell (with a generic kill-tree message)
+                    # rather than surfacing our timeout — cancel and
+                    # discard its result/exception either way, and always
+                    # report our own message.
+                    task.cancel()
+                    try:
+                        await task
+                    except (asyncio.CancelledError, Exception):
+                        pass
                     cell = Cell(
                         code=engine_def.test_snippet,
                         stdout="",
@@ -78,6 +99,7 @@ async def run_connection_test(
                         ),
                     )
                     break
+                cell = task.result()
                 if cell.error and "ModuleNotFoundError" in cell.error:
                     match = re.search(r"No module named '([^']+)'", cell.error)
                     if match:
@@ -98,6 +120,8 @@ async def run_connection_test(
             console.print()
             console.print(f"        Error: {last_line}")
             console.print()
+            if not interactive:
+                return False
             retry = await prompt_or_cancel(
                 "(anton) Would you like to re-enter your credentials?",
                 choices=["y", "n"], default="n",

--- a/anton/commands/datasource/verify.py
+++ b/anton/commands/datasource/verify.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 from typing import TYPE_CHECKING, Awaitable, Callable
 
 from anton.commands.datasource.helpers import prompt_field_value
+from anton.core.backends.base import Cell
 from anton.core.datasources.data_vault import DataVault, LocalDataVault
 from anton.core.datasources.datasource_registry import DatasourceEngine, DatasourceField, DatasourceRegistry
 from anton.utils.datasources import parse_connection_slug, register_secret_vars, restore_namespaced_env
@@ -15,6 +17,8 @@ from anton.utils.prompt import prompt_or_cancel
 if TYPE_CHECKING:
     from rich.console import Console
     from anton.core.backends.manager import ScratchpadManager
+
+CONNECTION_TEST_TIMEOUT_SECONDS = 30
 
 
 async def run_connection_test(
@@ -57,7 +61,23 @@ async def run_connection_test(
 
             cell = None
             for attempt in range(3):
-                cell = await pad.execute(engine_def.test_snippet)
+                try:
+                    cell = await asyncio.wait_for(
+                        pad.execute(engine_def.test_snippet),
+                        timeout=CONNECTION_TEST_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    cell = Cell(
+                        code=engine_def.test_snippet,
+                        stdout="",
+                        stderr="",
+                        error=(
+                            f"Connection test timed out after "
+                            f"{CONNECTION_TEST_TIMEOUT_SECONDS}s — the server "
+                            f"did not respond."
+                        ),
+                    )
+                    break
                 if cell.error and "ModuleNotFoundError" in cell.error:
                     match = re.search(r"No module named '([^']+)'", cell.error)
                     if match:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1109,7 +1109,7 @@ class ChatSession:
             )
             self._extra_tools = [
                 CONNECT_DATASOURCE_TOOL_NO_CONSOLE
-                if tool.name == CONNECT_DATASOURCE_TOOL.name
+                if tool is CONNECT_DATASOURCE_TOOL
                 else tool
                 for tool in self._extra_tools
             ]

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1100,6 +1100,19 @@ class ChatSession:
         self._workspace = config.workspace
         self._data_vault = config.data_vault
         self._console = config.console
+        if self._console is None:
+            # connect_new_datasource's interactive mode needs a terminal to
+            # prompt in; without one, don't advertise it to the model (ENG-1849).
+            from anton.tools import (
+                CONNECT_DATASOURCE_TOOL,
+                CONNECT_DATASOURCE_TOOL_NO_CONSOLE,
+            )
+            self._extra_tools = [
+                CONNECT_DATASOURCE_TOOL_NO_CONSOLE
+                if tool.name == CONNECT_DATASOURCE_TOOL.name
+                else tool
+                for tool in self._extra_tools
+            ]
         self._history: list[dict] = (
             list(config.initial_history) if config.initial_history else []
         )

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -176,6 +176,11 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
                         engine_def,
                         test_credentials,
                         active_fields,
+                        # Mode (a) is driven by the model, not a human at a
+                        # keyboard — there's no one to answer a "retry?"
+                        # prompt, and prompt_or_cancel would otherwise drive
+                        # a real terminal regardless of `console`.
+                        interactive=False,
                     )
                     if not ok:
                         if _settings:
@@ -246,11 +251,23 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
     # console can't service it, so bail out with an actionable message
     # instead of hanging or crashing on a prompt read.
     if session._console is None:
+        # dropped_scrubbed's console.print warning above never reaches the
+        # model (nor, in this no-console host, anyone else) — repeat it here
+        # so the model knows *why* known_variables wasn't enough, rather
+        # than re-sending the same scrub-marker placeholder again.
+        note = ""
+        if dropped_scrubbed:
+            note = (
+                f" Scrubbed-placeholder values for "
+                f"{', '.join(sorted(dropped_scrubbed))} were ignored — those "
+                f"are not real credentials; pass the actual secret values "
+                f"instead."
+            )
         return (
             "Interactive connection setup isn't available in this environment "
-            "(no terminal to prompt in). Ask the user for the credential "
-            "values directly in chat, then call connect_new_datasource again "
-            "with known_variables set."
+            "(no terminal to prompt in)." + note + " Ask the user for the "
+            "credential values directly in chat, then call "
+            "connect_new_datasource again with known_variables set."
         )
 
     console.print()
@@ -350,6 +367,17 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
     )
 
 
+# Shared by both description variants below — what mode (a) actually does.
+# One copy so the two descriptions can't drift out of sync with each other.
+_CONNECT_DATASOURCE_MODE_A_BODY = (
+    "this tool IMMEDIATELY when the user shares credentials in chat (host, "
+    "password, API token, service account JSON, etc.). Pass all extracted "
+    "values as known_variables. The tool saves to the vault without any "
+    "prompts and returns a confirmation. This ensures credentials are "
+    "persisted before being used anywhere — never reference chat-supplied "
+    "credentials directly in scratchpad code; always go through the vault."
+)
+
 # Shared by both description variants below — everything that doesn't
 # depend on whether an interactive terminal is available.
 _CONNECT_DATASOURCE_DESCRIPTION_TAIL = (
@@ -370,13 +398,7 @@ CONNECT_DATASOURCE_TOOL = ToolDef(
     name = "connect_new_datasource",
     description = (
         "Connect a data source to Anton's Local Vault. Two modes:\n\n"
-        "(a) Non-interactive: call this tool IMMEDIATELY when the user shares "
-        "credentials in chat (host, password, API token, service account JSON, "
-        "etc.). Pass all extracted values as known_variables. The tool saves "
-        "to the vault without any prompts and returns a confirmation. This "
-        "ensures credentials are persisted before being used anywhere — never "
-        "reference chat-supplied credentials directly in scratchpad code; always "
-        "go through the vault.\n\n"
+        "(a) Non-interactive: call " + _CONNECT_DATASOURCE_MODE_A_BODY + "\n\n"
         "(b) Interactive: call with just engine and no known_variables when the "
         "user has no credentials in context yet. Anton runs the same flow as "
         "/connect, prompting for fields one at a time.\n\n"
@@ -427,14 +449,8 @@ CONNECT_DATASOURCE_TOOL = ToolDef(
 CONNECT_DATASOURCE_TOOL_NO_CONSOLE = dataclasses.replace(
     CONNECT_DATASOURCE_TOOL,
     description = (
-        "Connect a data source to Anton's Local Vault. Call this tool "
-        "IMMEDIATELY when the user shares credentials in chat (host, "
-        "password, API token, service account JSON, etc.). Pass all "
-        "extracted values as known_variables. The tool saves to the vault "
-        "without any prompts and returns a confirmation. This ensures "
-        "credentials are persisted before being used anywhere — never "
-        "reference chat-supplied credentials directly in scratchpad code; "
-        "always go through the vault.\n\n"
+        "Connect a data source to Anton's Local Vault. Call "
+        + _CONNECT_DATASOURCE_MODE_A_BODY + "\n\n"
         "There is no interactive prompt flow in this environment — do NOT "
         "call this tool with just an engine and no known_variables; there is "
         "nothing to prompt with and the call will fail. If the user hasn't "
@@ -442,6 +458,13 @@ CONNECT_DATASOURCE_TOOL_NO_CONSOLE = dataclasses.replace(
         "tool once you have real values to pass.\n\n"
         + _CONNECT_DATASOURCE_DESCRIPTION_TAIL
     ),
+    # Own copy, not shared with CONNECT_DATASOURCE_TOOL: this variant has no
+    # prompt flow to fall back on, so known_variables is mandatory here,
+    # matching the description above.
+    input_schema = {
+        **CONNECT_DATASOURCE_TOOL.input_schema,
+        "required": ["engine", "known_variables"],
+    },
 )
 
 

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import re
 import uuid
 from typing import TYPE_CHECKING
@@ -65,9 +66,12 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
         if isinstance(raw_known, dict) else {}
     )
 
-    console = session._console
-    if console is None:
-        return "Cannot connect datasource — no console available."
+    # Mode (a) below needs no terminal — it writes straight to the vault. A
+    # quiet console swallows its status prints instead of crashing on
+    # `None.print()`. The real console (if any) is required only for mode
+    # (b)'s prompts, gated further down.
+    from rich.console import Console
+    console = session._console or Console(quiet=True)
 
     dropped_scrubbed = [
         k for k, v in known_variables.items() if SCRUBBED_VALUE_RE.match(v)
@@ -237,6 +241,18 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
                     f"in scratchpad code — never embed raw values."
                 )
 
+    # Below this point is mode (b), the interactive field-by-field prompt
+    # flow. It needs a real terminal (Rich prompts, Live spinners); a quiet
+    # console can't service it, so bail out with an actionable message
+    # instead of hanging or crashing on a prompt read.
+    if session._console is None:
+        return (
+            "Interactive connection setup isn't available in this environment "
+            "(no terminal to prompt in). Ask the user for the credential "
+            "values directly in chat, then call connect_new_datasource again "
+            "with known_variables set."
+        )
+
     console.print()
     console.print(
         f"[anton.prompt]anton>[/] I can help with that \u2014 let's connect [bold]{engine}[/] to Anton."
@@ -334,6 +350,22 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
     )
 
 
+# Shared by both description variants below — everything that doesn't
+# depend on whether an interactive terminal is available.
+_CONNECT_DATASOURCE_DESCRIPTION_TAIL = (
+    "Supported engines: see the built-in registry (PostgreSQL, MySQL, Snowflake, "
+    "BigQuery, Redshift, Databricks, MariaDB, MSSQL, Oracle, HubSpot, Salesforce, "
+    "Shopify, Gmail, and more). Unknown engines (not in the built-in registry) "
+    "are also saved silently as ad-hoc connections when known_variables are "
+    "provided — no prompts, no auth-method interrogation. A minimal engine "
+    "definition is appended to ~/.anton/datasources.md so future sessions "
+    "recognize it. Reference credentials via DS_<ENGINE>_<NAME>__<FIELD> env "
+    "vars like any other connection.\n\n"
+    "Partial credentials are fine — save what the user provided. Ask for missing "
+    "pieces in a later turn only if needed. Never invent values.\n\n"
+    "Do NOT print any message before calling this tool — it handles the user-facing output."
+)
+
 CONNECT_DATASOURCE_TOOL = ToolDef(
     name = "connect_new_datasource",
     description = (
@@ -348,17 +380,7 @@ CONNECT_DATASOURCE_TOOL = ToolDef(
         "(b) Interactive: call with just engine and no known_variables when the "
         "user has no credentials in context yet. Anton runs the same flow as "
         "/connect, prompting for fields one at a time.\n\n"
-        "Supported engines: see the built-in registry (PostgreSQL, MySQL, Snowflake, "
-        "BigQuery, Redshift, Databricks, MariaDB, MSSQL, Oracle, HubSpot, Salesforce, "
-        "Shopify, Gmail, and more). Unknown engines (not in the built-in registry) "
-        "are also saved silently as ad-hoc connections when known_variables are "
-        "provided — no prompts, no auth-method interrogation. A minimal engine "
-        "definition is appended to ~/.anton/datasources.md so future sessions "
-        "recognize it. Reference credentials via DS_<ENGINE>_<NAME>__<FIELD> env "
-        "vars like any other connection.\n\n"
-        "Partial credentials are fine — save what the user provided. Ask for missing "
-        "pieces in a later turn only if needed. Never invent values.\n\n"
-        "Do NOT print any message before calling this tool — it handles the user-facing output."
+        + _CONNECT_DATASOURCE_DESCRIPTION_TAIL
     ),
     input_schema = {
         "type": "object",
@@ -394,6 +416,32 @@ CONNECT_DATASOURCE_TOOL = ToolDef(
         "required": ["engine"],
     },
     handler = handle_connect_datasource,
+)
+
+# Console-less hosts (Cowork desktop: session._console is None) can't service
+# mode (b) — there's no terminal to prompt in, and handle_connect_datasource
+# refuses it with an actionable error rather than crashing (ENG-1849). Don't
+# advertise a mode the model would then have to be told, mid-turn, doesn't
+# work here — swapped in by ChatSession.__init__ (anton/core/session.py)
+# once session._console is known.
+CONNECT_DATASOURCE_TOOL_NO_CONSOLE = dataclasses.replace(
+    CONNECT_DATASOURCE_TOOL,
+    description = (
+        "Connect a data source to Anton's Local Vault. Call this tool "
+        "IMMEDIATELY when the user shares credentials in chat (host, "
+        "password, API token, service account JSON, etc.). Pass all "
+        "extracted values as known_variables. The tool saves to the vault "
+        "without any prompts and returns a confirmation. This ensures "
+        "credentials are persisted before being used anywhere — never "
+        "reference chat-supplied credentials directly in scratchpad code; "
+        "always go through the vault.\n\n"
+        "There is no interactive prompt flow in this environment — do NOT "
+        "call this tool with just an engine and no known_variables; there is "
+        "nothing to prompt with and the call will fail. If the user hasn't "
+        "shared credentials yet, ask for them in chat first, then call this "
+        "tool once you have real values to pass.\n\n"
+        + _CONNECT_DATASOURCE_DESCRIPTION_TAIL
+    ),
 )
 
 

--- a/tests/test_run_connection_test_env_filter.py
+++ b/tests/test_run_connection_test_env_filter.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import os
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -46,3 +47,47 @@ async def test_underscore_prefixed_credentials_not_injected_as_env(tmp_path):
     )
     assert "DS__USER_LABEL" not in captured
     assert captured.get("DS_HOST") == "db.example.com"
+
+
+@pytest.mark.asyncio
+async def test_hung_snippet_times_out_instead_of_blocking_forever(tmp_path):
+    """A test_snippet stuck on e.g. a dead TCP connect() must not hang the
+    caller forever — it's bounded by CONNECTION_TEST_TIMEOUT_SECONDS and
+    reported as a normal connection failure."""
+    vault = LocalDataVault(vault_dir=tmp_path / "vault")
+    engine_def = DatasourceEngine(
+        engine="postgresql",
+        display_name="PostgreSQL",
+        fields=[DatasourceField(name="host", required=True, description="host")],
+        test_snippet="connect_forever()",
+    )
+    console = MagicMock()
+    scratchpads = MagicMock()
+    pad = AsyncMock()
+    pad.reset = AsyncMock()
+    pad.install_packages = AsyncMock(return_value="")
+
+    async def _execute_hangs(_snippet):
+        await asyncio.sleep(3600)  # simulates a wedged connect() to a dead host
+        raise AssertionError("should have been cancelled by the timeout")
+
+    pad.execute = AsyncMock(side_effect=_execute_hangs)
+    scratchpads.get_or_create = AsyncMock(return_value=pad)
+
+    with (
+        patch("anton.commands.datasource.verify.CONNECTION_TEST_TIMEOUT_SECONDS", 0.05),
+        patch(
+            "anton.commands.datasource.verify.prompt_or_cancel",
+            new=AsyncMock(return_value="n"),  # decline the "retry?" prompt
+        ),
+    ):
+        ok = await asyncio.wait_for(
+            run_connection_test(
+                console, scratchpads, vault, engine_def,
+                {"host": "unreachable.example.com"}, engine_def.fields,
+            ),
+            timeout=5,
+        )
+    assert ok is False
+    printed = " ".join(str(c.args[0]) for c in console.print.call_args_list if c.args)
+    assert "timed out" in printed

--- a/tests/test_run_connection_test_env_filter.py
+++ b/tests/test_run_connection_test_env_filter.py
@@ -91,3 +91,88 @@ async def test_hung_snippet_times_out_instead_of_blocking_forever(tmp_path):
     assert ok is False
     printed = " ".join(str(c.args[0]) for c in console.print.call_args_list if c.args)
     assert "timed out" in printed
+
+
+@pytest.mark.asyncio
+async def test_timeout_message_survives_a_backend_that_swallows_cancellation(tmp_path):
+    """LocalScratchpadRuntime.execute_streaming catches its own
+    CancelledError and returns a Cell instead of re-raising it, so a bare
+    `asyncio.wait_for(pad.execute(...))` would silently hand back that
+    Cell's generic kill-tree message rather than raising TimeoutError. The
+    friendly "timed out after Ns" message must still win."""
+    vault = LocalDataVault(vault_dir=tmp_path / "vault")
+    engine_def = DatasourceEngine(
+        engine="postgresql",
+        display_name="PostgreSQL",
+        fields=[DatasourceField(name="host", required=True, description="host")],
+        test_snippet="connect_forever()",
+    )
+    console = MagicMock()
+    scratchpads = MagicMock()
+    pad = AsyncMock()
+    pad.reset = AsyncMock()
+    pad.install_packages = AsyncMock(return_value="")
+
+    async def _execute_swallows_cancellation(_snippet):
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            # What the real local backend does on cancellation: catch it and
+            # return a Cell instead of letting it propagate.
+            return MagicMock(stdout="", stderr="", error="Killed: cancelled by caller.")
+        raise AssertionError("should have been cancelled by the timeout")
+
+    pad.execute = AsyncMock(side_effect=_execute_swallows_cancellation)
+    scratchpads.get_or_create = AsyncMock(return_value=pad)
+
+    with (
+        patch("anton.commands.datasource.verify.CONNECTION_TEST_TIMEOUT_SECONDS", 0.05),
+        patch(
+            "anton.commands.datasource.verify.prompt_or_cancel",
+            new=AsyncMock(return_value="n"),
+        ),
+    ):
+        ok = await asyncio.wait_for(
+            run_connection_test(
+                console, scratchpads, vault, engine_def,
+                {"host": "unreachable.example.com"}, engine_def.fields,
+            ),
+            timeout=5,
+        )
+    assert ok is False
+    printed = " ".join(str(c.args[0]) for c in console.print.call_args_list if c.args)
+    assert "timed out after" in printed
+    assert "Killed: cancelled by caller" not in printed
+
+
+@pytest.mark.asyncio
+async def test_non_interactive_skips_retry_prompt_on_failure(tmp_path):
+    """Mode (a) callers pass interactive=False — there's no human present to
+    answer "retry?", so a failed test must fail closed without prompting.
+    prompt_or_cancel drives a real terminal regardless of `console`, so
+    reaching it here would hang/crash in a console-less host."""
+    vault = LocalDataVault(vault_dir=tmp_path / "vault")
+    engine_def = DatasourceEngine(
+        engine="postgresql",
+        display_name="PostgreSQL",
+        fields=[DatasourceField(name="host", required=True, description="host")],
+        test_snippet="print('fail')",
+    )
+    console = MagicMock()
+    scratchpads = MagicMock()
+    pad = AsyncMock()
+    pad.reset = AsyncMock()
+    pad.install_packages = AsyncMock(return_value="")
+    pad.execute = AsyncMock(return_value=MagicMock(stdout="", stderr="boom", error=None))
+    scratchpads.get_or_create = AsyncMock(return_value=pad)
+
+    with patch(
+        "anton.commands.datasource.verify.prompt_or_cancel",
+        new=AsyncMock(side_effect=AssertionError("must not prompt when non-interactive")),
+    ):
+        ok = await run_connection_test(
+            console, scratchpads, vault, engine_def,
+            {"host": "db.example.com"}, engine_def.fields,
+            interactive=False,
+        )
+    assert ok is False

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,7 +10,12 @@ import pytest
 from anton.chat import ChatSession
 from anton.core.datasources.data_vault import LocalDataVault
 from anton.core.session import ChatSessionConfig
-from anton.tools import handle_connect_datasource
+from anton.tools import (
+    CONNECT_DATASOURCE_TOOL,
+    CONNECT_DATASOURCE_TOOL_NO_CONSOLE,
+    DEFAULT_SESSION_TOOLS,
+    handle_connect_datasource,
+)
 
 _UUID8 = re.compile(r"^[0-9a-f]{8}$")
 
@@ -20,8 +25,7 @@ def vault_dir(tmp_path):
     return tmp_path / "vault"
 
 
-def _make_session(vault_dir):
-    """Return a minimal ChatSession wired for tool-handler tests."""
+def _mock_llm_client():
     from anton.core.llm.provider import ProviderConnectionInfo
 
     mock_llm = AsyncMock()
@@ -32,8 +36,20 @@ def _make_session(vault_dir):
     mock_llm.coding_model = "claude-sonnet-4-6"
     mock_llm.planning_provider = MagicMock()
     mock_llm.planning_provider.native_web_tools = MagicMock(return_value=set())
-    session = ChatSession(ChatSessionConfig(llm_client=mock_llm))
-    session._console = MagicMock()
+    return mock_llm
+
+
+def _make_session(vault_dir, console=None):
+    """Return a minimal ChatSession wired for tool-handler tests.
+
+    `console=None` matches real Cowork construction (no `config.console` is
+    ever passed there) — callers that need a console for the handler itself
+    override `session._console` afterward, same as before.
+    """
+    session = ChatSession(ChatSessionConfig(
+        llm_client=_mock_llm_client(), console=console, tools=list(DEFAULT_SESSION_TOOLS),
+    ))
+    session._console = MagicMock() if console is None else console
     session._scratchpads = AsyncMock()
     session._data_vault = LocalDataVault(vault_dir=vault_dir)
     session._settings = None
@@ -64,6 +80,25 @@ def _patch_test_fail():
         "anton.commands.datasource.verify.run_connection_test",
         new=AsyncMock(return_value=False),
     )
+
+
+class TestConnectDatasourceToolDescriptionGating:
+    """ENG-1849 step 4: don't advertise the interactive prompt flow to a
+    host that has no console to prompt in."""
+
+    def test_no_console_at_init_swaps_in_the_no_console_description(self, vault_dir):
+        session = _make_session(vault_dir, console=None)
+        registered = {t.name: t for t in session._extra_tools}
+        tool = registered["connect_new_datasource"]
+        assert tool.description == CONNECT_DATASOURCE_TOOL_NO_CONSOLE.description
+        assert "(b) Interactive" not in tool.description
+
+    def test_console_at_init_keeps_the_full_description(self, vault_dir):
+        session = _make_session(vault_dir, console=MagicMock())
+        registered = {t.name: t for t in session._extra_tools}
+        tool = registered["connect_new_datasource"]
+        assert tool.description == CONNECT_DATASOURCE_TOOL.description
+        assert "(b) Interactive" in tool.description
 
 
 class TestNonInteractiveSave:
@@ -446,6 +481,66 @@ class TestNonInteractiveSave:
         with patch("anton.commands.datasource.handle_connect_datasource", new=interactive):
             await handle_connect_datasource(session, {"engine": "postgres"})
         interactive.assert_called_once()
+        assert session._data_vault.list_connections() == []
+
+
+class TestNoConsole:
+    """Regression coverage for ENG-1849: mode (a) must not require a console."""
+
+    @pytest.mark.asyncio
+    async def test_saves_with_no_console(self, vault_dir):
+        """known_variables save to the vault even with session._console = None."""
+        session = _make_session(vault_dir)
+        session._console = None
+        with _patch_test_ok():
+            result = await handle_connect_datasource(
+                session,
+                {
+                    "engine": "postgres",
+                    "known_variables": {
+                        "host": "db.example.com",
+                        "database": "sales",
+                        "user": "admin",
+                        "password": "x",
+                    },
+                },
+            )
+        assert result.startswith("Saved connection")
+        assert len(session._data_vault.list_connections()) == 1
+
+    @pytest.mark.asyncio
+    async def test_scrubbed_placeholder_warning_does_not_raise_with_no_console(
+        self, vault_dir
+    ):
+        """The scrub-marker warning path must not call None.print()."""
+        session = _make_session(vault_dir)
+        session._console = None
+        with _patch_test_ok():
+            result = await handle_connect_datasource(
+                session,
+                {
+                    "engine": "postgres",
+                    "known_variables": {
+                        "host": "db.example.com",
+                        "database": "sales",
+                        "user": "admin",
+                        "password": "[DS_POSTGRES_OLD__PASSWORD]",
+                    },
+                },
+            )
+        # password was dropped as a scrub-marker, so it's a missing required
+        # field → falls through to interactive, which also has no console.
+        assert "Interactive connection setup isn't available" in result
+
+    @pytest.mark.asyncio
+    async def test_interactive_fallback_without_console_returns_actionable_message(
+        self, vault_dir
+    ):
+        """No known_variables + no console → clear message, not a crash/hang."""
+        session = _make_session(vault_dir)
+        session._console = None
+        result = await handle_connect_datasource(session, {"engine": "postgres"})
+        assert "Interactive connection setup isn't available" in result
         assert session._data_vault.list_connections() == []
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -100,6 +100,18 @@ class TestConnectDatasourceToolDescriptionGating:
         assert tool.description == CONNECT_DATASOURCE_TOOL.description
         assert "(b) Interactive" in tool.description
 
+    def test_no_console_variant_requires_known_variables(self, vault_dir):
+        """The no-console tool has no prompt flow to fall back on, so its
+        schema must require known_variables — not just say so in prose."""
+        session = _make_session(vault_dir, console=None)
+        registered = {t.name: t for t in session._extra_tools}
+        tool = registered["connect_new_datasource"]
+        assert tool.input_schema["required"] == ["engine", "known_variables"]
+        # Sharing engine/properties by reference is fine — only `required`
+        # needs to differ from the full-description variant.
+        assert tool.input_schema is not CONNECT_DATASOURCE_TOOL.input_schema
+        assert CONNECT_DATASOURCE_TOOL.input_schema["required"] == ["engine"]
+
 
 class TestNonInteractiveSave:
     @pytest.mark.asyncio
@@ -531,6 +543,11 @@ class TestNoConsole:
         # password was dropped as a scrub-marker, so it's a missing required
         # field → falls through to interactive, which also has no console.
         assert "Interactive connection setup isn't available" in result
+        # The model gets no other channel for this (console output isn't
+        # visible to it) — the bail-out message must name the rejected
+        # field itself, not just say "interactive setup unavailable".
+        assert "password" in result
+        assert "scrub" in result.lower()
 
     @pytest.mark.asyncio
     async def test_interactive_fallback_without_console_returns_actionable_message(


### PR DESCRIPTION
Changes
- connect_new_datasource's non-interactive path (known_variables) no longer needs a terminal — it returned "no console available" on every call from Cowork.
- Interactive mode now fails with a clear message instead of hanging/crashing when there's no console, and the tool stops advertising that mode to hosts that can't service it.
- Connection test now times out after 30s instead of hanging forever when the target server doesn't respond.

Fixes https://linear.app/mindsdb/issue/ENG-1849/connect-new-datasource-is-dead-in-cowork-a-console-guard-blocks-the