### PR TITLE
ENG-1796: the pod image reports the version it was built from

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-# Version is pinned via SETUPTOOLS_SCM_PRETEND_VERSION in the Dockerfile, so .git is not needed.
+# .git is excluded to keep the build context lean, so hatch-vcs cannot derive a version here.
+# The workflow resolves it from tags and passes --build-arg ANTON_VERSION instead (ENG-1796).
 .git
 .venv
 **/__pycache__

--- a/.github/workflows/scratchpad-dev-build.yml
+++ b/.github/workflows/scratchpad-dev-build.yml
@@ -56,11 +56,34 @@ jobs:
         # class of failure this whole change exists to remove. Fail instead.
         run: |
           set -euo pipefail
-          version="$(uvx hatch version)"
-          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]'; then
-            echo "::error::could not resolve an anton version (got: '$version')"
+          # `tail -n 1`: hatch prints progress to stderr today, but a stray line
+          # on stdout would otherwise ride along into $GITHUB_OUTPUT, where a
+          # second line is parsed as another key=value pair rather than failing.
+          version="$(uvx hatch version | tail -n 1)"
+
+          # Whole-line match, PEP 440 characters only. This is a boundary, not a
+          # formatting nicety: the shared action expands `extra-build-args`
+          # UNQUOTED into `docker buildx build`, so anything containing
+          # whitespace becomes additional arguments to that command.
+          if ! printf '%s' "$version" | grep -Eqx '[0-9]+\.[0-9][0-9A-Za-z.!+]*'; then
+            echo "::error::refusing to build: '$version' is not a bare PEP 440 version"
             exit 1
           fi
+
+          # Reject the fallback explicitly. With no tags reachable, hatch-vcs
+          # resolves `2.0.0.dev1+g<sha>` (and `2.0.0-dev` with no .git at all) —
+          # both well-formed, both accepted by the check above, and both the
+          # very 2.0.0 family this change exists to eliminate. anton is CalVer,
+          # so a 2.0.0 version is never legitimate and always means the tags did
+          # not arrive.
+          case "$version" in
+            2.0.0*)
+              echo "::error::'$version' is the hatch-vcs fallback — the checkout has no tags."
+              echo "::error::Building would bake a 2.0.0 version back into the image (ENG-1796)."
+              exit 1
+              ;;
+          esac
+
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "anton version: $version"
 

--- a/.github/workflows/scratchpad-dev-build.yml
+++ b/.github/workflows/scratchpad-dev-build.yml
@@ -22,7 +22,50 @@ concurrency:
 
 jobs:
 
+  # The version the image will report, resolved from tags (ENG-1796).
+  #
+  # Its own job, on ubuntu-latest, for two reasons. The build runs on the
+  # self-hosted mdb-dev runner and nothing in this repo has ever run setup-uv
+  # there, so resolving the version in the build job would put an unproven
+  # dependency in front of the image. And keeping it separate leaves the build's
+  # checkout shallow: .git never enters the docker context (see .dockerignore),
+  # so only this job needs the history.
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # hatch-vcs derives the version by describing against tags, and the
+          # default fetch-depth of 1 fetches none of them.
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+      - id: resolve
+        name: Resolve the anton version from tags
+        # The image reported a hardcoded 2.0.0 until 2026-08-26, so a pod turn
+        # could not say which anton served it and bumping the image pin produced
+        # no observable change at all.
+        #
+        # `hatch version` prints the version to stdout and its progress to
+        # stderr, so the capture is exactly the version. The shape check is a
+        # belt against that ever changing: a malformed value here would be baked
+        # into the image and reported by every turn it serves, which is the
+        # class of failure this whole change exists to remove. Fail instead.
+        run: |
+          set -euo pipefail
+          version="$(uvx hatch version)"
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]'; then
+            echo "::error::could not resolve an anton version (got: '$version')"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "anton version: $version"
+
   build:
+    needs: version
     runs-on: mdb-dev
     outputs:
       image: ${{ steps.build.outputs.image }}
@@ -38,3 +81,7 @@ jobs:
           # Override the repo-slug default so the image lands at .../minds-anton-scratchpad.
           module-name: minds-anton-scratchpad
           build-for-environment: development
