### PR TITLE
Yolo mode: edit artifact files with a diff (ENG-2186)

### DIFF
--- a/anton/core/yolo/__init__.py
+++ b/anton/core/yolo/__init__.py
@@ -1,0 +1,76 @@
+"""Yolo mode: edit files with a diff instead of a program that writes one.
+
+Anton's existing way to change an artifact is the scratchpad — the model
+writes Python that writes the file. That works, and for anything
+generative it is the right tool. For *modifying* a file that already
+exists it is a long way round: the model reasons about string surgery,
+writes a program to perform it, and the program is a second thing that can
+be wrong. A one-line title change becomes a script.
+
+Yolo mode is the short way. The model is shown the folder, asks for the
+files it needs, and returns a diff. The diff is applied here, by finding
+each hunk's text in the file — no line numbers involved.
+
+What was learned building yolocoder, and what this preserves:
+
+* **Models get diff content right and diff arithmetic wrong.** Line
+  numbers, hunk counts and trailing context are the failure, not the
+  edit. So all of it is ignored and hunks are placed by their text.
+  This is the single highest-value idea here.
+* **Models pick files well.** Given a listing of thirty paths they ask
+  for the right two or three. That judgement is worth one cheap call and
+  is not worth second-guessing.
+* **Plan and patch belong in one call.** Split, the second call resends
+  every file to learn nothing.
+* **Failure evidence must include the model's own output.** Told only
+  "it failed", a model reproduces the same diff.
+* **Refusing beats guessing.** An unfindable hunk, or a short one
+  matching in three places, is an error — not a reason to pick the
+  first match and edit the wrong function.
+
+`patch.py` and `workspace.py` import nothing at all — they are pure
+functions over strings, which is what makes the engine provable in
+milliseconds. `agent.py` uses anton's own `LLMClient` directly, so a yolo
+run gets the configured provider, the coding-model split, forced
+`tool_choice`, pydantic validation and turn tracing for free, and the
+handler passes the same client the rest of the agent already holds.
+
+    from anton.core.yolo import Workspace, YoloEditor
+
+    editor = YoloEditor(workspace=Workspace(folder), llm_client=llm_client)
+    outcome = await editor.edit("rename the title to TicTacTris")
+    if not outcome.applied:
+        ...  # outcome.detail says why; fall back to the scratchpad
+"""
+
+from anton.core.yolo.agent import MAX_ATTEMPTS, YoloEditor, apply_patch_text
+from anton.core.yolo.models import Change, Outcome, Progress, ReadRequest
+from anton.core.yolo.patch import (
+    FilePatch,
+    Hunk,
+    PatchError,
+    apply_hunks,
+    is_apply_patch_format,
+    locate,
+    parse_patch,
+)
+from anton.core.yolo.workspace import Workspace, WorkspaceError
+
+__all__ = [
+    "MAX_ATTEMPTS",
+    "Change",
+    "FilePatch",
+    "Hunk",
+    "Outcome",
+    "PatchError",
+    "Progress",
+    "ReadRequest",
+    "Workspace",
+    "WorkspaceError",
+    "YoloEditor",
+    "apply_hunks",
+    "apply_patch_text",
+    "is_apply_patch_format",
+    "locate",
+    "parse_patch",
+]

