### PR TITLE
ci(scratchpad): run both pod entrypoints before the image can be pushed (ENG-2126)

### DIFF
--- a/.github/workflows/scratchpad-dev-build.yml
+++ b/.github/workflows/scratchpad-dev-build.yml
@@ -6,6 +6,11 @@ name: Scratchpad image - Dev build on PR
 # rebuilds. The scratchpad-controller references the resulting tag via
 # SCRATCHPAD_CONTROLLER__SCRATCHPAD_IMAGE; there is no Helm chart for this image, so this
 # workflow only builds and scans (no deploy job).
+#
+# The image is smoke-tested inside the build, not here: the Dockerfile's last layer runs
+# docker/image_smoke.py as UID 1000, which executes both entrypoints the controller execs.
+# It sits in the build rather than in a step below it so a failure blocks the PUSH — an
+# image no pod can serve a turn with never reaches ECR to be pinned by mistake.
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,5 +69,11 @@ RUN printf '#!/bin/sh\nexec python -m anton.core.backends.scratchpad_boot\n' \
 RUN useradd -u 1000 -m -s /bin/sh scratchpad
 USER 1000
 
+# Run both entrypoints once, as the pod's uid, before this image can be pushed.
+# The build is otherwise green for an image no pod can serve a turn with: every
+# check up to here proves the image was ASSEMBLED, none proves it RUNS. See
+# docker/image_smoke.py for what each check is guarding against.
+RUN python /app/docker/image_smoke.py
+
 # The controller always execs an explicit command; this default keeps the image runnable standalone.
 CMD ["python", "-m", "anton.cloud_turn"]