+          # Expanded unquoted by the shared action, so the value must not contain
+          # whitespace — a PEP 440 version never does, and the shape check in the
+          # `version` job would have rejected it.
+          extra-build-args: --build-arg ANTON_VERSION=${{ needs.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,12 @@ RUN test -n "$SETUPTOOLS_SCM_PRETEND_VERSION" \
          echo "       restore the exact constant this guard exists to remove (ENG-1796)." >&2; \
          exit 1 ;; \
        esac \
+    && { test ! -e /app/.git \
+         || { echo "ERROR: .git entered the build context (ENG-1796). This image is" >&2; \
+              echo "       SINGLE-STAGE, so it would ship the repo's full history to every" >&2; \
+              echo "       pod — and the pretend-version hides it: the version stays correct," >&2; \
+              echo "       so nothing else would ever fail. Keep .git in .dockerignore." >&2; \
+              exit 1; }; } \
     && uv venv "$VIRTUAL_ENV" \
     && UV_PROJECT_ENVIRONMENT="$VIRTUAL_ENV" uv sync --frozen --no-dev --no-cache \
     && uv pip install --no-cache boto3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,22 @@ FROM python:3.12-slim
 # via ANTON_UV_PATH=/usr/local/bin/uv, so uv must be present at exactly that path.
 COPY --from=ghcr.io/astral-sh/uv:0.6.14 /uv /usr/local/bin/uv
 
-# hatch-vcs would otherwise need the .git history (excluded from the build context); the image
-# only needs a valid version string, so pin one for the build.
+# The version, supplied by the caller because hatch-vcs cannot derive it here:
+# .git is excluded from the build context (see .dockerignore) to keep the image
+# lean, so there is no history to describe. The workflow resolves it from tags
+# and passes it in (ENG-1796).
+#
+# This was the constant 2.0.0 until 2026-08-26, which meant every pod that ever
+# ran reported the same version. It was not a fallback that fired occasionally —
+# it was the only value cloud ever reported, and being a well-formed release
+# number it read as a legitimate cohort in any breakdown rather than as a null.
+# Whatever replaces it must stay derived; a constant here is undetectable
+# downstream.
+ARG ANTON_VERSION
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    SETUPTOOLS_SCM_PRETEND_VERSION=2.0.0 \
+    SETUPTOOLS_SCM_PRETEND_VERSION=${ANTON_VERSION} \
     VIRTUAL_ENV=/opt/anton-venv \
     PATH=/opt/anton-venv/bin:/usr/local/bin:$PATH \
     UV_LINK_MODE=copy
@@ -26,7 +37,13 @@ COPY . /app
 # what silently pulled anthropic 1.x (httpx2) into pods while the lockfile
 # still pinned 0.x. boto3 is imported by anton at runtime but not declared as
 # a dependency, so add it explicitly (the one unlocked package).
-RUN uv venv "$VIRTUAL_ENV" \
+# The empty-ARG guard runs first: with no pretend-version and no .git, hatch-vcs
+# fails deep inside the sync with an error that does not mention the build arg.
+# Fail here instead, naming the cause — and never fall back to a made-up version,
+# which is the failure mode this whole change exists to remove.
+RUN test -n "$SETUPTOOLS_SCM_PRETEND_VERSION" \
+    || { echo "ERROR: --build-arg ANTON_VERSION is required (ENG-1796)." >&2; exit 1; } \
+    && uv venv "$VIRTUAL_ENV" \
     && UV_PROJECT_ENVIRONMENT="$VIRTUAL_ENV" uv sync --frozen --no-dev --no-cache \
     && uv pip install --no-cache boto3 \
     && chown -R 1000:1000 "$VIRTUAL_ENV"

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,12 @@ COPY . /app
 # which is the failure mode this whole change exists to remove.
 RUN test -n "$SETUPTOOLS_SCM_PRETEND_VERSION" \
     || { echo "ERROR: --build-arg ANTON_VERSION is required (ENG-1796)." >&2; exit 1; } \
+    && case "$SETUPTOOLS_SCM_PRETEND_VERSION" in 2.0.0*) \
+         echo "ERROR: ANTON_VERSION=$SETUPTOOLS_SCM_PRETEND_VERSION is the hatch-vcs" >&2; \
+         echo "       fallback, which means the resolver found no tags. Baking it would" >&2; \
+         echo "       restore the exact constant this guard exists to remove (ENG-1796)." >&2; \
+         exit 1 ;; \
+       esac \
     && uv venv "$VIRTUAL_ENV" \
     && UV_PROJECT_ENVIRONMENT="$VIRTUAL_ENV" uv sync --frozen --no-dev --no-cache \
     && uv pip install --no-cache boto3 \

--- a/tests/test_pod_image_version.py
+++ b/tests/test_pod_image_version.py
@@ -94,6 +94,47 @@ def test_the_fallback_version_is_rejected_by_the_build(dockerfile: str) -> None:
     )
 
 
