### PR TITLE
ENG-1957 FIX: Reusing a vaulted password for a second connection 

### DIFF
--- a/anton/tools.py
+++ b/anton/tools.py
@@ -74,18 +74,20 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
     from rich.console import Console
     console = session._console or Console(quiet=True)
 
-    # Resolve markers naming an already-vaulted field (reused password); drop
-    # the rest (provider keys, [REDACTED_API_KEY], stale markers) — the model
-    # can't influence _DS_SECRET_VARS, so this is what ENG-463 relies on.
-    from anton.utils.datasources import _DS_SECRET_VARS
+    from anton.core.datasources.data_vault import LocalDataVault
+    vault = session._data_vault or LocalDataVault()
+
+    # Resolve markers naming a field already saved in THIS vault (reused
+    # password); drop the rest. Scoped to `vault`, not global os.environ —
+    # see unscrub_marker's docstring.
+    from anton.utils.datasources import unscrub_marker
 
     resolved_from_vault = []
     dropped_scrubbed = []
     for k, v in list(known_variables.items()):
         if not SCRUBBED_VALUE_RE.match(v):
             continue
-        marker_key = v[1:-1]
-        resolved = os.environ.get(marker_key, "") if marker_key in _DS_SECRET_VARS else ""
+        resolved = unscrub_marker(vault, v)
         if resolved:
             known_variables[k] = resolved
             resolved_from_vault.append(k)
@@ -121,9 +123,6 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
     if _settings:
         from anton.analytics import send_event
         send_event(_settings, "ds_connect_attempt", engine=engine)
