### PR TITLE
[ENG-208] Oauth hardening followups

### DIFF
--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -586,6 +586,14 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
 
     cortex = _build_cortex(request.memory, llm_client)
 
+    # Unconditional, even when this turn has no oauth block: a prior call's
+    # DS_* vars (and known/secret registrations) must never survive into a
+    # turn that has no vault of its own to reset them — see clear_ds_env()'s
+    # docstring. Safe to call twice; restore_namespaced_env() below re-clears.
+    from anton.utils.datasources import clear_ds_env
+
+    clear_ds_env()
+
     # Connectors ON only when this turn carries an oauth block (Google
     # Drive/Gmail today). restore_namespaced_env() is the exact same
     # function desktop's harness.py already calls for LocalDataVault: it

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -586,20 +586,8 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
 
     cortex = _build_cortex(request.memory, llm_client)
 
-    # Unconditional, even when this turn has no oauth block: a prior call's
-    # DS_* vars (and known/secret registrations) must never survive into a
-    # turn that has no vault of its own to reset them — see clear_ds_env()'s
-    # docstring. Safe to call twice; restore_namespaced_env() below re-clears.
-    from anton.utils.datasources import clear_ds_env
-
-    clear_ds_env()
-
     # Connectors ON only when this turn carries an oauth block (Google
-    # Drive/Gmail today). restore_namespaced_env() is the exact same
-    # function desktop's harness.py already calls for LocalDataVault: it
-    # clears+reinjects DS_* env vars and registers them for credential
-    # scrubbing (so a token can't leak into LLM-visible output) before the
-    # sandbox subprocess inherits this process's env via runtime_factory.
+    # Drive/Gmail today) — clears+reinjects DS_* env before the sandbox subprocess inherits it.
     data_vault = None
     if request.oauth:
         from anton.core.datasources.data_vault import TurnKeyDataVault
@@ -607,6 +595,12 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
 
         data_vault = TurnKeyDataVault(request.oauth)
         restore_namespaced_env(data_vault)
