### PR TITLE
ENG-1858: Record why the completion verifier produced no verdict on turn_completed

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -166,7 +166,11 @@ _pending_lock = threading.Lock()
 #                    rounds, continuations, peak_context_tokens, duration_ms,
 #                    {planning,coding,router}_{model,tokens,calls},
 #                    unknown_{tokens,calls}, llm_provider, endpoint_class,
-#                    error_type, harness, surface (desktop / web / cli — WHERE
+#                    error_type, verifier_failure + verifier_error_type (WHY
+#                    the completion verifier produced no verdict — the loop's
+#                    truncated/transient/hard/denied class and the content-
+#                    free exception type; "" on verified turns; ENG-1858),
+#                    harness, surface (desktop / web / cli — WHERE
 #                    the user was, "" when the host did not say; ENG-1945),
 #                    anton_version, conversation_id, turn_index
 #

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -495,6 +495,12 @@ class StructuredOutputError(ValueError):
       arguments. A bigger budget only helps until the payload grows again; the
       cure is a smaller response (ENG-1523).
 
+    The flag is meaningful on NON-truncated errors too — it is computed from
+    whether the response carried any tool call, independent of truncation. There
+    it separates a model that answered in prose instead of calling the tool
+    (``False``) from one whose call the schema rejected (``True``); the verifier
+    reports that split as ``:no_call`` / ``:unusable_call`` (ENG-1858).
+
     Subclasses ``ValueError`` so call sites catching the documented ``ValueError``
     from ``generate_object``/``generate_object_code`` keep working.
     """

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -534,6 +534,26 @@ def _safe_error_type(exc: BaseException) -> str:
         return "unavailable"
 
 
+def _verifier_error_type(exc: BaseException | None) -> str:
+    """`_safe_error_type` for the verdict call, with the one split it needs.
+
+    A non-truncated `StructuredOutputError` is two different failures that
+    ENG-1095 pulls apart: the model never produced the forced tool call at all
+    (`:no_call` — the shape a model without reliable tool-calling shows), or it
+    produced one the schema rejected (`:unusable_call` — fable's `{}` at 8
+    output tokens). Same class name, opposite cures, so the type alone would
+    merge them back into one PostHog row (ENG-1858). Content-free: the suffix
+    is derived from a boolean, never from the message. Cannot raise: the only
+    attribute read is a plain bool set in `StructuredOutputError.__init__`.
+    """
+    if exc is None:
+        return ""
+    name = _safe_error_type(exc)
+    if isinstance(exc, StructuredOutputError):
+        return name + (":unusable_call" if exc.reached_tool_call else ":no_call")
+    return name
+
+
 def _is_provider_auth_error(exc: BaseException) -> bool:
     """A provider-auth 401 — anton's "Invalid API key — …" copy from
     `openai.py`/`anthropic.py` (ENG-1310): the credential is wrong, not the