-
-    from anton.core.datasources.data_vault import LocalDataVault
-    vault = session._data_vault or LocalDataVault()
 
     if known_variables:
         from anton.core.datasources.datasource_registry import (

--- a/anton/tools.py
+++ b/anton/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import os
 import re
 import uuid
 from typing import TYPE_CHECKING
@@ -73,21 +74,39 @@ async def handle_connect_datasource(session: ChatSession, tc_input: dict) -> str
     from rich.console import Console
     console = session._console or Console(quiet=True)
 
-    dropped_scrubbed = [
-        k for k, v in known_variables.items() if SCRUBBED_VALUE_RE.match(v)
-    ]
+    # Resolve markers naming an already-vaulted field (reused password); drop
+    # the rest (provider keys, [REDACTED_API_KEY], stale markers) — the model
+    # can't influence _DS_SECRET_VARS, so this is what ENG-463 relies on.
+    from anton.utils.datasources import _DS_SECRET_VARS
+
+    resolved_from_vault = []
+    dropped_scrubbed = []
+    for k, v in list(known_variables.items()):
+        if not SCRUBBED_VALUE_RE.match(v):
+            continue
+        marker_key = v[1:-1]
+        resolved = os.environ.get(marker_key, "") if marker_key in _DS_SECRET_VARS else ""
+        if resolved:
+            known_variables[k] = resolved
+            resolved_from_vault.append(k)
+        else:
+            dropped_scrubbed.append(k)
+
     if dropped_scrubbed:
-        known_variables = {
-            k: v
-            for k, v in known_variables.items()
-            if not SCRUBBED_VALUE_RE.match(v)
-        }
+        for k in dropped_scrubbed:
+            del known_variables[k]
         console.print()
         console.print(
             f"[anton.warning](anton)[/] Ignoring scrubbed-placeholder values "
             f"for {', '.join(dropped_scrubbed)} — those bracketed strings are "
             f"scrub-markers, not real credentials. Pass the actual secret "
             f"values instead."
+        )
+    if resolved_from_vault:
+        console.print()
+        console.print(
+            f"[anton.muted](anton)[/] Reusing the existing vaulted value for "
+            f"{', '.join(sorted(resolved_from_vault))}."
         )
 
     # ── Telemetry: connection attempt ────────────────────────────────
@@ -391,6 +410,13 @@ _CONNECT_DATASOURCE_DESCRIPTION_TAIL = (
     "vars like any other connection.\n\n"
     "Partial credentials are fine — save what the user provided. Ask for missing "
     "pieces in a later turn only if needed. Never invent values.\n\n"
+    "If a value in chat appears as a bracketed placeholder like [DS_POSTGRES_ABC12__PASSWORD] "
+    "instead of a real value, that means it was already masked before reaching you — the user "
+    "is referencing a credential already saved from an earlier connection (e.g. reusing the "
+    "same password for a second database). Pass that placeholder string through as-is in "
+    "known_variables; it resolves server-side to the real value without you ever seeing it. "
+    "Never invent a bracketed placeholder yourself — only pass one exactly as it appeared in "
+    "the conversation.\n\n"
     "Do NOT print any message before calling this tool — it handles the user-facing output."
 )
 

--- a/anton/utils/datasources.py
+++ b/anton/utils/datasources.py
@@ -177,6 +177,24 @@ def scrub_credentials(text: str) -> str:
     return text
 
 
+def unscrub_marker(vault: "DataVault", marker: str) -> str | None:
+    """Reverse of `scrub_credentials` for a single `[DS_...]` marker.
+
+    Scoped to `vault`'s own saved connections, not the global
+    `_DS_SECRET_VARS`/`os.environ` — those can hold another session's
+    in-flight test credentials or flat leftovers. Returns None if `marker`
+    isn't `[...]`-bracketed or matches no field in `vault`.
+    """
+    if not (marker.startswith("[") and marker.endswith("]")):
+        return None
+    key = marker[1:-1]
+    for conn in vault.list_connections():
+        env = vault.env_for(conn["engine"], conn["name"])
+        if env and key in env:
+            return env[key]
+    return None
+
+
 def _parse_picked_files(raw: str | None) -> list[dict]:
     """Parse a `_picked_files` JSON field, dropping malformed entries so they
     can't crash a later f.get(...) call or embed "None" as a fileId."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -422,51 +422,58 @@ class TestNonInteractiveSave:
 
     @pytest.mark.asyncio
     async def test_scrubbed_marker_for_vaulted_field_resolves_and_saves(
-        self, vault_dir, monkeypatch
+        self, vault_dir
     ):
-        """ENG-1957: a marker naming an already-vaulted field resolves via
-        os.environ instead of being dropped — the model reuses a password
-        from an earlier connection without ever seeing it."""
-        marker_key = "DS_POSTGRES_ABC12__PASSWORD"
-        monkeypatch.setenv(marker_key, "s3cr3t-reused")
-        _DS_SECRET_VARS.add(marker_key)
-        try:
-            session = _make_session(vault_dir)
-            with _patch_test_ok():
-                await handle_connect_datasource(
-                    session,
-                    {
-                        "engine": "postgres",
-                        "known_variables": {
-                            "host": "db.example.com",
-                            "database": "sales",
-                            "user": "admin",
-                            "password": f"[{marker_key}]",
-                        },
+        """ENG-1957: a marker naming a field of a connection already saved in
+        THIS session's own vault resolves instead of being dropped — the
+        model reuses a password from an earlier connection without ever
+        seeing it."""
+        session = _make_session(vault_dir)
+        session._data_vault.save(
+            "postgres",
+            "abc12345",
+            {
+                "host": "db.example.com",
+                "port": "5432",
+                "database": "sales",
+                "user": "admin",
+                "password": "s3cr3t-reused",
+            },
+        )
+        marker = "[DS_POSTGRES_ABC12345__PASSWORD]"
+        with _patch_test_ok():
+            await handle_connect_datasource(
+                session,
+                {
+                    "engine": "postgres",
+                    "known_variables": {
+                        "host": "db2.example.com",
+                        "database": "analytics",
+                        "user": "admin",
+                        "password": marker,
                     },
-                )
-            conns = session._data_vault.list_connections()
-            assert len(conns) == 1
-            saved = session._data_vault.load("postgres", conns[0]["name"])
-            assert saved["password"] == "s3cr3t-reused"
-            printed = " ".join(
-                str(c.args[0])
-                for c in session._console.print.call_args_list
-                if c.args
+                },
             )
-            assert "Reusing the existing vaulted value" in printed
-            assert "password" in printed
-        finally:
-            _DS_SECRET_VARS.discard(marker_key)
+        conns = session._data_vault.list_connections()
+        assert len(conns) == 2
+        new_conn = next(c for c in conns if c["name"] != "abc12345")
+        saved = session._data_vault.load("postgres", new_conn["name"])
+        assert saved["password"] == "s3cr3t-reused"
+        printed = " ".join(
+            str(c.args[0])
+            for c in session._console.print.call_args_list
+            if c.args
+        )
+        assert "Reusing the existing vaulted value" in printed
+        assert "password" in printed
 
     @pytest.mark.asyncio
     async def test_provider_key_marker_does_not_resolve_even_if_env_var_exists(
         self, vault_dir, monkeypatch
     ):
-        """Security-critical (ENG-463): a marker naming a key NOT in
-        _DS_SECRET_VARS must stay dropped even when a same-named env var
-        happens to hold a real secret — only the closed vaulted-field set
-        may be resolved."""
+        """Security-critical (ENG-463): a marker naming a provider key must
+        stay dropped even when a same-named env var holds a real secret —
+        it isn't a namespaced field of any connection in this vault."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-actual-platform-secret")
         session = _make_session(vault_dir)
         interactive = _fake_interactive(session)
@@ -494,6 +501,50 @@ class TestNonInteractiveSave:
         )
         assert "scrubbed-placeholder" in printed
         assert "Reusing the existing vaulted value" not in printed