+    else:
+        # No vault this turn — still clear, so a prior call's DS_* vars
+        # can never survive into a turn with nothing of its own to reset them.
+        from anton.utils.datasources import clear_ds_env
+
+        clear_ds_env()
 
     config = ChatSessionConfig(
         llm_client=llm_client,

--- a/anton/core/datasources/data_vault.py
+++ b/anton/core/datasources/data_vault.py
@@ -503,6 +503,14 @@ class TurnKeyDataVault:
         return fields
 
     def _fetch_uncached(self, engine: str, name: str) -> dict[str, str] | None:
+        # Defense in depth: auth's own org+user-scoped query already prevents
+        # crossing an org boundary, but this vault should never even attempt a
+        # fetch for a connection cowork-server didn't list for this turn (e.g.
+        # one the caller's own disabled_connections filter deliberately
+        # excluded) — don't rely solely on a different repo's scoping.
+        if not any(c["engine"] == engine and c["name"] == name for c in self._connections):
+            logger.warning("TurnKeyDataVault: %s/%s not in this turn's connection list; refusing", engine, name)
+            return None
         if not self._turn_key:
             logger.warning("TurnKeyDataVault: no turn key available for %s/%s", engine, name)
             return None

--- a/anton/core/datasources/data_vault.py
+++ b/anton/core/datasources/data_vault.py
@@ -117,6 +117,16 @@ def resolve_modify_merge(
     return merged, secure_keys
 
 
+def _sweep_ds_env_vars() -> None:
+    """Remove every DS_* variable from os.environ.
+
+    Shared by every clear_ds_env() implementation (module-level and both
+    vault classes) so the sweep logic lives in exactly one place.
+    """
+    for key in [k for k in os.environ if k.startswith("DS_")]:
+        del os.environ[key]
+
+
 def _slug_env_prefix(engine: str, name: str) -> str:
     """Return the DS_ prefix for a namespaced connection env var.
 
@@ -363,9 +373,7 @@ class LocalDataVault:
 
     def clear_ds_env(self) -> None:
         """Remove all DS_* variables from os.environ."""
-        ds_keys = [k for k in os.environ if k.startswith("DS_")]
-        for key in ds_keys:
-            del os.environ[key]
+        _sweep_ds_env_vars()
 
     def next_connection_number(self, engine: str) -> int:
         """Return the next auto-increment number for an engine (1-based).
@@ -419,6 +427,7 @@ class TurnKeyDataVault:
             for c in (oauth.get("connections") or [])
             if isinstance(c, dict) and c.get("engine") and c.get("name")
         ]
+        self._connection_keys = frozenset((c["engine"], c["name"]) for c in self._connections)
         self._base_url = (
             base_url
             or os.environ.get(ANTON_CLOUD_AUTH_BASE_URL_ENV)
@@ -491,8 +500,11 @@ class TurnKeyDataVault:
         return list(env)
 
     def clear_ds_env(self) -> None:
-        for key in [k for k in os.environ if k.startswith("DS_")]:
-            del os.environ[key]
+        """Remove all DS_* variables from os.environ and drop this vault's
+        per-connection token cache, so a later fetch can't return stale
+        pre-clear credentials."""
+        _sweep_ds_env_vars()
+        self._cache.clear()
 
     def _fetch(self, engine: str, name: str) -> dict[str, str] | None:
         cache_key = (engine, name)
@@ -503,16 +515,13 @@ class TurnKeyDataVault:
         return fields
 
     def _fetch_uncached(self, engine: str, name: str) -> dict[str, str] | None:
-        # Defense in depth: auth's own org+user-scoped query already prevents
-        # crossing an org boundary, but this vault should never even attempt a
-        # fetch for a connection cowork-server didn't list for this turn (e.g.
-        # one the caller's own disabled_connections filter deliberately
-        # excluded) — don't rely solely on a different repo's scoping.
-        if not any(c["engine"] == engine and c["name"] == name for c in self._connections):
-            logger.warning("TurnKeyDataVault: %s/%s not in this turn's connection list; refusing", engine, name)
-            return None
         if not self._turn_key:
             logger.warning("TurnKeyDataVault: no turn key available for %s/%s", engine, name)
+            return None
+        # Defense in depth: don't rely solely on auth's own org-scoped query —
+        # never fetch a connection cowork-server didn't list for this turn.
+        if (engine, name) not in self._connection_keys:
+            logger.warning("TurnKeyDataVault: %s/%s not in this turn's connection list; refusing", engine, name)
             return None
         from anton.minds_client import minds_request  # local: avoid a module-load-time dep from core.datasources
 

--- a/anton/core/runtime.py
+++ b/anton/core/runtime.py
@@ -150,6 +150,12 @@ async def build_chat_session(
     data_vault = LocalDataVault() if LocalDataVault is not None else None
     if data_vault is not None:
         try:
+            # A prior build in this same long-lived process may have left
+            # DS_* vars for a connection that's since been deleted/renamed.
+            data_vault.clear_ds_env()
+        except Exception:
+            logger.debug("Could not clear Anton data vault env", exc_info=True)
+        try:
             connections = data_vault.list_connections()
         except Exception:
             logger.debug("Could not list Anton data vault connections", exc_info=True)

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -396,10 +396,21 @@ def _is_oauth_connection(vault: DataVault, engine: str, name: str) -> bool:
     return fields.get("auth_type") == "oauth"
 
 
+def clear_ds_env() -> None:
+    """Unconditionally clear every DS_* env var and reset the known/secret
+    registries — call this even on a turn with nothing to reinject (e.g. no
+    oauth block this turn), so a var from a prior call can never survive into
+    a turn that has no vault of its own to reset it. Every DataVault
+    implementation's own clear_ds_env() does this same os.environ sweep; this
+    is the version callers with no vault instance in hand can still use."""
+    _reset_registered_ds_vars()
+    for key in [k for k in os.environ if k.startswith("DS_")]:
+        del os.environ[key]
+
+
 def restore_namespaced_env(vault: DataVault) -> None:
     """Clear all DS_* vars, then reinject every saved connection as namespaced."""
-    _reset_registered_ds_vars()
-    vault.clear_ds_env()
+    clear_ds_env()
     dreg = DatasourceRegistry()
     for conn in vault.list_connections():
         vault.inject_env(conn["engine"], conn["name"])  # flat=False by default

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -12,6 +12,7 @@ from anton.core.datasources.data_vault import (
     DataVault,
     LocalDataVault,
     _slug_env_prefix,
+    _sweep_ds_env_vars,
     is_secret_key,
 )
 from anton.core.datasources.datasource_registry import DatasourceRegistry, _YAML_BLOCK_RE
@@ -400,17 +401,22 @@ def clear_ds_env() -> None:
     """Unconditionally clear every DS_* env var and reset the known/secret
     registries — call this even on a turn with nothing to reinject (e.g. no
     oauth block this turn), so a var from a prior call can never survive into
-    a turn that has no vault of its own to reset it. Every DataVault
-    implementation's own clear_ds_env() does this same os.environ sweep; this
-    is the version callers with no vault instance in hand can still use."""
+    a turn that has no vault of its own to reset it. This is the version
+    callers with no vault instance in hand can use; callers that do have one
+    should call `restore_namespaced_env()` so any vault-specific override of
+    `clear_ds_env()` (e.g. cache invalidation) still runs."""
     _reset_registered_ds_vars()
-    for key in [k for k in os.environ if k.startswith("DS_")]:
-        del os.environ[key]
+    _sweep_ds_env_vars()
 
 
 def restore_namespaced_env(vault: DataVault) -> None:
-    """Clear all DS_* vars, then reinject every saved connection as namespaced."""
-    clear_ds_env()
+    """Clear all DS_* vars, then reinject every saved connection as namespaced.
+
+    Clears via `vault.clear_ds_env()` rather than the module-level
+    `clear_ds_env()` so a vault implementation's own override runs.
+    """
+    _reset_registered_ds_vars()
+    vault.clear_ds_env()
     dreg = DatasourceRegistry()
     for conn in vault.list_connections():
         vault.inject_env(conn["engine"], conn["name"])  # flat=False by default

--- a/tests/test_build_chat_session_google_drive.py
+++ b/tests/test_build_chat_session_google_drive.py
@@ -13,6 +13,7 @@ given, and ChatSystemPromptBuilder.build() calls suffix.strip() unconditionally.
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -69,6 +70,27 @@ async def test_no_connections_and_no_suffix_does_not_crash(workspace_path):
     prompt = await session._build_system_prompt()  # must not raise
 
     assert "Google Drive" not in prompt
+
+
+async def test_deleted_connection_env_does_not_survive_into_a_later_build(workspace_path):
+    """Regression: build_chat_session() never cleared DS_* env before
+    injecting connections, so a connection deleted between two builds in
+    the same process left its DS_* var behind for a later build to inherit."""
+    from anton.core.datasources.data_vault import LocalDataVault
+    from anton.core.runtime import build_chat_session
+
+    vault = LocalDataVault()
+    vault.save("postgres", "leftover", {"host": "leftover.example.com"})
+    try:
+        await build_chat_session(session_id="test-leak-1", workspace_path=str(workspace_path))
+        assert os.environ.get("DS_POSTGRES_LEFTOVER__HOST") == "leftover.example.com"
+
+        vault.delete("postgres", "leftover")
+
+        await build_chat_session(session_id="test-leak-2", workspace_path=str(workspace_path))
+        assert "DS_POSTGRES_LEFTOVER__HOST" not in os.environ
+    finally:
+        os.environ.pop("DS_POSTGRES_LEFTOVER__HOST", None)
 
 
 async def test_explicit_system_prompt_suffix_still_appended(workspace_path):

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -795,6 +795,15 @@ def test_no_oauth_block_leaves_data_vault_none(tmp_path, monkeypatch):
     assert cfg.data_vault is None
 
 
+def test_no_oauth_block_still_clears_a_leftover_ds_env_var(tmp_path, monkeypatch):
+    """A DS_* var left over from a prior call (e.g. if a process were ever
+    reused across turns) must never survive into a turn that has no oauth
+    block of its own to reset it via restore_namespaced_env()."""
+    monkeypatch.setenv("DS_LEFTOVER_FROM_PRIOR_TURN", "should-be-cleared")
+    _build(tmp_path, monkeypatch)
+    assert "DS_LEFTOVER_FROM_PRIOR_TURN" not in os.environ
+
+
 def test_oauth_block_produces_a_turn_key_data_vault(tmp_path, monkeypatch):
     from anton.core.datasources.data_vault import TurnKeyDataVault
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -2686,6 +2686,22 @@ class TestTemporaryFlatExecution:
         assert "DS_HOST" not in os.environ
         assert os.environ.get("DS_POSTGRES_ANALYTICS__HOST") == "analytics.example.com"
 
+    def test_restore_namespaced_env_calls_the_vaults_own_clear_ds_env(self):
+        """restore_namespaced_env must dispatch through vault.clear_ds_env()
+        (not the module-level clear_ds_env()) so a vault-specific override
+        (e.g. cache invalidation) still runs."""
+        calls = []
+
+        class FakeVault:
+            def clear_ds_env(self):
+                calls.append("cleared")
+
+            def list_connections(self):
+                return []
+
+        restore_namespaced_env(FakeVault())
+        assert calls == ["cleared"]
+
     def test_restore_namespaced_env_reinjects_all_connections(self, vault_dir):
         """_restore_namespaced_env restores ALL saved connections, not just one."""
         vault = LocalDataVault(vault_dir=vault_dir)

--- a/tests/test_turn_key_data_vault.py
+++ b/tests/test_turn_key_data_vault.py
@@ -40,6 +40,30 @@ def test_malformed_connection_entries_are_dropped():
     assert vault.list_connections() == []
 
 
+def test_fetch_refuses_a_connection_not_in_this_turns_list(monkeypatch):
+    """Defense in depth: this vault must never fetch a connection
+    cowork-server didn't list for this turn (e.g. one the caller's own
+    disabled_connections filter deliberately excluded), even though auth's
+    own org+user-scoped query would already stop it from crossing an org.
+
+    Tracks whether minds_request was ever called, rather than raising from
+    the fake — _fetch_uncached's own `except Exception` would otherwise
+    swallow a raised assertion and return None for the wrong reason, letting
+    this test pass even without the allowlist check.
+    """
+    calls = []
+
+    def track(*a, **kw):
+        calls.append((a, kw))
+        return b'{"access_token": "tok"}'
+
+    monkeypatch.setattr("anton.minds_client.minds_request", track)
+    vault = _vault(connections=[{"engine": "google_drive", "name": "primary"}])
+    assert vault.load("google_drive", "other-connection") is None
+    assert vault.load("gmail", "primary") is None
+    assert calls == []
+
+
 def test_load_fetches_and_shapes_the_token_response(monkeypatch):
     def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
         assert url.endswith("/v1/oauth/google_drive/token")

--- a/tests/test_turn_key_data_vault.py
+++ b/tests/test_turn_key_data_vault.py
@@ -208,3 +208,33 @@ def test_base_url_env_override(monkeypatch):
     monkeypatch.setattr("anton.minds_client.minds_request", fake)
     _vault().load("google_drive", "primary")
     assert seen["url"] == "https://auth.pr-123.dev.mindshub.ai/v1/oauth/google_drive/token"
+
+
+def test_no_turn_key_diagnostic_wins_over_the_allowlist_one(monkeypatch, caplog):
+    """A turn with neither a turn key nor a matching connection should log
+    the more actionable "no turn key" message, not the allowlist refusal —
+    the turn-key check must run first."""
+    def fail(*a, **kw):
+        raise AssertionError("must not call out with no turn key")
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fail)
+    vault = TurnKeyDataVault({"turn_key": "", "connections": []})
+    with caplog.at_level("WARNING"):
+        assert vault.load("google_drive", "primary") is None
+    assert any("no turn key available" in r.message for r in caplog.records)
+    assert not any("not in this turn's connection list" in r.message for r in caplog.records)
+
+
+def test_clear_ds_env_drops_the_per_connection_cache(monkeypatch):
+    """A later fetch after clear_ds_env() must not return a cached
+    pre-clear value."""
+    responses = iter([b'{"access_token": "first"}', b'{"access_token": "second"}'])
+
+    def fake(url, api_key, *, method="GET", payload=None, verify=True, timeout=30):
+        return next(responses)
+
+    monkeypatch.setattr("anton.minds_client.minds_request", fake)
+    vault = _vault()
+    assert vault.load("google_drive", "primary")["access_token"] == "first"
+    vault.clear_ds_env()
+    assert vault.load("google_drive", "primary")["access_token"] == "second"


### PR DESCRIPTION
`TurnKeyDataVault._fetch_uncached()` now refuses any (engine, name) not in the turn's own connection list, before it ever calls out. Added a standalone `clear_ds_env()` in `utils/datasources.py` and call it unconditionally at the top of `build_cloud_chat_session()`, not only inside `if request.oauth: restore_namespaced_env()` now calls it too instead of duplicating the sweep.