### PR TITLE
fix(vision): stop guessing Anthropic image blocks by gateway hostname (ENG-1992)

### DIFF
--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -443,22 +443,14 @@ if _scratchpad_model:
                 "ssl_verify": _llm_ssl_verify,
                 "api_version": _llm_api_version,
             }
-            # Only Minds / MindsHub / MDB.AI proxy Anthropic over the OpenAI HTTP
-            # envelope, so ONLY they need image blocks in Anthropic native format.
-            # Gate on the host, NOT on "openai-compatible" generally: other
-            # OpenAI-compatible endpoints (e.g. Gemini at
-            # generativelanguage.googleapis.com, or a generic proxy) expect
-            # standard OpenAI image_url blocks. Forcing anthropic format for all
-            # openai-compatible mangled images for Gemini. OpenAIProvider already
-            # defaults to supports_vision=True / vision_format="openai", so the
-            # non-proxy case needs no override.
-            _llm_url_lower = (_llm_base_url or "").lower()
-            _anthropic_proxy = any(
-                host in _llm_url_lower for host in ("mdb.ai", "mindshub.ai")
-            )
-            if _anthropic_proxy:
-                _llm_provider_kwargs["supports_vision"] = True
-                _llm_provider_kwargs["vision_format"] = "anthropic"
+            # OpenAIProvider already defaults to supports_vision=True /
+            # vision_format="openai" — every gateway we route openai-compatible
+            # requests through (MindsHub/mdb.ai included) normalizes a standard
+            # OpenAI image_url block into whatever the resolved backend natively
+            # needs, so no per-host override is needed here. Forcing
+            # vision_format="anthropic" for every mdb.ai/mindshub.ai host used
+            # to assume every model behind it was Claude, which broke non-Claude
+            # models sharing the same gateway (ENG-1992).
             # Resolve the OpenAI "flavor" so the injected web_search() helper can
             # route through whatever native web tooling the endpoint exposes.
             # Detect Minds/mdb.ai by HOST, not provider name (always "openai" for

--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -428,18 +428,6 @@ class LLMClient:
 
         api_version = getattr(settings, "openai_api_version", None)
         compatible_flavor = _resolve_openai_compatible_flavor(settings)
-        # Only Minds / MindsHub / MDB.AI proxy Anthropic over the OpenAI HTTP
-        # envelope and need Anthropic-shaped image blocks. Gate on the base-URL
-        # host, NOT on the "openai-compatible" provider name — other compatible
-        # endpoints (Gemini at generativelanguage.googleapis.com, generic
-        # proxies) expect standard OpenAI image_url. Mirrors the scratchpad_boot
-        # gate; forcing anthropic format unconditionally mangled Gemini images.
-        _oc_base_host = (settings.openai_base_url or "").lower()
-        _oc_vision_format = (
-            "anthropic"
-            if any(h in _oc_base_host for h in ("mdb.ai", "mindshub.ai"))
-            else "openai"
-        )
         # Each factory takes the per-role effort so planning and coding stay
         # independent even when they resolve to the same provider type.
         providers = {
@@ -461,7 +449,16 @@ class LLMClient:
                 ssl_verify=settings.minds_ssl_verify,
                 api_version=api_version,
                 supports_vision=True,
-                vision_format=_oc_vision_format,
+                # vision_format defaults to "openai" — every gateway we route
+                # openai-compatible requests through (MindsHub/mdb.ai included)
+                # already normalizes a standard OpenAI image_url block into
+                # whatever the resolved backend natively needs (Anthropic,
+                # Responses API, ...). Guessing "anthropic" from the base-URL
+                # host here used to assume every model behind that host was
+                # Claude, which broke non-Claude models sharing the same
+                # gateway (ENG-1992: MindsHub Air screenshots 400'd because
+                # this sent Anthropic-shaped image blocks to an OpenAI
+                # Responses-backed model).
                 flavor=compatible_flavor,
                 reasoning_effort=effort,
             ),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -156,12 +156,16 @@ class TestLLMClientFromSettings:
         )
         return LLMClient.from_settings(settings)._planning_provider._vision_format
 