--- a/docker/image_smoke.py
+++ b/docker/image_smoke.py
@@ -1,0 +1,180 @@
+"""Prove the built image can actually run a turn, before it is pushed.
+
+Run as a Dockerfile layer AFTER `USER 1000`, so every check sees exactly what a
+scratchpad pod sees: the same venv, the same interpreter, the same uid.
+
+The point is the class of failure where the image is well-formed and the build is
+green, but no pod that pulls it can serve a turn. On 2026-08-31 every `sp-live-*`
+pod failed before anton ran, and because nothing had ever executed the entrypoint
+outside a pod there was no earlier signal to read: the first evidence the image
+was unusable was that prod stopped answering. Each check below is one way that
+can happen.
+
+Every check RUNS the real entrypoint rather than importing it. An import proves
+the module resolves; only running it proves the whole graph loads and the wire
+still speaks the contract the controller reads.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+# Both entrypoints read one bounded thing from stdin and stop at EOF, so an empty
+# stdin drives a complete, harmless run: cloud_turn fails to parse the empty line
+# and emits its terminal event, scratchpad_boot sees EOF and leaves its cell loop.
+EMPTY_STDIN = b""
+TIMEOUT_S = 120
+
+
+def run_module(module: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        [sys.executable, "-m", module],
+        input=EMPTY_STDIN,
+        capture_output=True,
+        timeout=TIMEOUT_S,
+    )
+
+
+def check_runtime_user() -> list[str]:
+    """The layer must sit below `USER 1000`, or none of this tests the pod.
+
+    Running these checks as root would pass while the pod still fails, which is
+    worse than not running them: it reports a guarantee the image does not hold.
+    """
+    if os.getuid() != 1000:
+        return [f"runtime user: running as uid {os.getuid()}, expected 1000"]
+    return []
+
+
+def check_version() -> list[str]:
+    """The version the image reports must be the one the workflow resolved.
+
+    A wrong version here is invisible in the cluster: every pod reports it, it is
+    well-formed, and it reads as a real cohort in any breakdown rather than as a
+    missing value (ENG-1796).
+    """
+    import anton
+
+    want = os.environ.get("SETUPTOOLS_SCM_PRETEND_VERSION", "")
+    if not want:
+        return ["version: SETUPTOOLS_SCM_PRETEND_VERSION is not set in the image"]
+
+    found = []
+    if anton.__version__ != want:
+        found.append(
+            f"version: anton reports {anton.__version__!r}, image was built as {want!r}"
+        )
+    if anton.__version__.startswith("2.0.0"):
+        found.append(f"version: {anton.__version__!r} is the hatch-vcs fallback")
+    return found
+
+
+def check_cloud_turn() -> list[str]:
+    """`python -m anton.cloud_turn` is what the controller execs for a whole turn.
+
+    Empty stdin fails to parse, which is the shortest path that still loads the
+    entire turn graph and writes to the protocol descriptor. Exactly one line, and
+    it must be a terminal event: the controller reads the terminal off the EVENT,
+    not off the exit code, so a process that exits 0 having printed nothing is a
+    turn that hangs until the stall timer fires.
+    """
+    proc = run_module("anton.cloud_turn")
+    if proc.returncode != 0:
+        tail = proc.stderr.decode(errors="replace")[-2000:]
+        return [f"cloud_turn: exited {proc.returncode}\n{tail}"]
+
+    lines = [ln for ln in proc.stdout.decode(errors="replace").splitlines() if ln.strip()]
+    if len(lines) != 1:
+        return [
+            f"cloud_turn: expected 1 protocol line on stdout, got {len(lines)}: {lines[:5]}"
+        ]
+    try:
+        event = json.loads(lines[0])
+    except ValueError as exc:
+        return [f"cloud_turn: stdout line is not JSON ({exc}): {lines[0][:200]!r}"]
+    if event.get("kind") != "turn_failed":
+        return [f"cloud_turn: expected a turn_failed terminal, got {event.get('kind')!r}"]
+    return []
+
+
+def check_scratchpad_boot() -> list[str]:
+    """`/usr/local/bin/scratchpad-boot.sh` is what the controller execs for one cell.
+
+    It has no main guard: the module body IS the cell loop, so running it is the
+    only way to load it. EOF on stdin ends that loop with no cell executed.
+    """
+    proc = run_module("anton.core.backends.scratchpad_boot")
+    if proc.returncode != 0:
+        tail = proc.stderr.decode(errors="replace")[-2000:]
+        return [f"scratchpad_boot: exited {proc.returncode}\n{tail}"]
+    return []
+
+
+def check_runtime_uv() -> list[str]:
+    """scratchpad_boot shells out to `uv pip install` for a package a cell imports.
+
+    ANTON_UV_PATH points at this exact path, so a uv that moved or lost its
+    execute bit turns every missing-package recovery into a failed cell.
+    """
+    uv = "/usr/local/bin/uv"
+    if not os.access(uv, os.X_OK):
+        return [f"runtime uv: {uv} is missing or not executable"]
+    return []
+
+
+def check_venv_writable() -> list[str]:
+    """That same install writes into the venv as uid 1000.
+
+    The Dockerfile chowns the venv for exactly this. A chown that stops covering
+    it leaves an image that serves turns normally right up until a cell imports
+    something that is not installed.
+    """
+    venv = os.environ.get("VIRTUAL_ENV", "")
+    if not venv:
+        return ["venv: VIRTUAL_ENV is not set in the image"]
+    if not os.access(venv, os.W_OK):
+        return [f"venv: {venv} is not writable by uid {os.getuid()}"]
+    return []
+
+
+CHECKS = (
+    check_runtime_user,
+    check_version,
+    check_cloud_turn,
+    check_scratchpad_boot,
+    check_runtime_uv,
+    check_venv_writable,
+)
+
+
+def run_checks(checks=CHECKS) -> list[str]:
+    """Run every check and collect what failed.
+
+    A check that raises counts as a failed check rather than a crashed script: one
+    broken check must not hide the verdict of the other five, and a smoke that
+    dies partway through is indistinguishable from one that never ran.
+    """
+    failures: list[str] = []
+    for check in checks:
+        try:
+            failures.extend(check())
+        except Exception as exc:
+            failures.append(f"{check.__name__}: raised {type(exc).__name__}: {exc}")
+    return failures
+
+
+def main() -> int:
+    failures = run_checks()
+    if failures:
+        print("image smoke FAILED:", file=sys.stderr)
+        for line in failures:
+            print(f"  - {line}", file=sys.stderr)
+        return 1
+    print("image smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -1,0 +1,121 @@
+"""The scratchpad image's build-time smoke (`docker/image_smoke.py`).
+
+That script is a build gate, so its own failure mode matters: a smoke that
+reports success no matter what is worse than no smoke, because the build stays
+green while claiming the image was exercised. These pin the ways it could go
+quietly blind.
+
+The script lives outside the package (it runs inside the image, against the
+image's venv), so it is loaded by path rather than imported.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SMOKE_PATH = Path(__file__).resolve().parents[1] / "docker" / "image_smoke.py"
+
+
+@pytest.fixture(scope="module")
+def smoke():
+    spec = importlib.util.spec_from_file_location("image_smoke", SMOKE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _completed(returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+    return subprocess.CompletedProcess(args=["python"], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
+def test_cloud_turn_passes_on_one_terminal_event(smoke, monkeypatch):
+    line = json.dumps({"kind": "turn_failed", "error": "JSONDecodeError: ..."}).encode()
+    monkeypatch.setattr(smoke, "run_module", lambda _: _completed(0, line + b"\n"))
+    assert smoke.check_cloud_turn() == []
+
+
+def test_cloud_turn_fails_when_the_entrypoint_dies(smoke, monkeypatch):
+    """The image that cannot start at all — the shape of the 2026-08-31 pods."""
+    monkeypatch.setattr(
+        smoke, "run_module",
+        lambda _: _completed(1, b"", b"ModuleNotFoundError: No module named 'dill'"),
+    )
+    (failure,) = smoke.check_cloud_turn()
+    assert "exited 1" in failure
+    # The reason has to survive into the build log, or the gate just says "no".
+    assert "dill" in failure
+
+
+def test_cloud_turn_fails_on_a_silent_exit(smoke, monkeypatch):
+    """Exit 0 with nothing on stdout is the worst case, not a pass.
+
+    The controller reads the terminal off the event, so a turn that emits none
+    hangs until the stall timer fires rather than failing.
+    """
+    monkeypatch.setattr(smoke, "run_module", lambda _: _completed(0, b""))
+    (failure,) = smoke.check_cloud_turn()
+    assert "expected 1 protocol line" in failure
+
+
+def test_cloud_turn_fails_when_something_else_writes_to_stdout(smoke, monkeypatch):
+    """stdout is the protocol wire. A stray line corrupts the stream the
+    controller parses, which is why the entrypoint isolates FD 1 at all."""
+    noise = b'starting up\n{"kind": "turn_failed", "error": "x"}\n'
+    monkeypatch.setattr(smoke, "run_module", lambda _: _completed(0, noise))
+    (failure,) = smoke.check_cloud_turn()
+    assert "expected 1 protocol line" in failure
+
+
+def test_cloud_turn_fails_on_a_non_terminal_event(smoke, monkeypatch):
+    monkeypatch.setattr(
+        smoke, "run_module",
+        lambda _: _completed(0, json.dumps({"kind": "delta", "text": "hi"}).encode()),
+    )
+    (failure,) = smoke.check_cloud_turn()
+    assert "turn_failed" in failure
+
+
+def test_a_check_that_raises_is_reported_not_swallowed(smoke):
+    """A crashed check must not read as a passed check.
+
+    Without this the script would exit non-zero from the traceback and the build
+    would fail for the right reason by accident — until someone wrapped the call.
+    """
+    def explodes():
+        raise RuntimeError("boom")
+
+    (failure,) = smoke.run_checks(checks=(explodes,))
+    assert "explodes" in failure
+    assert "RuntimeError: boom" in failure
+
+
+def test_one_broken_check_does_not_hide_the_others(smoke):
+    def explodes():
+        raise RuntimeError("boom")
+
+    def reports():
+        return ["venv: not writable"]
+
+    failures = smoke.run_checks(checks=(explodes, reports))
+    assert len(failures) == 2
+
+
+def test_main_reports_success_only_when_nothing_failed(smoke, monkeypatch):
+    monkeypatch.setattr(smoke, "run_checks", lambda: [])
+    assert smoke.main() == 0
+    monkeypatch.setattr(smoke, "run_checks", lambda: ["cloud_turn: exited 1"])
+    assert smoke.main() == 1
+
+
+def test_the_dockerfile_runs_the_smoke_below_the_runtime_user(smoke):
+    """The layer's position is the whole premise: above `USER 1000` every check
+    runs as root and passes for an image the pod still cannot use."""
+    dockerfile = (SMOKE_PATH.parents[1] / "Dockerfile").read_text().splitlines()
+    user_line = next(i for i, ln in enumerate(dockerfile) if ln.strip() == "USER 1000")
+    smoke_line = next(i for i, ln in enumerate(dockerfile) if "image_smoke.py" in ln)
+    assert smoke_line > user_line


### PR DESCRIPTION
Preventive work from the 2026-08-31 outage. Ticket: [ENG-2126](https://linear.app/mindsdb/issue/ENG-2126).

## Why

Nothing had ever executed this image's entrypoints outside a pod. The build proved the image was **assembled**; nothing proved it **ran**. So the first evidence that pods could not serve a turn was prod going quiet, and there was no earlier signal anywhere to read.

To be explicit about scope: **this would not have prevented the 2026-08-31 outage.** That was a bad image reference, so the container never started and no image-level check could fire. It closes the adjacent hole, which the investigation kept walking into: an image that pulls fine, starts fine, and cannot serve a turn.

## What it does

The Dockerfile's last layer runs `docker/image_smoke.py` as UID 1000, below `USER 1000`, so every check sees exactly what a scratchpad pod sees: same venv, same interpreter, same uid.

It **runs** both entrypoints the controller execs, with empty stdin. An import proves the module resolves; only running it proves the whole graph loads and the wire still speaks the contract the controller reads.

| Check | What it catches |
|---|---|
| `python -m anton.cloud_turn` exits 0 with exactly one JSON line on the protocol descriptor, and that line is a terminal event | An import break anywhere in the turn graph. Also the worst case: exit 0 with nothing printed. The controller reads the terminal off the **event**, not the exit code, so that is a turn which hangs until the stall timer fires rather than one that fails |
| stdout carries exactly one line | Anything else writing to FD 1 corrupts the stream the controller parses. This is why the entrypoint isolates FD 1 at all |
| `python -m anton.core.backends.scratchpad_boot` exits 0 | The single-cell entrypoint. It has no main guard (the module body **is** the cell loop), so running it is the only way to load it. EOF ends the loop with no cell executed |
| reported version equals the one the workflow resolved, and is not `2.0.0*` | A wrong version here is invisible in the cluster: well-formed, reported by every pod, reads as a real cohort rather than a null (ENG-1796) |
| uv executable at `/usr/local/bin/uv` | `scratchpad_boot` shells out to `uv pip install` for a package a cell imports. `ANTON_UV_PATH` names that exact path |
| venv writable by uid 1000 | Same install. A chown that stops covering the venv gives an image that serves turns normally right up until a cell imports something missing |

## Why in the build, not in a step below it

A failure blocks the **push**. An image no pod can serve a turn with never reaches ECR to be pinned by mistake.

It also needs no docker daemon on the `mdb-dev` runner. `build-push-ecr` targets the in-cluster buildkit agent, so the image is never in the runner's local daemon and a `docker run` step would have to pull it back first.

Cost: about 1 second.

## Verified both ways

Against a real `docker build`, not by inspection.

- Good image: `image smoke passed`, build succeeds.
- Startup-path dependency removed (`rm -rf .../site-packages/dill*`): build **fails** at that layer with `ModuleNotFoundError: No module named 'dill'` in the log.

Worth recording from that exercise: removing `httpx` did **not** fail the smoke, because `anthropic` and `openai` import it lazily when a client is constructed. That independently re-confirms the httpx theory considered during the investigation was never the cause. A pod missing httpx starts fine.

## Tests

`tests/test_image_smoke.py`, 9 tests. A gate that reports success no matter what is worse than no gate, so the smoke's own failure modes are pinned: silent exit, polluted stdout, non-terminal event, a check that raises (must be reported, not swallowed), one broken check not hiding the others, and the layer's position below `USER 1000`.

That last one matters: above `USER 1000` every check runs as root and passes for an image the pod still cannot use.

## Note

This PR triggers `scratchpad-dev-build.yml`, so CI here is itself the gate running against a real image build.