--- a/anton/core/yolo/agent.py
+++ b/anton/core/yolo/agent.py
@@ -1,0 +1,374 @@
+"""The yolo loop: pick files, write one diff, place it, repair, give up well.
+
+Shape of a run, and the reasoning behind each step:
+
+    map ──▶ pick files ──▶ read ──▶ plan + diff ──▶ apply ─┬─▶ done
+             + search                  (1 call)            │
+             (1 call)                     ▲                │
+                                          └── evidence ◀───┘
+                                             widen / search
+                                              (up to MAX_ATTEMPTS)
+
+Two LLM calls for a change that lands, and the second one is the only one
+that repeats. Everything else — searching, locating hunks, checking that
+promised files exist, deciding whether a match is ambiguous — is
+arithmetic done here, because it is arithmetic and models are bad at it.
+
+Searching in particular costs no model call at all, which is why the
+model may ask for it freely: at the pick step when file names give
+nothing away, and again on a failed attempt when it turns out to have
+been looking in the wrong file.
+
+Giving up is a designed step, not a fallthrough. When the diff will not
+apply after MAX_ATTEMPTS, the outcome carries the last failure verbatim so
+the caller can hand the job to something else with the diagnosis attached.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from anton.core.llm.client import LLMClient
+from anton.core.yolo.models import Change, Outcome, Progress, ReadRequest
+from anton.core.yolo.patch import PatchError, apply_hunks, parse_patch
+from anton.core.yolo.prompts import (
+    CHANGE_INSTRUCTIONS,
+    READ_INSTRUCTIONS,
+    render_task,
+)
+from anton.core.yolo.workspace import (
+    SCHEMA_SUFFIX,
+    Workspace,
+    WorkspaceError,
+    is_generated_data,
+)
+
+__all__ = ["MAX_ATTEMPTS", "YoloEditor", "apply_patch_text"]
+
+
+# How many diffs to accept before handing the job on. Three is not
+# arbitrary: in yolocoder, a diff that fails three times with the file
+# contents already in front of the model is almost never fixed by a
+# fourth — the model is wrong about the file, not careless, and more
+# attempts spend tokens to arrive at the same place.
+MAX_ATTEMPTS = 3
+
+# A read budget. Models pick files well but will happily ask for the whole
+# folder if the folder is small enough to seem free.
+MAX_READS = 12
+
+
+class _Quiet:
+    def status(self, message: str) -> None: ...
+    def log(self, message: str) -> None: ...
+
+
+@dataclass
+class YoloEditor:
+    """Makes one change to one folder."""
+
+    workspace: Workspace
+    llm_client: LLMClient
+    progress: Progress = field(default_factory=_Quiet)
+    max_attempts: int = MAX_ATTEMPTS
+
+    async def edit(self, task: str, background: str = "") -> Outcome:
+        """Make the change, or come back saying exactly why not."""
+        try:
+            return await self._edit(task, background)
+        except WorkspaceError as error:
+            return Outcome(applied=False, detail=str(error), status="error")
+
+    async def _edit(self, task: str, background: str) -> Outcome:
+        file_map = self.workspace.map()
+        self.progress.status("Looking at the folder...")
+        self.progress.log(f"  {len(self.workspace.files())} files")
+
+        wanted, found = await self._pick_files(task, file_map, background)
+        contents = ""
+        if wanted:
+            self.progress.log("  reading " + ", ".join(wanted))
+            contents = self.workspace.read_many(wanted)
+
+        evidence = ""
+        change: Change | None = None
+
+        for attempt in range(1, self.max_attempts + 1):
+            self.progress.status(
+                "Working out the change..." if attempt == 1 else "Trying again..."
+            )
+            change = await self.llm_client.generate_object_code(
+                Change,
+                system=CHANGE_INSTRUCTIONS,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": render_task(
+                            task, file_map, contents, background, evidence, found
+                        ),
+                    }
+                ],
+            )
+            if attempt == 1:
+                self.progress.log(f"  plan: {change.summary}")
+
+            if not change.diff.strip():
+                # "I need to see more first" is a legitimate answer, not a
+                # dead end. Honour it rather than treating an empty diff as
+                # a failure to produce one.
+                widened, extra = self._widen(wanted, change)
+                if (widened != wanted or extra) and attempt < self.max_attempts:
+                    wanted, contents = widened, self.workspace.read_many(widened)
+                    found = _join(found, extra)
+                    evidence = _asked_note(change.need_files, change.need_search)
+                    self.progress.log(
+                        "  asked for "
+                        + ", ".join(change.need_files + change.need_search)
+                    )
+                    continue
+                # Otherwise there is nothing to apply and nothing to repair
+                # from; another attempt asks the same question again.
+                return Outcome(
+                    applied=False,
+                    summary=change.summary,
+                    detail="the model returned no diff",
+                    attempts=attempt,
+                    status="no_diff",
+                )
+
+            self.progress.status("Applying the patch...")
+            try:
+                written = apply_patch_text(self.workspace, change.diff)
+            except (PatchError, WorkspaceError) as error:
+                self.progress.log(f"  patch did not apply: {error}")
+                # A wrong first pick is the one failure the repair note
+                # cannot fix. Telling a model to copy the lines more
+                # carefully is useless advice about a file it was never
+                # shown, and without widening the read set it will rewrite
+                # the same doomed diff until the attempts run out. So when
+                # the patch named a file we did not read, that — not the
+                # careless-copying lecture — is the evidence to send back.
+                widened, extra = self._widen(wanted, change)
+                fresh = [path for path in widened if path not in wanted]
+                if fresh or extra:
+                    if fresh:
+                        self.progress.log("  reading " + ", ".join(fresh) + " and retrying")
+                    wanted, contents = widened, self.workspace.read_many(widened)
+                    found = _join(found, extra)
+                    evidence = _unseen_note(fresh, str(error))
+                else:
+                    evidence = _repair_note(str(error), change.diff)
+                continue
+
+            # The model said which files it would touch. That claim is
+            # worth checking, because a patch that quietly omits the new
+            # file it promised applies perfectly and looks like success.
+            missing = [
+                path
+                for path in change.files
+                if not self.workspace.exists(path) and path not in written
+            ]
+            if missing:
+                self.progress.log(f"  but {', '.join(missing)} was not created")
+                evidence = _missing_note(missing)
+                # This patch did apply, so the files on disk are no longer
+                # the ones quoted in the prompt. Re-read them, or the next
+                # attempt writes a diff against a version that is gone and
+                # fails for a reason that has nothing to do with the task.
+                wanted = _merge(wanted, sorted(written))
+                contents = self.workspace.read_many(wanted)
+                continue
+
+            self.progress.log(f"  wrote {', '.join(sorted(written))}")
+            return Outcome(
+                applied=True,
+                summary=change.summary,
+                files=sorted(written),
+                attempts=attempt,
+                status="applied",
+            )
+
+        return Outcome(
+            applied=False,
+            summary=change.summary if change else "",
+            files=list(change.files) if change else [],
+            detail=evidence,
+            attempts=self.max_attempts,
+            status="patch_failed",
+        )
+
+    def _widen(self, wanted: list[str], change: Change) -> tuple[list[str], str]:
+        """Widen the read set from what the model named or asked to find.
+
+        This is the bounded stand-in for a read/search tool loop. The loop
+        in yolocoder was not really about the first pick — models are good
+        at that — it was about recovering when the first pick was wrong.
+        Removing it left nothing to recover with.
+
+        Rather than reopen an unbounded loop, the read set widens only in
+        reaction to a failure, only to files the model itself named or
+        found, and only within the attempts already budgeted. Searching is
+        free — it calls no model — so it costs nothing to answer.
+
+        Returns the new read set and any search results to show.
+        """
+        widened = list(wanted)
+        rendered, hits = "", []
+        if change.need_search:
+            rendered, hits = self.workspace.search_many(change.need_search)
+        for path in list(change.need_files) + hits + list(change.files):
+            path = path.strip().lstrip("./")
+            if path and path not in widened and self.workspace.exists(path):
+                widened.append(path)
+        return widened[:MAX_READS], rendered
+
+    async def _pick_files(
+        self, task: str, file_map: str, background: str
+    ) -> tuple[list[str], str]:
+        """Ask which files the change needs, and search for what it cannot name.
+
+        This is the step models are reliably good at, which is why it gets
+        its own cheap call instead of a tool loop: one request, a list of
+        names, done. Anything they name that is not in the folder is
+        dropped here rather than becoming a confusing read error.
+
+        Where names are not enough — forty files and no clue which one
+        sets the title — the same call can ask for a search instead. The
+        search itself is deterministic and costs no model call, so the
+        whole discovery step stays at one request. Files that match are
+        added to the read set, and the matching lines are shown so the
+        model can see why they are there.
+        """
+        self.progress.status("Choosing what to read...")
+        request = await self.llm_client.generate_object_code(
+            ReadRequest,
+            system=READ_INSTRUCTIONS,
+            messages=[
+                {
+                    "role": "user",
+                    "content": render_task(task, file_map, background=background),
+                }
+            ],
+        )
+        rendered, hits = "", []
+        if request.search:
+            self.progress.log("  searching for " + ", ".join(request.search))
+            rendered, hits = self.workspace.search_many(request.search)
+
+        known = {info.path for info in self.workspace.files()}
+        wanted, seen = [], set()
+        for path in list(request.paths) + hits:
+            path = path.strip().lstrip("./")
+            if path in known and path not in seen:
+                seen.add(path)
+                wanted.append(path)
+        return wanted[:MAX_READS], rendered
+
+
+def apply_patch_text(workspace: Workspace, diff: str) -> set[str]:
+    """Apply a whole patch, all files or none.
+
+    Every file's new contents are worked out before anything is written,
+    so a hunk that will not place in the third file does not leave the
+    first two edited and the change half-done. Returns the paths written.
+    """
+    patches = parse_patch(diff)
+    updated: dict[str, str] = {}
+
+    for file_patch in patches:
+        if not file_patch.hunks:
+            continue
+        # A patch may touch one file in several blocks — models happily
+        # emit two "*** Begin Patch" sections for the same path. Each has
+        # to build on the last, or the final block silently discards
+        # everything before it.
+        if file_patch.path in updated:
+            current = updated[file_patch.path]
+        elif workspace.exists(file_patch.path):
+            current = workspace.read(file_patch.path)
+        else:
+            current = ""  # a new file: hunks are pure insertions
+        try:
+            updated[file_patch.path] = apply_hunks(current, file_patch.hunks)
+        except PatchError as error:
+            raise PatchError(f"{file_patch.path}: {error}") from error
+
+    if not updated:
+        raise PatchError("the patch changed nothing")
+
+    # Generated data belongs to whatever produced it. A diff against two
+    # megabytes of rows is not an edit anyone reviewed, and regenerating
+    # the file is both correct and cheaper. Enforced rather than merely
+    # instructed, for the same reason an ambiguous hunk is refused: the
+    # rule is checkable here, so it should not depend on the model
+    # remembering it.
+    generated = sorted(path for path in updated if is_generated_data(path))
+    if generated:
+        raise PatchError(
+            f"{', '.join(generated)} is generated data and is not edited by hand. "
+            f"Change whatever produces it and let it be written again. To use it, "
+            f"read its {SCHEMA_SUFFIX} sidecar and write code against the global it names."
+        )
+
+    for path, content in updated.items():
+        workspace.write(path, content)
+    return set(updated)
+
+
+def _merge(existing: list[str], extra: list[str]) -> list[str]:
+    """Add paths to the read set, keeping order and dropping duplicates."""
+    merged = list(existing)
+    for path in extra:
+        if path not in merged:
+            merged.append(path)
+    return merged[:MAX_READS]
+
+
+def _repair_note(error: str, diff: str) -> str:
+    """What to tell the model after a diff would not apply.
+
+    It gets both the complaint and the diff back. Without seeing its own
+    output a model has no way to tell what was wrong with it, and
+    reproduces it almost verbatim — the single most common way a repair
+    loop burns three attempts achieving nothing.
+    """
+    return (
+        "Your diff did not apply. Hunks are placed by finding their text in the file, so "
+        "line numbers were not the problem — the context or removed lines did not match "
+        "the file exactly. Compare the lines below against the file contents you were "
+        "shown and copy them character for character, including indentation, quoting and "
+        "HTML entities. If a hunk was called ambiguous, give it more surrounding context.\n\n"
+        f"WHAT FAILED:\n{error}\n\nTHE DIFF THAT FAILED:\n{diff}"
+    )
+
+
+def _unseen_note(fresh: list[str], error: str) -> str:
+    """What to say when the diff failed against a file we had not read."""
+    return (
+        f"Your diff did not apply, and it touched {', '.join(fresh)} — which you had not "
+        f"been shown when you wrote it. The contents are included above now. Write the "
+        f"change again against what is actually there.\n\nWHAT FAILED:\n{error}"
+    )
+
+
+def _asked_note(files: list[str], queries: list[str]) -> str:
+    asked = ", ".join(files + [f'"{query}"' for query in queries])
+    return (
+        f"You asked about {asked} before writing the change. What was found is above. "
+        f"Now write it."
+    )
+
+
+def _join(existing: str, extra: str) -> str:
+    """Keep earlier search results alongside later ones."""
+    return "\n".join(block for block in (existing, extra) if block.strip())
+
+
+def _missing_note(missing: list[str]) -> str:
+    return (
+        f"The patch applied but did not create {', '.join(missing)}, which you listed as "
+        "files it touches. A file that does not exist yet must be created by the patch "
+        'itself: use "*** Add File: <path>" followed by every line of its contents each '
+        'prefixed with "+", or a unified diff whose header is "--- /dev/null". Include the '
+        "complete contents, not a description of them."
+    )

--- a/anton/core/yolo/data.py
+++ b/anton/core/yolo/data.py
@@ -1,0 +1,270 @@
+"""Generated data files and the schemas that describe them.
+
+A data file is one line:
+
+    window.ANTON_DATA_prices = [{"date": "2026-08-31", "price": 41.22}];
+
+That shape is chosen so it can be two things at once. A browser loads it
+with a plain `<script>` tag, which is the only thing that works both
+locally (an artifact opened from disk cannot `fetch()` a sibling file —
+browsers treat `file://` as cross-origin) and published over HTTP. And
+because the value is a JSON literal behind a fixed prefix, anything can
+read it back by stripping the wrapper — no JavaScript engine required.
+
+That second property is what makes the schema sidecar trustworthy.
+Rather than asking whoever wrote the data to also describe it — and
+hoping the description stays true — the schema is **derived from the
+bytes on disk**, and can be re-derived at any time. A sidecar cannot
+drift from its data, because nothing is ever asked to keep them in step.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from anton.core.yolo.workspace import (
+    DATA_SUFFIX,
+    Workspace,
+    WorkspaceError,
+    is_generated_data,
+    is_schema,
+    schema_for,
+)
+
+__all__ = [
+    "DataError",
+    "derive_schema",
+    "global_name",
+    "read_data",
+    "reconcile",
+    "write_data",
+]
+
+# Every generated global is prefixed, so a page can tell data apart from
+# whatever else it has hung on window.
+GLOBAL_PREFIX = "ANTON_DATA_"
+
+# The wrapper, and the pattern that undoes it.
+_ASSIGNMENT = re.compile(
+    r"^\s*window\.(" + GLOBAL_PREFIX + r"\w+)\s*=\s*(.*?);?\s*$", re.DOTALL
+)
+
+# How many rows to inspect when working out the shape. Enough to catch a
+# column that is null in the first row and a number in the second;
+# cheap enough to run on every reconcile.
+SAMPLE_ROWS = 200
+
+
+class DataError(Exception):
+    """A data file that could not be read back."""
+
+
+def global_name(name: str) -> str:
+    """The global a data file defines, from its base name."""
+    return GLOBAL_PREFIX + re.sub(r"\W", "_", name)
+
+
+def write_data(
+    workspace: Workspace, name: str, rows: Any, notes: str = ""
+) -> tuple[str, str]:
+    """Write `<name>.data.js` and its derived `<name>.schema.json`.
+
+    Returns both paths. `notes` is the one thing that cannot be derived —
+    units, gaps, timezones — so it is the only thing asked for.
+    """
+    data_path = f"{name}{DATA_SUFFIX}"
+    payload = json.dumps(rows, ensure_ascii=False, default=str)
+    workspace.write(data_path, f"window.{global_name(name)} = {payload};\n")
+    schema_path = _write_schema(workspace, data_path, rows, notes)
+    return data_path, schema_path
+
+
+def read_data(workspace: Workspace, data_path: str) -> Any:
+    """Read a data file back, without running any JavaScript."""
+    try:
+        text = workspace.read(data_path)
+    except WorkspaceError as error:
+        raise DataError(str(error)) from error
+    match = _ASSIGNMENT.match(text)
+    if not match:
+        raise DataError(
+            f"{data_path} is not in the expected "
+            f"`window.{GLOBAL_PREFIX}<name> = <json>;` shape"
+        )
+    try:
+        return json.loads(match.group(2))
+    except json.JSONDecodeError as error:
+        raise DataError(f"{data_path} does not hold valid JSON: {error}") from error
+
+
+def derive_schema(name: str, rows: Any, notes: str = "") -> dict:
+    """Work out what is in the data by looking at it.
+
+    Never by asking. A hand-written `{"price": "number"}` over rows that
+    actually hold `"1,234.00"` strings makes whoever reads the schema
+    write code against a lie — and that failure renders as a broken chart
+    rather than an error.
+    """
+    schema: dict[str, Any] = {
+        "global": global_name(name),
+        "file": f"{name}{DATA_SUFFIX}",
+        "shape": _shape(rows),
+        "generated": {"at": datetime.now(timezone.utc).isoformat(timespec="seconds")},
+    }
+    if isinstance(rows, list):
+        schema["rows"] = len(rows)
+        sample = rows[:SAMPLE_ROWS]
+        if sample and all(isinstance(row, dict) for row in sample):
+            schema["fields"] = _fields(sample)
+        elif sample:
+            schema["items"] = {"type": _type_of(sample[0])}
+    elif isinstance(rows, dict):
+        schema["fields"] = _fields([rows])
+    if notes.strip():
+        schema["notes"] = notes.strip()
+    return schema
+
+
+def reconcile(workspace: Workspace) -> list[str]:
+    """Make every data file's sidecar match the data, and report what changed.
+
+    This is the whole answer to sidecar drift: rather than requiring one
+    blessed way to produce data and hoping nothing else ever writes one,
+    the sidecars are recomputed from what is actually on disk. Run it
+    after anything that may have touched the folder.
+
+    A `notes` line already in a sidecar is preserved — it is the one field
+    nobody can derive, and regenerating over it would throw away the only
+    part a human wrote.
+    """
+    report: list[str] = []
+    data_files = [info.path for info in workspace.files() if is_generated_data(info.path)]
+
+    for data_path in data_files:
+        name = data_path[: -len(DATA_SUFFIX)]
+        sidecar = schema_for(data_path)
+        try:
+            rows = read_data(workspace, data_path)
+        except DataError as error:
+            report.append(f"{data_path}: cannot read it back — {error}")
+            continue
+
+        existing = _load_schema(workspace, sidecar)
+        fresh = derive_schema(name, rows, notes=str(existing.get("notes", "")))
+        if not existing:
+            _save(workspace, sidecar, fresh)
+            report.append(f"{sidecar}: written (it was missing)")
+        elif _differs(existing, fresh):
+            _save(workspace, sidecar, fresh)
+            report.append(f"{sidecar}: refreshed (it no longer matched the data)")
+
+    for info in workspace.files():
+        if is_schema(info.path) and not workspace.exists(_data_for(info.path)):
+            report.append(f"{info.path}: describes a data file that is not there")
+    return report
+
+
+# ── internals ───────────────────────────────────────────────────────────
+
+
+def _write_schema(workspace: Workspace, data_path: str, rows: Any, notes: str) -> str:
+    schema_path = schema_for(data_path)
+    _save(workspace, schema_path, derive_schema(data_path[: -len(DATA_SUFFIX)], rows, notes))
+    return schema_path
+
+
+def _save(workspace: Workspace, path: str, schema: dict) -> None:
+    workspace.write(path, json.dumps(schema, indent=2, ensure_ascii=False) + "\n")
+
+
+def _load_schema(workspace: Workspace, path: str) -> dict:
+    if not workspace.exists(path):
+        return {}
+    try:
+        loaded = json.loads(workspace.read(path))
+    except (WorkspaceError, json.JSONDecodeError):
+        return {}  # unreadable is as good as missing: it gets rewritten
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _differs(existing: dict, fresh: dict) -> bool:
+    """Compare what was derived, ignoring what was not.
+
+    `generated` is a timestamp and `notes` is human text; neither says
+    anything about whether the schema still describes the data.
+    """
+    keys = {"global", "file", "shape", "rows", "fields", "items"}
+    return {key: existing.get(key) for key in keys} != {
+        key: fresh.get(key) for key in keys
+    }
+
+
+def _data_for(schema_path: str) -> str:
+    return schema_path[: -len(".schema.json")] + DATA_SUFFIX
+
+
+def _shape(rows: Any) -> str:
+    if isinstance(rows, list):
+        if rows and all(isinstance(row, dict) for row in rows[:SAMPLE_ROWS]):
+            return "array<object>"
+        return "array"
+    if isinstance(rows, dict):
+        return "object"
+    return _type_of(rows)
+
+
+def _fields(sample: list[dict]) -> dict:
+    """Describe each column from the values actually present."""
+    fields: dict[str, Any] = {}
+    for key in _ordered_keys(sample):
+        values = [row.get(key) for row in sample]
+        present = [value for value in values if value is not None]
+        types = sorted({_type_of(value) for value in present})
+        field: dict[str, Any] = {
+            "type": types[0] if len(types) == 1 else " | ".join(types) or "null"
+        }
+        # Missing entirely and present-but-null are the same thing to
+        # whoever writes the code that reads it.
+        if len(present) != len(values):
+            field["nullable"] = True
+        if present:
+            field["example"] = _example(present[0])
+        fields[key] = field
+    return fields
+
+
+def _ordered_keys(sample: list[dict]) -> list[str]:
+    """Every key any row has, in the order first seen."""
+    keys: list[str] = []
+    for row in sample:
+        for key in row:
+            if key not in keys:
+                keys.append(key)
+    return keys
+
+
+def _type_of(value: Any) -> str:
+    # bool before int: in Python, True is an int, and calling it a number
+    # would send someone looking for arithmetic on a flag.
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return "null"
+
+
+def _example(value: Any) -> Any:
+    if isinstance(value, str) and len(value) > 80:
+        return value[:80] + "…"
+    if isinstance(value, (list, dict)):
+        return f"<{_type_of(value)}>"
+    return value

