### PR TITLE
Record which artifacts a turn touched, as the tools touch them

### DIFF
--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1113,6 +1113,13 @@ class ChatSession:
         # Where `create_skill_draft` stages skills the agent builds. None means
         # the host stages none, and the tool is not registered at all.
         self._skill_drafts_root = getattr(s, "skill_drafts_root", None)
+        # Slugs of artifacts this turn created or opened for editing, recorded
+        # by the artifact tool handlers as they run. A host builds the turn's
+        # artifact cards from this rather than diffing the artifacts directory:
+        # the set names what THIS turn actually touched, so a concurrent turn
+        # writing into the same (shared, project-wide) directory can never be
+        # mistaken for this turn's work. Reset at the top of every turn.
+        self._artifacts_touched: set[str] = set()
         # Cerebellum: supervised error learning over scratchpad cells.
         # Buffers errored/warning cells across the turn, runs one diff
         # call at end-of-turn, and encodes lessons via cortex.encode().
@@ -1208,6 +1215,15 @@ class ChatSession:
     @property
     def history(self) -> list[dict]:
         return self._history
+
+    @property
+    def artifacts_touched(self) -> set[str]:
+        """Slugs this turn created or opened for editing.
+
+        A copy: a host reads this after the turn to decide which artifacts to
+        surface, and must not be able to mutate the session's own record.
+        """
+        return set(self._artifacts_touched)
 
     @property
     def last_compaction(self) -> dict | None:
@@ -3645,6 +3661,10 @@ class ChatSession:
         self.emitter = TurnEmitter()
         self.question_count = 0
         self.answer_wait_s = 0.0