@@ -2689,12 +2709,13 @@ class ChatSession:
             _root_cause_fields = {}
         logger.info(
             "turn_cost session=%s turn=%d ended_by=%s verification_skipped=%s "
-            "tokens_total=%d "
+            "verifier_failure=%s verifier_error_type=%s tokens_total=%d "
             "input=%d output=%d cache_read=%d cache_creation=%d "
             "llm_calls=%d rounds=%d continuations=%d peak_context=%d duration_ms=%d "
             "by_role=%s %s",
             self._session_id, turn_index, tc.ended_by,
-            str(tc.verification_skipped).lower(), tc.total_tokens,
+            str(tc.verification_skipped).lower(),
+            tc.verifier_failure, tc.verifier_error_type, tc.total_tokens,
             tc.input_tokens, tc.output_tokens, tc.cache_read_tokens,
             tc.cache_creation_tokens, tc.llm_calls, tc.rounds,
             tc.continuations, tc.peak_context_tokens, tc.duration_ms,
@@ -2808,6 +2829,12 @@ class ChatSession:
                 # ENG-1632) must be excludable from the honest-stop
                 # denominator without a per-conversation Langfuse hop.
                 verification_skipped=str(tc.verification_skipped).lower(),
+                # WHY the verifier produced no verdict (ENG-1858): the loop's
+                # own truncated/transient/hard/denied class plus the content-
+                # free exception type. Empty on verified turns. See
+                # `TurnCost.verifier_failure`.
+                verifier_failure=tc.verifier_failure,
+                verifier_error_type=tc.verifier_error_type,
                 tokens_total=str(tc.total_tokens),
                 input_tokens=str(tc.input_tokens),
                 output_tokens=str(tc.output_tokens),
@@ -5240,6 +5267,12 @@ class ChatSession:
                     # emit (late finalizers would see a later turn's state).
                     if self._turn_cost is not None:
                         self._turn_cost.verification_skipped = True
+                        # ...and WHY it was skipped (ENG-1858): no call was
+                        # made this turn, so there is no exception type — the
+                        # latch reason is the whole story.
+                        self._turn_cost.verifier_failure = (
+                            f"latched_{self._verifier_latch_reason or 'hard'}"
+                        )
                     break
                 _verifier_log.info(
                     "completion-verifier re-probing after %d skipped verifications",
@@ -5258,6 +5291,10 @@ class ChatSession:
             # latch: a blown budget is a tail sample of one model's verbosity,
             # an identical hard error twice is a capability problem (ENG-1155).
             verdict_failure: str | None = None
+            # The last attempt's exception, kept only long enough to stamp
+            # its TYPE on the turn books below (ENG-1858). `except ... as exc`
+            # unbinds `exc` at the end of each clause, hence the copy.
+            verdict_exc: BaseException | None = None
             for attempt, budget in enumerate(_VERIFIER_TOKEN_BUDGETS):
                 try:
                     verdict = await self._llm.generate_object_code(
@@ -5276,6 +5313,7 @@ class ChatSession:
                         _VERIFIER_TOKEN_BUDGETS
                     )
                     verdict_failure = "truncated" if exc.truncated else "hard"
+                    verdict_exc = exc
                     _verifier_log.info(
                         "completion-verifier verdict=%s budget=%d output_tokens=%d "
                         "stop_reason=%s retrying=%s",
@@ -5290,6 +5328,7 @@ class ChatSession:
                     # transient tuple). Retrying, diagnosing, or telling the
                     # user buys nothing: handled below by latching silently.
                     verdict_failure = "denied"
+                    verdict_exc = exc
                     _verifier_log.info(
                         "completion-verifier verdict=DENIED budget=%d error=%s",
                         budget, _safe_error_detail(exc),
@@ -5306,6 +5345,7 @@ class ChatSession:
                     # still gets its honest diagnosis (ENG-1079); it just doesn't
                     # latch. See `_TRANSIENT_VERDICT_ERRORS` for what qualifies.
                     verdict_failure = "transient"
+                    verdict_exc = exc
                     _verifier_log.info(
                         "completion-verifier verdict=TRANSIENT budget=%d error=%s",
                         budget, _safe_error_detail(exc),
@@ -5317,6 +5357,7 @@ class ChatSession:
                     # the exception message, which can carry conversation
                     # content (ENG-1081).
                     verdict_failure = "hard"
+                    verdict_exc = exc
                     _verifier_log.info(
                         "completion-verifier verdict=ERROR budget=%d error=%s",
                         budget, _safe_error_detail(exc),
@@ -5333,6 +5374,17 @@ class ChatSession:
                 status = verdict.status
                 reason = verdict.reason.strip()
             else:
+                # Every no-verdict exit below — denied latch, hard latch,
+                # failed re-probe, honest handback — books the SAME two
+                # facts, so stamp them once here rather than at each site
+                # (ENG-1858). Class + exception type only; the exception
+                # message can quote conversation content and never leaves
+                # the process.
+                if self._turn_cost is not None:
+                    self._turn_cost.verifier_failure = verdict_failure or "hard"
+                    self._turn_cost.verifier_error_type = _verifier_error_type(
+                        verdict_exc
+                    )
                 if verdict_failure == "denied":
                     # A denied verdict recurs every turn by construction, so
                     # don't wait for a second sample: latch NOW and end the

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -124,6 +124,25 @@ class TurnCost:
     # note below on stamped-at-open fields). Handback terminals don't need it:
     # their ended_by already distinguishes them.
     verification_skipped: bool = False
+    # WHY the completion verifier produced no verdict this turn (ENG-1858).
+    # `ended_by="handback_verifier_failure"` and `verification_skipped=True`
+    # both say only THAT it failed; 343 such turns / 14 days (5.3% of real
+    # turns, 3x the tokens of a completed one) had no groupable cause. Values
+    # are the classification the verdict loop already draws for the latch —
+    # `truncated` / `transient` / `hard` / `denied` — plus `latched_hard` /
+    # `latched_denied` for turns that never made the call because an earlier
+    # one latched. Empty when a verdict was produced or the verifier was
+    # not applicable. Stamped at the loop's exits, never read from latch
+    # state at emit (late finalizers would see a later turn's latch).
+    verifier_failure: str = ""
+    # Exception TYPE of the last verdict attempt — `_safe_error_type`, i.e.
+    # the class name only, never the message (which can quote model output
+    # derived from the user's conversation). `StructuredOutputError` carries
+    # a `:no_call` / `:unusable_call` suffix: the model never produced the
+    # forced call vs produced one the schema rejected — the split ENG-1095
+    # needs. Empty when no exception ended the verdict (verdict produced, or
+    # latched skip with no call made).
+    verifier_error_type: str = ""
     started_monotonic: float = field(default_factory=time.monotonic)
     # Set when these books have been reported. Replaces "the shared slot is
     # None" as the double-emit guard, because a late finalizer now emits the

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -26,7 +26,9 @@ from anton.core.llm.provider import (
     LLMResponse,
     StreamComplete,
     StreamTextDelta,
+    StructuredOutputError,
     TokenLimitExceeded,
+    TransientProviderError,
     ToolCall,
     Usage,
 )
@@ -87,6 +89,13 @@ def _stub_tools(session) -> None:
 def _ended_by(send_event_mock) -> str:
     assert send_event_mock.called, "no turn_completed event emitted"
     return send_event_mock.call_args.kwargs["ended_by"]
+
+
+def _verifier_fields(send_event_mock) -> tuple[str, str]:
+    """(verifier_failure, verifier_error_type) on the last emitted event."""
+    assert send_event_mock.called, "no turn_completed event emitted"
+    k = send_event_mock.call_args.kwargs
+    return k["verifier_failure"], k["verifier_error_type"]
 
 
 async def test_task_cancel_reports_cancelled_not_error(workspace):
@@ -370,6 +379,76 @@ async def test_verifier_failure_reports_handback_verifier_failure(workspace):
         async for _ in session.turn_stream("run my script"):
             pass
     assert _ended_by(send) == "handback_verifier_failure"
+    # ENG-1858: the handback also says WHY. A bare exception is the "hard"
+    # class, and the type — never the message — names it.
+    assert _verifier_fields(send) == ("hard", "RuntimeError")
+
+
+async def _handback_with(workspace, exc) -> tuple[str, str]:
+    """Run one turn whose every verdict attempt raises `exc`; return the
+    (verifier_failure, verifier_error_type) pair the turn event carried."""
+    mock_llm = _verdict_llm("COMPLETE")
+    mock_llm.generate_object_code = AsyncMock(side_effect=exc)
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace, session_id="conv-t"))
+    _stub_tools(session)
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("run my script"):
+            pass
+    assert _ended_by(send) == "handback_verifier_failure"
+    return _verifier_fields(send)
+
+
+async def test_truncated_verdict_reports_truncated_class(workspace):
+    # ENG-1081's shape: the model narrated past every budget in the ladder
+    # and never reached the tool call. Groupable as `truncated` — the cure is
+    # budget, not capability — and the type says it never got to the call.
+    assert await _handback_with(
+        workspace,
+        StructuredOutputError("narrated", truncated=True, output_tokens=512, max_tokens=512),
+    ) == ("truncated", "StructuredOutputError:no_call")
+
+
+async def test_no_call_verdict_reports_hard_no_call(workspace):
+    # The nemotron suspicion (ENG-1858): a model that returns prose instead of
+    # the forced call, within budget. Not truncation — a bigger budget won't
+    # help — so it is `hard`, and `:no_call` is what separates it from a
+    # schema rejection in PostHog.
+    assert await _handback_with(
+        workspace,
+        StructuredOutputError("no tool call", truncated=False, reached_tool_call=False),
+    ) == ("hard", "StructuredOutputError:no_call")
+
+
+async def test_unusable_call_verdict_reports_hard_unusable_call(workspace):
+    # ENG-1095's fable shape: the call arrived but its arguments failed the
+    # schema. Same class, opposite cure (smaller/looser schema, not a fallback
+    # for models that can't call tools) — hence the suffix.
+    assert await _handback_with(
+        workspace,
+        StructuredOutputError("bad args", truncated=False, reached_tool_call=True),
+    ) == ("hard", "StructuredOutputError:unusable_call")
+
+
+async def test_transient_verdict_reports_transient_class(workspace):
+    # A provider blip is the opposite claim from a capability failure: it
+    # hands back (ENG-1079) but must not read as "this model can't verify".
+    assert await _handback_with(
+        workspace, TransientProviderError("overloaded", provider="minds-cloud")
+    ) == ("transient", "TransientProviderError")
+
+
+async def test_verified_turn_carries_no_verifier_failure(workspace):
+    # A produced verdict leaves both fields empty — they mean "no verdict",
+    # not "verdict was COMPLETE".
+    session = ChatSession(
+        ChatSessionConfig(llm_client=_verdict_llm("COMPLETE"), workspace=workspace, session_id="conv-t")
+    )
+    _stub_tools(session)
+    with patch("anton.analytics.send_event") as send:
+        async for _ in session.turn_stream("run my script"):
+            pass
+    assert _ended_by(send) == "completed"
+    assert _verifier_fields(send) == ("", "")
 
 
 async def test_denied_verdict_reports_completed_not_verifier_failure(workspace):
@@ -396,6 +475,9 @@ async def test_denied_verdict_reports_completed_not_verifier_failure(workspace):
     # honest-stop denominators exclude unverified turns without a
     # per-conversation Langfuse hop (ENG-1632 review).
     assert send.call_args.kwargs["verification_skipped"] == "true"
+    # ...and says WHY (ENG-1858): a denied turn is the one skipped-verifier
+    # shape that must stay separable from a hard latch in PostHog.
+    assert _verifier_fields(send) == ("denied", "TokenLimitExceeded")
 
 
 async def test_verified_turn_reports_verification_not_skipped(workspace):
@@ -600,6 +682,7 @@ async def test_hard_latch_and_failed_reprobe_turns_also_stamp_verification_skipp
     session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace, session_id="conv-t"))
     _stub_tools(session)
     rows = []
+    why = []
     with patch("anton.analytics.send_event") as send:
         for i in range(_VERIFIER_LATCH_REPROBE_TURNS + 2):
             plans = [
@@ -615,6 +698,7 @@ async def test_hard_latch_and_failed_reprobe_turns_also_stamp_verification_skipp
                 pass
             k = send.call_args.kwargs
             rows.append((k["ended_by"], k["verification_skipped"]))
+            why.append((k["verifier_failure"], k["verifier_error_type"]))
     # Turn 1: honest diagnosis, distinguished by its own terminal.
     assert rows[0] == ("handback_verifier_failure", "false")
     # Turn 2: the second-hard-failure latch site.
@@ -622,6 +706,14 @@ async def test_hard_latch_and_failed_reprobe_turns_also_stamp_verification_skipp
     # Every later turn — the latched skips AND the failed re-probe that falls
     # inside this window — books completed and must carry the flag.
     assert all(r == ("completed", "true") for r in rows[2:]), rows[2:]
+    # ENG-1858: each of those exits also says WHY. Turns 1 and 2 made the
+    # call and saw it fail (hard + the exception type); the skipped turns
+    # made no call and carry the latch reason instead; the re-probe (turn
+    # _VERIFIER_LATCH_REPROBE_TURNS + 2, index -1) made the call again.
+    assert why[0] == ("hard", "RuntimeError")
+    assert why[1] == ("hard", "RuntimeError")
+    assert all(w == ("latched_hard", "") for w in why[2:-1]), why[2:-1]
+    assert why[-1] == ("hard", "RuntimeError")
 
 
 # ─── error_type: naming the failure, not just counting it (ENG-1689) ─────────

--- a/tests/test_turn_cost_terminals.py
+++ b/tests/test_turn_cost_terminals.py
@@ -647,6 +647,7 @@ async def test_latched_skip_turns_also_stamp_verification_skipped(workspace):
     session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace, session_id="conv-t"))
     _stub_tools(session)
     rows = []
+    why = []
     with patch("anton.analytics.send_event") as send:
         for i in range(2):
             # _verdict_llm's plan list is consumed by turn 1; re-arm per turn.
@@ -663,8 +664,13 @@ async def test_latched_skip_turns_also_stamp_verification_skipped(workspace):
                 pass
             k = send.call_args.kwargs
             rows.append((k["ended_by"], k["verification_skipped"]))
+            why.append((k["verifier_failure"], k["verifier_error_type"]))
     # Turn 1 = the denied-latch site; turn 2 = the latched-skip site.
     assert rows == [("completed", "true"), ("completed", "true")]
+    # ENG-1858: turn 1 made the call and was denied (class + type); turn 2
+    # made no call, so it carries the latch reason and no type. This is the
+    # one `latched_*` value the hard-latch test cannot reach.
+    assert why == [("denied", "TokenLimitExceeded"), ("latched_denied", "")]
 
 
 async def test_hard_latch_and_failed_reprobe_turns_also_stamp_verification_skipped(workspace):


### PR DESCRIPTION
Linear: [ENG-1858](https://linear.app/mindsdb/issue/ENG-1858/a-turn-can-end-because-the-completion-verifier-failed-and-nothing)

## What

`turn_completed` could say **that** the completion verifier failed — `ended_by=handback_verifier_failure`, or `verification_skipped=true` for a latched/denied turn — but nothing said **why**. This adds two content-free properties that surface the classification the verdict loop already computes.

## Why

Re-measured 2026-08-26 in PostHog 424726, 14 days, real turns only: **343 handbacks / 6,468 turns = 5.3%**, 50 installs, avg 514k tokens (3.1× a completed turn, ~176M total), still 6.3% on the newest build. Concentrated by model (nemotron 83/195 = 42.6%; `qwen3.5-122b` 23/26; `gpt-4o` 19/28) but with 59 properties on the event and zero about the verifier, none of it is groupable. The likely causes — model can't produce the forced tool call (ENG-1095), model narrates past the budget ladder (ENG-1081), provider blip (ENG-673) — produce byte-identical events today.

## How

The verdict loop in `session.py` already assigns `verdict_failure ∈ {truncated, transient, hard, denied}` per attempt for the latch, then drops it at end of scope. This PR:

- Adds `TurnCost.verifier_failure` and `TurnCost.verifier_error_type`, stamped at **every** no-verdict exit — one stamp after the attempt loop (covers denied latch, hard latch, failed re-probe, honest handback) plus one at the latched-skip site (`latched_hard` / `latched_denied`, no call was made so no exception type).
- `verifier_error_type` is `_safe_error_type(exc)` — the existing helper, class name only, never the message — with `StructuredOutputError` split into `:no_call` (model never produced the forced call, the nemotron suspicion) vs `:unusable_call` (call present, schema rejected it). Same class, opposite cures, so the bare type would merge them back into one PostHog row.
- Emits both next to `error_type`; `send_event(**extra)` passes new keys through untouched, so no sink change. Also added to the `turn_cost` log line and to the `analytics.py` key-list comment.

**Deliberately not done:** reusing `error_type` (ENG-1689). Its documented contract is "empty on handback"; overloading it would change its meaning by `ended_by` and silently alter existing queries.

## Before / after

| | before | after |
|---|---|---|
| handback event | `ended_by=handback_verifier_failure`, `error_type=''` | + `verifier_failure=hard`, `verifier_error_type=StructuredOutputError:no_call` |
| latched-skip event | `ended_by=completed`, `verification_skipped=true` | + `verifier_failure=latched_hard`, `verifier_error_type=''` |
| verified event | unchanged | + `verifier_failure=''`, `verifier_error_type=''` |
| user-visible behaviour | — | **unchanged** — instrumentation only |

After a week of traffic on a build carrying this, `GROUP BY planning_model, verifier_failure, verifier_error_type` partitions the population into budget problems / capability problems / provider noise, and the nemotron follow-up gets written from data.

## Tests

`tests/test_turn_cost_terminals.py` — 5 new tests (one per class: truncated, hard/no_call, hard/unusable_call, transient, and the verified-turn empty case) plus 3 existing tests extended (handback, denied, hard-latch/re-probe sequence). 31/31 green locally.

Mutation-verified, each watched failing:
- remove the post-loop stamp → 7 tests fail
- remove the latched-skip stamp → 1 test fails
- remove the `:no_call`/`:unusable_call` suffix → 3 tests fail

Ruff on the touched files: 47 findings before, 47 after (zero new).

## Security check

Done. The two new properties are a fixed-vocabulary string and an exception **class name**; the exception message (which can quote model output derived from the user's conversation) never leaves the process — the existing `_safe_error_type` helper is reused unchanged, and the `StructuredOutputError` suffix is derived from a bool. No new inputs, endpoints, or credentials. No raw model free-text reaches the analytics sink (ticket's explicit constraint).

## Delivery

anton-only. Reaches users via anton `main` → cowork-server's `anton-agent` git pin → the desktop train; web via the scratchpad image rebuild. Nothing to coordinate in other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