--- a/anton/core/yolo/models.py
+++ b/anton/core/yolo/models.py
@@ -1,0 +1,108 @@
+"""What a yolo run asks for and what it produces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, Field
+
+__all__ = ["Change", "Outcome", "Progress", "ReadRequest"]
+
+
+class Change(BaseModel):
+    """One attempt at the whole job.
+
+    Plan and patch are deliberately one object, and one request. Splitting
+    them cost a round trip and, worse, resent every file: the contents are
+    already in the conversation from the read calls, so a separate patch
+    request shipped them again to learn nothing new. Measured on
+    yolocoder, merging the two cut input bytes by roughly 60%.
+
+    `summary` and `files` come before `diff` in the schema so the model
+    still states its intent before writing the edit — the ordering is the
+    only thing left doing the work the separate planning call used to do.
+    """
+
+    summary: str = Field(description="One line saying what the change does.")
+    files: list[str] = Field(
+        default_factory=list,
+        description="Every file the diff modifies or creates, workspace-relative.",
+    )
+    diff: str = Field(
+        description=(
+            "The patch. Either a unified diff or the "
+            "'*** Begin Patch / *** Update File:' format."
+        )
+    )
+    need_files: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Files you must see before you can write this change. Leave empty "
+            "if you have everything. Asking is always better than guessing at "
+            "the contents of a file you were not shown."
+        ),
+    )
+    need_search: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Regular expressions to find, when you do not know which file holds "
+            "what you need to change. Leave empty if you know where to look."
+        ),
+    )
+
+
+class ReadRequest(BaseModel):
+    """The model asking to see files before it commits to a change."""
+
+    paths: list[str] = Field(
+        default_factory=list,
+        description="Workspace-relative paths to read, from the map.",
+    )
+    search: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Regular expressions to find, when the file names alone do not tell "
+            "you where something lives. Case-insensitive, matched per line, at "
+            "most 5 patterns. Escape anything you mean literally. Avoid nested "
+            "quantifiers like (x+)+ — they are cut off as runaway."
+        ),
+    )
+    reason: str = Field(default="", description="Why these files.")
+
+
+@dataclass
+class Outcome:
+    """What the run amounted to."""
+
+    applied: bool
+    summary: str = ""
+    files: list[str] = field(default_factory=list)
+    # Why it ended where it did. On failure this is the evidence to hand
+    # to whatever picks the job up next, which is the whole point of
+    # keeping it rather than collapsing to a bool.
+    detail: str = ""
+    attempts: int = 0
+    # Which rung it stopped on, so a caller can tell "the model would not
+    # produce a usable diff" from "the folder is not writable".
+    # Spelled `status` and not `reason` on purpose. anton reserves the
+    # `reason="..."` kwarg for handler failure sentinels, which are tiered
+    # in core/root_cause.py as self-fixable or environment wall, and a
+    # tree-wide test asserts every one of them is classified. These are
+    # not that — "applied" is a success — so registering them would put
+    # unrelated values into a telemetry taxonomy and skew the wall counts
+    # it exists to measure.
+    status: Literal["applied", "patch_failed", "no_diff", "error", ""] = ""
+
+
+class Progress(Protocol):
+    """Where a run says what it is doing.
+
+    A protocol rather than a logger so the caller decides: anton streams
+    these into the chat UI, tests collect them into a list, a CLI prints
+    them.
+    """
+
+    def status(self, message: str) -> None: ...
+
+    def log(self, message: str) -> None: ...

--- a/anton/core/yolo/patch.py
+++ b/anton/core/yolo/patch.py
@@ -1,0 +1,257 @@
+"""Applying a model-written diff by finding its content.
+
+The one thing worth knowing about LLMs and diffs, learned the hard way
+building yolocoder: **models get the content right and the arithmetic
+wrong.** They reproduce the lines of a file faithfully and then miscount
+`@@ -14,7 +14,9 @@`, start a hunk one line off, or end a hunk on its
+last change with no trailing context — which `git apply` rejects outright,
+because a hunk with no trailing context asserts the file ends there.
+
+None of that bookkeeping needs the model. The file is right here. So this
+module throws away every line number and count in the patch and places
+each hunk by locating its text.
+
+That single change took patch application from roughly half of attempts to
+almost all of them, and it is the reason this module exists as pure
+functions over strings with no dependencies: it is the valuable part, and
+it should be trivially testable and liftable into any other project.
+
+The other half of the lesson is where it *refuses*. A hunk whose context
+cannot be found, or a short hunk matching in several places, is not
+something to guess at — guessing means editing the wrong part of someone's
+file and reporting success. Both are errors, and their messages are
+written to be fed straight back to the model as evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = [
+    "Hunk",
+    "FilePatch",
+    "PatchError",
+    "apply_hunks",
+    "is_apply_patch_format",
+    "locate",
+    "parse_patch",
+]
+
+
+class PatchError(Exception):
+    """A patch that could not be read or could not be placed.
+
+    The message is written for the model, not only for the log: it is fed
+    back as the evidence for the next attempt, so it says what was looked
+    for and what was wrong rather than just that something failed.
+    """
+
+
+@dataclass
+class Hunk:
+    """One contiguous edit.
+
+    `before` is what must be found in the file (context + removed lines,
+    in order); `after` is what replaces it (context + added lines). Line
+    numbers are deliberately absent — there is nowhere to put them.
+    """
+
+    before: list[str] = field(default_factory=list)
+    after: list[str] = field(default_factory=list)
+
+    @property
+    def empty(self) -> bool:
+        return not self.before and not self.after
+
+
+@dataclass
+class FilePatch:
+    path: str
+    hunks: list[Hunk] = field(default_factory=list)
+
+
+# Headers of OpenAI's apply_patch (V4A) format. Models trained on it reach
+# for it whatever you ask for, and it happens to suit content placement
+# perfectly because it carries no line numbers at all — so it is accepted
+# rather than fought.
+_BEGIN = "*** Begin Patch"
+_END = "*** End Patch"
+_UPDATE = "*** Update File:"
+_ADD = "*** Add File:"
+_DELETE = "*** Delete File:"
+
+
+def is_apply_patch_format(patch: str) -> bool:
+    """Whether the patch uses apply_patch headers rather than a unified diff."""
+    for line in patch.split("\n"):
+        line = line.strip()
+        if line.startswith((_BEGIN, _UPDATE, _ADD, _DELETE)):
+            return True
+        if line.startswith(("diff --git ", "--- ")):
+            return False
+    return False
+
+
+def parse_patch(patch: str) -> list[FilePatch]:
+    """Pull the per-file hunks out of a diff, in either dialect.
+
+    Accepting both is not indulgence. Which one a model reaches for
+    depends on what it was trained on, and rejecting the other dialect
+    throws away a perfectly good edit over its packaging.
+    """
+    patches: list[FilePatch] = []
+    current: FilePatch | None = None
+    active: Hunk | None = None
+
+    # Trailing blank lines come from the patch text ending in a newline,
+    # not from empty context lines. Counting them as context makes every
+    # final hunk unmatchable.
+    for line in patch.rstrip("\n").split("\n"):
+        if line.startswith(("diff --git ", "--- ")):
+            active = None
+        elif line.startswith("+++ "):
+            active = None
+            path = _patch_path(line[len("+++ ") :])
+            if not path:
+                current = None
+                continue
+            current = FilePatch(path=path)
+            patches.append(current)
+
+        elif line.startswith((_BEGIN, _END)):
+            active = None
+        elif line.startswith((_UPDATE, _ADD)):
+            _, _, raw = line.partition(":")
+            path = _patch_path(raw)
+            if not path:
+                current, active = None, None
+                continue
+            current = FilePatch(path=path)
+            patches.append(current)
+            # "*** Add File:" is followed straight by its "+" lines with no
+            # "@@" of its own. Start collecting immediately or the whole
+            # file's contents are read as noise and nothing gets created.
+            # "*** Update File:" normally does have a "@@"; the empty hunk
+            # that leaves behind is dropped at the end.
+            active = Hunk()
+            current.hunks.append(active)
+        elif line.startswith(_DELETE):
+            _, _, raw = line.partition(":")
+            raise PatchError(
+                f"the patch deletes {raw.strip()}, which this does not do"
+            )
+
+        elif line.startswith("@@"):
+            if current is None:
+                raise PatchError("hunk before any file header")
+            active = Hunk()
+            current.hunks.append(active)
+        elif active is None:
+            pass  # preamble, index lines, or trailing noise
+        elif line.startswith("-"):
+            active.before.append(line[1:])
+        elif line.startswith("+"):
+            active.after.append(line[1:])
+        elif line.startswith(" "):
+            active.before.append(line[1:])
+            active.after.append(line[1:])
+        elif line == "":
+            # Empty inside a hunk is an empty context line; empty at the
+            # end of the patch is not. It only counts while collecting.
+            active.before.append("")
+            active.after.append("")
+        elif line.startswith("\\"):
+            pass  # "\ No newline at end of file"
+        else:
+            active = None
+
+    if not patches:
+        raise PatchError("no file headers in patch")
+
+    # A hunk that collected nothing carries no instruction, and leaving one
+    # in would read as "replace this file with nothing".
+    for file_patch in patches:
+        file_patch.hunks = [hunk for hunk in file_patch.hunks if not hunk.empty]
+    return patches
+
+
+def _patch_path(raw: str) -> str:
+    """Turn a diff header path into a workspace-relative one."""
+    raw = raw.strip()
+    tab = raw.find("\t")
+    if tab != -1:
+        raw = raw[:tab]
+    if raw == "/dev/null":
+        return ""
+    for prefix in ("a/", "b/"):
+        if raw.startswith(prefix):
+            return raw[len(prefix) :]
+    return raw
+
+
+def apply_hunks(content: str, hunks: list[Hunk]) -> str:
+    """Apply hunks to content, placing each by its text.
+
+    Hunks are applied in order against the running result, so two edits to
+    the same file compose instead of the second being measured against a
+    file that no longer looks like that.
+    """
+    lines = content.split("\n")
+    for hunk in hunks:
+        if not hunk.before:
+            # A pure insertion has no context, so there is nowhere it
+            # provably belongs — unless the file is empty, in which case
+            # there is only one place it can go.
+            if not content.strip():
+                lines = list(hunk.after)
+                continue
+            raise PatchError("a hunk has no context to place it by")
+        index = locate(lines, hunk.before)
+        lines = lines[:index] + list(hunk.after) + lines[index + len(hunk.before) :]
+    return "\n".join(lines)
+
+
+def locate(lines: list[str], block: list[str]) -> int:
+    """Find the one place block occurs in lines.
+
+    Two refusals are deliberate. A block that cannot be found is not
+    quietly skipped, and a short block found in several places is not
+    resolved by taking the first — that is how an edit lands in the wrong
+    function and reports success. Both raise, and both messages are
+    written to be handed back to the model.
+    """
+    matches = _find_all(lines, block, lambda a, b: a == b)
+    if not matches:
+        # Fall back to ignoring indentation drift, which a model
+        # reproducing a file by eye often gets slightly wrong while
+        # getting every actual character right.
+        matches = _find_all(lines, block, lambda a, b: a.strip() == b.strip())
+
+    if not matches:
+        raise PatchError(
+            "could not find this hunk's lines in the file:\n" + _preview(block)
+        )
+    if len(matches) > 1 and len(block) < _AMBIGUOUS_BELOW:
+        raise PatchError(
+            f"this hunk's lines appear {len(matches)} times, "
+            f"too ambiguous to place:\n{_preview(block)}"
+        )
+    return matches[0]
+
+
+# Below this many lines, a block matching more than once is treated as
+# ambiguous rather than resolved by position. Three is where a match stops
+# being a coincidence in practice.
+_AMBIGUOUS_BELOW = 3
+
+
+def _find_all(lines: list[str], block: list[str], equal) -> list[int]:
+    matches = []
+    for start in range(len(lines) - len(block) + 1):
+        if all(equal(lines[start + offset], want) for offset, want in enumerate(block)):
+            matches.append(start)
+    return matches
+
+
+def _preview(block: list[str]) -> str:
+    return "\n".join(block[:4])

--- a/anton/core/yolo/prompts.py
+++ b/anton/core/yolo/prompts.py
@@ -1,0 +1,103 @@
+"""The instructions, and why each paragraph is there.
+
+Every rule below was added because something specific went wrong. They are
+kept in one place, with the reason attached, so that nobody trims one for
+being wordy without knowing which failure it is holding back.
+"""
+
+from __future__ import annotations
+
+__all__ = ["CHANGE_INSTRUCTIONS", "READ_INSTRUCTIONS", "render_task"]
+
+
+# Read selection. Models are genuinely good at this — shown thirty paths
+# they ask for the right two or three — so the instruction is short and
+# mostly about not over-reading.
+READ_INSTRUCTIONS = """\
+You are about to make one change to a folder, and you are looking at its file listing.
+
+Name the files you need to see to make the change correctly. Ask for the ones you will edit
+and the ones you must not break: a file that imports what you are changing, a config that
+names it, a test that covers it.
+
+If the file names do not tell you where something lives, put a regular expression in search
+instead of guessing at paths. Searching costs nothing — it does not call a model — so a query is
+always cheaper than reading a file on the off-chance. Patterns are case-insensitive and matched
+a line at a time; escape anything you mean literally, and keep them simple, because a pattern
+that backtracks badly is cut off rather than waited for.
+
+Do not ask for everything. Reading a file you do not need costs the room you will want for
+the edit itself. Three or four files is usually right; more than eight almost never is.
+Return an empty list only if the listing alone is genuinely enough."""
+
+
+# The change itself. Every paragraph after the first is scar tissue.
+CHANGE_INSTRUCTIONS = """\
+You are making one change to a folder. You have been shown its file listing and the full
+contents of the files you asked for.
+
+Answer with the change: a one-line summary, every file it touches, and the diff that makes it.
+Make the smallest complete change that does the job.
+
+The diff may be a unified diff or the "*** Begin Patch / *** Update File:" format. Either is
+read by matching its text against the file, so line numbers, @@ headers and hunk counts are
+IGNORED and do not need to be correct. Do not spend effort on them.
+
+What must be exact is the text. Copy every context line and every removed line from the file
+character for character: the same indentation, the same quotes, the same HTML entities
+(&amp; stays &amp;), the same trailing spaces. A line that differs by one character cannot be
+found, and the hunk it belongs to will not apply.
+
+Surround each change with a few unchanged lines above and below, so there is exactly one place
+in the file it could go. A hunk with one line of context that appears in twenty places will be
+refused as ambiguous rather than applied to the wrong one.
+
+A file that does not exist yet is created by the same diff: use "*** Add File: <path>" followed
+by every line of its contents, each prefixed with "+", or a unified diff whose header is
+"--- /dev/null". Every file you list must actually appear in the diff with its full contents.
+Naming a file you meant to add, or describing it instead of including it, leaves it uncreated
+and the change half-done.
+
+Some folders carry generated data as "<name>.data.js" with a "<name>.schema.json" sidecar
+beside it. The schemas are shown to you in full; the data files never are, because they are far
+too large. Never write a diff against a .data.js file — it is produced by something else and
+editing it by hand is not a change anyone can review. To use the data, read its schema and write
+code against the global variable the schema names.
+
+If you find you cannot write the change because you have not seen the right file, say so
+instead of guessing: put the paths in need_files, or — if you do not know which file it is —
+put a regular expression in need_search, and leave diff empty. You will be shown what
+was found and asked again. A guessed diff against a file you were never shown cannot apply.
+
+Do not delete files. Do not touch anything outside the folder."""
+
+
+def render_task(
+    task: str,
+    file_map: str,
+    contents: str = "",
+    background: str = "",
+    evidence: str = "",
+    found: str = "",
+) -> str:
+    """Lay out one request.
+
+    The order is not cosmetic. It runs from the part that never changes to
+    the part that changes every attempt — background, then the map, then
+    the file contents, then the task, and the failure evidence last. A
+    provider's prefix cache can only reuse an unchanged head, so anything
+    stable that sits behind something volatile is paid for again on every
+    retry. On a three-attempt repair loop that is most of the bill.
+    """
+    blocks = []
+    if background.strip():
+        blocks.append(f"BACKGROUND:\n{background.strip()}")
+    blocks.append(f"THE FOLDER:\n{file_map}")
+    if found.strip():
+        blocks.append(f"SEARCH RESULTS:\n{found.strip()}")
+    if contents.strip():
+        blocks.append(f"FILE CONTENTS:\n{contents.rstrip()}")
+    blocks.append(f"TASK:\n{task.strip()}")
+    if evidence.strip():
+        blocks.append(f"WHAT WENT WRONG LAST TIME:\n{evidence.strip()}")
+    return "\n\n".join(blocks)

