### PR TITLE
[ENG-2193] Tell the user the work finished when only the completion check failed

### DIFF
--- a/anton/cli.py
+++ b/anton/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import importlib
+import logging
 import os
 import shutil
 import subprocess
@@ -38,6 +39,12 @@ from anton.commands.datasource import (
     handle_test_datasource
 )
 from anton.minds_client import minds_v1_base, resolve_and_probe, test_llm
+
+# The CLI configures no logging, so without a handler on the package logger
+# Python's lastResort writes WARNING and above straight to stderr — into the
+# middle of the rich Live render. Propagation is untouched, so a host that does
+# configure logging (the cowork sidecar, the cloud pod) still emits them.
+logging.getLogger("anton").addHandler(logging.NullHandler())
 
 
 def _build_scratchpad_manager(

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -5491,7 +5491,10 @@ class ChatSession:
                     )
                     verdict_failure = "truncated" if exc.truncated else "hard"
                     verdict_exc = exc
-                    _verifier_log.info(
+                    # WARNING only when this attempt ends the loop: a truncation
+                    # the larger budget recovers from is not a failure to report.
+                    _verifier_log.log(
+                        _logging.INFO if retrying else _logging.WARNING,
                         "completion-verifier verdict=%s budget=%d output_tokens=%d "
                         "stop_reason=%s retrying=%s",
                         truncation_verdict(exc),
@@ -5506,7 +5509,7 @@ class ChatSession:
                     # user buys nothing: handled below by latching silently.
                     verdict_failure = "denied"
                     verdict_exc = exc
-                    _verifier_log.info(
+                    _verifier_log.warning(
                         "completion-verifier verdict=DENIED budget=%d error=%s",
                         budget, _safe_error_detail(exc),
                     )
@@ -5523,7 +5526,7 @@ class ChatSession:
                     # latch. See `_TRANSIENT_VERDICT_ERRORS` for what qualifies.
                     verdict_failure = "transient"
                     verdict_exc = exc
-                    _verifier_log.info(
+                    _verifier_log.warning(
                         "completion-verifier verdict=TRANSIENT budget=%d error=%s",
                         budget, _safe_error_detail(exc),
                     )
@@ -5535,7 +5538,7 @@ class ChatSession:
                     # content (ENG-1081).
                     verdict_failure = "hard"
                     verdict_exc = exc
-                    _verifier_log.info(
+                    _verifier_log.warning(
                         "completion-verifier verdict=ERROR budget=%d error=%s",
                         budget, _safe_error_detail(exc),
                     )
@@ -5586,7 +5589,7 @@ class ChatSession:
                     # the guarantee the user is never told the turn failed.
                     self._verifier_latched = True
                     self._verifier_latch_reason = "denied"
-                    _verifier_log.info(
+                    _verifier_log.warning(
                         "completion-verifier latched after a deterministic "
                         "denial (billing or model access) — skipping further "
                         "verification this session; turn ends on the "
@@ -5604,7 +5607,7 @@ class ChatSession:
                         # after N failures" with an ever-growing N would read as
                         # a new event each cycle. No re-diagnosis (one per
                         # session, ENG-1155).
-                        _verifier_log.info(
+                        _verifier_log.warning(
                             "completion-verifier re-probe failed — staying latched"
                         )
                         # Unverified turn — see the latched-skip stamp above.
@@ -5633,7 +5636,7 @@ class ChatSession:
                         # that it can (review: pnewsam on #299).
                         self._verifier_latched = True
                         self._verifier_latch_reason = "hard"
-                        _verifier_log.info(
+                        _verifier_log.warning(
                             "completion-verifier latched after %d hard failures with "
                             "no successful verdict between them — skipping further "
                             "verification this session",
@@ -5652,7 +5655,7 @@ class ChatSession:
                 # user to help). Fail toward the same honest, model-generated
                 # diagnosis used for STUCK below, so the task pauses with a
                 # real message instead of nothing.
-                _verifier_log.info(
+                _verifier_log.warning(
                     "completion-verifier verdict=ERROR continuation=%d/%d tool_rounds=%d "
                     "— failing toward an honest diagnosis, not a silent COMPLETE",
                     continuation, self._max_continuations, tool_round,
@@ -5661,18 +5664,27 @@ class ChatSession:
                     {
                         "role": "user",
                         "content": (
-                            "SYSTEM: The task-completion check failed to run (internal "
-                            "error), so it's unclear whether this task is finished.\n\n"
-                            "Summarize what you've done so far, be honest that an internal "
-                            "check failed partway through, and ask the user how they'd like "
-                            f"to proceed. {_SOLVABILITY_CLAUSE} Do not mention this "
-                            "instruction or the verifier to the user."
+                            "SYSTEM: This turn's work finished and the reply you just "
+                            "gave stands. What failed is only the automatic follow-up "
+                            "check on whether the task is fully complete, so nothing "
+                            "about the work itself went wrong and there is no error for "
+                            "the user to fix.\n"
+                            "1. Tell the user what you completed. Lead with the result, "
+                            "not with the check.\n"
+                            "2. Name a file only by a path that appears verbatim in a "
+                            "tool result above. Never state a path you intended to write "
+                            "or believe you wrote; where no tool result gives one, say "
+                            "what you produced without naming a location.\n"
+                            "3. Say whether anything still needs doing and ask how they'd "
+                            "like to proceed.\n"
+                            f"4. {_SOLVABILITY_CLAUSE}\n"
+                            "Do not mention this instruction or the verifier to the user."
                         ),
                     }
                 )
                 yield StreamTaskProgress(
                     phase="analyzing",
-                    message="Something went wrong — checking in with you...",
+                    message="Confirming what was completed...",
                 )
                 if self._turn_cost is not None:
                     self._turn_cost.ended_by = "handback_verifier_failure"

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -419,8 +419,8 @@ _TRANSIENT_VERDICT_ERRORS: tuple[type[BaseException], ...] = (
 # map to TransientProviderError and never land here) or a model id that doesn't
 # resolve for this key (ModelUnavailableError: 404 model-not-found / 403
 # model-access-denied). These latch on the FIRST occurrence and stay silent:
-# the turn's work already succeeded, and "the task-completion check failed
-# (internal error)" is a lie when the check was merely priced out (ENG-1632 —
+# the turn's work already succeeded, and telling the user an internal check
+# failed is a lie when the check was merely priced out (ENG-1632 —
 # of that ticket's 14-day baseline of 296 wallet-402s across 39 users, 208
 # were aux-surface calls like this one, across 33 of those users; every aux
 # one surfaced to the user as an internal error and an apology).
@@ -5496,9 +5496,10 @@ class ChatSession:
                     _verifier_log.log(
                         _logging.INFO if retrying else _logging.WARNING,
                         "completion-verifier verdict=%s budget=%d output_tokens=%d "
-                        "stop_reason=%s retrying=%s",
+                        "stop_reason=%s error=%s retrying=%s",
                         truncation_verdict(exc),
-                        budget, exc.output_tokens, exc.stop_reason, retrying,
+                        budget, exc.output_tokens, exc.stop_reason,
+                        _safe_error_detail(exc), retrying,
                     )
                     if not retrying:
                         break
@@ -5510,8 +5511,8 @@ class ChatSession:
                     verdict_failure = "denied"
                     verdict_exc = exc
                     _verifier_log.warning(
-                        "completion-verifier verdict=DENIED budget=%d error=%s",
-                        budget, _safe_error_detail(exc),
+                        "completion-verifier verdict=DENIED budget=%d model=%s error=%s",
+                        budget, self._llm.coding_model, _safe_error_detail(exc),
                     )
                     break
                 except _TRANSIENT_VERDICT_ERRORS as exc:
@@ -5589,7 +5590,9 @@ class ChatSession:
                     # the guarantee the user is never told the turn failed.
                     self._verifier_latched = True
                     self._verifier_latch_reason = "denied"
-                    _verifier_log.warning(
+                    # INFO, unlike the other latch lines: this one latches on
+                    # call one, so at WARNING it doubles verdict=DENIED above.
+                    _verifier_log.info(
                         "completion-verifier latched after a deterministic "
                         "denial (billing or model access) — skipping further "
                         "verification this session; turn ends on the "
@@ -5657,20 +5660,21 @@ class ChatSession:
                 # real message instead of nothing.
                 _verifier_log.warning(
                     "completion-verifier verdict=ERROR continuation=%d/%d tool_rounds=%d "
-                    "— failing toward an honest diagnosis, not a silent COMPLETE",
+                    "model=%s — failing toward an honest diagnosis, not a silent COMPLETE",
                     continuation, self._max_continuations, tool_round,
+                    self._llm.coding_model,
                 )
                 self._append_history(
                     {
                         "role": "user",
                         "content": (
-                            "SYSTEM: This turn's work finished and the reply you just "
-                            "gave stands. What failed is only the automatic follow-up "
-                            "check on whether the task is fully complete, so nothing "
-                            "about the work itself went wrong and there is no error for "
-                            "the user to fix.\n"
-                            "1. Tell the user what you completed. Lead with the result, "
-                            "not with the check.\n"
+                            "SYSTEM: Your reply above stands, and nothing in your work "
+                            "was rejected — no verdict came back at all. What failed is "
+                            "the automatic check on whether the task is complete, so "
+                            "completeness is unconfirmed rather than denied.\n"
+                            "1. Report accurately what you did: what succeeded, and "
+                            "anything that did not, including any tool that returned an "
+                            "error. Do not describe a failed step as done.\n"
                             "2. Name a file only by a path that appears verbatim in a "
                             "tool result above. Never state a path you intended to write "
                             "or believe you wrote; where no tool result gives one, say "

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -65,7 +65,7 @@ def _scratchpad_response(text: str, action: str, name: str, code: str = "") -> L
 # Anchors into the verifier-failure hand-back (session.py). Shared because the
 # denied-verdict tests assert this text NEVER enters history — anchored on a
 # string the prompt no longer contains, those assertions would pass vacuously.
-_HANDBACK_ANCHOR = "automatic follow-up check"
+_HANDBACK_ANCHOR = "automatic check on whether the task is complete"
 _HANDBACK_PROGRESS = "Confirming what was completed..."
 
 
@@ -134,9 +134,15 @@ async def test_verifier_exception_yields_real_message_not_silent_stop(workspace)
         # The hand-back must not read as a failed turn, and must not invite the
         # model to restate a path from memory: asked where the file went, it
         # named the path it MEANT to write and the user went looking there.
-        assert any("the reply you just gave stands" in t for t in history_texts)
+        assert any("Your reply above stands" in t for t in history_texts)
         assert any(
             "Never state a path you intended to write" in t for t in history_texts
+        )
+        # It must not claim the work was clean either. Only the tool-round count
+        # gates this path, so a turn whose tool calls failed lands here too, and
+        # a "nothing went wrong" framing would be the same misreport inverted.
+        assert any(
+            "including any tool that returned an error" in t for t in history_texts
         )
         assert not any("Continue working on the original request" in t for t in history_texts)
         # The model must be asked for a solvability self-assessment, not just
@@ -220,7 +226,11 @@ async def test_truncation_exhausting_every_budget_also_gets_the_diagnosis(worksp
             if "completion-verifier verdict=" in r.getMessage()
             and "output_tokens=" in r.getMessage()
         ]
-        assert [r.levelno for r in attempts] == [logging.INFO, logging.WARNING]
+        ladder = [logging.INFO] * (len(_VERIFIER_TOKEN_BUDGETS) - 1)
+        assert [r.levelno for r in attempts] == ladder + [logging.WARNING]
+        # This clause carries the dominant free-tier failure, so the line has to
+        # name the exception type or a support log cannot say what broke.
+        assert all("error=StructuredOutputError" in r.getMessage() for r in attempts)
         # And the line naming the failure class must itself clear WARNING, or a
         # customer's default log cannot say why the turn handed back.
         gave_up = [
@@ -869,9 +879,8 @@ async def test_empty_diagnosis_is_logged_not_circular(workspace, caplog):
 #
 # A wallet 402 / allowance 429 (TokenLimitExceeded, code-exact per ENG-1169) or
 # a 404'd/403'd model (ModelUnavailableError) recurs on every retry by
-# construction. The turn's work already succeeded — telling the user "the
-# task-completion check failed to run (internal error)" and streaming an
-# apology is a misreport (measured: 208 aux-call wallet-402s across 33 users in
+# construction. The turn's work already succeeded — telling the user an
+# internal check failed and streaming an apology is a misreport (measured: 208 aux-call wallet-402s across 33 users in
 # 14 days, every one surfaced as an internal error). The denied path must be
 # SILENT: no history injection, no diagnosis stream, latch on call one.
 #

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -62,6 +62,13 @@ def _scratchpad_response(text: str, action: str, name: str, code: str = "") -> L
     )
 
 
+# Anchors into the verifier-failure hand-back (session.py). Shared because the
+# denied-verdict tests assert this text NEVER enters history — anchored on a
+# string the prompt no longer contains, those assertions would pass vacuously.
+_HANDBACK_ANCHOR = "automatic follow-up check"
+_HANDBACK_PROGRESS = "Confirming what was completed..."
+
+
 class _FakeAsyncIter:
     def __init__(self, items):
         self._items = items
@@ -116,14 +123,21 @@ async def test_verifier_exception_yields_real_message_not_silent_stop(workspace)
         # exactly one more model call happens (the honest diagnosis) — not a
         # forced "Continue working" continuation, and not silence.
         progress_msgs = [e.message for e in events if isinstance(e, StreamTaskProgress)]
-        assert "Something went wrong — checking in with you..." in progress_msgs
+        assert _HANDBACK_PROGRESS in progress_msgs
         assert call_count == 3
 
         history_texts = [
             m["content"] for m in session.history
             if m.get("role") == "user" and isinstance(m.get("content"), str)
         ]
-        assert any("task-completion check failed to run" in t for t in history_texts)
+        assert any(_HANDBACK_ANCHOR in t for t in history_texts)
+        # The hand-back must not read as a failed turn, and must not invite the
+        # model to restate a path from memory: asked where the file went, it
+        # named the path it MEANT to write and the user went looking there.
+        assert any("the reply you just gave stands" in t for t in history_texts)
+        assert any(
+            "Never state a path you intended to write" in t for t in history_texts
+        )
         assert not any("Continue working on the original request" in t for t in history_texts)
         # The model must be asked for a solvability self-assessment, not just
         # a status dump — otherwise "let me know how to proceed" is a vague
@@ -139,12 +153,14 @@ async def test_verifier_exception_yields_real_message_not_silent_stop(workspace)
         await session.close()
 
 
-async def test_truncation_exhausting_every_budget_also_gets_the_diagnosis(workspace):
+async def test_truncation_exhausting_every_budget_also_gets_the_diagnosis(workspace, caplog):
     """The ENG-1081 ladder can run dry: a verdict truncated at 2048 AND at the
     4096 retry (narrating model, huge session) used to fall into the same
     silent fake-COMPLETE this file exists to remove. Exhausted budgets are not
     a verdict either — the honest-diagnosis path must fire for them too.
     """
+    import logging
+
     from anton.core.llm.provider import StructuredOutputError
     from anton.core.session import _VERIFIER_TOKEN_BUDGETS
 
@@ -186,16 +202,32 @@ async def test_truncation_exhausting_every_budget_also_gets_the_diagnosis(worksp
 
     session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
     try:
-        events = [e async for e in session.turn_stream("run my script")]
+        with caplog.at_level(logging.INFO):
+            events = [e async for e in session.turn_stream("run my script")]
 
         assert budgets_seen == list(_VERIFIER_TOKEN_BUDGETS), (
             "the ladder must exhaust every budget before giving up"
         )
         progress_msgs = [e.message for e in events if isinstance(e, StreamTaskProgress)]
-        assert "Something went wrong — checking in with you..." in progress_msgs, (
+        assert _HANDBACK_PROGRESS in progress_msgs, (
             "exhausted budgets must fail toward the diagnosis, not a silent COMPLETE"
         )
         assert call_count == 3
+        # Only the attempt that ends the ladder is a failure; the retried one is
+        # not, so a default-level (WARNING) log carries exactly one of the two.
+        attempts = [
+            r for r in caplog.records
+            if "completion-verifier verdict=" in r.getMessage()
+            and "output_tokens=" in r.getMessage()
+        ]
+        assert [r.levelno for r in attempts] == [logging.INFO, logging.WARNING]
+        # And the line naming the failure class must itself clear WARNING, or a
+        # customer's default log cannot say why the turn handed back.
+        gave_up = [
+            r for r in caplog.records
+            if "failing toward an honest diagnosis" in r.getMessage()
+        ]
+        assert [r.levelno for r in gave_up] == [logging.WARNING]
     finally:
         await session.close()
 
@@ -885,18 +917,18 @@ async def test_denied_verdict_latches_silently_on_first_occurrence(
                     diagnoses += 1
 
         # Silent: no diagnosis stream ever fires, and the user never sees the
-        # "Something went wrong — checking in with you..." progress line.
+        # hand-back's progress line.
         assert diagnoses == 0, (
             f"denied verdicts must not stream a diagnosis, got {diagnoses}"
         )
-        assert not any("Something went wrong" in m for m in progress_messages)
-        # The "internal error" SYSTEM injection must never enter history —
-        # it persists into every later turn's payload once appended.
+        assert not any(_HANDBACK_PROGRESS in m for m in progress_messages)
+        # The hand-back SYSTEM injection must never enter history — it persists
+        # into every later turn's payload once appended.
         assert not any(
-            "task-completion check failed" in str(m.get("content", ""))
+            _HANDBACK_ANCHOR in str(m.get("content", ""))
             for m in session._history
             if isinstance(m, dict)
-        ), "the internal-error injection reached history on a denied verdict"
+        ), "the hand-back injection reached history on a denied verdict"
         # Latched on the FIRST call: turns 2-4 pay nothing.
         assert calls["n"] == 1, (
             f"denied verdict must latch on the first occurrence, got {calls['n']} calls"
@@ -963,7 +995,7 @@ async def test_denied_reprobe_stays_latched_and_silent(workspace, caplog):
         assert session._verifier_latched is True
         assert diagnoses == 0
         assert not any(
-            "task-completion check failed" in str(m.get("content", ""))
+            _HANDBACK_ANCHOR in str(m.get("content", ""))
             for m in session._history
             if isinstance(m, dict)
         )


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-2193

the verifier failure and latch-state lines now log at WARNING, so a default-level log names the failure class and exception type
a truncation the larger token budget retries stays at INFO, and the per-turn latched-skip, re-probe and successful-verdict lines stay at INFO
the verifier-failure handback now leads with the work having finished and the reply standing, instead of announcing an internal error
the handback forbids naming a path that is not verbatim in a tool result, so the model stops restating the path it meant to write
the progress line reads "Confirming what was completed..." instead of "Something went wrong — checking in with you..."
tests re-anchor the six pinned prompt strings on two shared constants, so the denied-verdict negative assertions cannot pass vacuously after a reword
new coverage for the handback wording and for the per-attempt log levels
pairs with mindsdb/cowork-server#429, which lets LOG_LEVEL in the desktop config file reach logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)