### PR TITLE
feat(anton): Turn-Key Data Vault for cloud OAuth connectors

### DIFF
--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -191,7 +191,11 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
     terminal_emitted = False
     try:
         req = TurnRequestV1.from_json(raw_line)
-        session = builder(req)
+        # build_cloud_chat_session() can block synchronously for several
+        # seconds (a turn-key OAuth token fetch per connector) — run it off
+        # the event loop thread so the heartbeat ticker above keeps firing
+        # instead of the controller seeing the turn go silent and stall it.
+        session = await asyncio.get_running_loop().run_in_executor(None, builder, req)
         # Length of the seeded history — everything anton appends past this
         # index belongs to this turn. Captured BEFORE turn_stream, so the
         # current turn's user input lands inside the slice and is trimmed off

--- a/anton/cloud_turn/contract.py
+++ b/anton/cloud_turn/contract.py
@@ -64,6 +64,11 @@ class TurnRequestV1:
     #: needs declaring in three repos (cowork-server -> scratchpad-controller's
     #: allowlist -> here), so a block keeps the next key to two.
     trace: dict | None = None
+    #: Optional turn-key OAuth credential set by cowork-server:
+    #: {"turn_key": str, "connections": [{"engine", "name"}, ...]}. Absent or
+    #: empty means no connectors for this turn — see cloud_turn/session.py's
+    #: build_cloud_chat_session, which is the only place this is read.
+    oauth: dict | None = None
 
     @staticmethod
     def from_json(raw: str) -> "TurnRequestV1":
@@ -81,4 +86,6 @@ class TurnRequestV1:
             # A controller too old to forward it simply yields None, which reads
             # as "no attribution" rather than failing the turn.
             trace=d.get("trace") if isinstance(d.get("trace"), dict) else None,
+            # Same defensive isinstance check as trace, for the same reason.
+            oauth=d.get("oauth") if isinstance(d.get("oauth"), dict) else None,
         )

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -2,14 +2,17 @@
 
 Assembles a :class:`~anton.core.session.ChatSession` scoped to the tenant's
 mounted workspace with the desktop-only, tenant-leaky behaviours OFF. It does
-NOT call the desktop ``build_chat_session`` (which loads workspace ``.env``,
-uses ``~/.anton`` personal memory, and injects vault creds into ``os.environ``).
+NOT call the desktop ``build_chat_session`` (which loads workspace ``.env``
+and uses ``~/.anton`` personal memory).
 
 Safety posture (all internal — nothing here is on the wire):
 
 * Trusted pod-side workspace mount, never taken from the request.
 * No dotenv loading (``AntonSettings(_env_file=None)``, shared into Workspace).