+def test_git_is_excluded_from_the_build_context() -> None:
+    """anton is SINGLE-STAGE, so .dockerignore is the only thing keeping history out.
+
+    This is the wrong-quietly case, and it is worse here than the version bug it
+    accompanies. Un-ignoring ``.git`` produces no signal whatsoever:
+    ``SETUPTOOLS_SCM_PRETEND_VERSION`` wins over VCS discovery (measured: it
+    overrides a real ``2.26.8.12.1rc6.dev8+g19c6e7515`` with whatever it is set
+    to), so the version stays correct, every guard passes, and the build is
+    green -- while ``COPY . /app`` puts the repo's entire history into the
+    runtime image of every scratchpad pod.
+
+    cowork-server is multi-stage and deletes ``.git`` in the builder, so its
+    equivalent mistake is caught by a boundary that does not exist here. The
+    exclusion is load-bearing in this repo and was the only unguarded thing in
+    it.
+    """
+    lines = [ln.strip() for ln in (_ROOT / ".dockerignore").read_text().splitlines()]
+    assert ".git" in lines, (
+        ".git is no longer excluded from the build context. This image is "
+        "single-stage, so the full history would ship in every pod — and "
+        "nothing at build or run time would report it (ENG-1796)."
+    )
+
+
+def test_the_build_refuses_a_context_containing_git() -> None:
+    """Belt for the above: catches .git arriving by any route, not just this file.
+
+    A negation pattern, a different context, or a build that bypasses
+    .dockerignore would all defeat the assertion above. Mirrors the reasoning
+    behind cowork-server's 0.0.0 guard -- the check belongs where the mistake
+    happens, not only where one spelling of it is written down.
+    """
+    assert "test ! -e /app/.git" in _DOCKERFILE_TEXT(), (
+        "the build no longer refuses a context containing .git"
+    )
+
+
+def _DOCKERFILE_TEXT() -> str:
+    return _DOCKERFILE.read_text()
+
+
 def _resolve_step(workflow: dict) -> dict:
     for step in workflow["jobs"]["version"]["steps"]:
         if step.get("id") == "resolve":

--- a/tests/test_pod_image_version.py
+++ b/tests/test_pod_image_version.py
@@ -76,6 +76,60 @@ def test_an_empty_version_fails_the_build(dockerfile: str) -> None:
     assert "exit 1" in dockerfile
 
 
+def test_the_fallback_version_is_rejected_by_the_build(dockerfile: str) -> None:
+    """The hole a non-empty check leaves open, and the nastiest one here.
+
+    With no tags reachable hatch-vcs resolves ``2.0.0.dev1+g<sha>``, and with no
+    .git at all it resolves ``2.0.0-dev`` (both measured). Those are well-formed
+    versions that a non-empty guard happily accepts -- so losing the tags would
+    bake the 2.0.0 family straight back in, which is the entire bug.
+
+    anton is CalVer, so a 2.0.0 version is never legitimate and always means the
+    tags did not arrive. In the Dockerfile rather than only the workflow so it
+    holds however the image is built.
+    """
+    assert 'in 2.0.0*)' in dockerfile, (
+        "the fallback guard is gone; a tagless resolve would rebuild the exact "
+        "2.0.0 constant this change removes (ENG-1796)"
+    )
+
+
+def _resolve_step(workflow: dict) -> dict:
+    for step in workflow["jobs"]["version"]["steps"]:
+        if step.get("id") == "resolve":
+            return step
+    raise AssertionError("no `resolve` step in the version job")
+
+
+def test_the_resolved_version_is_validated_whole_line(workflow: dict) -> None:
+    """A prefix match is not enough, because the value reaches a shell unquoted.
+
+    The shared action expands ``extra-build-args`` unquoted into ``docker buildx
+    build``, so ``2.26.8 --build-arg EVIL=1`` passes a ``^[0-9]+\.[0-9]`` prefix
+    check and becomes extra arguments to that command. ``grep -Eqx`` anchors
+    both ends, which is what actually closes it.
+    """
+    run = _resolve_step(workflow).get("run", "")
+    assert "grep -Eqx" in run, (
+        "the version is no longer whole-line validated; a prefix match lets "
+        "whitespace through into an unquoted shell expansion"
+    )
+    assert "2.0.0*)" in run, "the workflow no longer rejects the hatch-vcs fallback"
+
+
+def test_only_one_line_is_captured(workflow: dict) -> None:
+    """A second stdout line would be parsed by $GITHUB_OUTPUT as another pair.
+
+    Asserted on the pipeline itself, not on the bare string: the comment above
+    it in the same ``run`` block names ``tail -n 1`` too, so a substring check
+    stayed green when the pipe was deleted -- caught by mutation, not by review.
+    """
+    run = _resolve_step(workflow).get("run", "")
+    assert "uvx hatch version | tail -n 1" in run, (
+        "a multi-line capture would corrupt $GITHUB_OUTPUT rather than fail"
+    )
+
+
 def _steps(workflow: dict, job: str) -> list[dict]:
     return workflow["jobs"][job]["steps"]
 