+
+    @pytest.mark.asyncio
+    async def test_another_sessions_live_test_credential_does_not_resolve(
+        self, vault_dir, monkeypatch
+    ):
+        """Security-critical (ENG-1957 follow-up): a flat DS_* marker left in
+        os.environ/_DS_SECRET_VARS by another session's in-flight connection
+        test (see run_connection_test in verify.py) must NOT resolve just
+        because it's process-global — only namespaced fields of THIS
+        session's own vault may resolve. This is what actually closes the
+        cross-session leak, not merely restricting to secret fields."""
+        marker_key = "DS_PASSWORD"
+        monkeypatch.setenv(marker_key, "another-sessions-live-test-value")
+        _DS_SECRET_VARS.add(marker_key)
+        try:
+            session = _make_session(vault_dir)
+            interactive = _fake_interactive(session)
+            with patch(
+                "anton.commands.datasource.handle_connect_datasource",
+                new=interactive,
+            ):
+                await handle_connect_datasource(
+                    session,
+                    {
+                        "engine": "postgres",
+                        "known_variables": {
+                            "host": "db.example.com",
+                            "database": "sales",
+                            "user": "admin",
+                            "password": f"[{marker_key}]",
+                        },
+                    },
+                )
+            interactive.assert_called_once()
+            assert session._data_vault.list_connections() == []
+            printed = " ".join(
+                str(c.args[0])
+                for c in session._console.print.call_args_list
+                if c.args
+            )
+            assert "scrubbed-placeholder" in printed
+            assert "Reusing the existing vaulted value" not in printed
+        finally:
+            _DS_SECRET_VARS.discard(marker_key)
 
     @pytest.mark.asyncio
     async def test_yolo_dedups_matching_connection(self, vault_dir):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,6 +16,7 @@ from anton.tools import (
     DEFAULT_SESSION_TOOLS,
     handle_connect_datasource,
 )
+from anton.utils.datasources import _DS_SECRET_VARS
 
 _UUID8 = re.compile(r"^[0-9a-f]{8}$")
 
@@ -418,6 +419,81 @@ class TestNonInteractiveSave:
         )
         assert "scrubbed-placeholder" in printed
         assert "host" in printed
+
+    @pytest.mark.asyncio
+    async def test_scrubbed_marker_for_vaulted_field_resolves_and_saves(
+        self, vault_dir, monkeypatch
+    ):
+        """ENG-1957: a marker naming an already-vaulted field resolves via
+        os.environ instead of being dropped — the model reuses a password
+        from an earlier connection without ever seeing it."""
+        marker_key = "DS_POSTGRES_ABC12__PASSWORD"
+        monkeypatch.setenv(marker_key, "s3cr3t-reused")
+        _DS_SECRET_VARS.add(marker_key)
+        try:
+            session = _make_session(vault_dir)
+            with _patch_test_ok():
+                await handle_connect_datasource(
+                    session,
+                    {
+                        "engine": "postgres",
+                        "known_variables": {
+                            "host": "db.example.com",
+                            "database": "sales",
+                            "user": "admin",
+                            "password": f"[{marker_key}]",
+                        },
+                    },
+                )
+            conns = session._data_vault.list_connections()
+            assert len(conns) == 1
+            saved = session._data_vault.load("postgres", conns[0]["name"])
+            assert saved["password"] == "s3cr3t-reused"
+            printed = " ".join(
+                str(c.args[0])
+                for c in session._console.print.call_args_list
+                if c.args
+            )
+            assert "Reusing the existing vaulted value" in printed
+            assert "password" in printed
+        finally:
+            _DS_SECRET_VARS.discard(marker_key)
+
+    @pytest.mark.asyncio
+    async def test_provider_key_marker_does_not_resolve_even_if_env_var_exists(
+        self, vault_dir, monkeypatch
+    ):
+        """Security-critical (ENG-463): a marker naming a key NOT in
+        _DS_SECRET_VARS must stay dropped even when a same-named env var
+        happens to hold a real secret — only the closed vaulted-field set
+        may be resolved."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-actual-platform-secret")
+        session = _make_session(vault_dir)
+        interactive = _fake_interactive(session)
+        with patch(
+            "anton.commands.datasource.handle_connect_datasource", new=interactive
+        ):
+            await handle_connect_datasource(
+                session,
+                {
+                    "engine": "postgres",
+                    "known_variables": {
+                        "host": "db.example.com",
+                        "database": "sales",
+                        "user": "admin",
+                        "password": "[ANTHROPIC_API_KEY]",
+                    },
+                },
+            )
+        interactive.assert_called_once()
+        assert session._data_vault.list_connections() == []
+        printed = " ".join(
+            str(c.args[0])
+            for c in session._console.print.call_args_list
+            if c.args
+        )
+        assert "scrubbed-placeholder" in printed
+        assert "Reusing the existing vaulted value" not in printed
 
     @pytest.mark.asyncio
     async def test_yolo_dedups_matching_connection(self, vault_dir):


### PR DESCRIPTION
**Problem:**
If you'd already saved a password for one connection and reused it while setting up a second one, saving the second connection would just silently fail — the app treated the reused password as fake and dropped it.

**Fix:**
Now it recognizes when you're referencing a credential you already saved and reuses it automatically, without ever exposing the actual password value anywhere it shouldn't be.


Fixes: https://linear.app/mindsdb/issue/ENG-1957/reusing-an-already-vaulted-password-for-a-second-connection-silently