### PR TITLE
fix(ci): gate the scratchpad build on the pull request being first-party (ENG-1999)

### DIFF
--- a/.github/workflows/scratchpad-dev-build.yml
+++ b/.github/workflows/scratchpad-dev-build.yml
@@ -1,9 +1,11 @@
 name: Scratchpad image - Dev build on PR
 
 # Builds and pushes the minds-anton-scratchpad image (the sandbox pod image) to ECR as
-# development-<sha> when a PR carries a deploy label. The scratchpad-controller references
-# the resulting tag via SCRATCHPAD_CONTROLLER__SCRATCHPAD_IMAGE; there is no Helm chart for
-# this image, so this workflow only builds and scans (no deploy job).
+# development-<sha>, on every pull request whose branch lives in this repository. No label
+# is required and none is checked: `labeled` sits in the trigger list so that adding one
+# rebuilds. The scratchpad-controller references the resulting tag via
+# SCRATCHPAD_CONTROLLER__SCRATCHPAD_IMAGE; there is no Helm chart for this image, so this
+# workflow only builds and scans (no deploy job).
 
 on:
   pull_request:
@@ -21,6 +23,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # One gate answering "may this pull request reach the cluster-side build".
+  #
+  # This repo is PUBLIC and `mdb-dev` is a pod inside the newdev cluster with IRSA
+  # into the build/ECR account, so without a guard a pull request from any GitHub
+  # account executes its own code there. Fork PRs get no secrets and a read-only
+  # token, but the runner itself is the prize: cloud credentials, a network
+  # position inside the cluster, and a tool cache later internal jobs reuse.
+  # GitHub's first-time-contributor approval does not cover anyone with a merged
+  # PR, and the approval a maintainer clicks is a courtesy extended before anyone
+  # has read the Dockerfile.
+  #
+  # The `version` job below stays ungated on purpose. It runs on a GitHub-hosted
+  # runner holding no credentials, and a hosted runner executing a fork's code is
+  # what every fork pull request in the world already does.
+  #
+  # Unlike the same gate in cowork and cowork-server, this one does NOT skip a
+  # `staging` -> `main` promotion PR. There those rebuild an image the release
+  # pipeline already produced; here this workflow is the only thing that builds
+  # minds-anton-scratchpad at all, so skipping a promotion would leave that commit
+  # with no image.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Decide whether this pull request may reach the runner
+        id: decide
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$HEAD_REPO" != "$THIS_REPO" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Build skipped: fork pull request"
+              echo
+              echo "The scratchpad image build runs on a self-hosted runner inside our"
+              echo "cluster, so it does not execute code from a fork. Nothing is wrong"
+              echo "with this pull request."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
 
   # The version the image will report, resolved from tags (ENG-1796).
   #
@@ -88,7 +135,8 @@ jobs:
           echo "anton version: $version"
 
   build:
-    needs: version
+    needs: [version, gate]
+    if: needs.gate.outputs.run == 'true'
     runs-on: mdb-dev
     outputs:
       image: ${{ steps.build.outputs.image }}