+        # Per-turn, so a long-lived session (the CLI reuses one across turns)
+        # reports only what the CURRENT turn touched. Hosts that build a fresh
+        # session per turn get the same result either way.
+        self._artifacts_touched = set()
         # Bind the inner generator so we can close it explicitly. A bare
         # `async for` would leave it suspended at its own `yield` when a host
         # abandons this wrapper: GeneratorExit lands on OUR yield, the loop is

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -126,6 +126,73 @@ def _track_artifact(session: "ChatSession", store, slug: str, *, summary: str = 
         _log.warning("could not record turn provenance for artifact %s", slug, exc_info=True)
 
 
+def _artifact_content_mtime(folder: Path) -> float:
+    """Max mtime across an artifact folder's user-content files.
+
+    Excludes the store's own housekeeping files, mirroring cowork-server's
+    `content_mtime` gate so both sides agree on what "changed" means.
+    """
+    from anton.core.artifacts.store import (
+        METADATA_FILENAME,
+        PUBLISHED_FILENAME,
+        README_FILENAME,
+    )
+
+    housekeeping = {METADATA_FILENAME, README_FILENAME, PUBLISHED_FILENAME}
+    try:
+        return max(
+            (
+                p.stat().st_mtime
+                for p in folder.rglob("*")
+                if p.is_file()
+                and not p.is_symlink()
+                and str(p.relative_to(folder)) not in housekeeping
+            ),
+            default=0.0,
+        )
+    except OSError:
+        return 0.0
+
+
+def _snapshot_existing_artifact_mtimes(store) -> dict[str, float]:
+    """slug -> content mtime, for every artifact folder that exists right now."""
+    root = store.root
+    if not root.is_dir():
+        return {}
+    mtimes: dict[str, float] = {}
+    for child in root.iterdir():
+        if child.is_dir() and (child / "metadata.json").is_file():
+            mtimes[child.name] = _artifact_content_mtime(child)
+    return mtimes
+
+
+def _track_edits_since(session: "ChatSession", store, before: dict[str, float]) -> None:
+    """Catch an artifact edit the agent made without calling `open_artifact`.
+
+    `open_artifact` is how attribution is SUPPOSED to work (see
+    `_track_artifact` above), but nothing forces the agent to call it again
+    once it already has an artifact's path from earlier in the conversation —
+    it can (and in practice does) just write straight into a remembered
+    folder via the scratchpad, skipping the tool call entirely. Without this,
+    that edit's `_artifacts_touched` stays empty and the host can never card
+    it, even though the file genuinely changed this turn (ENG-1933 follow-up).
+
+    Scoped to THIS cell's own execution window — the snapshot taken right
+    before `pad.execute` vs. right after — rather than the whole turn, to
+    keep the diff-based race this reintroduces (a concurrent sibling
+    conversation happening to bump some other artifact's mtime) as narrow as
+    possible: seconds, not minutes. Narrower than the pre-ENG-1933 exposure,
+    not zero — the same trade-off `index_turn_artifacts` already accepts for
+    Hermes's edits.
+    """
+    already_touched = getattr(session, "_artifacts_touched", None) or ()
+    after = _snapshot_existing_artifact_mtimes(store)
+    for slug, prev_mtime in before.items():
+        current = after.get(slug)
+        if current is not None and current > prev_mtime and slug not in already_touched:
+            _track_artifact(session, store, slug, summary="Edited via scratchpad")
+
+
 async def handle_create_artifact(session: "ChatSession", tc_input: dict) -> ToolOutcome:
     """Create a fresh artifact folder + metadata.json + README.md.
 
@@ -567,6 +634,16 @@ async def handle_scratchpad(
         )
         await _fire_pre_execute(session, prelim_cell)
 
+        # Snapshot existing artifacts' content mtimes before the cell runs, so
+        # an edit the cell makes without a prior `open_artifact` call this
+        # turn still gets attributed below (see `_track_edits_since`).
+        artifact_store = _artifact_store(session)
+        before_artifact_mtimes = (
+            _snapshot_existing_artifact_mtimes(artifact_store)
+            if artifact_store is not None
+            else {}
+        )
+
         cell = await pad.execute(
             code,
             description=description,
@@ -581,6 +658,8 @@ async def handle_scratchpad(
             # Post-execute ACC event (killed vs result) via the shared helper —
             # the streaming path emits the same.
             observe_scratchpad_cell(session, name, cell)
+            if artifact_store is not None:
+                _track_edits_since(session, artifact_store, before_artifact_mtimes)
         # The runtime's verdict: a raised error/timeout/kill is a failure;
         # stderr-only output (warnings) is not, and stdout containing words
         # like "failed" is not either — the streak reads this flag, never the

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -83,6 +83,49 @@ def _artifact_store(session: "ChatSession"):
     return ArtifactStore(workspace.artifacts_dir)
 
 
+def _track_artifact(session: "ChatSession", store, slug: str, *, summary: str = "") -> None:
+    """Record that THIS turn created or opened `slug`.
+
+    Two records, for two different readers:
+
+    * `session._artifacts_touched` — in-memory, per-turn. The host reads it
+      after the turn to build the turn's artifact cards. This is what makes
+      attribution correct without diffing the artifacts directory: several
+      turns can share one project-wide artifacts folder and each still knows
+      exactly what it touched.
+    * `provenance` in the artifact's own `metadata.json`, via
+      `record_turn()` — durable, and the only record that survives the
+      process. Answers "which conversations have ever worked on this?" for
+      any later reader.
+
+    Best-effort: attribution is bookkeeping, so a failure here must never
+    fail the tool call the agent actually made.
+    """
+    try:
+        session._artifacts_touched.add(slug)
+    except AttributeError:
+        # A session predating this field (or a test double) still gets
+        # durable provenance below.
+        pass
+    conversation_id = str(getattr(session, "_session_id", "") or "")
+    if not conversation_id:
+        # No host conversation to attribute to (a bare CLI session). The
+        # in-memory set above is still useful; provenance would be a row
+        # keyed by nothing.
+        return
+    try:
+        store.record_turn(
+            slug,
+            conversation_id=conversation_id,
+            conversation_title=None,
+            turn_index=getattr(session, "_turn_count", 0) + 1,
+            summary=summary,
+            files_touched=[],
+        )
+    except Exception:
+        _log.warning("could not record turn provenance for artifact %s", slug, exc_info=True)
+
+
 async def handle_create_artifact(session: "ChatSession", tc_input: dict) -> ToolOutcome:
     """Create a fresh artifact folder + metadata.json + README.md.
 
@@ -122,6 +165,7 @@ async def handle_create_artifact(session: "ChatSession", tc_input: dict) -> Tool
         primary=primary if isinstance(primary, str) else None,
     )
     folder = store.folder_for(artifact.slug)