--- a/anton/core/yolo/workspace.py
+++ b/anton/core/yolo/workspace.py
@@ -1,0 +1,412 @@
+"""The folder a yolo run is allowed to touch.
+
+Every path the model names is resolved against one root and refused if it
+lands outside it. This is not a sandbox — the process can still do
+anything — but it does mean a hallucinated `../../etc/hosts` in a diff is
+an error rather than a write, and that is the failure worth closing.
+
+Nothing here knows about anton. It is a folder, some files, and a size
+budget.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+import signal
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = [
+    "DATA_SUFFIX",
+    "Match",
+    "SearchResult",
+    "SCHEMA_SUFFIX",
+    "Workspace",
+    "WorkspaceError",
+    "is_generated_data",
+    "is_schema",
+    "schema_for",
+]
+
+# The naming convention that divides the two tools' territory.
+#
+# `prices.data.js` is written by the scratchpad, which is what should be
+# producing data: extraction, transformation, arithmetic. It is `.js`
+# rather than `.json` on purpose — an artifact opened over file:// cannot
+# fetch() a JSON file, so the data has to arrive as a <script> defining a
+# global.
+#
+# `prices.schema.json` is its sidecar: what the columns are, and what
+# global the data file defines. It is JSON rather than JavaScript because
+# nothing loads it — only the agent reads it — and a file that is never
+# executed should not look executable.
+#
+# Sidecar rather than a central registry: it survives the folder being
+# copied, it is visible to whoever opens the artifact, and there is only
+# one place to look.
+DATA_SUFFIX = ".data.js"
+SCHEMA_SUFFIX = ".schema.json"
+
+
+def is_generated_data(path: str) -> bool:
+    """Whether this is a generated data file, which yolo must not edit."""
+    return path.endswith(DATA_SUFFIX)
+
+
+def is_schema(path: str) -> bool:
+    return path.endswith(SCHEMA_SUFFIX)
+
+
+def schema_for(data_path: str) -> str:
+    """The sidecar that should describe this data file."""
+    return data_path[: -len(DATA_SUFFIX)] + SCHEMA_SUFFIX
+
+
+class WorkspaceError(Exception):
+    """A path that escaped the workspace, or a file that could not be read."""
+
+
+# Files above this size are listed in the map but never inlined: a single
+# bundled asset can otherwise eat the whole context window and leave no
+# room for the change itself.
+MAX_FILE_BYTES = 256 * 1024
+
+# Directories that are never worth mapping. Their contents are numerous,
+# uninteresting, and not what anyone means by "the artifact".
+SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        "dist",
+        "build",
+        ".next",
+        ".idea",
+        ".vscode",
+    }
+)
+
+
+# Caps on what one search can return. A common word must not be able to
+# flood the prompt: three lines from any one file is enough to say "it is
+# in here", and twenty across the folder is enough to say "here is where".
+MAX_MATCHES_PER_FILE = 3
+MAX_MATCHES_PER_QUERY = 20
+MAX_MATCH_LINE = 200
+
+# How long one pattern may run before it is cut off, and how many
+# patterns one request may ask for. The product is the worst case a
+# pathological regex can cost, and 5s is a pause rather than a hang.
+SEARCH_TIMEOUT = 1.0
+MAX_QUERIES = 5
+
+
+def _can_interrupt() -> bool:
+    """Whether a runaway match can be stopped here.
+
+    SIGALRM exists only on Unix, and a handler can only be installed from
+    the main thread. Both are checked because the alternative to knowing
+    is a hang with no way out.
+    """
+    return (
+        hasattr(signal, "SIGALRM")
+        and threading.current_thread() is threading.main_thread()
+    )
+
+
+@contextlib.contextmanager
+def _time_limit(seconds: float):
+    """Raise TimeoutError if the block runs longer than seconds.
+
+    This works on a regex specifically because `sre` checks for pending
+    signals while it matches — a plain thread could not interrupt it.
+    """
+    def ring(*_):
+        raise TimeoutError
+
+    previous = signal.signal(signal.SIGALRM, ring)
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+def _clip(line: str) -> str:
+    return line if len(line) <= MAX_MATCH_LINE else line[:MAX_MATCH_LINE] + " …"
+
+
+@dataclass
+class Match:
+    """One line of one file that matched."""
+
+    path: str
+    line: int
+    text: str
+
+
+@dataclass
+class SearchResult:
+    """What one query found, and anything the model should know about it.
+
+    `note` carries the things worth saying out loud: a pattern that would
+    not compile, one that had to be cut short, or a platform where the
+    search fell back to literal text. All three are feedback the model
+    can act on, which is why they travel with the result instead of being
+    logged and lost.
+    """
+
+    query: str
+    matches: list[Match] = field(default_factory=list)
+    note: str = ""
+
+
+@dataclass
+class FileInfo:
+    path: str  # workspace-relative, forward slashes
+    bytes: int
+
+
+class Workspace:
+    """Read and write access confined to one folder."""
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root).resolve()
+
+    # ── paths ────────────────────────────────────────────────────────
+
+    def resolve(self, relative: str) -> Path:
+        """Resolve a workspace-relative path, refusing anything outside.
+
+        The check is on the resolved path, so `a/../../b` is caught as
+        readily as `../b`. Symlinks are resolved too: a link pointing out
+        of the workspace is a way out of the workspace.
+        """
+        candidate = (self.root / relative).resolve()
+        if candidate != self.root and self.root not in candidate.parents:
+            raise WorkspaceError(f"{relative} is outside the workspace")
+        return candidate
+
+    # ── reading ──────────────────────────────────────────────────────
+
+    def read(self, relative: str) -> str:
+        path = self.resolve(relative)
+        if not path.is_file():
+            raise WorkspaceError(f"{relative} does not exist")
+        try:
+            return path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as error:
+            raise WorkspaceError(f"{relative} is not text") from error
+
+    def exists(self, relative: str) -> bool:
+        try:
+            return self.resolve(relative).is_file()
+        except WorkspaceError:
+            return False
+
+    def read_many(self, paths: list[str]) -> str:
+        """Read several files into one labelled block for the model.
+
+        A file that cannot be read reports why in place rather than
+        failing the batch: the model asked for five files and getting
+        four plus an explanation is more useful than getting none.
+        """
+        chunks = []
+        for relative in paths:
+            try:
+                body = self.read(relative)
+            except WorkspaceError as error:
+                chunks.append(f"--- {relative} ---\n({error})\n")
+                continue
+            if len(body.encode("utf-8")) > MAX_FILE_BYTES:
+                chunks.append(
+                    f"--- {relative} ---\n"
+                    f"(too large to show: {len(body.encode('utf-8'))} bytes)\n"
+                )
+                continue
+            chunks.append(f"--- {relative} ---\n{body}\n")
+        return "".join(chunks)
+
+    # ── writing ──────────────────────────────────────────────────────
+
+    def write(self, relative: str, content: str) -> None:
+        path = self.resolve(relative)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    # ── searching ────────────────────────────────────────────────────
+
+    def search(self, query: str) -> SearchResult:
+        """Find a regular expression in the workspace, case-insensitively.
+
+        Regex rather than literal text, because models write it well and
+        it is what makes the difference between finding a thing and
+        finding where a thing is defined: `function\\s+draw\\w*` beats
+        guessing at the exact spelling.
+
+        The one real hazard is catastrophic backtracking. It is not
+        hypothetical — `(a+)+b` against thirty characters takes 46
+        seconds on this machine, and grows exponentially from there, so
+        no cap on line length or file size contains it. What does contain
+        it is a wall-clock interrupt: `sre` checks for signals while
+        matching, so an alarm cuts a runaway pattern short.
+
+        Where an alarm cannot be armed — Windows, or off the main thread —
+        the pattern is escaped and searched for literally instead. That is
+        a real loss of power, but it is the honest trade against a hang,
+        and the result says which one happened.
+
+        Generated data is skipped. Searching two megabytes of rows for
+        "price" returns eight thousand lines of noise and buries the one
+        line of code that reads them.
+        """
+        pattern = query.strip()
+        if not pattern:
+            return SearchResult(query, [], "empty query")
+
+        note = ""
+        if not _can_interrupt():
+            # No way to stop a runaway match here, so do not start one.
+            pattern, note = re.escape(pattern), "searched literally (no regex on this platform)"
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error as error:
+            # Handed back to the model rather than raised: a bad pattern
+            # is something it can fix on the next attempt, and "invalid
+            # pattern" is more use to it than a stack trace.
+            return SearchResult(query, [], f"invalid pattern: {error}")
+
+        matches: list[Match] = []
+        try:
+            with _time_limit(SEARCH_TIMEOUT):
+                self._scan(compiled, matches)
+        except TimeoutError:
+            note = (
+                f"timed out after {SEARCH_TIMEOUT:g}s — the pattern backtracks badly; "
+                f"simplify it (avoid nested quantifiers like (x+)+)"
+            )
+        return SearchResult(query, matches, note)
+
+    def _scan(self, compiled: re.Pattern, matches: list[Match]) -> None:
+        """Fill matches, respecting the caps. Interruptible by the alarm."""
+        for info in self.files():
+            if is_generated_data(info.path) or info.bytes > MAX_FILE_BYTES:
+                continue
+            try:
+                content = self.read(info.path)
+            except WorkspaceError:
+                continue
+            found = 0
+            for number, line in enumerate(content.split("\n"), start=1):
+                if not compiled.search(line):
+                    continue
+                matches.append(Match(info.path, number, _clip(line.strip())))
+                found += 1
+                # Both caps are checked here. Testing the total only
+                # between files lets a single file overshoot it by up to
+                # MAX_MATCHES_PER_FILE - 1.
+                if found >= MAX_MATCHES_PER_FILE or len(matches) >= MAX_MATCHES_PER_QUERY:
+                    break
+            if len(matches) >= MAX_MATCHES_PER_QUERY:
+                return
+
+    def search_many(self, queries: list[str]) -> tuple[str, list[str]]:
+        """Run several searches, returning what to show and where to look.
+
+        A query with no matches is reported as such rather than omitted.
+        "that pattern matches nothing in this folder" is a real answer,
+        and the one that stops the model looking for it.
+        """
+        blocks: list[str] = []
+        hits: list[str] = []
+        for query in queries[:MAX_QUERIES]:
+            result = self.search(query)
+            header = f'"{result.query}"'
+            if result.note:
+                header += f"  [{result.note}]"
+            if not result.matches:
+                blocks.append(f"{header} — no matches")
+                continue
+            lines = [f"{header} —"]
+            for match in result.matches:
+                lines.append(f"  {match.path}:{match.line}  {match.text}")
+                if match.path not in hits:
+                    hits.append(match.path)
+            blocks.append("\n".join(lines))
+        if len(queries) > MAX_QUERIES:
+            blocks.append(
+                f"({len(queries) - MAX_QUERIES} further quer"
+                f"{'y was' if len(queries) - MAX_QUERIES == 1 else 'ies were'} not run: "
+                f"at most {MAX_QUERIES} per request)"
+            )
+        return "\n".join(blocks), hits
+
+    # ── mapping ──────────────────────────────────────────────────────
+
+    def files(self) -> list[FileInfo]:
+        """Every text-ish file in the workspace, sorted by path."""
+        found: list[FileInfo] = []
+        for path in sorted(self.root.rglob("*")):
+            if not path.is_file():
+                continue
+            if any(part in SKIP_DIRS for part in path.relative_to(self.root).parts):
+                continue
+            found.append(
+                FileInfo(
+                    path=path.relative_to(self.root).as_posix(),
+                    bytes=path.stat().st_size,
+                )
+            )
+        return found
+
+    def map(self) -> str:
+        """The listing the model starts from.
+
+        Paths and sizes, never contents — with one deliberate exception.
+        Which files matter is the one judgement models are reliably good
+        at: given the names, they ask for the right two or three out of
+        thirty. Inlining everything up front spends the context window to
+        save a decision they were going to make correctly anyway.
+
+        The exception is schema sidecars. A line reading
+        `prices.data.js (2.1 MB)` tells the model nothing it can write
+        code against, and the file itself can never be inlined. Its
+        sidecar can: a few hundred bytes that say what the columns are
+        and — the part that actually matters — what global the data file
+        defines. So schemas are always included in full, and the data
+        files they describe are always listed and never read.
+        """
+        entries = self.files()
+        if not entries:
+            return "(the folder is empty)"
+
+        lines = []
+        for entry in entries:
+            note = ""
+            if is_generated_data(entry.path):
+                sidecar = schema_for(entry.path)
+                note = (
+                    f"  ← generated data, see {sidecar}"
+                    if self.exists(sidecar)
+                    else "  ← generated data (no schema sidecar)"
+                )
+            lines.append(f"{entry.path} ({entry.bytes} bytes){note}")
+
+        schemas = [entry.path for entry in entries if is_schema(entry.path)]
+        if not schemas:
+            return "\n".join(lines)
+
+        blocks = ["\n".join(lines), "\nDATA SCHEMAS (read these instead of the data files):"]
+        for path in schemas:
+            try:
+                blocks.append(f"--- {path} ---\n{self.read(path).strip()}")
+            except WorkspaceError as error:
+                blocks.append(f"--- {path} ---\n({error})")
+        return "\n".join(blocks)

--- a/tests/test_yolo_agent.py
+++ b/tests/test_yolo_agent.py
@@ -1,0 +1,435 @@
+"""Coverage for the yolo workspace and edit loop.
+
+The LLM is a stub that returns whatever the test queues up, so the loop's
+behaviour — how many calls it makes, what it retries, when it gives up and
+what it says on the way out — is asserted exactly, with no provider and no
+network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from anton.core.yolo import (
+    MAX_ATTEMPTS,
+    Change,
+    Outcome,
+    ReadRequest,
+    Workspace,
+    WorkspaceError,
+    YoloEditor,
+)
+
+# ─── Workspace ──────────────────────────────────────────────────────────
+
+
+def test_a_path_outside_the_folder_is_refused(tmp_path: Path):
+    """A hallucinated ../.. in a diff must be an error, not a write."""
+    workspace = Workspace(tmp_path / "art")
+    workspace.root.mkdir(parents=True)
+    for escape in ["../secrets.txt", "a/../../secrets.txt", "/etc/hosts"]:
+        with pytest.raises(WorkspaceError, match="outside"):
+            workspace.resolve(escape)
+
+
+def test_reading_and_writing_round_trips(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    workspace.write("nested/deep/file.txt", "hello")
+    assert workspace.read("nested/deep/file.txt") == "hello"
+    assert workspace.exists("nested/deep/file.txt")
+    assert not workspace.exists("nope.txt")
+
+
+def test_the_map_lists_paths_and_sizes_but_never_contents(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    workspace.write("index.html", "<h1>secret marker</h1>")
+    workspace.write("src/app.js", "x")
+    file_map = workspace.map()
+    assert "index.html" in file_map and "src/app.js" in file_map
+    assert "secret marker" not in file_map
+
+
+def test_noise_directories_are_not_mapped(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    workspace.write("real.py", "x")
+    workspace.write("node_modules/pkg/index.js", "x")
+    workspace.write("__pycache__/real.pyc", "x")
+    assert [info.path for info in workspace.files()] == ["real.py"]
+
+
+def test_an_unreadable_file_explains_itself_instead_of_failing_the_batch(
+    tmp_path: Path,
+):
+    workspace = Workspace(tmp_path)
+    workspace.write("good.txt", "content")
+    text = workspace.read_many(["good.txt", "missing.txt"])
+    assert "content" in text
+    assert "does not exist" in text
+
+
+# ─── A stub coder ───────────────────────────────────────────────────────
+
+
+class StubCoder:
+    """Returns queued objects and records what it was asked."""
+
+    def __init__(self, *responses):
+        self.queue = list(responses)
+        self.calls: list[dict] = []
+
+    async def generate_object_code(
+        self, schema_class, *, system, messages, max_tokens=None
+    ):
+        self.calls.append(
+            {
+                "schema": schema_class,
+                "system": system,
+                "content": messages[0]["content"],
+            }
+        )
+        if not self.queue:
+            raise AssertionError("the loop asked for more calls than the test queued")
+        return self.queue.pop(0)
+
+
+def make_workspace(tmp_path: Path) -> Workspace:
+    workspace = Workspace(tmp_path)
+    workspace.write("index.html", "<title>Old Title</title>\n<p>body</p>\n")
+    workspace.write("style.css", "body { color: red; }\n")
+    return workspace
+
+
+# ─── The happy path ─────────────────────────────────────────────────────
+
+
+async def test_a_change_that_applies_takes_two_calls(tmp_path: Path):
+    """One to pick files, one to plan and patch. That is the budget."""
+    workspace = make_workspace(tmp_path)
+    coder = StubCoder(
+        ReadRequest(paths=["index.html"]),
+        Change(
+            summary="Retitled it",
+            files=["index.html"],
+            diff="--- a/index.html\n+++ b/index.html\n@@\n"
+            "-<title>Old Title</title>\n+<title>New Title</title>\n",
+        ),
+    )
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("retitle it")
+
+    assert outcome.applied
+    assert outcome.attempts == 1
+    assert outcome.files == ["index.html"]
+    assert len(coder.calls) == 2
+    assert "New Title" in workspace.read("index.html")
+    # The body it did not touch is still there.
+    assert "<p>body</p>" in workspace.read("index.html")
+
+
+async def test_only_the_files_asked_for_are_inlined(tmp_path: Path):
+    """Reading a file the change does not need spends the room the change
+    itself will want."""
+    workspace = make_workspace(tmp_path)
+    coder = StubCoder(
+        ReadRequest(paths=["index.html"]),
+        Change(summary="s", files=[], diff="--- a/index.html\n+++ b/index.html\n@@\n-<p>body</p>\n+<p>hi</p>\n"),
+    )
+    await YoloEditor(workspace=workspace, llm_client=coder).edit("change the body")
+
+    change_request = coder.calls[1]["content"]
+    assert "Old Title" in change_request  # index.html was inlined
+    assert "color: red" not in change_request  # style.css was not
+
+
+async def test_a_file_the_model_invents_is_dropped_not_read(tmp_path: Path):
+    workspace = make_workspace(tmp_path)
+    coder = StubCoder(
+        ReadRequest(paths=["index.html", "does_not_exist.js"]),
+        Change(summary="s", files=[], diff="--- a/index.html\n+++ b/index.html\n@@\n-<p>body</p>\n+<p>hi</p>\n"),
+    )
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("x")
+    assert outcome.applied
+    assert "does_not_exist.js" not in coder.calls[1]["content"]
+
+
+async def test_a_new_file_is_created_by_the_patch(tmp_path: Path):
+    workspace = make_workspace(tmp_path)
+    coder = StubCoder(
+        ReadRequest(paths=[]),
+        Change(
+            summary="Added French",
+            files=["fr.json"],
+            diff='*** Begin Patch\n*** Add File: fr.json\n+{\n+  "hello": "bonjour"\n+}\n*** End Patch\n',
+        ),
+    )
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("add french")
+    assert outcome.applied
+    assert "bonjour" in workspace.read("fr.json")
+
+
+# ─── The repair ladder ──────────────────────────────────────────────────
+
+
+async def test_a_failed_diff_is_retried_with_its_own_output_as_evidence(
+    tmp_path: Path,
+):
+    """Told only that it failed, a model reproduces the same diff. It has
+    to see what it wrote."""
+    workspace = make_workspace(tmp_path)
+    bad = "--- a/index.html\n+++ b/index.html\n@@\n-<title>WRONG</title>\n+<title>New</title>\n"
+    coder = StubCoder(
+        ReadRequest(paths=["index.html"]),
+        Change(summary="try one", files=["index.html"], diff=bad),
+        Change(
+            summary="try two",
+            files=["index.html"],
+            diff="--- a/index.html\n+++ b/index.html\n@@\n"
+            "-<title>Old Title</title>\n+<title>New</title>\n",
+        ),
+    )
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("retitle")
+
+    assert outcome.applied
+    assert outcome.attempts == 2
+    retry = coder.calls[2]["content"]
+    assert "WHAT WENT WRONG LAST TIME" in retry
+    assert "could not find" in retry  # the diagnosis
+    assert "<title>WRONG</title>" in retry  # its own failed diff
+
+
+async def test_it_gives_up_after_three_diffs_and_says_why(tmp_path: Path):
+    """The handoff contract. After MAX_ATTEMPTS the outcome carries the
+    diagnosis so the caller can pass the job on with it attached."""
+    workspace = make_workspace(tmp_path)
+    bad = Change(
+        summary="nope",
+        files=["index.html"],
+        diff="--- a/index.html\n+++ b/index.html\n@@\n-<title>WRONG</title>\n+<title>x</title>\n",
+    )
+    coder = StubCoder(ReadRequest(paths=["index.html"]), bad, bad, bad)
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("retitle")
+
+    assert not outcome.applied
+    assert outcome.status == "patch_failed"
+    assert outcome.attempts == MAX_ATTEMPTS
+    assert "could not find" in outcome.detail
+    # And the file was left exactly as it was.
+    assert workspace.read("index.html") == "<title>Old Title</title>\n<p>body</p>\n"
+
+
+async def test_a_promised_file_that_was_not_created_is_caught(tmp_path: Path):
+    """A patch that omits the new file it promised applies perfectly and
+    looks like success. It is not success."""
+    workspace = make_workspace(tmp_path)
+    lying = Change(
+        summary="added a helper",
+        files=["index.html", "helper.js"],  # helper.js never appears in the diff
+        diff="--- a/index.html\n+++ b/index.html\n@@\n-<p>body</p>\n+<p>new</p>\n",
+    )
+    honest = Change(
+        summary="added a helper",
+        files=["helper.js"],
+        diff="*** Begin Patch\n*** Add File: helper.js\n+export const x = 1;\n*** End Patch\n",
+    )
+    coder = StubCoder(ReadRequest(paths=[]), lying, honest)
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("add a helper")
+
+    assert outcome.applied
+    assert outcome.attempts == 2
+    assert "did not create helper.js" in coder.calls[2]["content"]
+    assert workspace.exists("helper.js")
+
+
+async def test_an_empty_diff_stops_immediately(tmp_path: Path):
+    """There is nothing to apply and nothing to repair from; another
+    attempt is the same question asked again."""
+    workspace = make_workspace(tmp_path)
+    coder = StubCoder(
+        ReadRequest(paths=[]),
+        Change(summary="I could not do it", files=[], diff="   "),
+    )
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("x")
+
+    assert not outcome.applied
+    assert outcome.status == "no_diff"
+    assert outcome.attempts == 1
+    assert len(coder.calls) == 2  # it did not retry
+
+
+async def test_nothing_is_written_when_a_later_file_will_not_apply(tmp_path: Path):
+    """All files or none. A hunk that will not place in the second file
+    must not leave the first one edited and the change half-done."""
+    workspace = make_workspace(tmp_path)
+    coder = StubCoder(
+        ReadRequest(paths=[]),
+        Change(
+            summary="two files",
+            files=["index.html", "style.css"],
+            diff=(
+                "--- a/index.html\n+++ b/index.html\n@@\n-<p>body</p>\n+<p>ok</p>\n"
+                "--- a/style.css\n+++ b/style.css\n@@\n-body { color: blue; }\n+body { color: green; }\n"
+            ),
+        ),
+        Change(summary="x", files=[], diff="   "),
+    )
+    await YoloEditor(workspace=workspace, llm_client=coder).edit("x")
+
+    assert workspace.read("index.html") == "<title>Old Title</title>\n<p>body</p>\n"
+    assert workspace.read("style.css") == "body { color: red; }\n"
+
+
+async def test_progress_is_reported(tmp_path: Path):
+    class Recorder:
+        def __init__(self):
+            self.lines: list[str] = []
+
+        def status(self, message: str) -> None:
+            self.lines.append(f"status: {message}")
+
+        def log(self, message: str) -> None:
+            self.lines.append(f"log: {message}")
+
+    workspace = make_workspace(tmp_path)
+    recorder = Recorder()
+    coder = StubCoder(
+        ReadRequest(paths=["index.html"]),
+        Change(
+            summary="Retitled it",
+            files=["index.html"],
+            diff="--- a/index.html\n+++ b/index.html\n@@\n-<title>Old Title</title>\n+<title>New</title>\n",
+        ),
+    )
+    await YoloEditor(workspace=workspace, llm_client=coder, progress=recorder).edit("x")
+
+    trail = "\n".join(recorder.lines)
+    assert "reading index.html" in trail
+    assert "plan: Retitled it" in trail
+    assert "wrote index.html" in trail
+
+
+async def test_a_broken_workspace_is_an_outcome_not_an_exception(tmp_path: Path):
+    """Callers get one shape back whatever went wrong."""
+    workspace = Workspace(tmp_path)
+    workspace.write("f.txt", "x")
+    escape = Change(
+        summary="s",
+        files=[],
+        diff="*** Begin Patch\n*** Add File: ../escape.txt\n+x\n*** End Patch\n",
+    )
+    coder = StubCoder(ReadRequest(paths=[]), escape, escape, escape)
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("x")
+    assert isinstance(outcome, Outcome)
+    assert not outcome.applied
+    assert not (tmp_path.parent / "escape.txt").exists()
+
+
+# ─── Recovering from a wrong file pick ──────────────────────────────────
+#
+# The bounded stand-in for a read/search tool loop. The loop was never
+# really about the first pick — models are good at that — it was about
+# recovering when the first pick turned out wrong. Without it, a model
+# rewrites the same doomed diff until the attempts run out.
+
+
+def three_file_project(tmp_path: Path) -> Workspace:
+    workspace = Workspace(tmp_path)
+    workspace.write("index.html", "<script src='chart.js'></script>\n")
+    workspace.write("chart.js", "import { fmt } from './utils.js';\n")
+    workspace.write("utils.js", "export const fmt = (n) => n.toFixed(2);\n")
+    return workspace
+
+
+async def test_a_failed_diff_against_an_unread_file_widens_the_read_set(
+    tmp_path: Path,
+):
+    """The first pick missed utils.js. The model writes against it anyway
+    and fails. It must be shown the file, not lectured about copying."""
+    workspace = three_file_project(tmp_path)
+    blind = Change(
+        summary="round to 0 dp",
+        files=["utils.js"],
+        diff="--- a/utils.js\n+++ b/utils.js\n@@\n"
+        "-export const fmt = (n) => n.toFixed(1);\n"   # wrong — never saw it
+        "+export const fmt = (n) => n.toFixed(0);\n",
+    )
+    sighted = Change(
+        summary="round to 0 dp",
+        files=["utils.js"],
+        diff="--- a/utils.js\n+++ b/utils.js\n@@\n"
+        "-export const fmt = (n) => n.toFixed(2);\n"
+        "+export const fmt = (n) => n.toFixed(0);\n",
+    )
+    coder = StubCoder(ReadRequest(paths=["chart.js"]), blind, sighted)
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("round it")
+
+    assert outcome.applied
+    assert outcome.attempts == 2
+    retry = coder.calls[2]["content"]
+    # utils.js is now in front of it, with its real contents.
+    assert "toFixed(2)" in retry
+    assert "had not been shown" in retry
+    assert "toFixed(0)" in workspace.read("utils.js")
+
+
+async def test_the_model_can_ask_for_files_instead_of_guessing(tmp_path: Path):
+    """An empty diff plus need_files is a legitimate answer, not a dead
+    end. Previously it ended the run as `no_diff`."""
+    workspace = three_file_project(tmp_path)
+    asking = Change(summary="", files=[], diff="", need_files=["utils.js"])
+    answering = Change(
+        summary="round to 0 dp",
+        files=["utils.js"],
+        diff="--- a/utils.js\n+++ b/utils.js\n@@\n"
+        "-export const fmt = (n) => n.toFixed(2);\n"
+        "+export const fmt = (n) => n.toFixed(0);\n",
+    )
+    coder = StubCoder(ReadRequest(paths=["chart.js"]), asking, answering)
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("round it")
+
+    assert outcome.applied, "asking for a file should not end the run"
+    assert outcome.attempts == 2
+    assert "toFixed(2)" in coder.calls[2]["content"]
+
+
+async def test_asking_for_a_file_that_does_not_exist_still_ends_the_run(
+    tmp_path: Path,
+):
+    """Widening only ever adds real files, so an invented name cannot loop."""
+    workspace = three_file_project(tmp_path)
+    coder = StubCoder(
+        ReadRequest(paths=["chart.js"]),
+        Change(summary="", files=[], diff="", need_files=["imaginary.js"]),
+    )
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("x")
+    assert outcome.status == "no_diff"
+    assert len(coder.calls) == 2
+
+
+async def test_widening_cannot_run_past_the_attempt_budget(tmp_path: Path):
+    """Recovery is bounded by the same 3 attempts — it is not a loop."""
+    workspace = three_file_project(tmp_path)
+    asking = Change(summary="", files=[], diff="", need_files=["utils.js", "index.html"])
+    coder = StubCoder(ReadRequest(paths=[]), asking, asking, asking)
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("x")
+
+    assert not outcome.applied
+    # 1 pick + at most 3 changes. It cannot keep asking forever.
+    assert len(coder.calls) <= 4
+
+
+async def test_a_plain_bad_diff_still_gets_the_copy_carefully_note(tmp_path: Path):
+    """Widening must not swallow the ordinary case. When every named file
+    was already read, the failure really is careless copying."""
+    workspace = three_file_project(tmp_path)
+    bad = Change(
+        summary="x",
+        files=["chart.js"],
+        diff="--- a/chart.js\n+++ b/chart.js\n@@\n-NOT IN THE FILE\n+y\n",
+    )
+    coder = StubCoder(ReadRequest(paths=["chart.js"]), bad, bad, bad)
+    await YoloEditor(workspace=workspace, llm_client=coder).edit("x")
+
+    retry = coder.calls[2]["content"]
+    assert "character for character" in retry
+    assert "had not been shown" not in retry

--- a/tests/test_yolo_data.py
+++ b/tests/test_yolo_data.py
@@ -1,0 +1,194 @@
+"""Generated data files, and why their schemas cannot drift.
+
+The design question this settles: how do you keep a `.data.js` and its
+`.schema.json` in step when anything might rewrite either?
+
+The answer is not to try. The schema is *derived* from the bytes on disk
+and can be re-derived at any moment, so nothing is ever asked to keep
+them in step — `reconcile()` just recomputes. That removes the need for
+one blessed way of producing data, which was the alternative.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from anton.core.yolo import Workspace
+from anton.core.yolo.data import (
+    DataError,
+    derive_schema,
+    global_name,
+    read_data,
+    reconcile,
+    write_data,
+)
+
+ROWS = [
+    {"date": "2026-08-31", "price": 41.22, "volume": 19773, "flagged": False},
+    {"date": "2026-09-01", "price": 41.90, "volume": None, "flagged": True},
+]
+
+
+def schema_of(workspace: Workspace, name: str = "prices") -> dict:
+    return json.loads(workspace.read(f"{name}.schema.json"))
+
+
+# ─── The file is two things at once ─────────────────────────────────────
+
+
+def test_a_data_file_is_loadable_by_a_script_tag(tmp_path: Path):
+    """The reason it is .js and not .json: an artifact opened from disk
+    cannot fetch() a sibling file, so the data has to arrive as a global.
+    The same file works unchanged when published over HTTP."""
+    workspace = Workspace(tmp_path)
+    write_data(workspace, "prices", ROWS)
+    text = workspace.read("prices.data.js")
+    assert text.startswith("window.ANTON_DATA_prices = ")
+    assert text.rstrip().endswith(";")
+
+
+def test_the_same_file_is_readable_without_a_javascript_engine(tmp_path: Path):
+    """The reason it is not awkward: the value is a JSON literal behind a
+    fixed prefix, so anything can read it back."""
+    workspace = Workspace(tmp_path)
+    write_data(workspace, "prices", ROWS)
+    assert read_data(workspace, "prices.data.js") == ROWS
+
+
+def test_a_data_file_in_the_wrong_shape_says_so(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    workspace.write("bad.data.js", "const x = [1,2,3];\n")
+    with pytest.raises(DataError, match="expected"):
+        read_data(workspace, "bad.data.js")
+
+
+def test_a_data_file_holding_broken_json_says_so(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    workspace.write("bad.data.js", "window.ANTON_DATA_bad = [1,2,;\n")
+    with pytest.raises(DataError, match="valid JSON"):
+        read_data(workspace, "bad.data.js")
+
+
+def test_awkward_names_still_make_a_legal_global(tmp_path: Path):
+    assert global_name("q3-sales report") == "ANTON_DATA_q3_sales_report"
+
+
+# ─── The schema is derived, never stated ────────────────────────────────
+
+
+def test_types_come_from_the_values_not_from_a_description(tmp_path: Path):
+    """The failure this prevents: a hand-written {"price": "number"} over
+    rows that actually hold "1,234.00" strings. Code written against that
+    renders a broken chart rather than raising."""
+    schema = derive_schema("prices", [{"price": "1,234.00"}])
+    assert schema["fields"]["price"]["type"] == "string"
+
+
+def test_a_boolean_is_not_reported_as_a_number(tmp_path: Path):
+    """True is an int in Python. Calling it a number sends whoever reads
+    the schema looking for arithmetic on a flag."""
+    assert derive_schema("f", [{"ok": True}])["fields"]["ok"]["type"] == "boolean"
+
+
+def test_nullability_is_observed(tmp_path: Path):
+    fields = derive_schema("prices", ROWS)["fields"]
+    assert fields["volume"]["nullable"] is True
+    assert "nullable" not in fields["price"]
+
+
+def test_a_column_with_mixed_types_admits_it(tmp_path: Path):
+    schema = derive_schema("m", [{"x": 1}, {"x": "two"}])
+    assert schema["fields"]["x"]["type"] == "number | string"
+
+
+def test_a_column_missing_from_some_rows_is_still_described(tmp_path: Path):
+    schema = derive_schema("m", [{"a": 1}, {"a": 2, "b": "late"}])
+    assert set(schema["fields"]) == {"a", "b"}
+    assert schema["fields"]["b"]["nullable"] is True
+
+
+def test_the_schema_names_the_global(tmp_path: Path):
+    """Perfect knowledge of the columns is useless if the chart cannot
+    find the array."""
+    workspace = Workspace(tmp_path)
+    write_data(workspace, "prices", ROWS)
+    assert schema_of(workspace)["global"] == "ANTON_DATA_prices"
+
+
+def test_notes_are_the_only_thing_asked_for(tmp_path: Path):
+    """Units, gaps and timezones cannot be inferred from the values, and
+    they are what produce plausible-looking wrong charts."""
+    workspace = Workspace(tmp_path)
+    write_data(workspace, "prices", ROWS, notes="Daily close. Gaps on weekends.")
+    assert "Gaps on weekends" in schema_of(workspace)["notes"]
+
+
+# ─── Reconciliation: drift is impossible, not merely discouraged ────────
+
+
+def test_a_missing_sidecar_is_written(tmp_path: Path):
+    """Data produced some other way — by hand, by an older cell — still
+    ends up described. This is what removes the need for one blessed
+    way of writing a data file."""
+    workspace = Workspace(tmp_path)
+    workspace.write("prices.data.js", 'window.ANTON_DATA_prices = [{"a": 1}];')
+
+    report = reconcile(workspace)
+    assert any("written" in line for line in report)
+    assert schema_of(workspace)["fields"]["a"]["type"] == "number"
+
+
+def test_a_stale_sidecar_is_refreshed(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    write_data(workspace, "prices", ROWS)
+    # Something else rewrites the data, with a different shape entirely.
+    workspace.write("prices.data.js", 'window.ANTON_DATA_prices = [{"date":"x","price":"1,234.00"}];')
+
+    report = reconcile(workspace)
+    assert any("refreshed" in line for line in report)
+    assert schema_of(workspace)["fields"]["price"]["type"] == "string"
+    assert schema_of(workspace)["rows"] == 1
+
+
+def test_reconciling_preserves_the_one_field_nobody_can_derive(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    write_data(workspace, "prices", ROWS, notes="Daily close. Gaps on weekends.")
+    workspace.write("prices.data.js", 'window.ANTON_DATA_prices = [{"date":"x"}];')
+
+    reconcile(workspace)
+    assert "Gaps on weekends" in schema_of(workspace)["notes"]
+
+
+def test_an_unchanged_sidecar_is_left_alone(tmp_path: Path):
+    """Rewriting it every time would churn the file and its timestamp for
+    no reason, and make every reconcile look like a change."""
+    workspace = Workspace(tmp_path)
+    write_data(workspace, "prices", ROWS)
+    before = workspace.read("prices.schema.json")
+    assert reconcile(workspace) == []
+    assert workspace.read("prices.schema.json") == before
+
+
+def test_unreadable_data_is_reported_rather_than_skipped(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    workspace.write("mystery.data.js", "this is not a data file at all\n")
+    [line] = reconcile(workspace)
+    assert "cannot read it back" in line
+
+
+def test_a_corrupt_sidecar_is_simply_rewritten(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    write_data(workspace, "prices", ROWS)
+    workspace.write("prices.schema.json", "{ not json")
+    assert any("written" in line for line in reconcile(workspace))
+    assert schema_of(workspace)["global"] == "ANTON_DATA_prices"
+
+
+def test_an_orphan_sidecar_is_flagged(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    workspace.write("gone.schema.json", '{"global": "ANTON_DATA_gone"}')
+    [line] = reconcile(workspace)
+    assert "not there" in line

--- a/tests/test_yolo_data_convention.py
+++ b/tests/test_yolo_data_convention.py
@@ -1,0 +1,130 @@
+"""The boundary between the scratchpad's files and yolo's.
+
+`<name>.data.js` is produced by whatever computes it — the scratchpad —
+and `<name>.schema.json` sits beside it saying what the columns are and,
+critically, what global the data file defines.
+
+These tests pin the two halves of the contract: the schema is always put
+in front of the model, and the data file is never edited by it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from anton.core.yolo import PatchError, Workspace, apply_patch_text
+from anton.core.yolo.workspace import (
+    DATA_SUFFIX,
+    SCHEMA_SUFFIX,
+    is_generated_data,
+    is_schema,
+    schema_for,
+)
+
+SCHEMA = {
+    "global": "ANTON_DATA_prices",
+    "file": "prices.data.js",
+    "shape": "array<object>",
+    "rows": 8432,
+    "fields": {"date": {"type": "string"}, "price": {"type": "number", "unit": "USD"}},
+    "notes": "Daily close. Gaps on weekends — do not interpolate.",
+}
+
+
+def artifact(tmp_path: Path) -> Workspace:
+    workspace = Workspace(tmp_path)
+    workspace.write("index.html", "<div id='chart'></div>\n")
+    workspace.write("chart.js", "// draws the chart\n")
+    # A data file far too large to ever inline.
+    workspace.write("prices.data.js", "window.ANTON_DATA_prices=[" + "0," * 50000 + "];\n")
+    workspace.write("prices.schema.json", json.dumps(SCHEMA, indent=2))
+    return workspace
+
+
+def test_the_naming_convention_classifies_files():
+    assert is_generated_data("prices" + DATA_SUFFIX)
+    assert not is_generated_data("chart.js")  # an ordinary .js is yolo's
+    assert is_schema("prices" + SCHEMA_SUFFIX)
+    assert schema_for("reports/q3.data.js") == "reports/q3.schema.json"
+
+
+def test_the_map_inlines_the_schema_and_never_the_data(tmp_path: Path):
+    """The whole point. A line reading `prices.data.js (2.1 MB)` tells the
+    model nothing it can write code against; its sidecar tells it
+    everything, for a few hundred bytes."""
+    file_map = artifact(tmp_path).map()
+
+    # The schema is there in full, including the part that actually
+    # matters — the global the data file defines.
+    assert "ANTON_DATA_prices" in file_map
+    assert "do not interpolate" in file_map
+    # The data file is listed but its contents never appear.
+    assert "prices.data.js" in file_map
+    assert "0,0,0,0,0" not in file_map
+    # And the listing points from one to the other.
+    assert "see prices.schema.json" in file_map
+
+
+def test_a_data_file_with_no_sidecar_says_so(tmp_path: Path):
+    """Silence would read as 'this file is unimportant'. It is not — it is
+    unusable, and that is worth saying."""
+    workspace = Workspace(tmp_path)
+    workspace.write("orphan.data.js", "window.X=[1,2,3];\n")
+    assert "no schema sidecar" in workspace.map()
+
+
+def test_yolo_refuses_to_edit_generated_data(tmp_path: Path):
+    """Enforced, not merely instructed. A diff against two megabytes of
+    rows is not a change anyone reviewed."""
+    workspace = artifact(tmp_path)
+    before = workspace.read("prices.data.js")
+
+    with pytest.raises(PatchError, match="generated data"):
+        apply_patch_text(
+            workspace,
+            "--- a/prices.data.js\n+++ b/prices.data.js\n@@\n"
+            "-window.ANTON_DATA_prices=[" + "0," * 50000 + "];\n"
+            "+window.ANTON_DATA_prices=[1];\n",
+        )
+    assert workspace.read("prices.data.js") == before
+
+
+def test_the_refusal_says_what_to_do_instead(tmp_path: Path):
+    """The message is fed back to the model, so it has to be actionable."""
+    workspace = artifact(tmp_path)
+    with pytest.raises(PatchError) as caught:
+        apply_patch_text(
+            workspace,
+            "*** Begin Patch\n*** Add File: new.data.js\n+window.X=[];\n*** End Patch\n",
+        )
+    message = str(caught.value)
+    assert "let it be written again" in message
+    assert SCHEMA_SUFFIX in message
+
+
+def test_a_mixed_patch_writes_nothing(tmp_path: Path):
+    """One legitimate file and one data file in the same patch is still a
+    refusal — all files or none, as everywhere else."""
+    workspace = artifact(tmp_path)
+    with pytest.raises(PatchError, match="generated data"):
+        apply_patch_text(
+            workspace,
+            "--- a/chart.js\n+++ b/chart.js\n@@\n-// draws the chart\n+// updated\n"
+            "*** Begin Patch\n*** Add File: extra.data.js\n+window.Y=[];\n*** End Patch\n",
+        )
+    assert workspace.read("chart.js") == "// draws the chart\n"
+
+
+def test_code_beside_data_is_still_editable(tmp_path: Path):
+    """The convention must not make ordinary .js files untouchable."""
+    workspace = artifact(tmp_path)
+    written = apply_patch_text(
+        workspace,
+        "--- a/chart.js\n+++ b/chart.js\n@@\n-// draws the chart\n"
+        "+const rows = window.ANTON_DATA_prices;\n",
+    )
+    assert written == {"chart.js"}
+    assert "ANTON_DATA_prices" in workspace.read("chart.js")

--- a/tests/test_yolo_isolation.py
+++ b/tests/test_yolo_isolation.py
@@ -1,0 +1,91 @@
+"""Pin what the yolo engine is allowed to depend on.
+
+`agent.py` imports anton's `LLMClient` directly — a yolo run should get
+the configured provider, the coding-model split, forced `tool_choice`,
+pydantic validation and turn tracing, and the handler should pass the
+same client the rest of the agent already holds. There is nothing to
+abstract there.
+
+`patch.py` and `workspace.py` are different. They are pure functions over
+strings and paths, and that is exactly why the engine is provable in
+milliseconds instead of needing a provider. That property is easy to lose
+to one convenience import, so it is pinned here.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+# Pure: these must reach for nothing at all.
+ENGINE = ["patch.py", "workspace.py"]
+# Builds on the engine, and on nothing else in anton.
+ENGINE_ADJACENT = ["data.py"]
+YOLO = pathlib.Path(__file__).resolve().parents[1] / "anton" / "core" / "yolo"
+
+
+def imports_of(filename: str) -> set[str]:
+    tree = ast.parse((YOLO / filename).read_text())
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            found.add(node.module.split(".")[0])
+    return found
+
+
+def test_the_engine_imports_only_the_standard_library():
+    """No anton, no pydantic, no SDKs. If this fails, ask whether the
+    import is worth giving up a test suite that runs without a provider."""
+    allowed = {
+        "__future__", "contextlib", "dataclasses", "datetime", "json",
+        "pathlib", "re", "signal", "threading", "typing",
+    }
+    for filename in ENGINE:
+        assert imports_of(filename) <= allowed, (
+            f"{filename} imports {sorted(imports_of(filename) - allowed)}; "
+            "the engine is meant to be pure"
+        )
+
+
+def test_the_engine_adjacent_modules_reach_no_further_than_the_engine():
+    """data.py may build on workspace.py. It may not reach into anton's
+    LLM layer, its settings, or its session — that would make the data
+    format untestable without a running agent."""
+    import ast
+
+    for filename in ENGINE_ADJACENT:
+        tree = ast.parse((YOLO / filename).read_text())
+        for node in ast.walk(tree):
+            module = getattr(node, "module", None)
+            if isinstance(node, ast.ImportFrom) and module and module.startswith("anton"):
+                assert module.startswith("anton.core.yolo"), (
+                    f"{filename} imports {module}; engine-adjacent code may only "
+                    "build on the yolo package itself"
+                )
+
+
+def test_the_engine_runs_with_no_provider_configured(tmp_path):
+    """The point of the rule above, demonstrated rather than asserted."""
+    from anton.core.yolo.patch import parse_patch
+    from anton.core.yolo.workspace import Workspace
+
+    workspace = Workspace(tmp_path)
+    workspace.write("f.txt", "before\n")
+    [file_patch] = parse_patch("--- a/f.txt\n+++ b/f.txt\n@@\n-before\n+after\n")
+    from anton.core.yolo.patch import apply_hunks
+
+    assert apply_hunks(workspace.read("f.txt"), file_patch.hunks) == "after\n"
+
+
+def test_the_loop_takes_the_real_client():
+    """agent.py names LLMClient, so a wrong object is a type error at the
+    call site rather than a surprise at runtime."""
+    import inspect
+
+    from anton.core.llm.client import LLMClient
+    from anton.core.yolo import YoloEditor
+
+    annotation = inspect.get_annotations(YoloEditor)["llm_client"]
+    assert annotation is LLMClient or annotation == "LLMClient"

--- a/tests/test_yolo_patch.py
+++ b/tests/test_yolo_patch.py
@@ -1,0 +1,199 @@
+"""Coverage for the deterministic patch engine.
+
+These are pure-string tests: no filesystem, no LLM, no anton. That is the
+point of the module they cover — the valuable part of yolo mode is a set
+of functions over strings, and it should be provable in milliseconds.
+
+The cases are the real failures seen while building yolocoder, not
+invented ones. Where a test looks oddly specific, it is because a model
+did exactly that.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from anton.core.yolo.patch import (
+    PatchError,
+    apply_hunks,
+    is_apply_patch_format,
+    locate,
+    parse_patch,
+)
+
+# ─── The headline behaviour: numbers are ignored ────────────────────────
+
+
+def test_wrong_line_numbers_do_not_matter():
+    """The whole reason this module exists.
+
+    Every number in this header is a lie — wrong start, wrong counts. The
+    content is right, so it applies.
+    """
+    content = "one\ntwo\nthree\nfour\n"
+    patch = (
+        "--- a/f.txt\n"
+        "+++ b/f.txt\n"
+        "@@ -99,44 +1201,7 @@\n"
+        " two\n"
+        "-three\n"
+        "+THREE\n"
+        " four\n"
+    )
+    [file_patch] = parse_patch(patch)
+    assert apply_hunks(content, file_patch.hunks) == "one\ntwo\nTHREE\nfour\n"
+
+
+def test_a_hunk_with_no_trailing_context_still_applies():
+    """git rejects this outright: a hunk ending on its last change asserts
+    the file ends there. Models write it constantly."""
+    content = "header\ntitle: old\nfooter\n"
+    patch = "--- a/f\n+++ b/f\n@@\n header\n-title: old\n+title: new\n"
+    [file_patch] = parse_patch(patch)
+    assert apply_hunks(content, file_patch.hunks) == "header\ntitle: new\nfooter\n"
+
+
+def test_indentation_drift_is_tolerated():
+    """A model reproducing a file by eye gets the characters right and the
+    leading whitespace slightly wrong. The exact pass fails, the stripped
+    pass finds it."""
+    content = "def f():\n        return 1\n"
+    patch = "--- a/f\n+++ b/f\n@@\n-    return 1\n+    return 2\n"
+    [file_patch] = parse_patch(patch)
+    assert "return 2" in apply_hunks(content, file_patch.hunks)
+
+
+# ─── Refusing rather than guessing ──────────────────────────────────────
+
+
+def test_an_unfindable_hunk_is_an_error_not_a_no_op():
+    content = "alpha\nbeta\n"
+    patch = "--- a/f\n+++ b/f\n@@\n-gamma\n+delta\n"
+    [file_patch] = parse_patch(patch)
+    with pytest.raises(PatchError, match="could not find"):
+        apply_hunks(content, file_patch.hunks)
+
+
+def test_a_short_ambiguous_hunk_is_refused():
+    """Picking the first match is how an edit lands in the wrong function
+    and reports success."""
+    lines = ["}", "", "}", "", "}"]
+    with pytest.raises(PatchError, match="ambiguous"):
+        locate(lines, ["}"])
+
+
+def test_a_long_repeated_block_is_placed_at_the_first_match():
+    """Ambiguity only applies to blocks short enough to be a coincidence.
+    Three identical lines in a row is a real location."""
+    lines = ["a", "b", "c", "x", "a", "b", "c"]
+    assert locate(lines, ["a", "b", "c"]) == 0
+
+
+def test_a_hunk_with_no_context_cannot_be_placed():
+    content = "some\nexisting\ncontent\n"
+    with pytest.raises(PatchError, match="no context"):
+        apply_hunks(content, parse_patch("--- a/f\n+++ b/f\n@@\n+new\n")[0].hunks)
+
+
+def test_a_pure_insertion_into_an_empty_file_is_unambiguous():
+    """There is only one place it can go."""
+    [file_patch] = parse_patch("--- a/f\n+++ b/f\n@@\n+hello\n+world\n")
+    assert apply_hunks("", file_patch.hunks) == "hello\nworld"
+
+
+# ─── apply_patch (V4A) dialect ──────────────────────────────────────────
+
+
+def test_add_file_creates_a_file_with_no_at_header():
+    """'*** Add File:' is followed straight by its + lines. Waiting for an
+    '@@' reads the whole file as noise and creates nothing."""
+    patch = (
+        "*** Begin Patch\n"
+        "*** Add File: greet.py\n"
+        "+def hi():\n"
+        '+    return "hi"\n'
+        "*** End Patch\n"
+    )
+    [file_patch] = parse_patch(patch)
+    assert file_patch.path == "greet.py"
+    assert apply_hunks("", file_patch.hunks) == 'def hi():\n    return "hi"'
+
+
+def test_update_file_drops_the_empty_hunk_its_header_creates():
+    patch = (
+        "*** Begin Patch\n"
+        "*** Update File: f.txt\n"
+        "@@\n"
+        " keep\n"
+        "-old\n"
+        "+new\n"
+        "*** End Patch\n"
+    )
+    [file_patch] = parse_patch(patch)
+    assert len(file_patch.hunks) == 1
+    assert apply_hunks("keep\nold\n", file_patch.hunks) == "keep\nnew\n"
+
+
+def test_the_format_is_detected_without_being_confused_by_a_unified_diff():
+    assert is_apply_patch_format("*** Begin Patch\n*** Add File: a\n+x\n")
+    assert not is_apply_patch_format("--- a/f\n+++ b/f\n@@\n-x\n+y\n")
+    assert not is_apply_patch_format("diff --git a/f b/f\n--- a/f\n")
+
+
+def test_deleting_a_file_is_refused_loudly():
+    with pytest.raises(PatchError, match="deletes"):
+        parse_patch("*** Begin Patch\n*** Delete File: important.txt\n*** End Patch\n")
+
+
+# ─── Parsing edge cases that cost real debugging time ───────────────────
+
+
+def test_a_trailing_blank_line_is_not_context():
+    """It comes from the patch ending in a newline. Counted as an empty
+    context line it makes every final hunk unmatchable."""
+    [file_patch] = parse_patch("--- a/f\n+++ b/f\n@@\n keep\n-old\n+new\n\n\n")
+    assert file_patch.hunks[0].before == ["keep", "old"]
+
+
+def test_an_empty_line_inside_a_hunk_is_context():
+    content = "top\n\nbottom\n"
+    [file_patch] = parse_patch("--- a/f\n+++ b/f\n@@\n top\n\n-bottom\n+BOTTOM\n")
+    assert apply_hunks(content, file_patch.hunks) == "top\n\nBOTTOM\n"
+
+
+def test_dev_null_headers_do_not_become_a_file_named_dev_null():
+    patch = "--- /dev/null\n+++ b/new.txt\n@@\n+created\n"
+    [file_patch] = parse_patch(patch)
+    assert file_patch.path == "new.txt"
+
+
+def test_ab_prefixes_are_stripped():
+    [file_patch] = parse_patch("--- a/src/x.py\n+++ b/src/x.py\n@@\n-a\n+b\n")
+    assert file_patch.path == "src/x.py"
+
+
+def test_a_patch_with_no_file_header_is_an_error():
+    with pytest.raises(PatchError, match="no file headers"):
+        parse_patch("just some prose the model wrote\n")
+
+
+def test_a_hunk_before_any_file_header_is_an_error():
+    with pytest.raises(PatchError, match="before any file header"):
+        parse_patch("@@\n-a\n+b\n")
+
+
+def test_several_hunks_in_one_file_compose():
+    content = "one\ntwo\nthree\nfour\nfive\n"
+    patch = (
+        "--- a/f\n+++ b/f\n"
+        "@@\n one\n-two\n+TWO\n"
+        "@@\n four\n-five\n+FIVE\n"
+    )
+    [file_patch] = parse_patch(patch)
+    assert apply_hunks(content, file_patch.hunks) == "one\nTWO\nthree\nfour\nFIVE\n"
+
+
+def test_a_no_newline_marker_is_ignored():
+    patch = "--- a/f\n+++ b/f\n@@\n-old\n\\ No newline at end of file\n+new\n"
+    [file_patch] = parse_patch(patch)
+    assert apply_hunks("old", file_patch.hunks) == "new"

--- a/tests/test_yolo_search.py
+++ b/tests/test_yolo_search.py
@@ -1,0 +1,223 @@
+"""Finding a file when its name does not tell you anything.
+
+The map lists paths. For a five-file artifact that is enough — the model
+reads the names and knows where the title lives. For forty files it is
+not, and no amount of retrying helps, because a retry can only widen to
+files the model already guessed at.
+
+Search closes that. It is deterministic, calls no model, and its results
+feed straight into the read set.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from anton.core.yolo import Change, ReadRequest, Workspace, YoloEditor
+from anton.core.yolo.workspace import (
+    MAX_MATCHES_PER_FILE,
+    MAX_MATCHES_PER_QUERY,
+    MAX_QUERIES,
+)
+
+from tests.test_yolo_agent import StubCoder
+
+
+def haystack(tmp_path: Path) -> Workspace:
+    """A folder where the names give nothing away."""
+    workspace = Workspace(tmp_path)
+    workspace.write("a.js", "export const NAV = 1;\n")
+    workspace.write("b.js", "// nothing interesting\n")
+    workspace.write("c.js", "document.title = 'Old Title';\n")
+    workspace.write("d.js", "// also nothing\n")
+    return workspace
+
+
+# ─── The search itself ──────────────────────────────────────────────────
+
+
+def test_search_finds_the_file_the_name_did_not_reveal(tmp_path: Path):
+    [match] = haystack(tmp_path).search("Old Title").matches
+    assert match.path == "c.js"
+    assert match.line == 1
+    assert "document.title" in match.text
+
+
+def test_search_ignores_case(tmp_path: Path):
+    assert haystack(tmp_path).search("OLD TITLE").matches
+    assert haystack(tmp_path).search("old title").matches
+
+
+def test_search_skips_generated_data(tmp_path: Path):
+    """Searching two megabytes of rows for a word returns thousands of
+    lines of noise and buries the one line of code that reads them."""
+    workspace = haystack(tmp_path)
+    workspace.write("prices.data.js", "window.X=['Old Title','Old Title'];\n")
+    assert [m.path for m in workspace.search("Old Title").matches] == ["c.js"]
+
+
+def test_one_common_word_cannot_flood_the_prompt(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    for name in "abcdefghij":
+        workspace.write(f"{name}.js", "hit\n" * 50)
+    matches = workspace.search("hit").matches
+    assert len(matches) <= MAX_MATCHES_PER_QUERY
+    per_file = [m for m in matches if m.path == "a.js"]
+    assert len(per_file) <= MAX_MATCHES_PER_FILE
+
+
+def test_a_very_long_line_is_clipped(tmp_path: Path):
+    workspace = Workspace(tmp_path)
+    workspace.write("min.js", "x" * 5000 + "needle" + "y" * 5000)
+    [match] = workspace.search("needle").matches
+    assert len(match.text) < 400
+
+
+def test_no_matches_is_reported_not_omitted(tmp_path: Path):
+    """'That string is nowhere in this folder' is a real answer, and the
+    one that stops the model looking for it."""
+    rendered, hits = haystack(tmp_path).search_many(["Old Title", "not here at all"])
+    assert "c.js:1" in rendered
+    assert '"not here at all" — no matches' in rendered
+    assert hits == ["c.js"]
+
+
+def test_an_empty_query_matches_nothing(tmp_path: Path):
+    assert haystack(tmp_path).search("   ").matches == []
+
+
+# ─── Search inside the loop ─────────────────────────────────────────────
+
+
+async def test_a_search_at_the_pick_step_finds_the_file_to_edit(tmp_path: Path):
+    """The model cannot tell from a.js/b.js/c.js/d.js which sets the
+    title, so it searches instead of guessing. One LLM call still."""
+    workspace = haystack(tmp_path)
+    coder = StubCoder(
+        ReadRequest(paths=[], search=["Old Title"]),
+        Change(
+            summary="Retitled",
+            files=["c.js"],
+            diff="--- a/c.js\n+++ b/c.js\n@@\n"
+            "-document.title = 'Old Title';\n+document.title = 'New Title';\n",
+        ),
+    )
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("retitle it")
+
+    assert outcome.applied
+    assert len(coder.calls) == 2, "search must not cost an extra model call"
+    # The change request was shown both the hit and the file it is in.
+    request = coder.calls[1]["content"]
+    assert "SEARCH RESULTS:" in request
+    assert "c.js:1" in request
+    assert "document.title" in request
+    assert "New Title" in workspace.read("c.js")
+
+
+async def test_the_model_can_search_to_recover_from_a_wrong_pick(tmp_path: Path):
+    """The recovery gap search was meant to close: it read the wrong file
+    and does not know the name of the right one."""
+    workspace = haystack(tmp_path)
+    coder = StubCoder(
+        ReadRequest(paths=["a.js"]),  # wrong file
+        Change(summary="", files=[], diff="", need_search=["Old Title"]),
+        Change(
+            summary="Retitled",
+            files=["c.js"],
+            diff="--- a/c.js\n+++ b/c.js\n@@\n"
+            "-document.title = 'Old Title';\n+document.title = 'New Title';\n",
+        ),
+    )
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("retitle it")
+
+    assert outcome.applied
+    assert outcome.attempts == 2
+    retry = coder.calls[2]["content"]
+    assert "c.js:1" in retry
+    assert "document.title = 'Old Title';" in retry  # the file itself, now read
+
+
+async def test_a_fruitless_search_still_terminates(tmp_path: Path):
+    """Searching for something that is not there must not loop."""
+    workspace = haystack(tmp_path)
+    asking = Change(summary="", files=[], diff="", need_search=["not here at all"])
+    coder = StubCoder(ReadRequest(paths=[]), asking, asking, asking)
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("x")
+
+    assert not outcome.applied
+    assert len(coder.calls) <= 4
+    # And it was told the search found nothing, rather than left guessing.
+    assert "no matches" in coder.calls[2]["content"]
+
+
+# ─── Regex, and the one hazard that comes with it ───────────────────────
+
+
+def test_search_takes_a_regular_expression(tmp_path: Path):
+    """The reason regex is worth the trouble: finding where a thing is
+    defined, not just where its exact spelling appears."""
+    workspace = Workspace(tmp_path)
+    workspace.write("a.js", "function drawChart(rows) {}\n")
+    workspace.write("b.js", "function drawLegend(rows) {}\n")
+    workspace.write("c.js", "const notAFunction = 1;\n")
+
+    found = workspace.search(r"function\s+draw\w+")
+    assert sorted(m.path for m in found.matches) == ["a.js", "b.js"]
+    assert not found.note
+
+
+def test_a_plain_word_is_still_a_valid_pattern(tmp_path: Path):
+    assert haystack(tmp_path).search("Old Title").matches
+
+
+def test_an_invalid_pattern_comes_back_as_feedback_not_a_crash(tmp_path: Path):
+    """A bad pattern is something the model can fix next attempt, so it is
+    handed back rather than raised."""
+    found = haystack(tmp_path).search("unclosed (group")
+    assert found.matches == []
+    assert "invalid pattern" in found.note
+
+
+def test_a_runaway_pattern_is_cut_off_rather_than_hung(tmp_path: Path):
+    """The hazard that made this worth thinking about. `(a+)+b` against
+    thirty characters takes ~46 seconds and grows exponentially, so no cap
+    on line or file size contains it — only a wall-clock interrupt does."""
+    workspace = Workspace(tmp_path)
+    workspace.write("evil.txt", "a" * 40 + "!")
+
+    started = time.monotonic()
+    found = workspace.search(r"(a+)+b")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5, f"took {elapsed:.1f}s — the interrupt did not fire"
+    assert "timed out" in found.note
+    # And it says what to do about it.
+    assert "nested quantifiers" in found.note
+
+
+async def test_a_runaway_pattern_does_not_take_the_run_down(tmp_path: Path):
+    """It has to degrade to 'no matches', not an exception."""
+    workspace = haystack(tmp_path)
+    workspace.write("evil.txt", "a" * 40 + "!")
+    coder = StubCoder(
+        ReadRequest(paths=[], search=[r"(a+)+b"]),
+        Change(
+            summary="Retitled",
+            files=["c.js"],
+            diff="--- a/c.js\n+++ b/c.js\n@@\n"
+            "-document.title = 'Old Title';\n+document.title = 'New';\n",
+        ),
+    )
+    outcome = await YoloEditor(workspace=workspace, llm_client=coder).edit("retitle")
+    assert outcome.applied
+    assert "timed out" in coder.calls[1]["content"]
+
+
+def test_too_many_queries_are_dropped_and_said_so(tmp_path: Path):
+    """The worst case is timeout x queries, so the count is capped too."""
+    rendered, _ = haystack(tmp_path).search_many([f"q{n}" for n in range(12)])
+    assert "not run" in rendered
+    assert f"at most {MAX_QUERIES}" in rendered


### PR DESCRIPTION
Library only — **nothing is wired into the agent yet**, so this can be reviewed on its own. The `edit_artifact` tool, the progress bridge and the scratchpad `emit_data` helper are the next commits, laid out as Phase 1 and Phase 2 in [ENG-2186](https://linear.app/mindsdb/issue/ENG-2186/yolo-mode-edit-artifacts-with-diffs-and-let-the-scratchpad-own-the).

## Why

Anton changes an artifact by writing a Python program that changes it:

> **User:** rename the title to TicTacTris
> **Anton** *(scratchpad)*: `html = open("index.html").read()` … `html.replace(...)` … `open(...,"w").write(html)`

That is right for *generating* something. For *modifying* a file that already exists it is the long way round, and the program is a second thing that can be wrong — a subtly wrong script mangles the artifact rather than leaving it alone.

This adds the second route: the model returns a diff, and we apply it.

## The idea it rests on

From the Go implementation in `mindsdb/yolocoder`, in daily use: **models get diff *content* right and diff *arithmetic* wrong.** They reproduce a file's lines faithfully, then miscount `@@ -14,7 +14,9 @@`, or end a hunk on its last change with no trailing context — which `git apply` rejects outright.

None of that bookkeeping needs the model, because the file is right here. So every line number and count is discarded and each hunk is placed by **locating its text**. That single change took patch application from roughly half of attempts to nearly all of them.

Everything else follows: arithmetic is done in Python, judgement is left to the model.

| Model does | We do |
|---|---|
| picks which files to read | place hunks by content |
| searches when names give nothing away | decide when a match is too ambiguous to risk |
| writes the diff | check the files it promised were actually created |

## Failing well

Three attempts, each shown the diagnosis **and its own failed diff** — told only "it failed", a model reproduces the same diff. Then the outcome carries the whole diagnosis out, so the caller can hand the job to the scratchpad with it attached.

Two refusals are deliberate: a hunk that cannot be found, and a short hunk matching in several places. Guessing there means editing the wrong part of someone's file and reporting success.

Writes are all-or-nothing — a hunk that will not place in the third file leaves the first two untouched.

## Generated data stays out of it

`<name>.data.js` is listed in the map but never inlined, and a diff against one is **refused in code**, not merely discouraged. Its `<name>.schema.json` sidecar is inlined in full instead:

```
prices.data.js (100028 bytes)  ← generated data, see prices.schema.json
prices.schema.json (361 bytes)

DATA SCHEMAS (read these instead of the data files):
--- prices.schema.json ---
{ "global": "ANTON_DATA_prices", "rows": 8432, "fields": {...} }
```

100 KB of rows costs four words; its shape costs 361 bytes. Sidecars are **derived from the bytes on disk** and recomputed by `reconcile()`, so they cannot drift from the data they describe.

## Notes for review

- **`patch.py` and `workspace.py` import only the standard library**, which is what makes the engine provable in milliseconds with no provider. `tests/test_yolo_isolation.py` pins it with an AST check.
- **`agent.py` uses `LLMClient` directly** and calls `generate_object_code`, so a run inherits the configured provider, the coding-model split, forced `tool_choice`, pydantic validation and turn tracing. No new way to configure a model.
- **`Outcome.status`, not `Outcome.reason`** — staging reserves the `reason="..."` kwarg for handler failure sentinels tiered in `core/root_cause.py`. These are not that (`"applied"` is a success), and registering them would skew the wall counts that taxonomy exists to measure. Caught by `test_every_sentinel_reason_is_mapped` when running the suite against this branch.
- **Search is regex, guarded by a wall-clock interrupt.** `(a+)+b` against thirty characters takes **46 seconds** unguarded and grows exponentially, so no cap on line or file size contains it — only `SIGALRM` does. It cuts at 1s and hands back "simplify the pattern" as feedback. On Windows it falls back to literal and says so.

## Testing

**87 new tests, all passing.** Full suite on this branch: **2848 passed**, 31 skipped, 2 failures in `test_chat_scratchpad.py` that are pre-existing on `staging` — verified by moving this code aside and watching them fail identically.

```
tests/test_yolo_patch.py            20  pure strings, no fs, no LLM
tests/test_yolo_agent.py            21  stub LLM, real tmp_path filesystem
tests/test_yolo_data.py             19  derived schemas, reconciliation
tests/test_yolo_search.py           16  regex, and the runaway-pattern guard
tests/test_yolo_data_convention.py   7  the sidecar contract
tests/test_yolo_isolation.py         4  the engine stays stdlib-only
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)