--- a/tests/test_fork_build_gate.py
+++ b/tests/test_fork_build_gate.py
@@ -1,0 +1,175 @@
+"""The scratchpad image build must never run a fork's code on the cluster runner.
+
+``mdb-dev`` is a pod inside the newdev cluster, not a disposable VM. Whatever
+runs there holds the runner's Kubernetes service-account token, its IRSA role
+into the build account, and a filesystem other repositories' credentialed jobs
+write into. A ``pull_request`` run builds the merge ref, which is the fork's
+tree, and GitHub reads the workflow from that same tree -- so the fork chooses
+the code and we choose only whether to start it.
+
+Nothing fails at runtime when the guard goes: the build succeeds, for someone it
+should not have succeeded for. So these are build assertions rather than
+behaviour tests, and the two that matter run the gate's own shell rather than
+grepping it, because a substring check passes on a script whose comparison has
+been inverted.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOW = _ROOT / ".github/workflows/scratchpad-dev-build.yml"
+
+_THIS_REPO = "mindsdb/anton"
+
+# GitHub-hosted runner images all carry one of these prefixes. Anything else is
+# one of ours, which is the whole point -- a label added later that nobody here
+# has heard of must read as self-hosted, not as safe.
+_HOSTED_PREFIXES = ("ubuntu-", "windows-", "macos-")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return yaml.safe_load(_WORKFLOW.read_text())
+
+
+def _labels(job: dict) -> list[str]:
+    runs_on = job.get("runs-on")
+    if isinstance(runs_on, str):
+        return [runs_on]
+    if isinstance(runs_on, list):
+        return [str(label) for label in runs_on]
+    if isinstance(runs_on, dict):
+        return [str(label) for label in (runs_on.get("labels") or [])] or ["<group>"]
+    return ["<missing>"]
+
+
+def _is_hosted(job: dict) -> bool:
+    labels = _labels(job)
+    return all(label.startswith(_HOSTED_PREFIXES) for label in labels)
+
+
+def _decide_step(workflow: dict) -> dict:
+    for step in workflow["jobs"]["gate"]["steps"]:
+        if step.get("id") == "decide":
+            return step
+    raise AssertionError("no `decide` step in the gate job")
+
+
+def _run_the_gate(workflow: dict, tmp_path: Path, head_repo: str) -> tuple[dict, str]:
+    """Execute the gate's real shell and hand back what it wrote."""
+    script = tmp_path / "decide.sh"
+    script.write_text(_decide_step(workflow)["run"])
+    output = tmp_path / "github_output"
+    summary = tmp_path / "github_step_summary"
+    output.touch()
+    summary.touch()
+
+    subprocess.run(
+        ["bash", str(script)],
+        check=True,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HEAD_REPO": head_repo,
+            "THIS_REPO": _THIS_REPO,
+            "GITHUB_OUTPUT": str(output),
+            "GITHUB_STEP_SUMMARY": str(summary),
+        },
+    )
+
+    written = dict(
+        line.split("=", 1) for line in output.read_text().splitlines() if "=" in line
+    )
+    return written, summary.read_text()
+
+
+def test_a_fork_pull_request_is_refused(workflow: dict, tmp_path: Path) -> None:
+    """The one that matters, run rather than read.
+
+    A pull request from any account outside this repository must not reach the
+    build. Executing the block is what catches a comparison someone flipped to
+    ``=`` while tidying, which every substring assertion in this file would
+    happily pass.
+    """
+    written, _ = _run_the_gate(workflow, tmp_path, head_repo="stranger/anton")
+    assert written.get("run") == "false", (
+        "the gate let a fork through: a pull request from any GitHub account "
+        "would build its own tree on a pod inside the cluster"
+    )
+
+
+def test_the_refusal_says_why(workflow: dict, tmp_path: Path) -> None:
+    """A silently skipped job reads as a broken pipeline to the contributor.
+
+    The reviewer who approved the run and the person who opened it both see the
+    run page and nothing else, so the reason has to be on it.
+    """
+    _, summary = _run_the_gate(workflow, tmp_path, head_repo="stranger/anton")
+    assert summary.strip(), "the gate skipped the build without writing a reason"
+    assert "fork" in summary.lower(), (
+        "the run summary does not name the fork as the reason, so the next "
+        "reviewer has to read the workflow to find out why nothing built"
+    )
+
+
+def test_a_branch_in_this_repository_is_allowed(workflow: dict, tmp_path: Path) -> None:
+    """The other half: this must not become a guard that skips everything.
+
+    A gate that refuses every pull request would pass the test above and stop
+    the scratchpad image being built at all, and no other workflow builds it.
+    """
+    written, _ = _run_the_gate(workflow, tmp_path, head_repo=_THIS_REPO)
+    assert written.get("run") == "true", (
+        "the gate refuses a first-party branch, so no pull request builds the "
+        "scratchpad image any more"
+    )
+
+
+def test_the_gate_reads_the_head_repository_from_the_event(workflow: dict) -> None:
+    """Which value gets compared is the part that is quietly wrong-able.
+
+    ``github.head_ref`` is a branch name the fork chooses, so a gate comparing
+    that would pass a fork calling its branch ``staging``. The repository's full
+    name on the pull request's head is the only field the fork does not control.
+    """
+    env = _decide_step(workflow).get("env") or {}
+    assert "github.event.pull_request.head.repo.full_name" in str(env.get("HEAD_REPO")), (
+        "the gate no longer compares the head repository; a branch name is "
+        "chosen by whoever opened the pull request"
+    )
+    assert "github.repository" in str(env.get("THIS_REPO"))
+
+
+def test_every_job_off_the_hosted_runners_is_gated(workflow: dict) -> None:
+    """The durable one: it covers the job nobody has added yet.
+
+    Guarding ``build`` alone protects today's file. The next job pointed at
+    ``mdb-dev`` will be written by someone who has never read this, so the
+    assertion is over every job rather than over that one.
+    """
+    for name, job in workflow["jobs"].items():
+        if name == "gate" or _is_hosted(job):
+            continue
+        condition = str(job.get("if", ""))
+        assert "needs.gate.outputs.run" in condition, (
+            f"job `{name}` runs on {_labels(job)} and is not gated on `gate`. "
+            "A fork pull request would execute its code inside the cluster."
+        )
+        assert "gate" in (job.get("needs") or []), (
+            f"job `{name}` reads the gate's output without needing it, so the "
+            "condition sees an empty string and the job is skipped for everyone"
+        )
+
+
+def test_the_gate_stays_on_a_hosted_runner(workflow: dict) -> None:
+    """A guard that runs on the thing it is guarding has already lost."""
+    assert _is_hosted(workflow["jobs"]["gate"]), (
+        f"the gate runs on {_labels(workflow['jobs']['gate'])}, which is a pod "
+        "inside the cluster. It has to decide from outside."
+    )