-    def test_openai_compatible_vision_format_gated_on_host(self):
-        # Minds/MindsHub proxy Anthropic → anthropic image blocks.
-        assert self._oc_vision_format("https://api.mindshub.ai/v1") == "anthropic"
-        assert self._oc_vision_format("https://mdb.ai/api/v1") == "anthropic"
-        # Gemini + generic OpenAI-compatible endpoints expect OpenAI image_url —
-        # NOT anthropic (the bug: unconditional anthropic mangled Gemini images).
+    def test_openai_compatible_vision_format_is_always_openai(self):
+        # ENG-1992: this used to guess "anthropic" for any mdb.ai/mindshub.ai
+        # host, which assumed every model behind that gateway was Claude — it
+        # broke non-Claude models sharing the same host (MindsHub Air routed
+        # to an OpenAI Responses-backed model got Anthropic-shaped image
+        # blocks and 400'd). The gateway itself already normalizes a standard
+        # OpenAI image_url block into whatever the resolved backend needs, so
+        # anton just sends OpenAI shape unconditionally now.
+        assert self._oc_vision_format("https://api.mindshub.ai/v1") == "openai"
+        assert self._oc_vision_format("https://mdb.ai/api/v1") == "openai"
         assert self._oc_vision_format(
             "https://generativelanguage.googleapis.com/v1beta/openai/"
         ) == "openai"


### PR DESCRIPTION
## Summary

Fixes [ENG-1992](https://linear.app/mindsdb/issue/ENG-1992/screenshots-not-working-in-mindshub-cowork) — screenshots failing in MindsHub Cowork with:
```
400: Invalid value: 'image'. Supported values are: 'input_text', 'input_image', ...
```

**Root cause.** `vision_format` for the `openai-compatible` provider was chosen purely by whether the base URL contained `mdb.ai`/`mindshub.ai`, on the assumption that *every* model reachable through that gateway was Claude proxied over an OpenAI HTTP envelope, and so needed Anthropic-shaped image blocks (`{"type": "image", "source": {...}}`). MindsHub Air isn't Claude — it's an OpenAI Responses-backed model routed through the same host — so it got Anthropic-shaped blocks it can't parse, and the request 400'd.

**Why the conversation died permanently, not just once.** The translation is stateless: it runs fresh from anton's own valid, uncorrupted internal history on every call. The *decision* was wrong, not the stored data, so every retry and every subsequent turn re-triggered the identical failure — nothing about the request changed between attempts.

**Why the fix is just "stop guessing" rather than "guess correctly."** The gateway (mindshub_inference) already normalizes a standard OpenAI `image_url` block into whatever the resolved backend natively needs — confirmed it has a working, symmetric `image_url → Anthropic` renderer (`_openai_content_to_anthropic`/`_image_url_to_anthropic_block`) alongside the `image_url → Responses input_image` one. So anton doesn't need to know or guess the destination's native shape at all — that's the gateway's job, and it already does it correctly in both directions. Anton now just sends OpenAI shape unconditionally for `openai-compatible` providers.

Two call sites had the same hostname-gated logic (a copy-paste): the main provider factory (`core/llm/client.py`) and the scratchpad's own sub-LLM (`core/backends/scratchpad_boot.py`). Both fixed.

A companion fix in `mindshub_inference` closes the gateway-side gap this also surfaced (an unrecognized content-part type was silently forwarded to the real upstream instead of rejected at the edge) — separate PR, same investigation.

## Test plan

- [x] `uv run pytest tests/test_client.py` — updated `test_openai_compatible_vision_format_gated_on_host` (now `..._is_always_openai`) to assert `vision_format` is `"openai"` regardless of host
- [x] `uv run pytest` (full suite) — 2644 passed, 31 skipped, 2 pre-existing failures unrelated to this change (`test_datasource.py::TestConnectionMessagesIncludeLabel`, verified failing identically on `staging` with these changes stashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)