### PR TITLE
feat: preserve artifact identity through publishing

### DIFF
--- a/anton/core/artifacts/__init__.py
+++ b/anton/core/artifacts/__init__.py
@@ -15,12 +15,16 @@ Provenance is server-managed (deterministic). Only `name`,
 """
 
 from anton.core.artifacts.models import (
+    ARTIFACT_ID_SLUG_PREFIX_LEN,
     ARTIFACT_TYPES,
     Artifact,
     ArtifactType,
     FileEntry,
     ProvenanceEntry,
     TurnEntry,
+    artifact_key,
+    canonical_artifact_id,
+    resolve_artifact_id,
 )
 from anton.core.artifacts.snapshot import (
     DirSnapshot,
@@ -30,6 +34,7 @@ from anton.core.artifacts.snapshot import (
 from anton.core.artifacts.store import ArtifactStore
 
 __all__ = [
+    "ARTIFACT_ID_SLUG_PREFIX_LEN",
     "ARTIFACT_TYPES",
     "Artifact",
     "ArtifactStore",
@@ -38,6 +43,9 @@ __all__ = [
     "FileEntry",
     "ProvenanceEntry",
     "TurnEntry",
+    "artifact_key",
+    "canonical_artifact_id",
     "diff_snapshots",
+    "resolve_artifact_id",
     "snapshot_dir",
 ]

--- a/anton/core/artifacts/models.py
+++ b/anton/core/artifacts/models.py
@@ -2,7 +2,7 @@
 
 Schema split:
   Server-managed (deterministic):
-    schemaVersion, id, stableId, slug, createdAt, updatedAt, files[], provenance[]
+    schemaVersion, id, slug, createdAt, updatedAt, files[], provenance[]
   Agent-supplied (validated at create_artifact / update_artifact time):
     name, description, type, primary, port, datasources[]
 
@@ -18,6 +18,7 @@ existed load as version 1 (the field default).
 
 from __future__ import annotations
 
+import re
 from typing import Literal
 from uuid import UUID, uuid5
 
@@ -28,15 +29,92 @@ from pydantic import BaseModel, Field, model_validator
 # and add a migration keyed off the loaded `schemaVersion`.
 METADATA_SCHEMA_VERSION = 1
 
-# A legacy artifact predates ``stableId``. Derive its canonical identity from
-# fields that already survive folder/project moves instead of inventing a new
-# value on every read. New artifacts always receive a random UUID in the store.
+# A legacy artifact was created when `id` was only eight hex characters — too
+# narrow to be a global identity. Widen it from fields that already survive
+# folder/project moves instead of inventing a new value on every read. New
+# artifacts get a full random id in the store.
 _LEGACY_ARTIFACT_NAMESPACE = UUID("4ba9bdf8-3f0e-4ce5-beb0-8f00a8d955e7")
 
+#: Width of the canonical `id`: a UUID spelled as bare lowercase hex.
+ARTIFACT_ID_LEN = 32
+#: Width of the `id` prefix that ends every slug `create()` mints.
+ARTIFACT_ID_SLUG_PREFIX_LEN = 8
 
-def legacy_stable_id(artifact_id: str, created_at: str) -> str:
-    """Deterministic UUID for metadata written before ``stableId`` existed."""
-    return str(uuid5(_LEGACY_ARTIFACT_NAMESPACE, f"{artifact_id}:{created_at}"))
+_LEGACY_ID_RE = re.compile(rf"^[0-9a-f]{{{ARTIFACT_ID_SLUG_PREFIX_LEN}}}$")
+
+#: Hex-only and wider than a legacy id, yet not parseable as a UUID: a
+#: truncated or padded identity, not a name. Widening it would mint a new one.
+_DAMAGED_ID_RE = re.compile(rf"^[0-9a-fA-F]{{{ARTIFACT_ID_SLUG_PREFIX_LEN + 1},}}$")
+
+
+def canonical_artifact_id(value: str) -> str:
+    """Normalize any accepted spelling of an id to 32 lowercase hex chars.
+
+    Raises `ValueError` on anything that is not a UUID — a corrupted identity
+    must not be silently replaced, because that detaches the artifact from its
+    published versions and comment threads.
+    """
+    return UUID(str(value)).hex
+
+
+def extend_legacy_id(artifact_id: str, created_at: str) -> str:
+    """Widen a short legacy id to a full 32-hex identity, deterministically.
+
+    The old eight characters stay as the *prefix*, so the `-<id[:8]>` suffix
+    already baked into the folder slug keeps addressing the same artifact. The
+    24-character tail is derived, never random: anton widens in memory only
+    while cowork-server persists, so both sides have to reach the same value
+    without coordinating — otherwise the identity would be minted by whoever
+    touched the artifact first and comment threads would fork.
+    """
+    derived = uuid5(_LEGACY_ARTIFACT_NAMESPACE, f"{artifact_id}:{created_at}").hex
+    prefix = (artifact_id or "").strip().lower()
+    if _LEGACY_ID_RE.match(prefix):
+        return prefix + derived[ARTIFACT_ID_SLUG_PREFIX_LEN:]
+    # An id that never was eight hex characters carries no slug contract worth
+    # preserving; take the derived value whole.
+    return derived
+
+
+def resolve_artifact_id(raw_id: str, inherited_id: str, created_at: str) -> str:
+    """Pick the canonical id for one metadata record's identity fields.
+
+    `raw_id` is the `id` field, `inherited_id` the `stableId` field written by
+    the short-lived two-field era.
+
+    An `id` that already parses wins outright. That makes a stale `stableId`
+    written by an older build inert, instead of letting it re-stamp an identity
+    that published versions are already keyed under. Only when `id` is still the
+    short form does `stableId` decide — there it already keyed those things, and
+    keeping them bound is worth more than the folder slug's readable suffix.
+
+    Everything else is widened rather than rejected: hand-written and very old
+    records carry names in `id` (`"static-art"`), and refusing them would drop
+    the artifact from every listing, which reads as a deletion. The one shape
+    that does raise is a value that plausibly IS a damaged identity — hex-only
+    and wider than a legacy id — because re-minting that would silently detach
+    the artifact from its published versions, auth rules and comment threads.
+    """
+    raw = (raw_id or "").strip()
+    try:
+        return canonical_artifact_id(raw)
+    except ValueError:
+        pass
+    inherited = (inherited_id or "").strip()
+    if inherited:
+        return canonical_artifact_id(inherited)
+    if _DAMAGED_ID_RE.match(raw):
+        raise ValueError(f"artifact id looks like a damaged UUID: {raw!r}")
+    return extend_legacy_id(raw, created_at)
+
+
+def artifact_key(artifact_id: str) -> str:
+    """The `artifact/<uuid>` key drafts, published versions and comments share.
+
+    Canonical dashed spelling: the upload lambda normalizes what it stores in
+    `_meta.json` the same way, so both sides of the comments API agree.
+    """
+    return f"artifact/{UUID(str(artifact_id))}"
 
 
 # Closed enum of artifact shapes. The renderer uses this to pick
@@ -144,10 +222,12 @@ class Artifact(BaseModel):
     # (the default); `create()` stamps the current
     # `METADATA_SCHEMA_VERSION` on fresh artifacts.
     schemaVersion: int = 1
-    id: str  # short hex (uuid4().hex[:8]) — stable across folder renames
-    # Globally unique identity used by drafts, published versions, revisions,
-    # and comments. ``id`` remains for slug/backwards compatibility only.
-    stableId: str = ""
+    # `uuid4().hex` — the artifact's one identity, stable across folder renames
+    # and re-publishes. Drafts, published versions, revisions and comments all
+    # key off it; `id[:8]` is the suffix carried by the folder slug.
+    # Constrained so a record `_widen_identity` could not widen is rejected here
+    # rather than surfacing later as `UUID('')` inside `artifact_key`.
+    id: str = Field(pattern=rf"^[0-9a-f]{{{ARTIFACT_ID_LEN}}}$")
     slug: str  # matches folder name; sanitized from `name` with collision suffix
     createdAt: str
     updatedAt: str
@@ -178,12 +258,26 @@ class Artifact(BaseModel):
     files: list[FileEntry] = Field(default_factory=list)
     provenance: list[ProvenanceEntry] = Field(default_factory=list)
 
-    @model_validator(mode="after")
-    def _backfill_stable_id(self) -> "Artifact":
-        """Give legacy records one repeatable identity without a write-on-read."""
-        if not self.stableId:
-            self.stableId = legacy_stable_id(self.id, self.createdAt)
-        else:
-            # Reject malformed persisted identities at the metadata boundary.
-            self.stableId = str(UUID(self.stableId))
-        return self
+    @model_validator(mode="before")
+    @classmethod
+    def _widen_identity(cls, data: object) -> object:
+        """Give pre-widening records their full id without a write-on-read.
+
+        Runs before field validation so the retired `stableId` field is still
+        visible in the raw document. Nothing is written back here — the value is
+        derived deterministically, so recomputing it on every load is free of
+        the mtime side effects a metadata rewrite would carry.
+        """
+        if not isinstance(data, dict):
+            return data
+        raw_id = str(data.get("id") or "")
+        inherited = str(data.get("stableId") or "")
+        if not raw_id and not inherited:
+            # Nothing to widen from. Let the field constraint reject the record
+            # rather than invent an identity — a wrong id detaches the artifact
+            # from its published versions and comment threads.
+            return data
+        resolved = resolve_artifact_id(raw_id, inherited, str(data.get("createdAt") or ""))
+        if resolved == data.get("id"):
+            return data
+        return {**data, "id": resolved}

--- a/anton/core/artifacts/models.py
+++ b/anton/core/artifacts/models.py
@@ -2,7 +2,7 @@
 
 Schema split:
   Server-managed (deterministic):
-    schemaVersion, id, slug, createdAt, updatedAt, files[], provenance[]
+    schemaVersion, id, stableId, slug, createdAt, updatedAt, files[], provenance[]
   Agent-supplied (validated at create_artifact / update_artifact time):
     name, description, type, primary, port, datasources[]
 
@@ -19,13 +19,24 @@ existed load as version 1 (the field default).
 from __future__ import annotations
 
 from typing import Literal
+from uuid import UUID, uuid5
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 # On-disk metadata.json layout version. Bump on incompatible changes
 # and add a migration keyed off the loaded `schemaVersion`.
 METADATA_SCHEMA_VERSION = 1
+
+# A legacy artifact predates ``stableId``. Derive its canonical identity from
+# fields that already survive folder/project moves instead of inventing a new
+# value on every read. New artifacts always receive a random UUID in the store.
+_LEGACY_ARTIFACT_NAMESPACE = UUID("4ba9bdf8-3f0e-4ce5-beb0-8f00a8d955e7")
+
+
+def legacy_stable_id(artifact_id: str, created_at: str) -> str:
+    """Deterministic UUID for metadata written before ``stableId`` existed."""
+    return str(uuid5(_LEGACY_ARTIFACT_NAMESPACE, f"{artifact_id}:{created_at}"))
 
 
 # Closed enum of artifact shapes. The renderer uses this to pick
@@ -134,6 +145,9 @@ class Artifact(BaseModel):
     # `METADATA_SCHEMA_VERSION` on fresh artifacts.
     schemaVersion: int = 1
     id: str  # short hex (uuid4().hex[:8]) — stable across folder renames
+    # Globally unique identity used by drafts, published versions, revisions,
+    # and comments. ``id`` remains for slug/backwards compatibility only.
+    stableId: str = ""
     slug: str  # matches folder name; sanitized from `name` with collision suffix
     createdAt: str
     updatedAt: str
@@ -163,3 +177,13 @@ class Artifact(BaseModel):
     # ── Server-managed contents ─────────────────────────────────
     files: list[FileEntry] = Field(default_factory=list)
     provenance: list[ProvenanceEntry] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _backfill_stable_id(self) -> "Artifact":
+        """Give legacy records one repeatable identity without a write-on-read."""
+        if not self.stableId:
+            self.stableId = legacy_stable_id(self.id, self.createdAt)
+        else:
+            # Reject malformed persisted identities at the metadata boundary.
+            self.stableId = str(UUID(self.stableId))
+        return self

--- a/anton/core/artifacts/models.py
+++ b/anton/core/artifacts/models.py
@@ -84,16 +84,20 @@ def resolve_artifact_id(raw_id: str, inherited_id: str, created_at: str) -> str:
 
     An `id` that already parses wins outright. That makes a stale `stableId`
     written by an older build inert, instead of letting it re-stamp an identity
-    that published versions are already keyed under. Only when `id` is still the
-    short form does `stableId` decide — there it already keyed those things, and
-    keeping them bound is worth more than the folder slug's readable suffix.
+    that published versions are already keyed under. Whenever `id` does NOT
+    parse — the short legacy form, a name, or a damaged value — `stableId`
+    decides if it is present: it already keyed those published versions, auth
+    rules and comment threads, and keeping them bound is worth more than the
+    folder slug's readable suffix (and more than re-deriving a value that
+    nothing out there is keyed under).
 
-    Everything else is widened rather than rejected: hand-written and very old
-    records carry names in `id` (`"static-art"`), and refusing them would drop
-    the artifact from every listing, which reads as a deletion. The one shape
-    that does raise is a value that plausibly IS a damaged identity — hex-only
-    and wider than a legacy id — because re-minting that would silently detach
-    the artifact from its published versions, auth rules and comment threads.
+    With no `stableId` to fall back on, everything else is widened rather than
+    rejected: hand-written and very old records carry names in `id`
+    (`"static-art"`), and refusing them would drop the artifact from every
+    listing, which reads as a deletion. The one shape that does raise is a
+    value that plausibly IS a damaged identity — hex-only and wider than a
+    legacy id — because re-minting that would silently detach the artifact
+    from its published versions, auth rules and comment threads.
     """
     raw = (raw_id or "").strip()
     try:

--- a/anton/core/artifacts/store.py
+++ b/anton/core/artifacts/store.py
@@ -45,6 +45,7 @@ PUBLISHED_FILENAME = ".published.json"
 # artifacts-service housekeeping set so the agent's view and the UI agree on
 # what counts as an artifact file.
 _HOUSEKEEPING_FILES = {METADATA_FILENAME, README_FILENAME, PUBLISHED_FILENAME}
+_HOUSEKEEPING_DIRS = {".revisions"}
 
 # Same character whitelist projects_store uses — keeps slug shapes
 # consistent across antontron's project names AND artifact slugs.
@@ -216,6 +217,7 @@ class ArtifactStore:
         artifact = Artifact(
             schemaVersion=METADATA_SCHEMA_VERSION,
             id=artifact_id,
+            stableId=str(uuid.uuid4()),
             slug=slug,
             createdAt=now,
             updatedAt=now,
@@ -390,7 +392,7 @@ class ArtifactStore:
             # fingerprint, so a Windows-written artifact must not disagree
             # with the same artifact written anywhere else.
             rel = p.relative_to(folder).as_posix()
-            if rel in _HOUSEKEEPING_FILES:
+            if rel in _HOUSEKEEPING_FILES or rel.split("/", 1)[0] in _HOUSEKEEPING_DIRS:
                 continue
             try:
                 stat = p.stat()

--- a/anton/core/artifacts/store.py
+++ b/anton/core/artifacts/store.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from anton.core.artifacts.models import (
+    ARTIFACT_ID_SLUG_PREFIX_LEN,
     METADATA_SCHEMA_VERSION,
     Artifact,
     ArtifactType,
@@ -65,13 +66,14 @@ def _utc_now() -> str:
 
 
 def _new_id() -> str:
-    return uuid.uuid4().hex[:8]
+    return uuid.uuid4().hex
 
 
-#: Width of `_new_id()`, plus the hyphen joining it to the name. Every slug ends
-#: in `-<id>` (see `create`), and the name is trimmed by this much so the whole
-#: slug still respects `_NAME_MAX_LEN`.
-_ID_SUFFIX_LEN = 8 + 1
+#: Width of the slug's id suffix, plus the hyphen joining it to the name. Every
+#: slug ends in `-<id[:8]>` (see `create`) — the full id is too long to read in
+#: a folder name — and the name is trimmed by this much so the whole slug still
+#: respects `_NAME_MAX_LEN`.
+_ID_SUFFIX_LEN = ARTIFACT_ID_SLUG_PREFIX_LEN + 1
 
 
 _UNSET = object()
@@ -177,13 +179,13 @@ class ArtifactStore:
     ) -> Artifact:
         """Create a fresh artifact folder + metadata.json + README.
 
-        Slug is `<sanitised name>-<id>`, e.g. `sales-report-a1b2c3d4`.
+        Slug is `<sanitised name>-<id[:8]>`, e.g. `sales-report-a1b2c3d4`.
         Returns the populated `Artifact`. The folder is empty other
         than the two metadata files — the agent writes its own
         files into it.
 
-        The id is IN the folder name, not just in metadata.json, because
-        the name alone does not identify an artifact:
+        The id prefix is IN the folder name, not just in metadata.json,
+        because the name alone does not identify an artifact:
 
         * `_sanitize_slug`'s whitelist is ASCII, so every artifact named
           in a non-Latin script collapses to the same `untitled-artifact`
@@ -209,15 +211,14 @@ class ArtifactStore:
         the file in the next scratchpad cell.
         """
         self.ensure_root()
-        # The id is part of the slug, so it has to exist before it.
+        # The id prefix is part of the slug, so the id has to exist before it.
         artifact_id = _new_id()
         slug_base = _sanitize_slug(name, max_len=_NAME_MAX_LEN - _ID_SUFFIX_LEN)
-        slug = self._unique_slug(f"{slug_base}-{artifact_id}")
+        slug = self._unique_slug(f"{slug_base}-{artifact_id[:ARTIFACT_ID_SLUG_PREFIX_LEN]}")
         now = _utc_now()
         artifact = Artifact(
             schemaVersion=METADATA_SCHEMA_VERSION,
             id=artifact_id,
-            stableId=str(uuid.uuid4()),
             slug=slug,
             createdAt=now,
             updatedAt=now,

--- a/anton/publish_access.py
+++ b/anton/publish_access.py
@@ -21,7 +21,7 @@ _EMAIL_SPLIT_RE = re.compile(r"[\s,;]+")
 # Keep in sync with anton.publisher._FULLSTACK_EXCLUDED (publisher.py:42):
 # backend.log is the running backend's runtime log — excluded from the
 # published bundle there, so it must not count as user content here either.
-_HOUSEKEEPING_FILES = {"metadata.json", "README.md", "backend.log", ".published.json"}
+_HOUSEKEEPING_FILES = {"metadata.json", "README.md", "backend.log", ".published.json", ".revisions"}
 
 
 def normalize_emails(values) -> list[str]:

--- a/anton/publish_access.py
+++ b/anton/publish_access.py
@@ -18,9 +18,11 @@ logger = logging.getLogger(__name__)
 _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 _EMAIL_SPLIT_RE = re.compile(r"[\s,;]+")
 
-# Keep in sync with anton.publisher._FULLSTACK_EXCLUDED (publisher.py:42):
-# backend.log is the running backend's runtime log — excluded from the
-# published bundle there, so it must not count as user content here either.
+# Keep in sync with anton.publisher._FULLSTACK_EXCLUDED: backend.log is the
+# running backend's runtime log — excluded from the published bundle there, so
+# it must not count as user content here either.
+# Matched against the artifact-relative path's FIRST component, so reserved
+# directories belong here too (`.revisions`, the private revision journal).
 _HOUSEKEEPING_FILES = {"metadata.json", "README.md", "backend.log", ".published.json", ".revisions"}
 
 

--- a/anton/publisher.py
+++ b/anton/publisher.py
@@ -203,8 +203,7 @@ def _zip_html(path: Path) -> bytes:
             # Bundle any referenced sibling files (JS, CSS, images, etc.)
             parent = path.resolve().parent
             for ref in _find_referenced_files(path):
-                arc_name = str(ref.relative_to(parent))
-                _write_scrubbed(zf, ref, arc_name)
+                _write_scrubbed(zf, ref, ref.relative_to(parent).as_posix())
         else:
             # Directory — include all files except owner-side housekeeping
             # (e.g. `.published.json`, which holds the plaintext access
@@ -212,7 +211,7 @@ def _zip_html(path: Path) -> bytes:
             for f in sorted(path.rglob("*")):
                 rel = f.relative_to(path)
                 if f.is_file() and not any(part in _BUNDLE_SKIP_NAMES for part in rel.parts):
-                    _write_scrubbed(zf, f, str(f.relative_to(path)))
+                    _write_scrubbed(zf, f, rel.as_posix())
     return buf.getvalue()
 
 
@@ -457,6 +456,20 @@ def publish(
         artifact_key = artifact_key or artifact_key_for(artifact.id)
     else:
         zipped = _zip_html(file_path)
+        # A static artifact publishes its primary *file*, not its folder, so the
+        # identity sits in the metadata.json next to that file. Derive it here
+        # too: otherwise only fullstack publishes carry `artifact_key` and the
+        # upload lambda locks static artifacts to the legacy
+        # `{user_dir}/{report_id}` key, detaching them from their drafts and
+        # comment threads. cowork-server passes the key explicitly, so this only
+        # covers a direct anton publish.
+        # Only the artifact root is consulted (a file's own folder), never an
+        # ancestor: publishing one page out of an artifact would otherwise mint
+        # a second report under the same key, and the auth rule is per key.
+        if not artifact_key:
+            owner = artifact if file_path.is_dir() else _load_artifact_metadata(file_path.parent)
+            if owner is not None:
+                artifact_key = artifact_key_for(owner.id)
 
     payload_dict["file_payload"] = base64.b64encode(zipped).decode()
     if report_id:

--- a/anton/publisher.py
+++ b/anton/publisher.py
@@ -13,7 +13,7 @@ import secrets
 import zipfile
 from pathlib import Path
 
-from anton.core.artifacts.models import Artifact
+from anton.core.artifacts.models import Artifact, artifact_key as artifact_key_for
 from anton.core.datasources.data_vault import DataVault, LocalDataVault
 from anton.minds_client import minds_request
 from anton.utils.datasources import scrub_credentials
@@ -454,7 +454,7 @@ def publish(
             payload_dict["state_manifest"] = state_manifest
         if missing:
             payload_dict["missing_datasources"] = missing
-        artifact_key = artifact_key or f"artifact/{artifact.stableId}"
+        artifact_key = artifact_key or artifact_key_for(artifact.id)
     else:
         zipped = _zip_html(file_path)
 

--- a/anton/publisher.py
+++ b/anton/publisher.py
@@ -39,7 +39,7 @@ _ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
 FULLSTACK_ARTIFACT_TYPES = frozenset({"fullstack-stateful-app", "fullstack-stateless-app"})
 
 # Filenames inside an artifact folder that are housekeeping — never bundled.
-_FULLSTACK_EXCLUDED = {"metadata.json", "README.md", "backend.log", ".published.json"}
+_FULLSTACK_EXCLUDED = {"metadata.json", "README.md", "backend.log", ".published.json", ".revisions"}
 
 
 DEFAULT_PUBLISH_URL = "https://view.mindshub.ai"
@@ -47,7 +47,7 @@ DEFAULT_PUBLISH_URL = "https://view.mindshub.ai"
 # Owner-side housekeeping files that must never enter the published
 # bundle. `.published.json` in particular holds the artifact's plaintext
 # access password (for the in-app eye-reveal) and must stay local.
-_BUNDLE_SKIP_NAMES = {".published.json"}
+_BUNDLE_SKIP_NAMES = {".published.json", ".revisions"}
 
 # PBKDF2 parameters for access passwords. Stdlib-only (no argon2 dep) so
 # the same verification runs in the anton-services viewer Lambda without
@@ -188,7 +188,8 @@ def _zip_html(path: Path) -> bytes:
             # (e.g. `.published.json`, which holds the plaintext access
             # password and must never be published).
             for f in sorted(path.rglob("*")):
-                if f.is_file() and f.name not in _BUNDLE_SKIP_NAMES:
+                rel = f.relative_to(path)
+                if f.is_file() and not any(part in _BUNDLE_SKIP_NAMES for part in rel.parts):
                     _write_scrubbed(zf, f, str(f.relative_to(path)))
     return buf.getvalue()
 
@@ -277,6 +278,7 @@ def publish(
     pwd_version: int = 1,
     access: dict | None = None,
     access_version: int = 1,
+    artifact_key: str | None = None,
     vault: DataVault | None = None,
 ) -> dict:
     """Zip and upload an HTML file/directory or a fullstack artifact directory.
@@ -303,6 +305,8 @@ def publish(
                   See `build_access_payload` for the outbound shape.
         access_version: Monotonic version bumped whenever the restricted list/
                   org flag changes, invalidating previously issued grants.
+        artifact_key: Stable ``artifact/<uuid>`` identity shared by the draft,
+                  every published version, and its comment threads.
         vault: Credential store to resolve datasource secrets from. Defaults
                   to anton's local vault (`~/.anton/data_vault`); cowork-server
                   passes its own vault so published secrets match where the
@@ -325,12 +329,15 @@ def publish(
         payload_dict["python_version"] = f"{sys.version_info.major}.{sys.version_info.minor}"
         if missing:
             payload_dict["missing_datasources"] = missing
+        artifact_key = artifact_key or f"artifact/{artifact.stableId}"
     else:
         zipped = _zip_html(file_path)
 
     payload_dict["file_payload"] = base64.b64encode(zipped).decode()
     if report_id:
         payload_dict["report_id"] = report_id
+    if artifact_key:
+        payload_dict["artifact_key"] = artifact_key
     # Access control: send the hash (never the plaintext) and, for restricted
     # mode, the normalized email list + org flag (auth is the source of truth;
     # neither the list nor the password plaintext enters the zip bundle). A

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from uuid import UUID
 
 import pytest
 
@@ -56,6 +57,7 @@ def test_create_writes_metadata_and_readme(store: ArtifactStore):
     )
     assert artifact.slug == f"nvda-btc-dashboard-{artifact.id}"
     assert len(artifact.id) == 8
+    assert str(UUID(artifact.stableId)) == artifact.stableId
     folder = store.folder_for(artifact.slug)
     assert folder.is_dir()
     assert (folder / "metadata.json").is_file()
@@ -78,6 +80,25 @@ def test_create_persists_round_trip(store: ArtifactStore):
     assert on_disk["type"] == "document"
     assert on_disk["files"] == []
     assert on_disk["provenance"] == []
+    assert on_disk["stableId"] == artifact.stableId
+
+
+def test_legacy_metadata_gets_repeatable_stable_identity():
+    legacy = {
+        "id": "a1b2c3d4",
+        "slug": "legacy-a1b2c3d4",
+        "createdAt": "2026-08-25T12:00:00+00:00",
+        "updatedAt": "2026-08-25T12:00:00+00:00",
+        "name": "Legacy",
+        "description": "",
+        "type": "document",
+    }
+
+    first = Artifact.model_validate(legacy)
+    second = Artifact.model_validate(legacy)
+
+    assert first.stableId == second.stableId
+    assert str(UUID(first.stableId)) == first.stableId
 
 
 # ─── Slug uniqueness ────────────────────────────────────────────────────────
@@ -328,6 +349,19 @@ def test_reconcile_excludes_published_json(store: ArtifactStore):
     (folder / "dashboard.html").write_text("<html></html>")
     (folder / ".published.json").write_text("{}")
     opened = store.open(artifact.slug)
+    assert {f.path for f in opened.files} == {"dashboard.html"}
+
+
+def test_reconcile_excludes_revision_journal(store: ArtifactStore):
+    artifact = store.create(name="Dash", description="x", type="html-app")
+    folder = store.folder_for(artifact.slug)
+    (folder / "dashboard.html").write_text("<html></html>")
+    journal = folder / ".revisions" / "entries"
+    journal.mkdir(parents=True)
+    (journal / "private-source.md").write_text("must not surface")
+
+    opened = store.open(artifact.slug)
+
     assert {f.path for f in opened.files} == {"dashboard.html"}
 
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -19,6 +19,7 @@ from anton.core.artifacts import (
     ARTIFACT_TYPES,
     Artifact,
     ArtifactStore,
+    artifact_key,
     diff_snapshots,
     snapshot_dir,
 )
@@ -55,9 +56,9 @@ def test_create_writes_metadata_and_readme(store: ArtifactStore):
         description="Compares NVDA and BTC.",
         type="html-app",
     )
-    assert artifact.slug == f"nvda-btc-dashboard-{artifact.id}"
-    assert len(artifact.id) == 8
-    assert str(UUID(artifact.stableId)) == artifact.stableId
+    assert artifact.slug == f"nvda-btc-dashboard-{artifact.id[:8]}"
+    assert len(artifact.id) == 32
+    assert UUID(artifact.id).hex == artifact.id
     folder = store.folder_for(artifact.slug)
     assert folder.is_dir()
     assert (folder / "metadata.json").is_file()
@@ -80,25 +81,106 @@ def test_create_persists_round_trip(store: ArtifactStore):
     assert on_disk["type"] == "document"
     assert on_disk["files"] == []
     assert on_disk["provenance"] == []
-    assert on_disk["stableId"] == artifact.stableId
+    assert on_disk["id"] == artifact.id
+    assert "stableId" not in on_disk
 
 
-def test_legacy_metadata_gets_repeatable_stable_identity():
-    legacy = {
-        "id": "a1b2c3d4",
-        "slug": "legacy-a1b2c3d4",
-        "createdAt": "2026-08-25T12:00:00+00:00",
-        "updatedAt": "2026-08-25T12:00:00+00:00",
-        "name": "Legacy",
-        "description": "",
-        "type": "document",
-    }
+LEGACY_METADATA = {
+    "id": "a1b2c3d4",
+    "slug": "legacy-a1b2c3d4",
+    "createdAt": "2026-08-25T12:00:00+00:00",
+    "updatedAt": "2026-08-25T12:00:00+00:00",
+    "name": "Legacy",
+    "description": "",
+    "type": "document",
+}
 
-    first = Artifact.model_validate(legacy)
-    second = Artifact.model_validate(legacy)
 
-    assert first.stableId == second.stableId
-    assert str(UUID(first.stableId)) == first.stableId
+def test_legacy_metadata_widens_to_a_repeatable_full_id():
+    """anton widens in memory while cowork-server persists, so two independent
+    readers have to land on the same value without coordinating."""
+    first = Artifact.model_validate(LEGACY_METADATA)
+    second = Artifact.model_validate(LEGACY_METADATA)
+
+    assert first.id == second.id
+    assert len(first.id) == 32
+    assert UUID(first.id).hex == first.id
+
+
+def test_legacy_widening_keeps_the_slug_suffix_addressable():
+    """The old eight characters stay the id prefix, so `<name>-<id[:8]>` folders
+    keep resolving after the widening."""
+    artifact = Artifact.model_validate(LEGACY_METADATA)
+
+    assert artifact.id[:8] == "a1b2c3d4"
+    assert artifact.slug.endswith(f"-{artifact.id[:8]}")
+
+
+def test_persisted_stable_id_wins_over_rederivation():
+    """Records from the two-field era already keyed published versions and
+    comment threads by `stableId`; adopting it keeps those keys bound."""
+    minted = "11111111-2222-4333-8444-555555555555"
+    artifact = Artifact.model_validate({**LEGACY_METADATA, "stableId": minted})
+
+    assert artifact.id == UUID(minted).hex
+
+
+@pytest.mark.parametrize("damaged_id", [
+    "7db94eb8f0a54c7e9c1d2b3a4f5e6d7",   # one char short of a UUID
+    "7db94eb8f0a54c7e9c1d2b3a4f5e6d700",  # one char long
+    "7db94eb8f0a5",                       # hex, wider than a legacy id
+])
+def test_a_damaged_id_is_rejected_not_re_minted(damaged_id):
+    """Hex-only and wider than a legacy id: a truncated or padded identity.
+    Re-minting it would detach the artifact from its published versions, auth
+    rules and comment threads."""
+    with pytest.raises(Exception):
+        Artifact.model_validate({**LEGACY_METADATA, "id": damaged_id})
+
+
+@pytest.mark.parametrize("name_like_id", ["static-art", "legacy", "z" * 32])
+def test_a_name_in_the_id_field_widens_rather_than_dropping_the_artifact(name_like_id):
+    """Hand-written and very old records carry names in `id`. Refusing them
+    would drop the artifact from every listing, which reads as a deletion."""
+    artifact = Artifact.model_validate({**LEGACY_METADATA, "id": name_like_id})
+
+    assert UUID(artifact.id).hex == artifact.id
+
+
+def test_an_empty_id_is_rejected():
+    """The early return in the widening validator leaves nothing to widen from;
+    the field constraint has to catch it, or `artifact_key('')` blows up later."""
+    with pytest.raises(Exception):
+        Artifact.model_validate({**LEGACY_METADATA, "id": ""})
+
+
+def test_a_malformed_persisted_stable_id_is_rejected():
+    with pytest.raises(Exception):
+        Artifact.model_validate({**LEGACY_METADATA, "stableId": "not-a-uuid"})
+
+
+def test_an_already_widened_id_ignores_a_stale_stable_id():
+    """An older build could re-add `stableId` to a record whose `id` is already
+    the identity that published versions are keyed under. `id` has to win, or
+    that stale write would re-stamp the artifact and orphan its comments."""
+    widened = "7db94eb8f0a54c7e9c1d2b3a4f5e6d70"
+
+    artifact = Artifact.model_validate({
+        **LEGACY_METADATA,
+        "id": widened,
+        "stableId": "080ee44e-9ebd-5f7f-ab07-cccfc6b9d56e",
+    })
+
+    assert artifact.id == widened
+
+
+def test_artifact_key_is_the_canonical_dashed_form():
+    """The upload lambda normalizes what it stores in `_meta.json` the same way,
+    so the browser shell and cowork agree on one comments key."""
+    artifact = Artifact.model_validate(LEGACY_METADATA)
+
+    assert artifact_key(artifact.id) == f"artifact/{UUID(artifact.id)}"
+    assert artifact_key(artifact.id) == artifact_key(str(UUID(artifact.id)))
 
 
 # ─── Slug uniqueness ────────────────────────────────────────────────────────
@@ -119,12 +201,12 @@ def test_same_name_yields_distinct_slugs(store: ArtifactStore):
 def test_slug_lowercases_and_sanitizes(store: ArtifactStore):
     artifact = store.create(name="Hello, World!", description="x", type="document")
     # Punctuation collapses to hyphens; runs deduped; lowercased.
-    assert artifact.slug == f"hello-world-{artifact.id}"
+    assert artifact.slug == f"hello-world-{artifact.id[:8]}"
 
 
 def test_slug_falls_back_when_name_is_garbage(store: ArtifactStore):
     artifact = store.create(name="!!!", description="x", type="document")
-    assert artifact.slug == f"untitled-artifact-{artifact.id}"
+    assert artifact.slug == f"untitled-artifact-{artifact.id[:8]}"
 
 
 def test_non_latin_names_still_get_distinct_folders(store: ArtifactStore):
@@ -146,7 +228,7 @@ def test_display_name_carries_no_id(store: ArtifactStore):
     artifact = store.create(name="", description="x", type="document")
 
     assert artifact.name == "untitled-artifact"
-    assert artifact.slug == f"untitled-artifact-{artifact.id}"
+    assert artifact.slug == f"untitled-artifact-{artifact.id[:8]}"
 
 
 def test_slug_stays_within_the_length_budget(store: ArtifactStore):
@@ -155,7 +237,7 @@ def test_slug_stays_within_the_length_budget(store: ArtifactStore):
     artifact = store.create(name="x" * 200, description="x", type="document")
 
     assert len(artifact.slug) <= 64
-    assert artifact.slug.endswith(f"-{artifact.id}")
+    assert artifact.slug.endswith(f"-{artifact.id[:8]}")
 
 
 # ─── List + open ────────────────────────────────────────────────────────────

--- a/tests/test_publish_artifact_key.py
+++ b/tests/test_publish_artifact_key.py
@@ -1,0 +1,76 @@
+"""The publish payload must carry `artifact_key` for static artifacts too.
+
+A static artifact publishes its primary *file*, so the identity has to be read
+from the metadata.json next to it. Without that the upload lambda locks the
+report to the legacy `{user_dir}/{report_id}` key and the artifact loses the
+key its draft, comment threads and access rule are grouped under.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+from uuid import UUID
+
+from anton import publisher
+from anton.core.artifacts import ArtifactStore, artifact_key
+from anton.publisher import publish
+
+
+def _capture(target: Path, **kwargs) -> dict:
+    captured: dict = {}
+
+    def fake_request(url, api_key, *, method="POST", payload=None, verify=True, timeout=30):
+        captured["payload"] = json.loads(payload.decode())
+        return json.dumps(
+            {"user_prefix": "u", "report_id": "r", "md5": "m", "view_url": "url", "version": 1, "files": []}
+        )
+
+    with mock.patch.object(publisher, "minds_request", fake_request):
+        publish(target, api_key="k", **kwargs)
+    return captured["payload"]
+
+
+def _static_artifact(tmp_path: Path) -> tuple[Path, str]:
+    """A real html-app artifact; returns (primary file, artifact id)."""
+    store = ArtifactStore(tmp_path / "artifacts")
+    artifact = store.create(name="Sales report", description="x", type="html-app")
+    folder = store.folder_for(artifact.slug)
+    primary = folder / "index.html"
+    primary.write_text("<html>hi</html>", encoding="utf-8")
+    return primary, artifact.id
+
+
+def test_static_publish_sends_the_artifact_key(tmp_path: Path):
+    primary, artifact_id = _static_artifact(tmp_path)
+    payload = _capture(primary)
+    assert payload["artifact_key"] == artifact_key(artifact_id)
+    assert payload["artifact_key"] == f"artifact/{UUID(artifact_id)}"
+
+
+def test_explicit_key_wins_over_the_derived_one(tmp_path: Path):
+    """cowork-server derives the key itself and passes it in; it must not be
+    second-guessed by the folder anton happens to see."""
+    primary, _artifact_id = _static_artifact(tmp_path)
+    given = "artifact/11111111-1111-1111-1111-111111111111"
+    assert _capture(primary, artifact_key=given)["artifact_key"] == given
+
+
+def test_loose_file_publish_sends_no_key(tmp_path: Path):
+    """A legacy loose file has no metadata — it keeps the service-generated key."""
+    loose = tmp_path / "index.html"
+    loose.write_text("<html>hi</html>", encoding="utf-8")
+    assert "artifact_key" not in _capture(loose)
+
+
+def test_page_inside_an_artifact_subfolder_sends_no_key(tmp_path: Path):
+    """Only the artifact root is consulted. Publishing one nested page would
+    otherwise mint a second report under the same key, and the auth rule the
+    upload lambda upserts is per key — the two reports would fight over it."""
+    primary, _artifact_id = _static_artifact(tmp_path)
+    nested = primary.parent / "pages"
+    nested.mkdir()
+    page = nested / "detail.html"
+    page.write_text("<html>detail</html>", encoding="utf-8")
+    assert "artifact_key" not in _capture(page)

--- a/tests/test_publish_revision_exclusion.py
+++ b/tests/test_publish_revision_exclusion.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import io
+import zipfile
+
+from anton.publisher import _zip_html
+
+
+def test_directory_publish_never_bundles_revision_journal(tmp_path):
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "index.html").write_text("<h1>Current</h1>")
+    revisions = artifact / ".revisions" / "entries"
+    revisions.mkdir(parents=True)
+    (revisions / "old.html").write_text("<h1>Private old source</h1>")
+
+    with zipfile.ZipFile(io.BytesIO(_zip_html(artifact))) as bundle:
+        assert bundle.namelist() == ["index.html"]


### PR DESCRIPTION
## Summary
- One canonical artifact identity: `metadata.json` keeps a single 32-hex UUID `id` (`uuid4().hex` for new artifacts; the folder slug uses `id[:8]`). Legacy 8-char ids are deterministically widened in memory on every load (`old_id + uuid5(old_id:createdAt).hex[8:]` — the old id stays the prefix, so slug-based folder addressing keeps working; no write-on-read). Records from the short-lived two-field era adopt their stored `stableId` as the id so already-minted publish/comment/auth keys never orphan.
- The publish payload carries `artifact_key: "artifact/<uuid>"` derived from that id, so all published versions, comments and access rules group under one key.
- The `.revisions/` journal directory is reserved and excluded from published bundles, file listings and content-mtime (`_FULLSTACK_EXCLUDED`, `_BUNDLE_SKIP_NAMES`, `_HOUSEKEEPING_DIRS/_FILES`).

History: `f4504ac1` introduced the identity as a second `stableId` field; `acbb74a9` collapsed the pair into the single `id` described above. Includes a merge of `origin/staging` (conflict in `publisher.py` resolved by unioning the exclusion sets with the anton_state entries).

## Testing
`pytest tests/`: 2658 passed, 30 skipped.

## Related branches (one feature across six repos)
- [mindsdb/anton](https://github.com/mindsdb/anton/tree/artifact-collaboration-workflow)
- [mindsdb/cowork-server](https://github.com/mindsdb/cowork-server/tree/artifact-collaboration-workflow)
- [mindsdb/cowork](https://github.com/mindsdb/cowork/tree/artifact-collaboration-workflow)
- [mindsdb/auth](https://github.com/mindsdb/auth/tree/artifact-collaboration-workflow)
- [mindsdb/mindshub_services](https://github.com/mindsdb/mindshub_services/tree/artifact-collaboration-workflow)
- [mindsdb/mindshub_inference](https://github.com/mindsdb/mindshub_inference/tree/artifact-collaboration-workflow)

The shared concept: every artifact carries one canonical identity — a 32-hex UUID `id` in its metadata (legacy 8-char ids are deterministically widened, keeping the old value as prefix so folder slugs keep resolving) — published as `artifact_key = "artifact/<uuid>"`, the key that ties together drafts, published versions, revisions, comments and access rules. Roles are `owner` (can edit, resolve comments, dispatch agent repairs) and `reviewer` (can view and comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)