### PR DESCRIPTION
## User story

**As an** engineer who reviews external contributions to our public repos
**I want** approving CI on a stranger's pull request to be a harmless act
**So that** a plausible-looking patch cannot execute its own code on a pod inside our cluster

## Why this matters

`anton` is public and has 119 forks. `scratchpad-dev-build.yml` triggers on `pull_request`, runs `runs-on: mdb-dev`, and until this change carried no job-level `if:` of any kind. `mdb-dev` is not a disposable VM; it is a pod inside the newdev cluster. So once a maintainer clicked "Approve and run", the fork's code executed there holding the runner's cluster-wide Kubernetes token (`secrets` and `pods/exec` in every namespace), its IRSA role into account `168681354662` (`iam:PassRole` and `ec2:RunInstances` on `*`, write and delete on the bucket behind `downloads.mindshub.ai`), and the shared FSx tool cache other repositories' credentialed jobs write into.

`pull_request` withholds GitHub secrets from a fork. It cannot withhold the pod's projected service-account token, and that asymmetry is the finding.

This is not hypothetical. Run [`31841652391`](https://github.com/mindsdb/anton/actions/runs/31841652391) ran to completion on runner `mdb-dev-jk8nx-runner-br2ng` from the fork `MohammedAlkindi/anton` on 2026-08-24. That contribution was legitimate; the capability it exercised is the point. `cowork` and `cowork-server` already carry the guard this adds, so the threat model was understood here and this one file was missed.

## What happens today

```mermaid
flowchart TD
    F["Fork PR to public anton"] --> APP{"Someone with push clicks Approve and run"}
    APP -->|"approved"| J["job build, runs-on mdb-dev, no if:"]
    J --> CO["actions/checkout@v4, merge ref is the fork tree"]
    CO --> BK["docker buildx against in-cluster buildkit"]
    J --> K8S["ClusterRole: secrets and pods/exec, cluster-wide"]
    J --> AWS["IRSA: PassRole and RunInstances on *, installer bucket write"]
    J --> FSX["shared FSx tool cache other repos consume"]
```

## What should happen

```mermaid
flowchart TD
    F["Fork PR to public anton"] --> APP{"Someone with push clicks Approve and run"}
    APP -->|"approved"| G{"gate on ubuntu-latest: head.repo.full_name == github.repository?"}
    G -->|"no, it is a fork"| SKIP["build skipped, run summary says why"]
    G -->|"yes, first-party branch"| J["job build, runs-on mdb-dev"]
```

## Acceptance criteria

- [x] A pull request from a fork, even after approval, does not run the `mdb-dev` build job; the PR shows the job as skipped with a stated reason. `.github/workflows/scratchpad-dev-build.yml:139` gates it, `:62` writes the reason.
- [x] A pull request from a branch in `mindsdb/anton` still builds and pushes the scratchpad image exactly as today. This PR is that pull request: watch `build` on it.
- [x] The header comment describes what the file actually does. `:3-8`.
- [x] Negative: a `staging` to `main` promotion PR is unaffected. The gate has no promotion clause, deliberately. See the notes below.
- [x] Negative: nothing about `cowork` or `cowork-server` changes. The diff is two files in this repo.

## How to test

1. Open a pull request from a personal fork of `mindsdb/anton`, approve the workflow run, and confirm `build` is skipped rather than executed. This needs the guard on `staging` first, so it is owed after merge, not before.
2. Read that run's summary and confirm it names the fork as the reason.
3. On this pull request, confirm `build` still runs on `mdb-dev` and pushes `development-<sha>` to ECR.

## Notes for the reviewer

**The promotion clause from `cowork-server` is deliberately not copied.** The gate there also skips a `staging` to `main` pull request, because those two rebuild an image their release pipeline already produced. Here this workflow is the only thing in the repo that builds `minds-anton-scratchpad`; `release.yml` and `publish-staging.yml` publish the PyPI wheel and nothing else calls `build-push-ecr`. Skipping a promotion would leave that commit with no image at all.

**The `version` job stays ungated on purpose.** It runs on `ubuntu-latest` with no credentials. A hosted runner executing a fork's code is what every fork pull request in the world already does, so gating it would buy nothing and cost a fork contributor the signal that their tree resolves a version.

**The test asserts over every job, not over `build`.** Guarding one job protects today's file. `test_every_job_off_the_hosted_runners_is_gated` walks all of them and treats any runner label outside the `ubuntu-`/`windows-`/`macos-` families as ours, so a label nobody here has heard of fails closed rather than reading as safe. That is the assertion that survives this PR.

**Two of the tests run the gate's shell rather than grepping it.** `tests/test_pod_image_version.py` records a substring assertion in this same workflow that stayed green after the pipe it checked was deleted, because a comment in the block still carried the words. So the fork and first-party cases execute the real `run:` block through `bash` and read what it wrote to `$GITHUB_OUTPUT`. An inverted comparison fails them; it would pass any grep.

**This is a stopgap and the ticket says so.** On `pull_request` the fork controls the workflow file, so a hostile fork can add its own job with `runs-on: mdb-dev` and bypass a guard written here. The control a fork cannot edit around is the runner group, which is ENG-2000. This closes the known path and buys the time to do that carefully.

**No before/after images.** The only rendered surface this adds is a run summary that appears on a fork pull request, and producing one needs the guard on `staging` first. It is step 1 above.

## Verified locally

| Check | Observed |
|---|---|
| `actionlint .github/workflows/scratchpad-dev-build.yml` | clean, before and after |
| `zizmor --config <org policy> --persona=regular` | 5 shown findings before and after (2 medium, 3 high), all pre-existing `unpinned-uses` on `@main`. My change adds one `anonymous-definition` at auditor level: the `gate` job has no `name:`, matching the two jobs already in the file |
| `pytest tests/test_fork_build_gate.py` | 6 passed |
| `pytest tests/test_pod_image_version.py` | 12 passed. It reads `jobs.build.needs`, which this PR changes from a string to a list |
| New tests fail without the change | reverted the workflow in the working tree, ran the file alone: 6 failed, restored |
| Nothing else references the workflow | `grep -rn scratchpad-dev-build` finds one caller, `tests/test_pod_image_version.py`, re-run above |
| Provenance grep over added lines | no ticket ids, section marks, or phase references |
| `mdb-dev` elsewhere in this repo | appears once in `.github/`, on the job this gates. `cla.yml` sets no `runs-on` and takes `ubuntu-latest` |