+    _track_artifact(session, store, artifact.slug, summary=f"Created artifact: {name}")
     return SideEffectResult(
         success=True,
         message=(
@@ -217,6 +261,7 @@ async def handle_update_artifact_metadata(session: "ChatSession", tc_input: dict
             f"Error: no artifact found for slug `{slug}`.", reason="artifact_not_found"
         )
     datasources = [d.slug for d in artifact.datasources]
+    _track_artifact(session, store, artifact.slug, summary=f"Updated artifact metadata: {artifact.name}")
     return SideEffectResult(
         success=True,
         message=(
@@ -368,6 +413,11 @@ async def handle_open_artifact(session: "ChatSession", tc_input: dict) -> str:
     if artifact is None:
         return f"Error: no artifact found for slug `{slug}`."
     folder = store.folder_for(artifact.slug)
+    # Opening is how the agent gets an artifact's path in order to write to
+    # it, so this is the turn's declaration of intent to modify. Tracked here
+    # rather than at write time because the writes themselves happen in
+    # scratchpad cells the tool layer never sees.
+    _track_artifact(session, store, artifact.slug, summary=f"Opened artifact: {artifact.name}")
     return json.dumps({
         "id": artifact.id,
         "slug": artifact.slug,

--- a/tests/test_artifact_turn_tracking.py
+++ b/tests/test_artifact_turn_tracking.py
@@ -17,12 +17,15 @@ artifact's own metadata for everyone after that.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
 
 from anton.core.artifacts import ArtifactStore
 from anton.core.tools.tool_handlers import (
+    _snapshot_existing_artifact_mtimes,
+    _track_edits_since,
     handle_create_artifact,
     handle_open_artifact,
     handle_update_artifact_metadata,
@@ -182,3 +185,105 @@ async def test_tracking_failure_never_fails_the_tool_call(session, root, monkeyp
 
     assert slug
     assert (root / slug / "metadata.json").is_file()
+
+
+# ─── edits made without re-opening (scratchpad mtime fallback) ─────────────
+#
+# `open_artifact` is how attribution is SUPPOSED to work, but nothing forces
+# the agent to call it again once it already has an artifact's path from
+# earlier in the conversation — it can (and in practice does) just write
+# straight into a remembered folder via the scratchpad. `_track_edits_since`
+# is the fallback: a before/after mtime diff scoped to one scratchpad cell's
+# own execution window, so that edit still gets attributed.
+
+
+def _bump_mtime(path: Path, delta_s: int = 2) -> None:
+    st = path.stat()
+    os.utime(path, (st.st_atime, st.st_mtime + delta_s))
+
+
+async def test_edit_without_reopening_is_tracked_via_mtime(session, root):
+    slug = await _create(session)
+    session._artifacts_touched.clear()
+
+    before = _snapshot_existing_artifact_mtimes(ArtifactStore(root))
+    # The scratchpad writing straight into the folder, bypassing open_artifact.
+    index = root / slug / "index.html"
+    index.write_text("<html>v2</html>")
+    _bump_mtime(index)
+
+    _track_edits_since(session, ArtifactStore(root), before)
+
+    assert session._artifacts_touched == {slug}
+
+
+async def test_housekeeping_only_mtime_bump_is_not_an_edit(session, root):
+    """metadata.json/README.md are the store's own bookkeeping, not artifact
+    content — touching only those must not read as the agent having edited
+    the artifact."""
+    slug = await _create(session)
+    session._artifacts_touched.clear()
+
+    before = _snapshot_existing_artifact_mtimes(ArtifactStore(root))
+    _bump_mtime(root / slug / "README.md")
+
+    _track_edits_since(session, ArtifactStore(root), before)
+
+    assert session._artifacts_touched == set()
+
+
+async def test_edit_without_reopening_stamps_provenance_too(session, root):
+    slug = await _create(session)
+    session._artifacts_touched.clear()
+
+    before = _snapshot_existing_artifact_mtimes(ArtifactStore(root))
+    index = root / slug / "index.html"
+    index.write_text("<html>v2</html>")
+    _bump_mtime(index)
+
+    _track_edits_since(session, ArtifactStore(root), before)
+
+    assert [e["conversation"] for e in _provenance(root, slug)] == ["conv-1"]
+
+
+async def test_untouched_artifact_is_not_tracked_by_mtime_fallback(session, root):
+    slug = await _create(session)
+    session._artifacts_touched.clear()
+
+    before = _snapshot_existing_artifact_mtimes(ArtifactStore(root))
+    # Nothing written this cell — the folder is exactly as it was.
+
+    _track_edits_since(session, ArtifactStore(root), before)
+
+    assert session._artifacts_touched == set()
+
+
+async def test_a_slug_that_did_not_exist_before_is_not_claimed_as_an_edit(session, root):
+    """A folder the scratchpad creates from scratch (bypassing create_artifact
+    too) isn't in `before` at all, so the mtime fallback correctly leaves it
+    alone — this path only ever claims EDITS to already-existing artifacts."""
+    before: dict[str, float] = {}
+    (root / "brand-new").mkdir(parents=True)
+    (root / "brand-new" / "metadata.json").write_text("{}")
+    (root / "brand-new" / "index.html").write_text("<html></html>")
+
+    _track_edits_since(session, ArtifactStore(root), before)
+
+    assert session._artifacts_touched == set()
+
+
+async def test_reopened_slug_is_not_double_tracked_by_the_fallback(session, root):
+    """When open_artifact WAS called this turn, the fallback is a no-op for
+    that slug — it only fills in what the tools missed."""
+    slug = await _create(session)
+    await handle_open_artifact(session, {"slug": slug})
+    assert session._artifacts_touched == {slug}
+
+    before = _snapshot_existing_artifact_mtimes(ArtifactStore(root))
+    index = root / slug / "index.html"
+    index.write_text("<html>v2</html>")
+    _bump_mtime(index)
+
+    _track_edits_since(session, ArtifactStore(root), before)
+
+    assert session._artifacts_touched == {slug}

--- a/tests/test_artifact_turn_tracking.py
+++ b/tests/test_artifact_turn_tracking.py
@@ -1,0 +1,184 @@
+"""Per-turn artifact attribution recorded by the tool handlers.
+
+A host (cowork-server) surfaces the artifacts a turn produced as cards on that
+turn's reply. It used to work that out by snapshotting the artifacts directory
+before the turn and diffing it after — which breaks as soon as two turns share
+one artifacts directory, because a concurrent turn's brand-new artifact lands
+in the other turn's diff and gets attributed to the wrong conversation
+(ENG-1933).
+
+These tests pin the replacement: the artifact tools record what they touched as
+they run, so attribution comes from the turn that actually did the work rather
+than from whatever else changed on disk meanwhile. Two records, two readers —
+an in-memory per-turn set for the host, and durable `provenance` in the
+artifact's own metadata for everyone after that.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from anton.core.artifacts import ArtifactStore
+from anton.core.tools.tool_handlers import (
+    handle_create_artifact,
+    handle_open_artifact,
+    handle_update_artifact_metadata,
+)
+
+
+class FakeWorkspace:
+    def __init__(self, root: Path) -> None:
+        self.artifacts_dir = root
+
+
+class FakeSession:
+    """The handful of ChatSession attributes the artifact handlers read."""
+
+    def __init__(self, root: Path, *, session_id: str | None = "conv-1", turn_count: int = 0) -> None:
+        self._workspace = FakeWorkspace(root)
+        self._session_id = session_id
+        self._turn_count = turn_count
+        self._artifacts_touched: set[str] = set()
+        self._data_vault = None
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    return tmp_path / "artifacts"
+
+
+@pytest.fixture
+def session(root: Path) -> FakeSession:
+    return FakeSession(root)
+
+
+def _provenance(root: Path, slug: str) -> list[dict]:
+    return json.loads((root / slug / "metadata.json").read_text())["provenance"]
+
+
+async def _create(session: FakeSession, name: str = "Dash") -> str:
+    """Create an artifact and return its slug.
+
+    Read back off the store rather than parsed out of the tool's own result,
+    so these tests don't depend on the outcome payload's shape.
+    """
+    await handle_create_artifact(
+        session, {"name": name, "description": "d", "type": "html-app"}
+    )
+    root = session._workspace.artifacts_dir
+    match = [a for a in ArtifactStore(root).list() if a.name == name]
+    assert match, f"create_artifact did not write an artifact named {name!r}"
+    return match[0].slug
+
+
+# ─── the in-memory per-turn set ─────────────────────────────────────────────
+
+
+async def test_create_tracks_the_slug_for_this_turn(session, root):
+    slug = await _create(session)
+
+    assert session._artifacts_touched == {slug}
+
+
+async def test_open_tracks_the_slug_for_this_turn(session, root):
+    """Opening is how the agent gets a path to write into, so it counts as
+    intent to modify — the writes themselves happen in scratchpad cells the
+    tool layer never observes."""
+    slug = await _create(session)
+    session._artifacts_touched.clear()
+
+    await handle_open_artifact(session, {"slug": slug})
+
+    assert session._artifacts_touched == {slug}
+
+
+async def test_update_metadata_tracks_the_slug(session, root):
+    slug = await _create(session)
+    session._artifacts_touched.clear()
+
+    await handle_update_artifact_metadata(session, {"slug": slug, "primary": "index.html"})
+
+    assert session._artifacts_touched == {slug}
+
+
+async def test_untouched_artifact_is_not_tracked(session, root):
+    """The whole point: an artifact sitting in the same directory that this
+    turn never touched must not be attributed to it. This is the case a
+    directory diff gets wrong when two turns share one artifacts folder."""
+    sibling = FakeSession(root, session_id="conv-2")
+    sibling_slug = await _create(sibling, name="Someone Elses Work")
+
+    slug = await _create(session, name="My Work")
+
+    assert session._artifacts_touched == {slug}
+    assert sibling_slug not in session._artifacts_touched
+
+
+async def test_open_of_a_missing_slug_tracks_nothing(session, root):
+    await _create(session)
+    session._artifacts_touched.clear()
+
+    await handle_open_artifact(session, {"slug": "no-such-artifact"})
+
+    assert session._artifacts_touched == set()
+
+
+# ─── durable provenance ─────────────────────────────────────────────────────
+
+
+async def test_create_stamps_provenance_with_the_conversation(session, root):
+    slug = await _create(session)
+
+    entries = _provenance(root, slug)
+    assert [e["conversation"] for e in entries] == ["conv-1"]
+    assert len(entries[0]["turns"]) == 1
+
+
+async def test_turn_index_follows_the_session(root):
+    session = FakeSession(root, turn_count=4)
+
+    slug = await _create(session)
+
+    # _turn_count is turns COMPLETED, so the turn in flight is the next one.
+    assert _provenance(root, slug)[0]["turns"][0]["index"] == 5
+
+
+async def test_two_conversations_accumulate_separate_provenance(session, root):
+    """The same artifact worked on by two conversations keeps one entry each —
+    that is the record of who has ever touched it, and the seed for any later
+    version history."""
+    slug = await _create(session)
+
+    other = FakeSession(root, session_id="conv-2")
+    await handle_open_artifact(other, {"slug": slug})
+
+    assert [e["conversation"] for e in _provenance(root, slug)] == ["conv-1", "conv-2"]
+
+
+async def test_no_conversation_id_skips_provenance_but_still_tracks(root):
+    """A bare CLI session has no host conversation to attribute to. Provenance
+    keyed by nothing is worse than none, but the in-memory set is still useful
+    to whatever is driving the session."""
+    session = FakeSession(root, session_id=None)
+
+    slug = await _create(session)
+
+    assert session._artifacts_touched == {slug}
+    assert _provenance(root, slug) == []
+
+
+async def test_tracking_failure_never_fails_the_tool_call(session, root, monkeypatch):
+    """Attribution is bookkeeping. If it breaks, the agent's actual work must
+    still succeed — a lost card is recoverable, a failed create is not."""
+    def boom(*_a, **_k):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(ArtifactStore, "record_turn", boom)
+
+    slug = await _create(session)
+
+    assert slug
+    assert (root / slug / "metadata.json").is_file()


### PR DESCRIPTION
## Summary

Part of the fix for [ENG-1933](https://linear.app/mindsdb/issue/ENG-1933) — artifact cards from one conversation showing up on another conversation's reply when two tasks run in parallel in the same project.

cowork-server surfaces a turn's artifacts as cards, and worked out *which* artifacts by snapshotting the artifacts directory before the turn and diffing it after. Every conversation in a project shares that directory, so a concurrent sibling turn's brand-new artifact appeared in the other turn's diff and got attributed to the wrong conversation. The diff can't tell "this turn made it" from "it showed up while this turn ran" — only the turn's own tools know.

So the tools now record it:

- `handle_create_artifact`, `handle_open_artifact` and `handle_update_artifact_metadata` call a shared `_track_artifact()` helper.
- **In-memory, per-turn**: `ChatSession.artifacts_touched` — what cowork-server reads after the turn to bound the cards it builds. Reset at the top of every `turn_stream()` so a long-lived session (the CLI reuses one across turns) reports only the current turn.
- **Durable**: `provenance` in the artifact's own `metadata.json`, via the store's existing `record_turn()`. This existed and was built for exactly this ("accumulate one ProvenanceEntry per conversation that ever touched it") — anton simply never called it, which is why Anton-created artifacts had empty provenance while Hermes-created ones didn't.

`open_artifact` counts as intent to modify: it's how the agent gets a path to write into, and the writes themselves happen in scratchpad cells the tool layer never sees. `launch_backend` is deliberately not tracked — it writes only a port into metadata, and the artifact it launches was already tracked when created or opened.

Best-effort throughout: attribution is bookkeeping, so a failure to record never fails the tool call the agent actually made. A session with no host conversation id (a bare CLI run) skips provenance — a row keyed by nothing is worse than none — but still populates the in-memory set.

Companion PR in cowork-server consumes this; it degrades to the previous diff-only behavior against an anton build without the field, so the two can land in either order.

## Test plan

- [x] `uv run pytest tests/test_artifact_turn_tracking.py` — 10 new tests: the per-turn set for create/open/update, that an untouched sibling artifact in the same directory is *not* tracked, provenance stamping and turn index, two conversations accumulating separate entries, the no-conversation-id case, and that a `record_turn` failure still leaves the artifact created.
- [x] `uv run pytest` — 2485 passed, 31 skipped. No regressions.