-* Connectors / data-vault / disk history OFF.
+* Data vault is a live :class:`~anton.core.datasources.data_vault.TurnKeyDataVault`
+  only when the turn carries an ``oauth`` block (Google Drive/Gmail via
+  auth's turn-key endpoint) — ``None`` (connectors OFF) otherwise. Disk
+  history stays OFF regardless.
 * Memory never persists pod-side: cowork sends the tenant's slots per turn, and
   writes are reported back for cowork to apply (see :func:`_build_cortex`).
 * Only reviewed, headless-safe tools are exposed (scratchpad + artifacts).
@@ -582,6 +585,20 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
 
     cortex = _build_cortex(request.memory, llm_client)
 
+    # Connectors ON only when this turn carries an oauth block (Google
+    # Drive/Gmail today). restore_namespaced_env() is the exact same
+    # function desktop's harness.py already calls for LocalDataVault: it
+    # clears+reinjects DS_* env vars and registers them for credential
+    # scrubbing (so a token can't leak into LLM-visible output) before the
+    # sandbox subprocess inherits this process's env via runtime_factory.
+    data_vault = None
+    if request.oauth:
+        from anton.core.datasources.data_vault import TurnKeyDataVault
+        from anton.utils.datasources import restore_namespaced_env
+
+        data_vault = TurnKeyDataVault(request.oauth)
+        restore_namespaced_env(data_vault)
+
     config = ChatSessionConfig(
         llm_client=llm_client,
         settings=settings,
@@ -599,7 +616,7 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
         cortex=cortex,                      # org memory; writes are reported, not stored
         episodic=None,
         self_awareness=None,
-        data_vault=None,                    # connectors OFF
+        data_vault=data_vault,              # connectors ON iff request.oauth is set
         history_store=None,                 # disk history OFF (DB authoritative)
         tools=[],                           # no host connector/publish tools
         tool_allowlist=CLOUD_TOOL_ALLOWLIST,  # only reviewed tools survive the build

--- a/anton/core/datasources/data_vault.py
+++ b/anton/core/datasources/data_vault.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
+import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
 
 
 # Sentinel used in modify-flow round-trips. The renderer fetches the
@@ -378,3 +382,150 @@ class LocalDataVault:
             if suffix.isdigit():
                 max_n = max(max_n, int(suffix))
         return max_n + 1
+
+
+#: Deployment-side override for auth's base URL (never taken from the wire
+#: request — same trust posture as ANTON_CLOUD_WORKSPACE_PATH etc. in
+#: cloud_turn/session.py). Lets a PR/staging pod point at a non-prod auth.
+ANTON_CLOUD_AUTH_BASE_URL_ENV = "ANTON_CLOUD_AUTH_BASE_URL"
+_DEFAULT_AUTH_BASE_URL = "https://auth.mindshub.ai"
+
+#: Non-secret fields the turn-key endpoint returns alongside access_token,
+#: same field names LocalDataVault already persists for these engines
+#: (cowork-server/cowork/services/connectors/oauth/google.py) — kept
+#: identical so scratchpad code sees the same DS_* var names on cloud and
+#: desktop.
+_TURNKEY_RESPONSE_FIELDS = ("access_token", "account_email", "token_type", "scope", "expires_at")
+
+
+class TurnKeyDataVault:
+    """Read-only DataVault backed by a live call to auth's turn-key token
+    endpoint (POST /v1/oauth/{engine}/token), for cloud turns only.
+
+    Connections are exactly what cowork-server resolved at enqueue time
+    (the turn's `oauth["connections"]` block) — this class never discovers
+    or persists connections on its own; `save`/`delete` are no-ops/errors,
+    matching the fact that a cloud turn never edits connections mid-turn.
+    """
+
+    def __init__(self, oauth: dict[str, Any], *, base_url: str | None = None) -> None:
+        self._turn_key = str(oauth.get("turn_key") or "")
+        self._connections: list[dict[str, str]] = [
+            {"engine": str(c["engine"]), "name": str(c["name"])}
+            for c in (oauth.get("connections") or [])
+            if isinstance(c, dict) and c.get("engine") and c.get("name")
+        ]
+        self._base_url = (
+            base_url
+            or os.environ.get(ANTON_CLOUD_AUTH_BASE_URL_ENV)
+            or _DEFAULT_AUTH_BASE_URL
+        ).rstrip("/")
+        # Per-turn cache: the loop in restore_namespaced_env() calls
+        # inject_env() once per connection already, but read_record()/load()
+        # may also be called for the same connection within the same turn
+        # (e.g. system-prompt building) — one token fetch per connection,
+        # not one per call.
+        self._cache: dict[tuple[str, str], dict[str, str] | None] = {}
+
+    def list_connections(self) -> list[dict[str, str]]:
+        """Return [{engine, name, created_at}] — created_at is unknown here,
+        so it's always empty; nothing reads it for OAuth connections today."""
+        return [{**c, "created_at": ""} for c in self._connections]
+
+    def load(self, engine: str, name: str) -> dict[str, str] | None:
+        return self._fetch(engine, name)
+
+    def read_record(self, engine: str, name: str) -> dict[str, Any] | None:
+        fields = self._fetch(engine, name)
+        if fields is None:
+            return None
+        return {
+            "engine": engine,
+            "name": name,
+            "created_at": "",
+            "updated_at": "",
+            "fields": fields,
+            "secure_keys": ["access_token"],
+        }
+
+    def save(
+        self,
+        engine: str,
+        name: str,
+        credentials: dict[str, str],
+        *,
+        secure_keys: list[str] | None = None,
+    ) -> object:
+        raise NotImplementedError("TurnKeyDataVault is read-only for the life of a turn")
+
+    def delete(self, engine: str, name: str) -> bool:
+        return False
+
+    def next_connection_number(self, engine: str) -> int:
+        return 1
+
+    def env_for(self, engine: str, name: str, *, flat: bool = False) -> dict[str, str] | None:
+        """Same contract as LocalDataVault.env_for() — see its docstring."""
+        fields = self._fetch(engine, name)
+        if fields is None:
+            return None
+        env: dict[str, str] = {}
+        if flat:
+            for key, value in fields.items():
+                env[f"DS_{key.upper()}"] = value
+        else:
+            prefix = _slug_env_prefix(engine, name)
+            for key, value in fields.items():
+                env[f"{prefix}__{key.upper()}"] = value
+        return env
+
+    def inject_env(self, engine: str, name: str, *, flat: bool = False) -> list[str] | None:
+        env = self.env_for(engine, name, flat=flat)
+        if env is None:
+            return None
+        os.environ.update(env)
+        return list(env)
+
+    def clear_ds_env(self) -> None:
+        for key in [k for k in os.environ if k.startswith("DS_")]:
+            del os.environ[key]
+
+    def _fetch(self, engine: str, name: str) -> dict[str, str] | None:
+        cache_key = (engine, name)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+        fields = self._fetch_uncached(engine, name)
+        self._cache[cache_key] = fields
+        return fields
+
+    def _fetch_uncached(self, engine: str, name: str) -> dict[str, str] | None:
+        if not self._turn_key:
+            logger.warning("TurnKeyDataVault: no turn key available for %s/%s", engine, name)
+            return None
+        from anton.minds_client import minds_request  # local: avoid a module-load-time dep from core.datasources
+
+        url = f"{self._base_url}/v1/oauth/{engine}/token"
+        try:
+            raw = minds_request(url, self._turn_key, method="POST", timeout=15)
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403):
+                # Clean, expected outcome — the connector needs reconnecting.
+                # Never a raw error or a hang: this just yields "no creds",
+                # same as a connection that was never made.
+                logger.info("connector %s/%s needs reconnecting (auth returned HTTP %s)", engine, name, e.code)
+            else:
+                logger.warning("turn-key token fetch failed for %s/%s: HTTP %s", engine, name, e.code)
+            return None
+        except Exception:
+            logger.warning("turn-key token fetch failed for %s/%s", engine, name, exc_info=True)
+            return None
+
+        try:
+            data = json.loads(raw.decode())
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            logger.warning("turn-key token fetch for %s/%s returned unparseable JSON", engine, name)
+            return None
+        if not isinstance(data, dict) or not data.get("access_token"):
+            logger.warning("turn-key token fetch for %s/%s returned no access_token", engine, name)
+            return None
+        return {k: str(data[k]) for k in _TURNKEY_RESPONSE_FIELDS if data.get(k) is not None}

--- a/anton/core/datasources/data_vault.py
+++ b/anton/core/datasources/data_vault.py
@@ -505,8 +505,13 @@ class TurnKeyDataVault:
         from anton.minds_client import minds_request  # local: avoid a module-load-time dep from core.datasources
 
         url = f"{self._base_url}/v1/oauth/{engine}/token"
+        # `name` disambiguates when an org has more than one connection for
+        # this engine — the endpoint auto-resolves a lone connection without
+        # it, but 400s on an ambiguous one. Sent as JSON body, matching
+        # auth's request.data.get("name") read.
+        payload = json.dumps({"name": name}).encode()
         try:
-            raw = minds_request(url, self._turn_key, method="POST", timeout=15)
+            raw = minds_request(url, self._turn_key, method="POST", payload=payload, timeout=15)
         except urllib.error.HTTPError as e:
             if e.code in (401, 403):
                 # Clean, expected outcome — the connector needs reconnecting.
@@ -528,4 +533,17 @@ class TurnKeyDataVault:
         if not isinstance(data, dict) or not data.get("access_token"):
             logger.warning("turn-key token fetch for %s/%s returned no access_token", engine, name)
             return None
-        return {k: str(data[k]) for k in _TURNKEY_RESPONSE_FIELDS if data.get(k) is not None}
+        fields = {k: str(data[k]) for k in _TURNKEY_RESPONSE_FIELDS if data.get(k) is not None}
+        # Every credential this vault serves is OAuth-backed by construction
+        # (the turn-key endpoint only exists for OAuth connectors) — this is
+        # the same signal LocalDataVault's own stored `auth_type` field gives
+        # build_datasource_context() on desktop, so synthesize it rather than
+        # depend on auth's response carrying it.
+        fields["auth_type"] = "oauth"
+        picked_files = data.get("_picked_files")
+        if picked_files:
+            # Auth doesn't send this yet (ENG follow-up), but the shape is
+            # ready: same JSON-string-in-a-field convention _parse_picked_files
+            # (anton/utils/datasources.py) reads from LocalDataVault.
+            fields["_picked_files"] = picked_files if isinstance(picked_files, str) else json.dumps(picked_files)
+        return fields

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -382,6 +382,20 @@ def _connection_identity(fields: dict, secure_keys: list | None = None) -> str |
     return None
 
 
+def _is_oauth_connection(vault: DataVault, engine: str, name: str) -> bool:
+    """True when this connection's own stored fields say auth_type=oauth.
+
+    An OAuth connection's engine name can collide with an unrelated registry
+    entry of the same name (gmail's registry entry is the legacy IMAP
+    connector) — its field schema never matches, so it must not be
+    classified against that registry entry. Cheap: TurnKeyDataVault caches
+    per (engine, name), so this never costs a second network fetch.
+    """
+    record = vault.read_record(engine, name) if hasattr(vault, "read_record") else None
+    fields = (record or {}).get("fields") or {}
+    return fields.get("auth_type") == "oauth"
+
+
 def restore_namespaced_env(vault: DataVault) -> None:
     """Clear all DS_* vars, then reinject every saved connection as namespaced."""
     _reset_registered_ds_vars()
@@ -390,7 +404,7 @@ def restore_namespaced_env(vault: DataVault) -> None:
     for conn in vault.list_connections():
         vault.inject_env(conn["engine"], conn["name"])  # flat=False by default
         edef = dreg.get(conn["engine"])
-        if edef is not None:
+        if edef is not None and not _is_oauth_connection(vault, conn["engine"], conn["name"]):
             register_secret_vars(edef, engine=conn["engine"], name=conn["name"])
         else:
             _register_unregistered_connection_vars(vault, conn["engine"], conn["name"])

--- a/tests/cloud_turn/test_heartbeat.py
+++ b/tests/cloud_turn/test_heartbeat.py
@@ -32,3 +32,33 @@ async def test_stream_turn_emits_heartbeat_during_slow_turn(monkeypatch):
     assert "heartbeat" in kinds
     assert kinds[-1] == "turn_completed"
     assert {"kind": "delta", "text": "done"} in events
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_emits_heartbeat_during_a_slow_synchronous_session_builder(monkeypatch):
+    """session_builder (build_cloud_chat_session in production) can block the
+    calling thread synchronously — e.g. a turn-key OAuth token fetch per
+    connector — before turn_stream() ever starts. The heartbeat ticker must
+    keep firing during that window too, not just once streaming begins."""
+    import time
+
+    from anton.core.llm.provider import StreamTextDelta
+
+    class FastSession:
+        async def turn_stream(self, user_input, **kwargs):
+            yield StreamTextDelta(text="done")
+
+        def close(self): ...
+
+    def slow_builder(req):
+        time.sleep(0.25)  # quiet period longer than the heartbeat interval
+        return FastSession()
+
+    monkeypatch.setenv("ANTON_CLOUD_TURN_HEARTBEAT_SECONDS", "0.05")
+    events = []
+    raw = '{"protocol_version":1,"conversation_id":"c","input":"hi"}'
+    await m.stream_turn(raw, emit=events.append, session_builder=slow_builder)
+
+    kinds = [e["kind"] for e in events]
+    assert "heartbeat" in kinds
+    assert kinds[-1] == "turn_completed"

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -828,6 +828,7 @@ def test_oauth_block_populates_ds_env_from_the_turn_key_endpoint(tmp_path, monke
     os.environ.pop("DS_GOOGLE_DRIVE_PRIMARY__TOKEN_TYPE", None)
     os.environ.pop("DS_GOOGLE_DRIVE_PRIMARY__SCOPE", None)
     os.environ.pop("DS_GOOGLE_DRIVE_PRIMARY__EXPIRES_AT", None)
+    os.environ.pop("DS_GOOGLE_DRIVE_PRIMARY__AUTH_TYPE", None)
 
 
 def test_needs_reconnect_yields_no_env_not_a_crash(tmp_path, monkeypatch):

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -10,6 +10,8 @@ Two layers:
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 import anton.core.llm.client as llm_client_mod
@@ -775,3 +777,69 @@ def test_a_trace_block_without_a_surface_leaves_it_unset(tmp_path, monkeypatch):
     # resolve). That must not become a junk value.
     _, cfg = _build(tmp_path, monkeypatch, trace={"install_channel": "hosted"})
     assert cfg.surface is None
+
+
+# ── turn-key OAuth data vault ────────────────────────────────────────────────
+# Turn-Key Token Handoff: a cloud turn with connectors gets a live
+# TurnKeyDataVault instead of None, and DS_* env is (re)populated for it the
+# same way desktop's harness.py does for LocalDataVault.
+
+def test_no_oauth_block_leaves_data_vault_none(tmp_path, monkeypatch):
+    _, cfg = _build(tmp_path, monkeypatch)
+    assert cfg.data_vault is None
+
+
+def test_oauth_block_produces_a_turn_key_data_vault(tmp_path, monkeypatch):
+    from anton.core.datasources.data_vault import TurnKeyDataVault
+
+    oauth = {"turn_key": "tk_abc", "connections": [{"engine": "google_drive", "name": "primary"}]}
+    _, cfg = _build(tmp_path, monkeypatch, oauth=oauth)
+    assert isinstance(cfg.data_vault, TurnKeyDataVault)
+    assert cfg.data_vault.list_connections() == [
+        {"engine": "google_drive", "name": "primary", "created_at": ""}
+    ]
+
+
+def test_oauth_block_populates_ds_env_from_the_turn_key_endpoint(tmp_path, monkeypatch):
+    import anton.core.datasources.data_vault as data_vault_mod
+
+    calls: list[str] = []
+
+    def fake_minds_request(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        calls.append(url)
+        assert api_key == "tk_abc"
+        assert method == "POST"
+        return b'{"access_token": "live-token", "account_email": "a@b.com", "token_type": "Bearer", "scope": "drive.file", "expires_at": "2026-08-26T00:00:00Z"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
+    monkeypatch.delenv("DS_GOOGLE_DRIVE_PRIMARY__ACCESS_TOKEN", raising=False)
+
+    oauth = {"turn_key": "tk_abc", "connections": [{"engine": "google_drive", "name": "primary"}]}
+    _build(tmp_path, monkeypatch, oauth=oauth)
+
+    assert os.environ["DS_GOOGLE_DRIVE_PRIMARY__ACCESS_TOKEN"] == "live-token"
+    assert os.environ["DS_GOOGLE_DRIVE_PRIMARY__ACCOUNT_EMAIL"] == "a@b.com"
+    # One fetch to build the env, and restore_namespaced_env's secret-var
+    # registration reuses the same cached result rather than fetching again.
+    assert calls == [f"{data_vault_mod._DEFAULT_AUTH_BASE_URL}/v1/oauth/google_drive/token"]
+
+    os.environ.pop("DS_GOOGLE_DRIVE_PRIMARY__ACCESS_TOKEN", None)
+    os.environ.pop("DS_GOOGLE_DRIVE_PRIMARY__ACCOUNT_EMAIL", None)
+    os.environ.pop("DS_GOOGLE_DRIVE_PRIMARY__TOKEN_TYPE", None)
+    os.environ.pop("DS_GOOGLE_DRIVE_PRIMARY__SCOPE", None)
+    os.environ.pop("DS_GOOGLE_DRIVE_PRIMARY__EXPIRES_AT", None)
+
+
+def test_needs_reconnect_yields_no_env_not_a_crash(tmp_path, monkeypatch):
+    import urllib.error
+
+    def fake_minds_request(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        raise urllib.error.HTTPError(url, 403, "Forbidden", {}, None)
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake_minds_request)
+
+    oauth = {"turn_key": "tk_abc", "connections": [{"engine": "gmail", "name": "primary"}]}
+    _, cfg = _build(tmp_path, monkeypatch, oauth=oauth)
+
+    assert cfg.data_vault.load("gmail", "primary") is None
+    assert "DS_GMAIL_PRIMARY__ACCESS_TOKEN" not in os.environ

--- a/tests/test_scrubbing.py
+++ b/tests/test_scrubbing.py
@@ -207,3 +207,36 @@ class TestCustomEngineRegistration:
         assert "https://legacy.acme-crm.example" in result
         assert passphrase not in result
         assert "[DS_ACME_CRM_LEGACY__PASSPHRASE]" in result
+
+
+class TestOAuthEngineRegistryCollision:
+    """A cloud gmail OAuth connection shares its engine name with the
+    registry's legacy IMAP gmail connector (datasources.md) — its OAuth
+    fields (access_token, account_email, ...) must classify against the
+    vault's own secure_keys, not the IMAP entry's (email, app_password)."""
+
+    def test_gmail_oauth_fields_classify_against_the_vault_not_the_imap_registry_entry(self, monkeypatch):
+        from anton.core.datasources.data_vault import TurnKeyDataVault
+        from anton.utils.datasources import restore_namespaced_env
+
+        # Long enough (> 8 chars) to actually exercise the coarse "unknown
+        # DS_* var" bucket if misclassified — a short value dodges it either
+        # way and would pass this test for the wrong reason.
+        email = "someone@example.com"
+
+        def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+            return f'{{"access_token": "ya29.live-token", "account_email": "{email}", "scope": "gmail.readonly"}}'.encode()
+
+        monkeypatch.setattr("anton.minds_client.minds_request", fake)
+        vault = TurnKeyDataVault({"turn_key": "tk_abc", "connections": [{"engine": "gmail", "name": "primary"}]})
+        restore_namespaced_env(vault)
+
+        result = scrub_credentials(f"token ya29.live-token for {email} scope gmail.readonly")
+        assert "ya29.live-token" not in result
+        assert "[DS_GMAIL_PRIMARY__ACCESS_TOKEN]" in result
+        # Non-secret metadata must stay visible — before the fix, both fell
+        # into the coarse "unknown DS_* var, len > 8" bucket instead, since
+        # the IMAP registry entry's fields (email, app_password) never
+        # registered these as known.
+        assert email in result
+        assert "gmail.readonly" in result

--- a/tests/test_turn_key_data_vault.py
+++ b/tests/test_turn_key_data_vault.py
@@ -49,8 +49,25 @@ def test_load_fetches_and_shapes_the_token_response(monkeypatch):
 
     monkeypatch.setattr("anton.minds_client.minds_request", fake)
     fields = _vault().load("google_drive", "primary")
-    assert fields == {"access_token": "tok", "account_email": "a@b.com"}
+    assert fields == {"access_token": "tok", "account_email": "a@b.com", "auth_type": "oauth"}
     assert "refresh_token" not in fields
+
+
+def test_load_sends_the_connection_name_so_auth_can_disambiguate(monkeypatch):
+    """A name-less request auto-resolves only when an org has exactly one
+    connection for the engine — auth 400s on more than one. Sending name
+    always avoids that instead of depending on org-specific connection counts."""
+    import json as _json
+
+    seen = {}
+
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        seen["payload"] = _json.loads(payload.decode()) if payload else None
+        return b'{"access_token": "tok"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    _vault().load("google_drive", "primary")
+    assert seen["payload"] == {"name": "primary"}
 
 
 def test_second_fetch_for_the_same_connection_is_cached(monkeypatch):
@@ -101,6 +118,7 @@ def test_env_for_namespaces_like_local_data_vault(monkeypatch):
     assert env == {
         "DS_GOOGLE_DRIVE_PRIMARY__ACCESS_TOKEN": "tok",
         "DS_GOOGLE_DRIVE_PRIMARY__ACCOUNT_EMAIL": "a@b.com",
+        "DS_GOOGLE_DRIVE_PRIMARY__AUTH_TYPE": "oauth",
     }
 
 
@@ -110,7 +128,7 @@ def test_env_for_flat_mode(monkeypatch):
 
     monkeypatch.setattr("anton.minds_client.minds_request", fake)
     env = _vault().env_for("google_drive", "primary", flat=True)
-    assert env == {"DS_ACCESS_TOKEN": "tok"}
+    assert env == {"DS_ACCESS_TOKEN": "tok", "DS_AUTH_TYPE": "oauth"}
 
 
 def test_read_record_marks_only_access_token_as_secret(monkeypatch):
@@ -121,6 +139,31 @@ def test_read_record_marks_only_access_token_as_secret(monkeypatch):
     record = _vault().read_record("google_drive", "primary")
     assert record["secure_keys"] == ["access_token"]
     assert record["fields"]["token_type"] == "Bearer"
+
+
+def test_auth_type_is_always_synthesized_as_oauth(monkeypatch):
+    """Every credential this vault serves is OAuth-backed by construction —
+    auth's response doesn't need to say so for build_datasource_context()
+    (anton/utils/datasources.py) to recognize a connected account."""
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        return b'{"access_token": "tok"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    fields = _vault().load("google_drive", "primary")
+    assert fields["auth_type"] == "oauth"
+
+
+def test_picked_files_passes_through_as_a_json_string(monkeypatch):
+    """Forward-compat: auth doesn't send `_picked_files` yet, but once it
+    does, this must land in the same JSON-string-in-a-field shape
+    _parse_picked_files() (anton/utils/datasources.py) reads from
+    LocalDataVault, not as a native list."""
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        return b'{"access_token": "tok", "_picked_files": [{"id": "f1", "name": "doc.pdf"}]}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    fields = _vault().load("google_drive", "primary")
+    assert fields["_picked_files"] == '[{"id": "f1", "name": "doc.pdf"}]'
 
 
 def test_save_and_delete_are_never_valid_mid_turn():

--- a/tests/test_turn_key_data_vault.py
+++ b/tests/test_turn_key_data_vault.py
@@ -1,0 +1,143 @@
+"""Unit coverage for TurnKeyDataVault — the cloud-turn DataVault backed by
+auth's turn-key token endpoint (see anton/cloud_turn/session.py).
+"""
+from __future__ import annotations
+
+import urllib.error
+
+import pytest
+
+from anton.core.datasources.data_vault import (
+    ANTON_CLOUD_AUTH_BASE_URL_ENV,
+    DataVault,
+    TurnKeyDataVault,
+)
+
+
+def _vault(**oauth_overrides) -> TurnKeyDataVault:
+    oauth = {"turn_key": "tk_abc", "connections": [{"engine": "google_drive", "name": "primary"}]}
+    oauth.update(oauth_overrides)
+    return TurnKeyDataVault(oauth)
+
+
+def test_satisfies_the_data_vault_protocol():
+    assert isinstance(_vault(), DataVault)
+
+
+def test_list_connections_reflects_the_oauth_block_without_a_network_call(monkeypatch):
+    def fail(*a, **kw):
+        raise AssertionError("list_connections must not make a network call")
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fail)
+    vault = _vault()
+    assert vault.list_connections() == [
+        {"engine": "google_drive", "name": "primary", "created_at": ""}
+    ]
+
+
+def test_malformed_connection_entries_are_dropped():
+    vault = _vault(connections=[{"engine": "google_drive"}, {"name": "primary"}, "not-a-dict", {}])
+    assert vault.list_connections() == []
+
+
+def test_load_fetches_and_shapes_the_token_response(monkeypatch):
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        assert url.endswith("/v1/oauth/google_drive/token")
+        assert method == "POST"
+        assert api_key == "tk_abc"
+        return b'{"access_token": "tok", "account_email": "a@b.com", "refresh_token": "must-not-leak"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    fields = _vault().load("google_drive", "primary")
+    assert fields == {"access_token": "tok", "account_email": "a@b.com"}
+    assert "refresh_token" not in fields
+
+
+def test_second_fetch_for_the_same_connection_is_cached(monkeypatch):
+    calls = []
+
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        calls.append(url)
+        return b'{"access_token": "tok"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    vault = _vault()
+    assert vault.load("google_drive", "primary") is not None
+    assert vault.env_for("google_drive", "primary") is not None
+    assert len(calls) == 1
+
+
+def test_403_reads_as_needs_reconnect_not_a_crash(monkeypatch):
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        raise urllib.error.HTTPError(url, 403, "Forbidden", {}, None)
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    assert _vault().load("google_drive", "primary") is None
+
+
+def test_missing_access_token_in_response_is_treated_as_a_miss(monkeypatch):
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        return b'{"account_email": "a@b.com"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    assert _vault().load("google_drive", "primary") is None
+
+
+def test_no_turn_key_short_circuits_without_a_network_call(monkeypatch):
+    def fail(*a, **kw):
+        raise AssertionError("must not call out with no turn key")
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fail)
+    vault = TurnKeyDataVault({"connections": [{"engine": "gmail", "name": "primary"}]})
+    assert vault.load("gmail", "primary") is None
+
+
+def test_env_for_namespaces_like_local_data_vault(monkeypatch):
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        return b'{"access_token": "tok", "account_email": "a@b.com"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    env = _vault().env_for("google_drive", "primary")
+    assert env == {
+        "DS_GOOGLE_DRIVE_PRIMARY__ACCESS_TOKEN": "tok",
+        "DS_GOOGLE_DRIVE_PRIMARY__ACCOUNT_EMAIL": "a@b.com",
+    }
+
+
+def test_env_for_flat_mode(monkeypatch):
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        return b'{"access_token": "tok"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    env = _vault().env_for("google_drive", "primary", flat=True)
+    assert env == {"DS_ACCESS_TOKEN": "tok"}
+
+
+def test_read_record_marks_only_access_token_as_secret(monkeypatch):
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        return b'{"access_token": "tok", "token_type": "Bearer"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    record = _vault().read_record("google_drive", "primary")
+    assert record["secure_keys"] == ["access_token"]
+    assert record["fields"]["token_type"] == "Bearer"
+
+
+def test_save_and_delete_are_never_valid_mid_turn():
+    vault = _vault()
+    with pytest.raises(NotImplementedError):
+        vault.save("google_drive", "primary", {"access_token": "x"})
+    assert vault.delete("google_drive", "primary") is False
+
+
+def test_base_url_env_override(monkeypatch):
+    monkeypatch.setenv(ANTON_CLOUD_AUTH_BASE_URL_ENV, "https://auth.pr-123.dev.mindshub.ai")
+    seen = {}
+
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        seen["url"] = url
+        return b'{"access_token": "tok"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    _vault().load("google_drive", "primary")
+    assert seen["url"] == "https://auth.pr-123.dev.mindshub.ai/v1/oauth/google_drive/token"


### PR DESCRIPTION
Linear ticket: https://linear.app/mindsdb/issue/ENG-208/mindshub-oauth-proxy-and-data-vault

## What was changed

- **Turn-Key Token Handoff** — new `TurnKeyDataVault` class (satisfying the same `DataVault` protocol `LocalDataVault` does) fetches a live connector token from `auth` using the turn's turn key, for cloud turns only. Wired into `build_cloud_chat_session()` in place of the previous `data_vault=None`. Desktop/local-mode turns are unaffected.

## Notes

- New ANTON_CLOUD_AUTH_BASE_URL env var defaults to auth.mindshub.ai, correct for production, but isn't set anywhere yet for other environments — needs to be explicitly set to the real auth hostname of whichever environment this gets tested in (e.g. staging's auth.staging.mindshub.ai, or a PR-environment's own per-instance auth URL).

TODO: set ANTON_CLOUD_AUTH_BASE_URL to the target environment's real auth hostname before testing there.

## Related PRs

- mindsdb/auth#327
- mindsdb/cowork-server#391
- mindsdb/cowork#730
- mindsdb/Mind-Castle#22
- mindsdb/scratchpad-controller#33
