### PR TITLE
Scope scratchpad subprocess env to the current data vault

### DIFF
--- a/anton/commands/datasource/verify.py
+++ b/anton/commands/datasource/verify.py
@@ -36,14 +36,18 @@ async def run_connection_test(
         console.print("[anton.cyan](anton)[/] Got it. Testing connection…")
 
         vault.clear_ds_env()
+        flat_ds_env: dict[str, str] = {}
         for key, value in credentials.items():
             if key.startswith("_"):
                 continue
             os.environ[f"DS_{key.upper()}"] = value
+            flat_ds_env[f"DS_{key.upper()}"] = value
         register_secret_vars(engine_def)  # flat mode, for scrubbing during test
 
         try:
-            pad = await scratchpads.get_or_create("__datasource_test__")
+            pad = await scratchpads.get_or_create(
+                "__datasource_test__", ds_env_override=flat_ds_env
+            )
             await pad.reset()
             if engine_def.pip:
                 if isinstance(engine_def.pip, list):
@@ -153,10 +157,13 @@ async def handle_test_datasource(
     vault.clear_ds_env()
     vault.inject_env(engine, name, flat=True)
     register_secret_vars(engine_def)  # flat names for scrubbing during test
+    flat_ds_env = vault.env_for(engine, name, flat=True) or {}
 
     cell = None
     try:
-        pad = await scratchpads.get_or_create("__datasource_test__")
+        pad = await scratchpads.get_or_create(
+            "__datasource_test__", ds_env_override=flat_ds_env
+        )
         await pad.reset()
         if engine_def.pip:
             await pad.install_packages([engine_def.pip])

--- a/anton/core/backends/base.py
+++ b/anton/core/backends/base.py
@@ -263,8 +263,7 @@ class ScratchpadRuntimeFactory(Protocol):
         # pad name without reading each other's state (ENG-1124). Optional so hosts
         # and test doubles that predate it keep working.
         session_id: str | None = None,
-        # Explicit DS_* env values for this pad, when the host has a data
-        # vault to scope them from. Optional so hosts and test doubles
-        # that predate it keep working.
+        # Explicit DS_* env values for this pad, when the host has a data vault
+        # to scope them from. Optional for hosts/test doubles that predate it.
         scratchpad_ds_env: dict[str, str] | None = None,
     ) -> ScratchpadRuntime: ...

--- a/anton/core/backends/base.py
+++ b/anton/core/backends/base.py
@@ -263,4 +263,8 @@ class ScratchpadRuntimeFactory(Protocol):
         # pad name without reading each other's state (ENG-1124). Optional so hosts
         # and test doubles that predate it keep working.
         session_id: str | None = None,
+        # Explicit DS_* env values for this pad, when the host has a data
+        # vault to scope them from. Optional so hosts and test doubles
+        # that predate it keep working.
+        scratchpad_ds_env: dict[str, str] | None = None,
     ) -> ScratchpadRuntime: ...