--- a/tests/test_pod_image_version.py
+++ b/tests/test_pod_image_version.py
@@ -1,0 +1,124 @@
+"""The pod image must report a derived version, never a constant (ENG-1796).
+
+Until 2026-08-26 ``Dockerfile`` set ``SETUPTOOLS_SCM_PRETEND_VERSION=2.0.0``, so
+every turn a scratchpad pod ever served reported ``anton_version=2.0.0``. That
+was not a fallback firing occasionally — it was the only value cloud reported,
+and because ``2.0.0`` is a well-formed release number it read as a legitimate
+cohort in any breakdown rather than as a null. At its peak it was 46% of the
+measured install population.
+
+Nothing failed when it was wrong, which is why it survived so long: the build
+succeeded, the pod ran, and the number looked plausible. These are build
+assertions rather than behaviour tests for the same reason — there is no
+runtime symptom to assert on, so the contract has to be pinned at the seam
+where it can actually be broken.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+_DOCKERFILE = _ROOT / "Dockerfile"
+_WORKFLOW = _ROOT / ".github/workflows/scratchpad-dev-build.yml"
+
+# The Dockerfile ENV line, whatever it is set to.
+_PRETEND = re.compile(r"SETUPTOOLS_SCM_PRETEND_VERSION=(\S+?)\s*\\?$", re.MULTILINE)
+
+
+@pytest.fixture(scope="module")
+def dockerfile() -> str:
+    return _DOCKERFILE.read_text()
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return yaml.safe_load(_WORKFLOW.read_text())
+
+
+def test_the_version_is_not_a_literal(dockerfile: str) -> None:
+    """The regression itself: a hardcoded version, in any form."""
+    found = _PRETEND.findall(dockerfile)
+    assert found, "Dockerfile no longer sets SETUPTOOLS_SCM_PRETEND_VERSION at all"
+    for value in found:
+        assert value.startswith("${") and value.endswith("}"), (
+            f"SETUPTOOLS_SCM_PRETEND_VERSION={value!r} is a literal. Every pod would "
+            "report it forever, and a well-formed one is indistinguishable from a "
+            "real release downstream (ENG-1796). Pass it in as a build arg."
+        )
+
+
+def test_the_build_arg_is_declared(dockerfile: str) -> None:
+    """``ARG`` before use, or docker silently substitutes an empty string."""
+    arg_at = dockerfile.find("ARG ANTON_VERSION")
+    use_at = dockerfile.find("SETUPTOOLS_SCM_PRETEND_VERSION=${ANTON_VERSION}")
+    assert arg_at != -1, "ARG ANTON_VERSION is not declared"
+    assert use_at != -1, "SETUPTOOLS_SCM_PRETEND_VERSION does not read ANTON_VERSION"
+    assert arg_at < use_at, "ARG must be declared before it is referenced"
+
+
+def test_an_empty_version_fails_the_build(dockerfile: str) -> None:
+    """No silent fallback: an unset arg must stop the build, not invent a version.
+
+    This is the criterion that keeps the fix from decaying back into the bug --
+    a build that quietly substitutes something plausible is exactly what 2.0.0
+    was.
+    """
+    assert 'test -n "$SETUPTOOLS_SCM_PRETEND_VERSION"' in dockerfile, (
+        "the empty-arg guard is gone; a build with no ANTON_VERSION would fail "
+        "deep inside the sync with an error that never names the build arg"
+    )
+    assert "exit 1" in dockerfile
+
+
+def _steps(workflow: dict, job: str) -> list[dict]:
+    return workflow["jobs"][job]["steps"]
+
+
+def test_the_version_job_fetches_tags(workflow: dict) -> None:
+    """hatch-vcs describes against tags, and the default fetch-depth fetches none.
+
+    The failure mode is silent: with no tags the version resolves to
+    ``0.0.0.dev1+g<sha>`` and the build still succeeds. cowork-server shipped
+    exactly that for months (ENG-1796).
+    """
+    checkout = [s for s in _steps(workflow, "version") if "actions/checkout" in str(s.get("uses", ""))]
+    assert checkout, "the version job no longer checks out the repo"
+    for step in checkout:
+        assert (step.get("with") or {}).get("fetch-depth") == 0, (
+            "checkout must use fetch-depth: 0 — without tags hatch-vcs cannot "
+            "derive a version and the build succeeds anyway with a wrong one"
+        )
+
+
+def test_the_build_waits_for_the_resolved_version(workflow: dict) -> None:
+    """Without the dependency the build reads an empty output and the guard fires.
+
+    Worth pinning because the failure is a red build rather than a wrong
+    version, so it would be diagnosed as flakiness rather than as this.
+    """
+    assert "version" in (workflow["jobs"]["build"].get("needs") or []), (
+        "the build job must need the version job, or the build arg is empty"
+    )
+
+
+def test_the_resolved_version_reaches_the_build(workflow: dict) -> None:
+    """The seam that made this reachable at all: the arg must be passed through.
+
+    Resolving the version on the runner and then not handing it to docker would
+    leave the guard above firing on every build.
+    """
+    passed = [
+        (s.get("with") or {}).get("extra-build-args", "")
+        for s in _steps(workflow, "build")
+        if "build-push-ecr" in str(s.get("uses", ""))
+    ]
+    assert passed, "the build job no longer calls build-push-ecr"
+    assert any("--build-arg ANTON_VERSION=" in str(p) for p in passed), (
+        "the resolved version is not passed to the image build"
+    )


### PR DESCRIPTION
## What

`anton/Dockerfile` hardcoded `SETUPTOOLS_SCM_PRETEND_VERSION=2.0.0`, so **every turn a scratchpad pod ever served reported `anton_version=2.0.0`.** The version is now resolved from tags on the runner and passed in as a build arg.

## Why it was invisible

Nothing failed. The build succeeded, the pod ran, and `2.0.0` is a well-formed release number — so a version breakdown read it as a legitimate cohort rather than as a null. And bumping the pod image pin produced **no observable change**, which makes "did the deploy actually land?" unanswerable for the one image that is pinned by digest and bumped by hand.

**Premise re-measured before building** (prod PostHog 424726, 3d, real turns only per ENG-1692's filter). It had grown, not decayed:

| `anton_version` | turns | installs | share |
| -- | -- | -- | -- |
| **`2.0.0`** | 166 | **109** | **46%** (was 35% on 2026-08-20) |
| `2.26.8.23.1` | 985 | 90 | 38% |
| `2.26.8.20.3` | 168 | 17 | 7% |

One caution for anyone quoting that: 166 turns across 109 "installs" is 1.5 each, consistent with near-ephemeral pod install-ids. That cohort is closer to *pods* than *people*.

## How

The constant existed for a real reason — `.dockerignore` excludes `.git` to keep the context lean, so hatch-vcs has nothing to describe. Rather than un-ignore it, the version is resolved on the runner and handed to the build.

**Resolution lives in its own `version` job on `ubuntu-latest`.** The build runs on the self-hosted `mdb-dev` runner, and **nothing in this repo has ever run `setup-uv` there** — every existing usage is on `ubuntu-latest`. Putting the resolver in the build job would have placed an unproven dependency in front of the image. Splitting it also leaves the build's checkout shallow, since only the resolver needs history.

An empty arg now **fails the build** rather than falling back. A build that quietly substitutes something plausible is precisely what `2.0.0` was.

## Blast radius — three things that could have broken, and don't

| Risk | Verdict |
| -- | -- |
| `uv sync --frozen` rejects a version that no longer matches the lock | ✅ `uv.lock` records `anton-agent` with `source = { editable = "." }` and **no `version =` line** (`dynamic = ["version"]`). `2.0.0` appears nowhere in it |
| A consumer parses or compares `anton_version` | ✅ Every consumer displays it — `cli.py:1620`, `channel/branding.py`, cowork's `UpdatesSection.jsx`, `server-process.ts`. No comparisons, no gates |
| The shared `build-push-ecr` action can't pass build args | ✅ `extra-build-args` is already an input; **no change to the org-wide action** |

Scope is the pod image only. This `Dockerfile` is referenced by one workflow; the PyPI wheel is built separately by `release.yml` / `publish-staging.yml`, which already resolve the version correctly.

`SETUPTOOLS_SCM_PRETEND_VERSION` is kept as `ENV` rather than narrowed to the build stage, deliberately — that is the conservative choice, identical in shape to today. See "follow-up" below.

## Verification

**Executed:**
- `uvx hatch version` resolves correctly here and prints **only** the version to stdout, so `$( )` captures exactly it — checked explicitly, since a captured progress line would be baked into the image: `captured=[2.26.8.26.2rc3] lines=0`
- The empty-arg guard, both branches. `A || B && C` precedence is a classic silent inversion, so it was run rather than reasoned about: version set → reaches the install step, exit 0; version empty → prints the error, exit 1, install never reached
- 6 build assertions, all **mutation-verified**, each mutation asserted to have actually modified the file first

**Measured during adversarial self-review** (these drove `4c685f4`):
- With **no tags**, hatch-vcs resolves `2.0.0.dev1+g19c6e7515`; with **no `.git`**, `2.0.0-dev`. Both well-formed, both accepted by the original non-empty check — so losing `fetch-depth: 0` would have rebuilt the 2.0.0 family silently. Now rejected in the Dockerfile *and* the workflow, so the guard holds however the image is built (mirroring cowork-server's `0.0.0*` guard)
- `pipefail` confirmed load-bearing: without it, a failing resolver is masked by `tail` and yields an empty version

**NOT executed:** the image itself is not built here — the local Docker daemon is not running. The build path is exercised by CI on this PR.

## Automated coverage

`tests/test_pod_image_version.py` — build assertions rather than behaviour tests, because there is no runtime symptom to assert on. That is the same property that let this survive so long.

| Mutation | Caught by |
| -- | -- |
| version back to the literal `2.0.0` | 2 tests |
| drop the `ARG` declaration | 1 |
| drop the empty-arg guard | 1 |
| drop `fetch-depth: 0` | 1 |
| build no longer `needs` the version job | 1 |
| stop passing the version to the build | 1 |
| Dockerfile stops rejecting the `2.0.0*` fallback | 1 |
| back to a prefix-only shape check | 1 |
| workflow stops rejecting the fallback | 1 |
| drop the single-line capture | 1 |

**One of these tests was vacuous and mutation caught it, not review.** The single-line-capture assertion matched `tail -n 1` anywhere in the `run` block — and the explanatory comment above the pipeline contains that string, so deleting the pipe left the test green. It now asserts on the pipeline itself. Recording it because a guard that cannot fail is worse than no guard: it reads as coverage.

## Security check

Read-only build-metadata change. No new endpoint, no auth surface, no user input. No secrets are read, logged, or baked. `.git` still does not enter the build context or the image.

The one surface worth stating: the resolved version is expanded **unquoted** by the shared action into `docker buildx build`, so it is a value that reaches a shell. An earlier revision of this PR validated it with a *prefix* match (`^[0-9]+\.[0-9]`) and this section claimed that "the check rejects" whitespace. **That claim was false** — `2.26.8 --build-arg EVIL=1` passes a prefix match and becomes extra arguments to `docker buildx build`. Found by adversarially reviewing this PR and fixed in `4c685f4`: validation is now `grep -Eqx '[0-9]+\.[0-9][0-9A-Za-z.!+]*'`, whole-line over PEP 440 characters only, so no whitespace or shell metacharacter can survive it. The value's origin is a git tag, so exploiting it required a hostile or garbled tag — but the claim was load-bearing and wrong, which is why it is corrected here rather than quietly edited.

## Merge order

None — this and the cowork-server half of ENG-1796 are independent repos with no shared contract. Either can land first.

## Follow-up, not in this PR

`SETUPTOOLS_SCM_PRETEND_VERSION` is set as `ENV`, so it persists at **runtime**, where `scratchpad_boot` shells out to `uv pip install` for missing packages. Any package built from an sdist in a pod inherits anton's version. Narrowing it to the build stage would fix that, but it changes runtime environment as a side effect of a reporting fix, so it is left out deliberately and noted on the ticket.