--- a/anton/core/backends/base.py
+++ b/anton/core/backends/base.py
@@ -102,6 +102,9 @@ class ScratchpadRuntime(ABC):
         """
         return None
 
+    def set_scratchpad_ds_env(self, ds_env: dict[str, str] | None) -> None:
+        """Override this pad's DS_* env for its next start()/reset(); no-op unless a backend supports it."""
+
     async def execute(
         self,
         code: str,

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -204,6 +204,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         cells: list[Cell] | None = None,
         workspace_path: Path | None = None,
         session_id: str | None = None,
+        scratchpad_ds_env: dict[str, str] | None = None,
         _venvs_base: Path | None = None,
     ) -> None:
         super().__init__(
@@ -227,6 +228,11 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         # conversation's UUID as `session_id`). Only used to scope the namespace
         # snapshot — see `_session_snapshot_path`.
         self._session_id: str | None = session_id
+        # Explicit DS_* values for this pad's subprocess, computed by
+        # ScratchpadManager from the current data vault. None (default)
+        # leaves DS_* handling exactly as before — the parent env's own
+        # copy, whatever it holds.
+        self._scratchpad_ds_env: dict[str, str] | None = scratchpad_ds_env
         self._proc: asyncio.subprocess.Process | None = None
         self._boot_path: str | None = None
         self._venv_dir: str | None = None
@@ -600,6 +606,14 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
 
         # Force UTF-8 in the child (ENG-824).
         env = _utf8_env(os.environ)
+        if self._scratchpad_ds_env is not None:
+            # Never trust inherited DS_* values — they may belong to a
+            # different conversation/connection set than this vault's
+            # current state. Strip whatever the parent process is
+            # holding, then overlay exactly what this pad should see.
+            for key in [k for k in env if k.startswith("DS_")]:
+                del env[key]
+            env.update(self._scratchpad_ds_env)
         if self._coding_model:
             env["ANTON_SCRATCHPAD_MODEL"] = self._coding_model
         if self._coding_provider:

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -616,8 +616,12 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
             env.update(self._scratchpad_ds_env)
         if self._coding_model:
             env["ANTON_SCRATCHPAD_MODEL"] = self._coding_model
+        else:
+            env.pop("ANTON_SCRATCHPAD_MODEL", None)
         if self._coding_provider:
             env["ANTON_SCRATCHPAD_PROVIDER"] = self._coding_provider
+        else:
+            env.pop("ANTON_SCRATCHPAD_PROVIDER", None)
         # Propagate provider credentials from the ANTON_* names into the SDK
         # names the scratchpad's nested get_llm() expects.
         if "ANTHROPIC_API_KEY" not in env and "ANTON_ANTHROPIC_API_KEY" in env:

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -1359,6 +1359,7 @@ def local_scratchpad_runtime_factory(
     cells: list[Cell] | None,
     workspace_path: Path | None,
     session_id: str | None = None,
+    scratchpad_ds_env: dict[str, str] | None = None,
 ) -> ScratchpadRuntime:
     return LocalScratchpadRuntime(
         name=name,
@@ -1369,4 +1370,5 @@ def local_scratchpad_runtime_factory(
         cells=cells,
         workspace_path=workspace_path,
         session_id=session_id,
+        scratchpad_ds_env=scratchpad_ds_env,
     )

--- a/anton/core/backends/local.py
+++ b/anton/core/backends/local.py
@@ -228,10 +228,7 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         # conversation's UUID as `session_id`). Only used to scope the namespace
         # snapshot — see `_session_snapshot_path`.
         self._session_id: str | None = session_id
-        # Explicit DS_* values for this pad's subprocess, computed by
-        # ScratchpadManager from the current data vault. None (default)
-        # leaves DS_* handling exactly as before — the parent env's own
-        # copy, whatever it holds.
+        # DS_* overlay for this pad's subprocess; None keeps legacy full-copy behaviour.
         self._scratchpad_ds_env: dict[str, str] | None = scratchpad_ds_env
         self._proc: asyncio.subprocess.Process | None = None
         self._boot_path: str | None = None
@@ -249,6 +246,9 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         self._venvs_base = (
             _venvs_base if _venvs_base is not None else default_venvs_base(workspace_path)
         )
+
+    def set_scratchpad_ds_env(self, ds_env: dict[str, str] | None) -> None:
+        self._scratchpad_ds_env = ds_env
 
     def _session_snapshot_path(self, *, create: bool = False) -> Path | None:
         """Where this pad's namespace snapshot lives, or None if it can't be written.
@@ -607,10 +607,8 @@ class LocalScratchpadRuntime(ScratchpadRuntime):
         # Force UTF-8 in the child (ENG-824).
         env = _utf8_env(os.environ)
         if self._scratchpad_ds_env is not None:
-            # Never trust inherited DS_* values — they may belong to a
-            # different conversation/connection set than this vault's
-            # current state. Strip whatever the parent process is
-            # holding, then overlay exactly what this pad should see.
+            # Never trust inherited DS_* values — strip them, then overlay
+            # exactly what this pad should see.
             for key in [k for k in env if k.startswith("DS_")]:
                 del env[key]
             env.update(self._scratchpad_ds_env)

--- a/anton/core/backends/manager.py
+++ b/anton/core/backends/manager.py
@@ -174,13 +174,7 @@ class ScratchpadManager:
         return sorted({d.metadata["Name"] for d in distributions()})
 
     def _scratchpad_ds_env(self) -> dict[str, str] | None:
-        """DS_* env values from the current vault state, or None without a vault.
-
-        Built fresh on every call, not cached, so a pad created after a
-        mid-session /connect sees the newly added connection — the same
-        timing LocalScratchpadRuntime's own os.environ-at-spawn-time
-        behaviour already has.
-        """
+        """DS_* env values from the current vault state, fresh each call; None without a vault."""
         if self._data_vault is None:
             return None
         env: dict[str, str] = {}

--- a/anton/core/backends/manager.py
+++ b/anton/core/backends/manager.py
@@ -6,6 +6,7 @@ import inspect
 from pathlib import Path
 
 from anton.core.backends.base import Cell, ScratchpadRuntime, ScratchpadRuntimeFactory
+from anton.core.datasources.data_vault import DataVault
 
 
 class ScratchpadManager:
@@ -21,6 +22,7 @@ class ScratchpadManager:
         cells: list[Cell] | None = None,
         workspace_path: Path | None = None,
         session_id: str | None = None,
+        data_vault: DataVault | None = None,
     ) -> None:
         self._pads: dict[str, ScratchpadRuntime] = {}
         self._runtime_factory = runtime_factory
@@ -33,6 +35,7 @@ class ScratchpadManager:
         # Conversation id, forwarded to each runtime so its namespace snapshot is
         # scoped per conversation (ENG-1124).
         self._session_id = session_id
+        self._data_vault = data_vault
         # Only pass `session_id` to factories that accept it. A default on the Protocol
         # does not adapt an existing callable, so passing it unconditionally raises
         # `TypeError: unexpected keyword argument` for an out-of-tree factory written
@@ -40,6 +43,9 @@ class ScratchpadManager:
         # uses to stay compatible with older anton builds. Resolved once, not per call.
         self._factory_takes_session_id = self._probe_factory_kwarg(
             runtime_factory, "session_id"
+        )
+        self._factory_takes_scratchpad_ds_env = self._probe_factory_kwarg(
+            runtime_factory, "scratchpad_ds_env"
         )
         self._available_packages: list[str] = self.probe_packages()
 
@@ -167,6 +173,21 @@ class ScratchpadManager:
 
         return sorted({d.metadata["Name"] for d in distributions()})
 
+    def _scratchpad_ds_env(self) -> dict[str, str] | None:
+        """DS_* env values from the current vault state, or None without a vault.
+
+        Built fresh on every call, not cached, so a pad created after a
+        mid-session /connect sees the newly added connection — the same
+        timing LocalScratchpadRuntime's own os.environ-at-spawn-time
+        behaviour already has.
+        """
+        if self._data_vault is None:
+            return None
+        env: dict[str, str] = {}
+        for conn in self._data_vault.list_connections():
+            env.update(self._data_vault.env_for(conn["engine"], conn["name"]) or {})
+        return env
+
     async def get_or_create(self, name: str) -> ScratchpadRuntime:
         """Return existing pad or create + start a new one."""
         if name not in self._pads:
@@ -179,6 +200,11 @@ class ScratchpadManager:
                 coding_base_url=self._coding_base_url,
                 workspace_path=self._workspace_path,
                 **({"session_id": self._session_id} if self._factory_takes_session_id else {}),
+                **(
+                    {"scratchpad_ds_env": self._scratchpad_ds_env()}
+                    if self._factory_takes_scratchpad_ds_env
+                    else {}
+                ),
             )
             await pad.start()
             self._pads[name] = pad

--- a/anton/core/backends/manager.py
+++ b/anton/core/backends/manager.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from pathlib import Path
 
 from anton.core.backends.base import Cell, ScratchpadRuntime, ScratchpadRuntimeFactory
 from anton.core.datasources.data_vault import DataVault
+
+logger = logging.getLogger(__name__)
 
 
 class ScratchpadManager:
@@ -173,17 +176,35 @@ class ScratchpadManager:
 
         return sorted({d.metadata["Name"] for d in distributions()})
 
-    def _scratchpad_ds_env(self) -> dict[str, str] | None:
+    def _derive_ds_env(self) -> dict[str, str] | None:
         """DS_* env values from the current vault state, fresh each call; None without a vault."""
         if self._data_vault is None:
             return None
         env: dict[str, str] = {}
-        for conn in self._data_vault.list_connections():
-            env.update(self._data_vault.env_for(conn["engine"], conn["name"]) or {})
+        try:
+            connections = self._data_vault.list_connections()
+        except Exception:
+            logger.debug("Could not list data vault connections", exc_info=True)
+            return env
+        for conn in connections:
+            # Per-connection try/except so one bad record can't abort
+            # building env for the rest.
+            engine = conn.get("engine")
+            name = conn.get("name")
+            if not (engine and name):
+                continue
+            try:
+                env.update(self._data_vault.env_for(engine, name) or {})
+            except Exception:
+                logger.debug(
+                    "Could not build scratchpad env for %s/%s", engine, name, exc_info=True
+                )
         return env
 
-    async def get_or_create(self, name: str) -> ScratchpadRuntime:
-        """Return existing pad or create + start a new one."""
+    async def get_or_create(
+        self, name: str, *, ds_env_override: dict[str, str] | None = None
+    ) -> ScratchpadRuntime:
+        """Return existing pad or create one; ds_env_override overrides its DS_* env for the next restart."""
         if name not in self._pads:
             pad = self._runtime_factory(
                 name=name,
@@ -195,13 +216,15 @@ class ScratchpadManager:
                 workspace_path=self._workspace_path,
                 **({"session_id": self._session_id} if self._factory_takes_session_id else {}),
                 **(
-                    {"scratchpad_ds_env": self._scratchpad_ds_env()}
+                    {"scratchpad_ds_env": self._derive_ds_env()}
                     if self._factory_takes_scratchpad_ds_env
                     else {}
                 ),
             )
             await pad.start()
             self._pads[name] = pad
+        if ds_env_override is not None:
+            self._pads[name].set_scratchpad_ds_env(ds_env_override)
         return self._pads[name]
 
     async def remove(self, name: str) -> str:

--- a/anton/core/datasources/data_vault.py
+++ b/anton/core/datasources/data_vault.py
@@ -171,6 +171,16 @@ class DataVault(Protocol):
         """Return [{engine, name, created_at}] for all stored connections."""
         ...
 
+    def env_for(self, engine: str, name: str, *, flat: bool = False) -> dict[str, str] | None:
+        """Build the DS_* env mapping for a connection WITHOUT mutating os.environ.
+
+        Returns the {var: value} mapping, or None if the connection isn't
+        found. Use this when the env should reach only a specific
+        subprocess; use `inject_env` when the variables must be visible in
+        the current process.
+        """
+        ...
+
     def inject_env(self, engine: str, name: str, *, flat: bool = False) -> list[str] | None:
         """Load credentials and set DS_* environment variables."""
         ...

--- a/anton/core/datasources/data_vault.py
+++ b/anton/core/datasources/data_vault.py
@@ -172,13 +172,7 @@ class DataVault(Protocol):
         ...
 
     def env_for(self, engine: str, name: str, *, flat: bool = False) -> dict[str, str] | None:
-        """Build the DS_* env mapping for a connection WITHOUT mutating os.environ.
-
-        Returns the {var: value} mapping, or None if the connection isn't
-        found. Use this when the env should reach only a specific
-        subprocess; use `inject_env` when the variables must be visible in
-        the current process.
-        """
+        """Build the DS_* env mapping for a connection, without touching os.environ."""
         ...
 
     def inject_env(self, engine: str, name: str, *, flat: bool = False) -> list[str] | None:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1167,6 +1167,7 @@ class ChatSession:
             cells=config.cells,
             workspace_path=config.workspace.base if config.workspace else None,
             session_id=config.session_id,
+            data_vault=config.data_vault,
         )
 
         self.tool_registry = ToolRegistry()

--- a/docs/superpowers/plans/2026-08-26-scratchpad-ds-env-scoping.md
+++ b/docs/superpowers/plans/2026-08-26-scratchpad-ds-env-scoping.md
@@ -1,0 +1,780 @@
+# Scratchpad DS_* Env Scoping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a scratchpad subprocess from inheriting `DS_*` datasource credentials it has no business seeing, by building its env from the current data vault instead of trusting whatever is sitting in the parent process's `os.environ`.
+
+**Architecture:** `LocalScratchpadRuntime.start()` gains an explicit `scratchpad_ds_env: dict[str, str] | None` — when set, it strips every inherited `DS_`-prefixed key from the copied parent env and overlays exactly this dict. `ScratchpadManager` computes that dict fresh, at the moment it creates a new pad, from a `data_vault` it's now handed. `ChatSession` passes its already-existing `config.data_vault` through. `None` anywhere in this chain (no vault) means today's behavior, unchanged.
+
+**Tech Stack:** Python 3.11+, `uv`, `pytest` (`pytest-asyncio`, tests are `async def` with no explicit marker per this repo's existing convention).
+
+**Spec:** `docs/superpowers/specs/2026-08-26-scratchpad-ds-env-scoping-design.md`
+
+## Global Constraints
+
+- Single repo: `anton` only. No `cowork-server` changes.
+- `scratchpad_ds_env=None` / `data_vault=None` anywhere in the chain must leave behavior byte-for-byte identical to today — this is the CLI/legacy path and must not regress.
+- Only the `DS_` prefix is ever stripped/overlaid. Every other env var (system vars, `ANTON_*`/`OPENAI_*`/`ANTHROPIC_*` coding-model vars) passes through exactly as it does today.
+- No new `ChatSessionConfig` field — `data_vault` already exists there.
+- New optional kwargs on `ScratchpadRuntimeFactory` follow the existing `_probe_factory_kwarg` compatibility pattern (see `manager.py:41-43,46-55`) so factories that don't know about them (e.g. `remote.py`'s) keep working unmodified.
+- Match existing code style in each file: `from __future__ import annotations`, type all signatures, comments explain *why* not *what*, ≤2 lines per comment.
+- Test convention in this repo for scratchpad backends is real subprocess execution (`await pad.start()` / `await pad.execute(...)`), not mocks — follow `tests/test_scratchpad.py::TestScratchpadEnvironment` exactly.
+- **Commit granularity:** one commit per logically-independent change, not one per task — small enough to revert individually without pulling in unrelated changes.
+- **Commit messages:** one short line stating the change. No ticket numbers, issue IDs, or ticket names.
+- **Comments/docstrings you write:** never reference a ticket number or issue ID. (Surrounding existing code in these files already does this in places — that's pre-existing convention; don't extend it in anything new you add.)
+
+---
+
+### Task 1: `LocalScratchpadRuntime` — accept and apply an explicit DS_* overlay
+
+**Files:**
+- Modify: `anton/core/backends/local.py:196-230` (`__init__`), `anton/core/backends/local.py:591-607` (`start`)
+- Test: `tests/test_scratchpad.py` (extend `class TestScratchpadEnvironment`, starts at line 497)
+
+**Interfaces:**
+- Consumes: nothing new from other tasks.
+- Produces: `LocalScratchpadRuntime.__init__(..., scratchpad_ds_env: dict[str, str] | None = None)` and the instance attribute `self._scratchpad_ds_env`, which Task 2 reads indirectly by passing this kwarg through the factory.
+
+This task lands as two small commits: the DS_* overlay itself, then the separate (smaller) model/provider leak fix.
+
+#### Part A — the DS_* overlay
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `tests/test_scratchpad.py`. Add these three tests at the end of `class TestScratchpadEnvironment` (after `test_api_key_bridged`, before the blank line that precedes `class TestScratchpadVenv:`):
+
+```python
+    async def test_scratchpad_ds_env_none_preserves_inherited_ds_vars(self, monkeypatch):
+        """scratchpad_ds_env=None (default) keeps today's behaviour: inherited
+        DS_* vars pass through untouched."""
+        monkeypatch.setenv("DS_POSTGRES_PROD__PASSWORD", "inherited-secret")
+        pad = make_scratchpad(name="ds-env-none")
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os; print(os.environ.get('DS_POSTGRES_PROD__PASSWORD', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "inherited-secret"
+        finally:
+            await pad.close()
+
+    async def test_scratchpad_ds_env_empty_strips_all_inherited_ds_vars(self, monkeypatch):
+        """An explicit empty dict (empty vault / all connections disabled)
+        strips every inherited DS_* var — none are added back."""
+        monkeypatch.setenv("DS_POSTGRES_PROD__PASSWORD", "should-not-leak")
+        pad = make_scratchpad(name="ds-env-empty", scratchpad_ds_env={})
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os; print(os.environ.get('DS_POSTGRES_PROD__PASSWORD', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "NOT_FOUND"
+        finally:
+            await pad.close()
+
+    async def test_scratchpad_ds_env_only_exposes_explicit_keys(self, monkeypatch):
+        """Only the DS_* pairs in scratchpad_ds_env are visible — a DS_* var
+        inherited for a different connection is stripped even though a
+        DIFFERENT DS_* var was explicitly allowed."""
+        monkeypatch.setenv("DS_SLACK_MAIN__BOT_TOKEN", "wrong-conversation-token")
+        pad = make_scratchpad(
+            name="ds-env-scoped",
+            scratchpad_ds_env={"DS_POSTGRES_PROD__PASSWORD": "right-conversation-secret"},
+        )
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os\n"
+                "print(os.environ.get('DS_POSTGRES_PROD__PASSWORD', 'NOT_FOUND'))\n"
+                "print(os.environ.get('DS_SLACK_MAIN__BOT_TOKEN', 'NOT_FOUND'))"
+            )
+            lines = cell.stdout.strip().splitlines()
+            assert lines[0] == "right-conversation-secret"
+            assert lines[1] == "NOT_FOUND"
+        finally:
+            await pad.close()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_scratchpad.py -k "test_scratchpad_ds_env" -v`
+
+Expected: `test_scratchpad_ds_env_none_preserves_inherited_ds_vars` PASSES already (describes today's behavior). The other two FAIL with `TypeError: __init__() got an unexpected keyword argument 'scratchpad_ds_env'`.
+
+- [ ] **Step 3: Add `scratchpad_ds_env` to `__init__`**
+
+In `anton/core/backends/local.py`, the `__init__` signature at line 196 currently reads (through line 230):
+
+```python
+    def __init__(
+        self,
+        name: str,
+        *,
+        coding_provider: str,
+        coding_model: str,
+        coding_api_key: str,
+        coding_base_url: str,
+        cells: list[Cell] | None = None,
+        workspace_path: Path | None = None,
+        session_id: str | None = None,
+        _venvs_base: Path | None = None,
+    ) -> None:
+```
+
+Add the new parameter after `session_id`:
+
+```python
+    def __init__(
+        self,
+        name: str,
+        *,
+        coding_provider: str,
+        coding_model: str,
+        coding_api_key: str,
+        coding_base_url: str,
+        cells: list[Cell] | None = None,
+        workspace_path: Path | None = None,
+        session_id: str | None = None,
+        scratchpad_ds_env: dict[str, str] | None = None,
+        _venvs_base: Path | None = None,
+    ) -> None:
+```
+
+Then at line 229 (`self._session_id: str | None = session_id`), add the new attribute right after it:
+
+```python
+        self._session_id: str | None = session_id
+        # Explicit DS_* values for this pad's subprocess, computed by
+        # ScratchpadManager from the current data vault. None (default)
+        # leaves DS_* handling exactly as before — the parent env's own
+        # copy, whatever it holds.
+        self._scratchpad_ds_env: dict[str, str] | None = scratchpad_ds_env
+        self._proc: asyncio.subprocess.Process | None = None
+```
+
+- [ ] **Step 4: Apply the overlay in `start()`**
+
+In `anton/core/backends/local.py`, lines 602-606 currently read:
+
+```python
+        env = _utf8_env(os.environ)
+        if self._coding_model:
+            env["ANTON_SCRATCHPAD_MODEL"] = self._coding_model
+        if self._coding_provider:
+            env["ANTON_SCRATCHPAD_PROVIDER"] = self._coding_provider
+```
+
+Replace with:
+
+```python
+        env = _utf8_env(os.environ)
+        if self._scratchpad_ds_env is not None:
+            # Never trust inherited DS_* values — they may belong to a
+            # different conversation/connection set than this vault's
+            # current state. Strip whatever the parent process is
+            # holding, then overlay exactly what this pad should see.
+            for key in [k for k in env if k.startswith("DS_")]:
+                del env[key]
+            env.update(self._scratchpad_ds_env)
+        if self._coding_model:
+            env["ANTON_SCRATCHPAD_MODEL"] = self._coding_model
+        if self._coding_provider:
+            env["ANTON_SCRATCHPAD_PROVIDER"] = self._coding_provider
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_scratchpad.py -k "test_scratchpad_ds_env" -v`
+
+Expected: all 3 PASS.
+
+- [ ] **Step 6: Run the full scratchpad test file**
+
+Run: `uv run pytest tests/test_scratchpad.py -v`
+
+Expected: PASS (no regressions in the ~180 pre-existing tests in this file).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add anton/core/backends/local.py tests/test_scratchpad.py
+git commit -m "Scope scratchpad subprocess env to an explicit DS_* overlay"
+```
+
+#### Part B — stop leaking an unconfigured model/provider
+
+- [ ] **Step 8: Write the failing tests**
+
+Add these two tests right after the three from Part A (still inside `class TestScratchpadEnvironment`):
+
+```python
+    async def test_scratchpad_model_not_leaked_when_unconfigured(self, monkeypatch):
+        """An inherited ANTON_SCRATCHPAD_MODEL must not reach a pad that has
+        no coding model configured."""
+        monkeypatch.setenv("ANTON_SCRATCHPAD_MODEL", "inherited-model")
+        pad = make_scratchpad(name="ds-env-no-model")  # coding_model="" by default
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os; print(os.environ.get('ANTON_SCRATCHPAD_MODEL', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "NOT_FOUND"
+        finally:
+            await pad.close()
+
+    async def test_scratchpad_provider_not_leaked_when_unconfigured(self, monkeypatch):
+        """An inherited ANTON_SCRATCHPAD_PROVIDER must not reach a pad that
+        has no coding provider configured."""
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PROVIDER", "inherited-provider")
+        pad = make_scratchpad(name="ds-env-no-provider", coding_provider="")
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os; print(os.environ.get('ANTON_SCRATCHPAD_PROVIDER', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "NOT_FOUND"
+        finally:
+            await pad.close()
+```
+
+- [ ] **Step 9: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_scratchpad.py -k "not_leaked_when_unconfigured" -v`
+
+Expected: both FAIL with an assertion mismatch (`"inherited-model" != "NOT_FOUND"` / `"inherited-provider" != "NOT_FOUND"`) — today nothing pops an inherited `ANTON_SCRATCHPAD_MODEL`/`PROVIDER` when the pad has no coding model/provider configured, so the monkeypatched value leaks straight through.
+
+- [ ] **Step 10: Pop the inherited var when unconfigured**
+
+In `anton/core/backends/local.py`, the block Step 4 just left reads:
+
+```python
+        if self._coding_model:
+            env["ANTON_SCRATCHPAD_MODEL"] = self._coding_model
+        if self._coding_provider:
+            env["ANTON_SCRATCHPAD_PROVIDER"] = self._coding_provider
+```
+
+Replace with:
+
+```python
+        if self._coding_model:
+            env["ANTON_SCRATCHPAD_MODEL"] = self._coding_model
+        else:
+            env.pop("ANTON_SCRATCHPAD_MODEL", None)
+        if self._coding_provider:
+            env["ANTON_SCRATCHPAD_PROVIDER"] = self._coding_provider
+        else:
+            env.pop("ANTON_SCRATCHPAD_PROVIDER", None)
+```
+
+- [ ] **Step 11: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_scratchpad.py -k "not_leaked_when_unconfigured" -v`
+
+Expected: both PASS.
+
+- [ ] **Step 12: Run the full scratchpad test file again**
+
+Run: `uv run pytest tests/test_scratchpad.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add anton/core/backends/local.py tests/test_scratchpad.py
+git commit -m "Stop an unconfigured scratchpad from inheriting a model/provider"
+```
+
+---
+
+### Task 2: `ScratchpadManager` derives the DS_* overlay from a data vault
+
+**Files:**
+- Modify: `anton/core/datasources/data_vault.py:170-176` (add `env_for` to the `DataVault` protocol)
+- Modify: `anton/core/backends/base.py:251-266` (`ScratchpadRuntimeFactory.__call__`)
+- Modify: `anton/core/backends/local.py:1334-1354` (`local_scratchpad_runtime_factory`)
+- Modify: `anton/core/backends/manager.py` (`ScratchpadManager.__init__` and `get_or_create`)
+- Test: `tests/test_scratchpad.py` (extend `class TestScratchpadManager`, starts at line 267)
+
+**Interfaces:**
+- Consumes: `LocalScratchpadRuntime(..., scratchpad_ds_env=...)` from Task 1; `DataVault.list_connections() -> list[dict[str, str]]` and `DataVault.env_for(engine: str, name: str, *, flat: bool = False) -> dict[str, str] | None` (already implemented by `LocalDataVault`, `anton/core/datasources/data_vault.py:287-306,308-339`).
+- Produces: `ScratchpadManager.__init__(..., data_vault: DataVault | None = None)`. Task 3 passes `config.data_vault` here.
+
+This task lands as three small commits: the protocol declaration, the factory plumbing, then the manager behavior + its tests.
+
+#### Part A — declare `env_for` on the `DataVault` protocol
+
+`ScratchpadManager` (Part C, below) is about to call `data_vault.env_for(...)` on a value typed as `DataVault` (the protocol), not `LocalDataVault` directly. `env_for` is already implemented on `LocalDataVault` (`anton/core/datasources/data_vault.py:308-339`) but isn't declared on the protocol itself, which would make it invisible to type checkers.
+
+- [ ] **Step 1: Add `env_for` to the protocol**
+
+In `anton/core/datasources/data_vault.py`, lines 170-176 currently read:
+
+```python
+    def list_connections(self) -> list[dict[str, str]]:
+        """Return [{engine, name, created_at}] for all stored connections."""
+        ...
+
+    def inject_env(self, engine: str, name: str, *, flat: bool = False) -> list[str] | None:
+        """Load credentials and set DS_* environment variables."""
+        ...
+```
+
+Insert a new method between them, so the protocol reads:
+
+```python
+    def list_connections(self) -> list[dict[str, str]]:
+        """Return [{engine, name, created_at}] for all stored connections."""
+        ...
+
+    def env_for(self, engine: str, name: str, *, flat: bool = False) -> dict[str, str] | None:
+        """Build the DS_* env mapping for a connection WITHOUT mutating os.environ.
+
+        Returns the {var: value} mapping, or None if the connection isn't
+        found. Use this when the env should reach only a specific
+        subprocess; use `inject_env` when the variables must be visible in
+        the current process.
+        """
+        ...
+
+    def inject_env(self, engine: str, name: str, *, flat: bool = False) -> list[str] | None:
+        """Load credentials and set DS_* environment variables."""
+        ...
+```
+
+- [ ] **Step 2: Sanity check — nothing broke**
+
+Run: `uv run pytest tests/test_data_vault.py -v`
+
+Expected: PASS. This step adds no new behavior (`LocalDataVault.env_for` already existed and is untouched); it only makes an existing method part of the declared protocol, so there's no new test to write here — just confirm the file still imports and the existing suite is green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add anton/core/datasources/data_vault.py
+git commit -m "Declare env_for on the DataVault protocol"
+```
+
+#### Part B — thread `scratchpad_ds_env` through the runtime factory
+
+- [ ] **Step 4: Update the factory protocol**
+
+In `anton/core/backends/base.py`, the `ScratchpadRuntimeFactory.__call__` signature at lines 251-266 currently ends:
+
+```python
+        workspace_path: Path | None,
+        # Conversation/session identifier, when the host supplies one. Scopes the
+        # namespace snapshot so two conversations in one workspace can reuse the same
+        # pad name without reading each other's state (ENG-1124). Optional so hosts
+        # and test doubles that predate it keep working.
+        session_id: str | None = None,
+    ) -> ScratchpadRuntime: ...
+```
+
+Add the new parameter after `session_id`:
+
+```python
+        workspace_path: Path | None,
+        # Conversation/session identifier, when the host supplies one. Scopes the
+        # namespace snapshot so two conversations in one workspace can reuse the same
+        # pad name without reading each other's state (ENG-1124). Optional so hosts
+        # and test doubles that predate it keep working.
+        session_id: str | None = None,
+        # Explicit DS_* env values for this pad, when the host has a data
+        # vault to scope them from. Optional so hosts and test doubles
+        # that predate it keep working.
+        scratchpad_ds_env: dict[str, str] | None = None,
+    ) -> ScratchpadRuntime: ...
+```
+
+(The `(ENG-1124)` reference above is pre-existing text you are not touching — leave it as is; just add the new parameter below it.)
+
+- [ ] **Step 5: Update `local_scratchpad_runtime_factory`**
+
+In `anton/core/backends/local.py`, `local_scratchpad_runtime_factory` at lines 1334-1354 currently reads:
+
+```python
+def local_scratchpad_runtime_factory(
+    *,
+    name: str,
+    coding_provider: str,
+    coding_model: str,
+    coding_api_key: str,
+    coding_base_url: str,
+    cells: list[Cell] | None,
+    workspace_path: Path | None,
+    session_id: str | None = None,
+) -> ScratchpadRuntime:
+    return LocalScratchpadRuntime(
+        name=name,
+        coding_provider=coding_provider,
+        coding_model=coding_model,
+        coding_api_key=coding_api_key,
+        coding_base_url=coding_base_url,
+        cells=cells,
+        workspace_path=workspace_path,
+        session_id=session_id,
+    )
+```
+
+Replace with:
+
+```python
+def local_scratchpad_runtime_factory(
+    *,
+    name: str,
+    coding_provider: str,
+    coding_model: str,
+    coding_api_key: str,
+    coding_base_url: str,
+    cells: list[Cell] | None,
+    workspace_path: Path | None,
+    session_id: str | None = None,
+    scratchpad_ds_env: dict[str, str] | None = None,
+) -> ScratchpadRuntime:
+    return LocalScratchpadRuntime(
+        name=name,
+        coding_provider=coding_provider,
+        coding_model=coding_model,
+        coding_api_key=coding_api_key,
+        coding_base_url=coding_base_url,
+        cells=cells,
+        workspace_path=workspace_path,
+        session_id=session_id,
+        scratchpad_ds_env=scratchpad_ds_env,
+    )
+```
+
+- [ ] **Step 6: Sanity check — nothing broke**
+
+Run: `uv run pytest tests/test_scratchpad.py -v`
+
+Expected: PASS. Nothing calls the factory with `scratchpad_ds_env` yet (that's Part C), so this is pure plumbing — confirm the signature change alone doesn't break any existing caller.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add anton/core/backends/base.py anton/core/backends/local.py
+git commit -m "Thread scratchpad_ds_env through the runtime factory"
+```
+
+#### Part C — `ScratchpadManager` derives and passes the overlay
+
+- [ ] **Step 8: Write the failing tests**
+
+Open `tests/test_scratchpad.py`. Add a fake vault class right after the `make_manager` helper (after line 35, before `class TestScratchpadBasicExecution:`):
+
+```python
+class _FakeVault:
+    """Duck-typed DataVault stand-in — ScratchpadManager only calls
+    list_connections() and env_for()."""
+
+    def __init__(self, connections: dict[tuple[str, str], dict[str, str] | None]) -> None:
+        self._connections = connections
+
+    def list_connections(self) -> list[dict[str, str]]:
+        return [{"engine": e, "name": n} for e, n in self._connections]
+
+    def env_for(self, engine: str, name: str, *, flat: bool = False) -> dict[str, str] | None:
+        return self._connections[(engine, name)]
+```
+
+Then add these three tests at the end of `class TestScratchpadManager` (after `test_close_all_does_not_restart_processes`, before the blank line that precedes `class TestScratchpadRenderNotebook:`):
+
+```python
+    async def test_get_or_create_derives_ds_env_from_vault(self):
+        """A new pad gets exactly this vault's current DS_* values."""
+        vault = _FakeVault({
+            ("postgres", "prod"): {"DS_POSTGRES_PROD__HOST": "db.example.com"},
+            ("slack", "main"): {"DS_SLACK_MAIN__BOT_TOKEN": "xoxb-123"},
+        })
+        mgr = make_manager(data_vault=vault)
+        try:
+            pad = await mgr.get_or_create("alpha")
+            assert pad._scratchpad_ds_env == {
+                "DS_POSTGRES_PROD__HOST": "db.example.com",
+                "DS_SLACK_MAIN__BOT_TOKEN": "xoxb-123",
+            }
+        finally:
+            await mgr.close_all()
+
+    async def test_get_or_create_skips_connection_whose_env_for_fails(self):
+        """A connection whose env_for() returns None contributes nothing,
+        not a crash."""
+        vault = _FakeVault({
+            ("postgres", "gone"): None,
+            ("postgres", "prod"): {"DS_POSTGRES_PROD__HOST": "db.example.com"},
+        })
+        mgr = make_manager(data_vault=vault)
+        try:
+            pad = await mgr.get_or_create("alpha")
+            assert pad._scratchpad_ds_env == {"DS_POSTGRES_PROD__HOST": "db.example.com"}
+        finally:
+            await mgr.close_all()
+
+    async def test_get_or_create_without_vault_passes_none(self):
+        """No data_vault (default) -> scratchpad_ds_env stays None, so
+        LocalScratchpadRuntime keeps its legacy full-copy behaviour."""
+        mgr = make_manager()  # no data_vault
+        try:
+            pad = await mgr.get_or_create("alpha")
+            assert pad._scratchpad_ds_env is None
+        finally:
+            await mgr.close_all()
+```
+
+- [ ] **Step 9: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_scratchpad.py -k "derives_ds_env or skips_connection_whose_env_for_fails or without_vault_passes_none" -v`
+
+Expected: `test_get_or_create_without_vault_passes_none` PASSES already (nothing changed yet, `scratchpad_ds_env` is already `None` by default from Task 1). The other two FAIL with `TypeError: __init__() got an unexpected keyword argument 'data_vault'`.
+
+- [ ] **Step 10: Add `data_vault` to `ScratchpadManager` and derive the overlay in `get_or_create`**
+
+In `anton/core/backends/manager.py`, add the import at the top (after the existing `from anton.core.backends.base import ...` line):
+
+```python
+from anton.core.datasources.data_vault import DataVault
+```
+
+The `__init__` signature currently reads:
+
+```python
+    def __init__(
+        self,
+        runtime_factory: ScratchpadRuntimeFactory,
+        coding_provider: str,
+        coding_model: str,
+        coding_api_key: str,
+        coding_base_url: str,
+        cells: list[Cell] | None = None,
+        workspace_path: Path | None = None,
+        session_id: str | None = None,
+    ) -> None:
+```
+
+Add `data_vault` after `session_id`:
+
+```python
+    def __init__(
+        self,
+        runtime_factory: ScratchpadRuntimeFactory,
+        coding_provider: str,
+        coding_model: str,
+        coding_api_key: str,
+        coding_base_url: str,
+        cells: list[Cell] | None = None,
+        workspace_path: Path | None = None,
+        session_id: str | None = None,
+        data_vault: DataVault | None = None,
+    ) -> None:
+```
+
+Right after `self._session_id = session_id` (line 35), store it:
+
+```python
+        self._session_id = session_id
+        self._data_vault = data_vault
+```
+
+Right after the existing `self._factory_takes_session_id = self._probe_factory_kwarg(...)` block (lines 41-43), add the second probe:
+
+```python
+        self._factory_takes_session_id = self._probe_factory_kwarg(
+            runtime_factory, "session_id"
+        )
+        self._factory_takes_scratchpad_ds_env = self._probe_factory_kwarg(
+            runtime_factory, "scratchpad_ds_env"
+        )
+```
+
+Add a new private method anywhere in the class (e.g. right before `get_or_create`):
+
+```python
+    def _scratchpad_ds_env(self) -> dict[str, str] | None:
+        """DS_* env values from the current vault state, or None without a vault.
+
+        Built fresh on every call, not cached, so a pad created after a
+        mid-session /connect sees the newly added connection — the same
+        timing LocalScratchpadRuntime's own os.environ-at-spawn-time
+        behaviour already has.
+        """
+        if self._data_vault is None:
+            return None
+        env: dict[str, str] = {}
+        for conn in self._data_vault.list_connections():
+            env.update(self._data_vault.env_for(conn["engine"], conn["name"]) or {})
+        return env
+```
+
+Finally, `get_or_create` (lines 170-185) currently reads:
+
+```python
+    async def get_or_create(self, name: str) -> ScratchpadRuntime:
+        """Return existing pad or create + start a new one."""
+        if name not in self._pads:
+            pad = self._runtime_factory(
+                name=name,
+                cells=self._cells,
+                coding_provider=self._coding_provider,
+                coding_model=self._coding_model,
+                coding_api_key=self._coding_api_key,
+                coding_base_url=self._coding_base_url,
+                workspace_path=self._workspace_path,
+                **({"session_id": self._session_id} if self._factory_takes_session_id else {}),
+            )
+            await pad.start()
+            self._pads[name] = pad
+        return self._pads[name]
+```
+
+Add the second conditional kwarg the same way:
+
+```python
+    async def get_or_create(self, name: str) -> ScratchpadRuntime:
+        """Return existing pad or create + start a new one."""
+        if name not in self._pads:
+            pad = self._runtime_factory(
+                name=name,
+                cells=self._cells,
+                coding_provider=self._coding_provider,
+                coding_model=self._coding_model,
+                coding_api_key=self._coding_api_key,
+                coding_base_url=self._coding_base_url,
+                workspace_path=self._workspace_path,
+                **({"session_id": self._session_id} if self._factory_takes_session_id else {}),
+                **(
+                    {"scratchpad_ds_env": self._scratchpad_ds_env()}
+                    if self._factory_takes_scratchpad_ds_env
+                    else {}
+                ),
+            )
+            await pad.start()
+            self._pads[name] = pad
+        return self._pads[name]
+```
+
+- [ ] **Step 11: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_scratchpad.py -k "derives_ds_env or skips_connection_whose_env_for_fails or without_vault_passes_none" -v`
+
+Expected: all 3 PASS.
+
+- [ ] **Step 12: Run the full scratchpad test file, and the data vault tests**
+
+Run: `uv run pytest tests/test_scratchpad.py tests/test_data_vault.py -v`
+
+Expected: PASS, no regressions.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add anton/core/backends/manager.py tests/test_scratchpad.py
+git commit -m "Derive the scratchpad DS_* overlay from the active vault"
+```
+
+---
+
+### Task 3: Wire `ChatSessionConfig.data_vault` into `ScratchpadManager`
+
+**Files:**
+- Modify: `anton/core/session.py:1161-1170`
+
+**Interfaces:**
+- Consumes: `ScratchpadManager(..., data_vault: DataVault | None = None)` from Task 2.
+- Produces: nothing further downstream — this is the last task, the point where CLI and desktop-sidecar cowork-server callers (both of which already populate `ChatSessionConfig.data_vault`, unchanged) start getting the real fix.
+
+- [ ] **Step 1: Wire it through**
+
+In `anton/core/session.py`, the `ScratchpadManager(...)` construction at lines 1161-1170 currently reads:
+
+```python
+        self._scratchpads = ScratchpadManager(
+            runtime_factory=config.runtime_factory,
+            coding_provider=coding_conn.provider,
+            coding_model=config.llm_client.coding_model,
+            coding_api_key=coding_conn.api_key or "",
+            coding_base_url=coding_conn.base_url or "",
+            cells=config.cells,
+            workspace_path=config.workspace.base if config.workspace else None,
+            session_id=config.session_id,
+        )
+```
+
+Add `data_vault`:
+
+```python
+        self._scratchpads = ScratchpadManager(
+            runtime_factory=config.runtime_factory,
+            coding_provider=coding_conn.provider,
+            coding_model=config.llm_client.coding_model,
+            coding_api_key=coding_conn.api_key or "",
+            coding_base_url=coding_conn.base_url or "",
+            cells=config.cells,
+            workspace_path=config.workspace.base if config.workspace else None,
+            session_id=config.session_id,
+            data_vault=config.data_vault,
+        )
+```
+
+No new test here: constructing a full `ChatSession` needs a live LLM client and many other dependencies (`tests/test_session_acc_init.py`'s own docstring notes this, and the `session_id=config.session_id` line right above — added earlier for a related fix — has no dedicated wiring test either, for the same reason). Task 2's `ScratchpadManager`-level tests already cover the behavior this line switches on; this step is verified by the full suite in Step 3 plus the manual check in Step 2.
+
+- [ ] **Step 2: Manual sanity check — the vault-to-subprocess-env chain works end to end**
+
+Run this from the `anton` worktree root (no fixtures, no test harness — a plain script against a throwaway vault dir):
+
+```bash
+uv run python -c "
+import asyncio, tempfile
+from pathlib import Path
+from anton.core.datasources.data_vault import LocalDataVault
+from anton.core.backends.local import LocalScratchpadRuntime
+
+async def main():
+    with tempfile.TemporaryDirectory() as d:
+        vault = LocalDataVault(Path(d))
+        vault.save('postgres', 'prod', {'host': 'db.example.com', 'password': 'sanity-check-secret'})
+        ds_env = {}
+        for conn in vault.list_connections():
+            ds_env.update(vault.env_for(conn['engine'], conn['name']) or {})
+        print('computed ds_env:', ds_env)
+
+        pad = LocalScratchpadRuntime(
+            name='sanity', coding_provider='anthropic', coding_model='',
+            coding_api_key='', coding_base_url='', scratchpad_ds_env=ds_env,
+        )
+        await pad.start()
+        try:
+            cell = await pad.execute('import os; print([k for k in os.environ if k.startswith(\"DS_\")])')
+            print('subprocess saw:', cell.stdout.strip())
+        finally:
+            await pad.close()
+
+asyncio.run(main())
+"
+```
+
+Expected: `computed ds_env` shows a `DS_POSTGRES_PROD__PASSWORD`-style key, and `subprocess saw:` lists that same key — confirming the whole chain (`env_for` → `ScratchpadManager`'s derivation logic, exercised here inline → `LocalScratchpadRuntime.start()`'s overlay) actually produces the intended subprocess env, not just the individually-unit-tested pieces.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `uv run pytest`
+
+Expected: PASS. Report any pre-existing failures unrelated to this change separately rather than attributing them to this task (per this workspace's testing convention).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add anton/core/session.py
+git commit -m "Pass the active data vault into the scratchpad manager"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every mechanism section of the design doc maps to a task — `env_for` reuse (Task 2, Part A), the `LocalScratchpadRuntime` strip-and-overlay (Task 1, Part A), the model/provider leak fix (Task 1, Part B), fresh-per-pad-creation derivation (Task 2, Part C — `_scratchpad_ds_env` docstring), `ChatSessionConfig.data_vault` reuse with no new field (Task 3). Explicitly-out-of-scope items (`scrub_credentials`, the cloud pod, the `pip install` env, `cowork-server`) have no task, by design.
+- **Placeholder scan:** no TBDs; every step has literal code or an exact runnable command.
+- **Type consistency:** `scratchpad_ds_env: dict[str, str] | None` is spelled identically in `LocalScratchpadRuntime.__init__`, `ScratchpadRuntimeFactory.__call__`, and `local_scratchpad_runtime_factory` across Tasks 1–2. `DataVault | None` is spelled identically in `ScratchpadManager.__init__` (Task 2) and matches the type already used in `ChatSessionConfig.data_vault` (Task 3, pre-existing).
+- **No ticket references introduced:** every new comment/docstring in every code block above was checked and contains no ticket number. Two pre-existing comments quoted verbatim as surrounding context (the `(ENG-1124)` line in `base.py`, Task 2 Part B) are existing code you are shown but not asked to change — leave them exactly as they are.

--- a/docs/superpowers/specs/2026-08-26-scratchpad-ds-env-scoping-design.md
+++ b/docs/superpowers/specs/2026-08-26-scratchpad-ds-env-scoping-design.md
@@ -1,0 +1,150 @@
+# Scratchpad DS_* env scoping (ENG-392)
+
+## Problem
+
+`LocalScratchpadRuntime.start()` (`anton/core/backends/local.py:591-733`) copies
+the entire parent process `os.environ` into every scratchpad subprocess
+(`env = _utf8_env(os.environ)`, line 602). On the desktop-sidecar / local
+single-tenant path, `AntonHarness._build_chat_session`
+(`cowork-server/cowork/harnesses/anton_harness/harness.py`) injects every one
+of the user's connected datasources into that same process's `os.environ` via
+`data_vault.inject_env()`. Combined, a scratchpad started for one conversation
+inherits `DS_*` credentials for every connected datasource, including
+connections disabled for, or unrelated to, that specific conversation — the
+exposure ENG-392 describes.
+
+## Scope
+
+Fix the desktop-sidecar / local in-process path. No `cowork-server` changes.
+
+The real hosted multi-tenant deployment never runs this code path at all:
+`harness.py:418-436` raises `RuntimeError` out of `_build_chat_session` whenever
+`tenancy_mode == "org"`, and `deployment/cowork-server/values.yaml` sets
+`COWORK_TENANCY_MODE=org` + `COWORK_TURN_BACKEND=remote` for every environment
+the chart deploys (dev/staging/prod). Org-mode turns instead go
+`cowork-server → Redis → scratchpad-controller → k8s exec python -m
+anton.cloud_turn` inside a per-conversation gVisor pod. That pod's
+`build_cloud_chat_session()` (`anton/cloud_turn/session.py:518-621`) builds
+`ChatSessionConfig(data_vault=None, ...)` — connectors are off on the cloud
+path entirely today, so nothing injects `DS_*` there to leak. The pod's
+`LocalScratchpadRuntime.start()` still does the same unfiltered `os.environ`
+copy, but this task does not change that: nothing confirmed exploitable there
+today, and out of scope per decision below.
+
+Explicitly out of scope, carried as follow-ups (see bottom):
+
+- `scrub_credentials()`'s own read of `os.environ` / `_DS_SECRET_VARS`
+  (`anton/utils/datasources.py:138-175`) — same hazard class, different
+  mechanism (needs values to redact, not just names to allow through).
+- The cloud pod's env copy — harmless only because `data_vault=None` there
+  today.
+- The `pip install` subprocess env (`local.py` ~line 1276) — doesn't need
+  `DS_*` credentials.
+- Any `cowork-server` code change.
+
+## Mechanism
+
+`DataVault.env_for(engine, name) -> dict[str, str] | None`
+(`anton/core/datasources/data_vault.py:308-339`) already exists and already
+does exactly what's needed: builds the `DS_*` mapping for one connection
+without touching `os.environ`. Nothing currently calls it for the scratchpad
+boundary.
+
+- `LocalScratchpadRuntime` gains an optional constructor param
+  `scratchpad_ds_env: dict[str, str] | None = None`.
+- In `start()`, immediately after `env = _utf8_env(os.environ)`: if
+  `scratchpad_ds_env is not None`, strip every `DS_`-prefixed key out of
+  `env`, then `env.update(scratchpad_ds_env)`. `None` (default) leaves
+  today's behavior byte-for-byte unchanged.
+- `ScratchpadManager` gains a `data_vault: DataVault | None = None`
+  constructor param. In `get_or_create(name)`, only when creating a *new*
+  pad (not a cached one) and `self._data_vault is not None`: build
+  `scratchpad_ds_env` by iterating `self._data_vault.list_connections()`,
+  merging `self._data_vault.env_for(conn["engine"], conn["name"]) or {}`
+  for each, and pass the merged dict to the runtime factory.
+- `ChatSession.__init__` (`core/session.py`) passes
+  `data_vault=config.data_vault` into `ScratchpadManager(...)`.
+  `ChatSessionConfig.data_vault` already exists — no new config field.
+- `ScratchpadRuntimeFactory` protocol (`core/backends/base.py`) and
+  `local_scratchpad_runtime_factory` gain the same `scratchpad_ds_env` param,
+  threaded straight through.
+- Carried over from the closed `anton#200` PR: in `start()`, when
+  `self._coding_model` is falsy, `env.pop("ANTON_SCRATCHPAD_MODEL", None)`
+  instead of leaving an inherited value in place; same for
+  `self._coding_provider` / `ANTON_SCRATCHPAD_PROVIDER`.
+
+No hand-maintained "system essentials" allowlist (PATH, HOME, ...) like the
+closed PRs used — that's what made them silently incompatible with `start()`
+as it exists today (it would have dropped `ANTON_OPENAI_BASE_URL`,
+`ANTON_MINDS_API_KEY`, etc., breaking the scratchpad's own coding-model
+wiring). Denylisting only the `DS_` prefix is safe because that prefix is
+already the codebase's dedicated, exclusive credential namespace —
+`clear_ds_env()` relies on the identical invariant.
+
+## Why fresh-per-pad-creation, not computed once at ChatSession init
+
+A CLI `ChatSession` can be long-lived across an interactive session; a user
+can `/connect` a new datasource mid-session, then start a scratchpad that
+didn't exist yet. Computing the `DS_*` overlay once at `ChatSession.__init__`
+would snapshot the vault too early and miss it. Computing it inside
+`ScratchpadManager.get_or_create()`, at the moment a *new* named pad is
+actually created, matches the timing `os.environ.copy()` already uses today
+(read at spawn time) — a freshly created pad sees current vault state, and a
+pad that's already running keeps whatever it started with, exactly like
+today.
+
+## Data flow
+
+1. CLI or desktop-sidecar cowork-server builds/loads `data_vault` (full local
+   vault, or cowork-server's temp filtered vault when `disabled_connections`
+   is set) exactly as today — unchanged.
+2. `ChatSession.__init__` hands `data_vault` to `ScratchpadManager`.
+3. First cell execution for a given scratchpad name → `get_or_create(name)`
+   finds no cached pad → reads `data_vault.list_connections()` + `env_for()`
+   per connection → builds `scratchpad_ds_env` → constructs
+   `LocalScratchpadRuntime(..., scratchpad_ds_env=scratchpad_ds_env)` →
+   `.start()`.
+4. Subprocess env = full parent copy, minus any inherited `DS_*`, plus
+   exactly this vault's current connections' `DS_*` pairs.
+
+## Error handling
+
+`env_for()` returns `None` for a connection that fails to load — the merge
+loop treats that as "contributes nothing," matching how existing
+`inject_env()` callers already tolerate a missing connection.
+
+## Testing
+
+In `anton`, mostly unit-level (inspect the dict `start()` builds, no
+subprocess needed), plus one subprocess-based integration test proving
+isolation end to end — mirrors the closed PR's test shape:
+
+- `scratchpad_ds_env=None` → full env copy unchanged, including any `DS_*`
+  present (legacy / no-vault case).
+- `scratchpad_ds_env={}` (empty vault, or all connections disabled) → every
+  inherited `DS_*` stripped, nothing added.
+- `scratchpad_ds_env={"DS_X__Y": "v"}` → only that key present in the `DS_`
+  namespace; any other inherited `DS_*` gone.
+- `ANTON_SCRATCHPAD_MODEL` / `ANTON_SCRATCHPAD_PROVIDER` stripped when the
+  coding model/provider isn't configured, even if inherited.
+- `ScratchpadManager.get_or_create()` derives the right dict from a fake
+  `DataVault` (connections list × `env_for()`), skips a connection whose
+  `env_for()` returns `None`, and does not recompute for an already-cached
+  pad.
+
+## Follow-ups (not this task — to note on the ticket once this lands)
+
+- `scrub_credentials()` reads secret values from `os.environ` /
+  `_DS_SECRET_VARS` process globals at redaction time — same hazard class,
+  different mechanism, unaddressed here.
+- The cloud pod's `LocalScratchpadRuntime.start()` still does a full,
+  unfiltered env copy; harmless today only because `data_vault=None` there.
+  Worth a dedicated look whenever cloud connectors are wired up. Separately
+  unconfirmed: whether k8s `enableServiceLinks` auto-injects
+  `*_SERVICE_HOST`/`*_SERVICE_PORT` topology vars into that pod, and whether
+  `scratchpad_extra_env` is truly never set in prod.
+- `cowork-server`'s `harness.py` calls `inject_env()` twice back to back
+  today (once via `restore_namespaced_env`, once again in a raw loop before
+  `picked_files_by_project`) — looks redundant. Not touched here.
+- Recommend closing `anton#200` and `cowork-server#79` for real, pointing at
+  this design instead of resurrecting their diffs.

--- a/tests/test_scratchpad.py
+++ b/tests/test_scratchpad.py
@@ -602,6 +602,56 @@ class TestScratchpadEnvironment:
         finally:
             await pad.close()
 
+    async def test_scratchpad_ds_env_none_preserves_inherited_ds_vars(self, monkeypatch):
+        """scratchpad_ds_env=None (default) keeps today's behaviour: inherited
+        DS_* vars pass through untouched."""
+        monkeypatch.setenv("DS_POSTGRES_PROD__PASSWORD", "inherited-secret")
+        pad = make_scratchpad(name="ds-env-none")
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os; print(os.environ.get('DS_POSTGRES_PROD__PASSWORD', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "inherited-secret"
+        finally:
+            await pad.close()
+
+    async def test_scratchpad_ds_env_empty_strips_all_inherited_ds_vars(self, monkeypatch):
+        """An explicit empty dict (empty vault / all connections disabled)
+        strips every inherited DS_* var — none are added back."""
+        monkeypatch.setenv("DS_POSTGRES_PROD__PASSWORD", "should-not-leak")
+        pad = make_scratchpad(name="ds-env-empty", scratchpad_ds_env={})
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os; print(os.environ.get('DS_POSTGRES_PROD__PASSWORD', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "NOT_FOUND"
+        finally:
+            await pad.close()
+
+    async def test_scratchpad_ds_env_only_exposes_explicit_keys(self, monkeypatch):
+        """Only the DS_* pairs in scratchpad_ds_env are visible — a DS_* var
+        inherited for a different connection is stripped even though a
+        DIFFERENT DS_* var was explicitly allowed."""
+        monkeypatch.setenv("DS_SLACK_MAIN__BOT_TOKEN", "wrong-conversation-token")
+        pad = make_scratchpad(
+            name="ds-env-scoped",
+            scratchpad_ds_env={"DS_POSTGRES_PROD__PASSWORD": "right-conversation-secret"},
+        )
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os\n"
+                "print(os.environ.get('DS_POSTGRES_PROD__PASSWORD', 'NOT_FOUND'))\n"
+                "print(os.environ.get('DS_SLACK_MAIN__BOT_TOKEN', 'NOT_FOUND'))"
+            )
+            lines = cell.stdout.strip().splitlines()
+            assert lines[0] == "right-conversation-secret"
+            assert lines[1] == "NOT_FOUND"
+        finally:
+            await pad.close()
+
 
 class TestScratchpadVenv:
     async def test_venv_created_on_start(self):

--- a/tests/test_scratchpad.py
+++ b/tests/test_scratchpad.py
@@ -374,6 +374,60 @@ class TestScratchpadManager:
         finally:
             await mgr.close_all()
 
+    async def test_get_or_create_applies_ds_env_override_to_new_pad(self):
+        """ds_env_override on a freshly created pad takes effect after reset()."""
+        mgr = make_manager()  # no data_vault
+        try:
+            pad = await mgr.get_or_create(
+                "test", ds_env_override={"DS_HOST": "override.example.com"}
+            )
+            await pad.reset()
+            cell = await pad.execute(
+                "import os; print(os.environ.get('DS_HOST', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "override.example.com"
+        finally:
+            await mgr.close_all()
+
+    async def test_get_or_create_applies_ds_env_override_to_cached_pad(self):
+        """ds_env_override on an ALREADY-cached pad also takes effect after
+        reset() — this is the exact shape the connection-test flow needs:
+        get_or_create the shared test pad, then override, then reset."""
+        mgr = make_manager()
+        try:
+            pad = await mgr.get_or_create("test")
+            await pad.reset()
+            cell = await pad.execute(
+                "import os; print(os.environ.get('DS_HOST', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "NOT_FOUND"
+
+            pad2 = await mgr.get_or_create(
+                "test", ds_env_override={"DS_HOST": "override.example.com"}
+            )
+            assert pad2 is pad
+            await pad2.reset()
+            cell2 = await pad2.execute(
+                "import os; print(os.environ.get('DS_HOST', 'NOT_FOUND'))"
+            )
+            assert cell2.stdout.strip() == "override.example.com"
+        finally:
+            await mgr.close_all()
+
+    async def test_get_or_create_does_not_recompute_for_cached_pad(self):
+        """A second get_or_create() for an existing pad name does not
+        re-derive scratchpad_ds_env — the pad keeps what it started with."""
+        vault = _FakeVault({("postgres", "prod"): {"DS_POSTGRES_PROD__HOST": "db.example.com"}})
+        mgr = make_manager(data_vault=vault)
+        try:
+            pad = await mgr.get_or_create("alpha")
+            vault._connections[("postgres", "prod")] = {"DS_POSTGRES_PROD__HOST": "changed.example.com"}
+            pad2 = await mgr.get_or_create("alpha")
+            assert pad2 is pad
+            assert pad2._scratchpad_ds_env == {"DS_POSTGRES_PROD__HOST": "db.example.com"}
+        finally:
+            await mgr.close_all()
+
 
 class TestScratchpadRenderNotebook:
     async def test_render_notebook_basic(self):
@@ -687,8 +741,10 @@ class TestScratchpadEnvironment:
     async def test_scratchpad_ds_env_only_exposes_explicit_keys(self, monkeypatch):
         """Only the DS_* pairs in scratchpad_ds_env are visible — a DS_* var
         inherited for a different connection is stripped even though a
-        DIFFERENT DS_* var was explicitly allowed."""
+        DIFFERENT DS_* var was explicitly allowed, and an inherited value for
+        the SAME key is overridden, not merged."""
         monkeypatch.setenv("DS_SLACK_MAIN__BOT_TOKEN", "wrong-conversation-token")
+        monkeypatch.setenv("DS_POSTGRES_PROD__PASSWORD", "stale-inherited-value")
         pad = make_scratchpad(
             name="ds-env-scoped",
             scratchpad_ds_env={"DS_POSTGRES_PROD__PASSWORD": "right-conversation-secret"},
@@ -703,6 +759,21 @@ class TestScratchpadEnvironment:
             lines = cell.stdout.strip().splitlines()
             assert lines[0] == "right-conversation-secret"
             assert lines[1] == "NOT_FOUND"
+        finally:
+            await pad.close()
+
+    async def test_set_scratchpad_ds_env_overrides_before_reset(self):
+        """set_scratchpad_ds_env() takes effect on the NEXT start()/reset(),
+        not retroactively on an already-running process."""
+        pad = make_scratchpad(name="override-test")
+        await pad.start()
+        try:
+            pad.set_scratchpad_ds_env({"DS_TEST__KEY": "new-value"})
+            await pad.reset()
+            cell = await pad.execute(
+                "import os; print(os.environ.get('DS_TEST__KEY', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "new-value"
         finally:
             await pad.close()
 

--- a/tests/test_scratchpad.py
+++ b/tests/test_scratchpad.py
@@ -652,6 +652,34 @@ class TestScratchpadEnvironment:
         finally:
             await pad.close()
 
+    async def test_scratchpad_model_not_leaked_when_unconfigured(self, monkeypatch):
+        """An inherited ANTON_SCRATCHPAD_MODEL must not reach a pad that has
+        no coding model configured."""
+        monkeypatch.setenv("ANTON_SCRATCHPAD_MODEL", "inherited-model")
+        pad = make_scratchpad(name="ds-env-no-model")  # coding_model="" by default
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os; print(os.environ.get('ANTON_SCRATCHPAD_MODEL', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "NOT_FOUND"
+        finally:
+            await pad.close()
+
+    async def test_scratchpad_provider_not_leaked_when_unconfigured(self, monkeypatch):
+        """An inherited ANTON_SCRATCHPAD_PROVIDER must not reach a pad that
+        has no coding provider configured."""
+        monkeypatch.setenv("ANTON_SCRATCHPAD_PROVIDER", "inherited-provider")
+        pad = make_scratchpad(name="ds-env-no-provider", coding_provider="")
+        await pad.start()
+        try:
+            cell = await pad.execute(
+                "import os; print(os.environ.get('ANTON_SCRATCHPAD_PROVIDER', 'NOT_FOUND'))"
+            )
+            assert cell.stdout.strip() == "NOT_FOUND"
+        finally:
+            await pad.close()
+
 
 class TestScratchpadVenv:
     async def test_venv_created_on_start(self):

--- a/tests/test_scratchpad.py
+++ b/tests/test_scratchpad.py
@@ -35,6 +35,20 @@ def make_manager(**kwargs) -> ScratchpadManager:
     return ScratchpadManager(**{**_MANAGER_DEFAULTS, **kwargs})
 
 
+class _FakeVault:
+    """Duck-typed DataVault stand-in — ScratchpadManager only calls
+    list_connections() and env_for()."""
+
+    def __init__(self, connections: dict[tuple[str, str], dict[str, str] | None]) -> None:
+        self._connections = connections
+
+    def list_connections(self) -> list[dict[str, str]]:
+        return [{"engine": e, "name": n} for e, n in self._connections]
+
+    def env_for(self, engine: str, name: str, *, flat: bool = False) -> dict[str, str] | None:
+        return self._connections[(engine, name)]
+
+
 class TestScratchpadBasicExecution:
     async def test_basic_execution(self):
         """print(42) should return '42' in stdout."""
@@ -319,6 +333,46 @@ class TestScratchpadManager:
         finally:
             await mgr.close_all()
         assert pad._proc is None, "close_all() must not restart the worker process"
+
+    async def test_get_or_create_derives_ds_env_from_vault(self):
+        """A new pad gets exactly this vault's current DS_* values."""
+        vault = _FakeVault({
+            ("postgres", "prod"): {"DS_POSTGRES_PROD__HOST": "db.example.com"},
+            ("slack", "main"): {"DS_SLACK_MAIN__BOT_TOKEN": "xoxb-123"},
+        })
+        mgr = make_manager(data_vault=vault)
+        try:
+            pad = await mgr.get_or_create("alpha")
+            assert pad._scratchpad_ds_env == {
+                "DS_POSTGRES_PROD__HOST": "db.example.com",
+                "DS_SLACK_MAIN__BOT_TOKEN": "xoxb-123",
+            }
+        finally:
+            await mgr.close_all()
+
+    async def test_get_or_create_skips_connection_whose_env_for_fails(self):
+        """A connection whose env_for() returns None contributes nothing,
+        not a crash."""
+        vault = _FakeVault({
+            ("postgres", "gone"): None,
+            ("postgres", "prod"): {"DS_POSTGRES_PROD__HOST": "db.example.com"},
+        })
+        mgr = make_manager(data_vault=vault)
+        try:
+            pad = await mgr.get_or_create("alpha")
+            assert pad._scratchpad_ds_env == {"DS_POSTGRES_PROD__HOST": "db.example.com"}
+        finally:
+            await mgr.close_all()
+
+    async def test_get_or_create_without_vault_passes_none(self):
+        """No data_vault (default) -> scratchpad_ds_env stays None, so
+        LocalScratchpadRuntime keeps its legacy full-copy behaviour."""
+        mgr = make_manager()  # no data_vault
+        try:
+            pad = await mgr.get_or_create("alpha")
+            assert pad._scratchpad_ds_env is None
+        finally:
+            await mgr.close_all()
 
 
 class TestScratchpadRenderNotebook:


### PR DESCRIPTION
Linear: https://linear.app/mindsdb/issue/ENG-392/harden-env-variables-leaking-into-scratchpads

scope scratchpad subprocess env to the current conversation's datasource credentials instead of the full parent environment
stop leaking an unconfigured coding model or provider into scratchpads
let a caller override a pad's env before its next restart
fix the datasource connection test after the env scoping change
guard against one bad vault connection breaking env derivation for the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
