### PR TITLE
Plug yolo mode into the agent as edit_artifact (ENG-2186)

### DIFF
--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -117,6 +117,7 @@ _SENTINEL_REASONS = {
     "scratchpad_missing_name": (TIER_SELF, "missing_name"),
     "missing_name": (TIER_SELF, "missing_argument"),
     "missing_slug": (TIER_SELF, "missing_argument"),
+    "missing_task": (TIER_SELF, "missing_argument"),
     "missing_description": (TIER_SELF, "missing_argument"),
     "invalid_type": (TIER_SELF, "invalid_argument"),
     "invalid_port": (TIER_SELF, "invalid_argument"),
@@ -129,6 +130,16 @@ _SENTINEL_REASONS = {
     # genuinely absent resource — but the agent chose the identifier and can
     # list the real ones, so it resolves to the non-tripping side.
     "artifact_not_found": (TIER_SELF, "unknown_resource"),
+    # edit_artifact could not land a diff. Self-inflicted rather than a
+    # wall: nothing in the environment is missing, the model's own diff
+    # did not match the file, and the tool result tells it to make the
+    # change with the scratchpad instead. Built as f"yolo_{status}" in
+    # the handler, so the tree scan cannot see these — they are listed
+    # here because the runtime classifier would otherwise bucket a
+    # perfectly ordinary fallback as unclassified.
+    "yolo_patch_failed": (TIER_SELF, "edit_not_applied"),
+    "yolo_no_diff": (TIER_SELF, "edit_not_applied"),
+    "yolo_error": (TIER_SELF, "edit_not_applied"),
     "unknown_datasource": (TIER_SELF, "unknown_resource"),
     # Genuine walls: the environment is missing something the agent cannot add.
     "package_install_failed": (TIER_WALL, "missing_dependency"),

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -78,6 +78,7 @@ from anton.core.turn_cost import UNKNOWN_ROLE, TurnCost
 from anton.core.tools.tool_defs import (
     ASK_USER_TOOL,
     CREATE_ARTIFACT_TOOL,
+    EDIT_ARTIFACT_TOOL,
     LAUNCH_BACKEND_TOOL,
     LIST_ARTIFACTS_TOOL,
     MEMORIZE_TOOL,
@@ -1376,6 +1377,17 @@ class ChatSession:
         return self._history
 
     @property
+    def llm_client(self) -> LLMClient:
+        """The session's LLM client, for tool handlers that need one.
+
+        Everything a handler runs should go through the same client the
+        rest of the turn uses — same provider, same coding/planning model
+        split, same tracing. Exposed as a property so a handler does not
+        have to reach into `_llm` to get it.
+        """
+        return self._llm
+
+    @property
     def artifacts_touched(self) -> set[str]:
         """Slugs this turn created or opened for editing.
 
@@ -2109,6 +2121,7 @@ class ChatSession:
             self.tool_registry.register_tool(CREATE_ARTIFACT_TOOL)
             self.tool_registry.register_tool(LIST_ARTIFACTS_TOOL)
             self.tool_registry.register_tool(OPEN_ARTIFACT_TOOL)
+            self.tool_registry.register_tool(EDIT_ARTIFACT_TOOL)
             self.tool_registry.register_tool(UPDATE_ARTIFACT_METADATA_TOOL)
             self.tool_registry.register_tool(LAUNCH_BACKEND_TOOL)
 

--- a/anton/core/tools/tool_defs.py
+++ b/anton/core/tools/tool_defs.py
@@ -5,6 +5,7 @@ from anton.core.tools.tool_handlers import (
     handle_launch_backend,
     handle_list_artifacts,
     handle_memorize,
+    handle_edit_artifact,
     handle_open_artifact,
     handle_read_image,
     handle_recall,
@@ -331,6 +332,41 @@ OPEN_ARTIFACT_TOOL = ToolDef(
         "required": ["slug"],
     },
     handler=handle_open_artifact,
+)
+
+
+EDIT_ARTIFACT_TOOL = ToolDef(
+    name="edit_artifact",
+    description=(
+        "Change files in an artifact that already exists, by describing the change "
+        "in plain language. Prefer this over the scratchpad for editing: it writes "
+        "the change as a diff and applies it, so it cannot half-apply, and it does "
+        "not need you to write a program that performs string surgery.\n\n"
+        "Use the scratchpad instead for: creating an artifact from nothing, "
+        "generating or transforming data, and anything that needs computation. "
+        "This tool will not write `*.data.js` files.\n\n"
+        "If it reports it could not apply the change, nothing was written — fall "
+        "back to the scratchpad and make the edit there."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "slug": {
+                "type": "string",
+                "description": "Folder slug of the artifact to edit.",
+            },
+            "task": {
+                "type": "string",
+                "description": (
+                    "What to change, in plain language — e.g. \"rename the title to "
+                    "TicTacTris\" or \"make the chart fill the viewport\". Be specific "
+                    "about the intended result; you do not need to say which files."
+                ),
+            },
+        },
+        "required": ["slug", "task"],
+    },
+    handler=handle_edit_artifact,
 )
 
 

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from anton.core.backends.base import Cell
+from anton.core.tools.progress import ToolProgress
 from anton.core.tools.registry import ToolOutcome
 from anton.core.tools.side_effect import SideEffectResult, now_iso
 from anton.core.utils.scratchpad import (
@@ -83,7 +84,14 @@ def _artifact_store(session: "ChatSession"):
     return ArtifactStore(workspace.artifacts_dir)
 
 
-def _track_artifact(session: "ChatSession", store, slug: str, *, summary: str = "") -> None:
+def _track_artifact(
+    session: "ChatSession",
+    store,
+    slug: str,
+    *,
+    summary: str = "",
+    files: list[str] | None = None,
+) -> None:
     """Record that THIS turn created or opened `slug`.
 
     Two records, for two different readers:
@@ -120,7 +128,7 @@ def _track_artifact(session: "ChatSession", store, slug: str, *, summary: str = 
             conversation_title=None,
             turn_index=getattr(session, "_turn_count", 0) + 1,
             summary=summary,
-            files_touched=[],
+            files_touched=list(files or []),
         )
     except Exception:
         _log.warning("could not record turn provenance for artifact %s", slug, exc_info=True)
@@ -494,6 +502,96 @@ async def handle_open_artifact(session: "ChatSession", tc_input: dict) -> str:
         "path": str(folder),
         "files": [{"path": f.path, "bytes": f.bytes} for f in artifact.files],
     }, indent=2)
+
+
+async def handle_edit_artifact(session: "ChatSession", tc_input: dict):
+    """Change files in an existing artifact by describing the change.
+
+    The fast path for *modifying* an artifact. The scratchpad remains the
+    right tool for generating one, and for anything that computes: this
+    exists because asking a model to write a Python program that performs
+    string surgery on a file adds a second thing that can be wrong, and a
+    subtly wrong program mangles the file rather than leaving it alone.
+
+    Streams progress as it goes (see `yolo_bridge`), because a run makes
+    two model calls and would otherwise be a silent pause.
+
+    On failure it writes nothing and says so, handing the diagnosis back
+    so the model can fall back to the scratchpad with something useful in
+    hand. That handoff is a message rather than orchestration on purpose:
+    the model already has the scratchpad and knows how to drive it.
+    """
+    import asyncio
+
+    from anton.core.tools.yolo_bridge import QueueProgress, run_with_progress
+    from anton.core.yolo import Workspace, YoloEditor
+
+    store = _artifact_store(session)
+    if store is None:
+        yield ToolOutcome(
+            content="Artifact store unavailable (no workspace bound to this session).",
+            ok=False,
+            reason="store_unavailable",
+        )
+        return
+
+    slug = (tc_input.get("slug") or "").strip()
+    task = (tc_input.get("task") or "").strip()
+    if not slug:
+        yield ToolOutcome(content="Error: `slug` is required.", ok=False, reason="missing_slug")
+        return
+    if not task:
+        yield ToolOutcome(content="Error: `task` is required.", ok=False, reason="missing_task")
+        return
+
+    artifact = store.open(slug)
+    if artifact is None:
+        yield ToolOutcome(
+            content=f"Error: no artifact found for slug `{slug}`.",
+            ok=False,
+            reason="artifact_not_found",
+        )
+        return
+
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    editor = YoloEditor(
+        workspace=Workspace(store.folder_for(artifact.slug)),
+        llm_client=session.llm_client,
+        progress=QueueProgress(queue),
+    )
+    work = asyncio.ensure_future(editor.edit(task))
+
+    outcome = None
+    async for item in run_with_progress(work, queue):
+        if isinstance(item, ToolProgress):
+            yield item
+        else:
+            outcome = item
+
+    if outcome is not None and outcome.applied:
+        # Yolo writes to the folder directly, so the store does not find
+        # out unless it is told. Without this the file list and README go
+        # stale and nothing complains.
+        store.rescan_files(artifact.slug)
+        _track_artifact(session, store, artifact.slug, summary=outcome.summary, files=outcome.files)
+        yield ToolOutcome(
+            content=f"Applied: {outcome.summary}\nFiles: {', '.join(outcome.files)}",
+            ok=True,
+        )
+        return
+
+    detail = (outcome.detail if outcome else "") or "no diff was produced"
+    yield ToolOutcome(
+        content=(
+            f"Could not apply the change after {outcome.attempts if outcome else 0} "
+            f"attempt(s). Nothing was written and the artifact is unchanged.\n\n"
+            f"{detail}\n\n"
+            f"Make this change with the scratchpad instead: read the file, modify it "
+            f"in Python, and write it back."
+        ),
+        ok=False,
+        reason=f"yolo_{outcome.status if outcome else 'error'}",
+    )
 
 
 async def handle_recall(session: ChatSession, tc_input: dict) -> str:

--- a/anton/core/tools/yolo_bridge.py
+++ b/anton/core/tools/yolo_bridge.py
@@ -1,0 +1,84 @@
+"""Turning a yolo run into a streaming tool call.
+
+Two impedance mismatches to solve, and they are the whole module.
+
+The first is direction. `YoloEditor` reports what it is doing by *calling*
+a `Progress` object, synchronously, from inside the coroutine doing the
+work. A streaming tool handler reports by *yielding* `ToolProgress` from
+an async generator. One pushes, the other pulls, so something has to sit
+between them: a queue the editor writes into and the generator drains.
+
+The second is that the work and the reporting have to proceed together.
+Awaiting the edit first and replaying its log afterwards would produce
+exactly the silent pause the progress exists to prevent — the lines would
+all arrive at the end, after the thing they describe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+from anton.core.tools.progress import ToolProgress
+
+__all__ = ["QueueProgress", "run_with_progress"]
+
+
+class QueueProgress:
+    """A yolo `Progress` that puts its lines on a queue.
+
+    `put_nowait` because the editor calls these from synchronous code and
+    cannot await. The queue is unbounded, which is safe here: a run emits
+    on the order of ten lines, and dropping progress to apply
+    backpressure to real work would be the wrong trade anyway.
+    """
+
+    def __init__(self, queue: asyncio.Queue[str]) -> None:
+        self._queue = queue
+
+    def status(self, message: str) -> None:
+        self._queue.put_nowait(message)
+
+    def log(self, message: str) -> None:
+        # Yolo indents its detail lines to sit under a status. That reads
+        # in a terminal; in a chat stream it is just leading whitespace.
+        self._queue.put_nowait(message.strip())
+
+
+async def run_with_progress(
+    work: asyncio.Future, queue: asyncio.Queue[str]
+) -> AsyncIterator[ToolProgress | object]:
+    """Yield progress as it arrives, then the result, in order.
+
+    Waits on the queue and the work at once so a line appears the moment
+    it is written rather than on a polling interval. When the work
+    finishes, whatever is still queued is drained before the result goes
+    out — those lines describe steps that really happened, and dropping
+    them would make the last thing the user sees be from the middle of
+    the run.
+
+    Cancellation is handled explicitly: the pending queue read is a task,
+    and leaving it dangling would log "Task was destroyed but it is
+    pending" every time a tool call ends.
+    """
+    pending_read: asyncio.Task | None = asyncio.ensure_future(queue.get())
+    try:
+        while True:
+            done, _ = await asyncio.wait(
+                {pending_read, work}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if pending_read in done:
+                yield ToolProgress(text=pending_read.result())
+                pending_read = asyncio.ensure_future(queue.get())
+            if work in done:
+                break
+    finally:
+        if pending_read is not None and not pending_read.done():
+            pending_read.cancel()
+
+    while not queue.empty():
+        yield ToolProgress(text=queue.get_nowait())
+    # Re-raises here if the work failed, which is what the caller wants:
+    # a crash inside the editor should surface as a failed tool call, not
+    # as a silently empty result.
+    yield work.result()

--- a/tests/test_yolo_tool.py
+++ b/tests/test_yolo_tool.py
@@ -1,0 +1,225 @@
+"""The `edit_artifact` tool: yolo wired into the agent.
+
+Covers the seams rather than the engine — the engine has its own tests.
+What matters here is what a tool call does to the world: whether it
+streams, whether the store finds out, and what the model is told when it
+does not work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from anton.core.artifacts import ArtifactStore
+from anton.core.tools.progress import ToolProgress
+from anton.core.tools.registry import ToolOutcome
+from anton.core.tools.tool_defs import EDIT_ARTIFACT_TOOL
+from anton.core.tools.tool_handlers import handle_edit_artifact
+from anton.core.yolo import Change, Outcome, ReadRequest
+
+
+class FakeSession:
+    """Enough ChatSession for the handler, and nothing more."""
+
+    def __init__(self, workspace_dir: Path, llm) -> None:
+        class _W:
+            artifacts_dir = workspace_dir / "artifacts"
+
+        self._workspace = _W()
+        self.llm_client = llm
+        self._session_id = "conv-1"
+        self._turn_count = 3
+        self._artifacts_touched: set[str] = set()
+
+
+class StubLLM:
+    def __init__(self, *responses):
+        self.queue = list(responses)
+
+    async def generate_object_code(self, schema_class, *, system, messages, max_tokens=None):
+        if not self.queue:
+            raise AssertionError("more model calls than the test queued")
+        return self.queue.pop(0)
+
+
+def artifact_with(tmp_path: Path, llm) -> tuple[FakeSession, ArtifactStore, str]:
+    session = FakeSession(tmp_path, llm)
+    store = ArtifactStore(tmp_path / "artifacts")
+    art = store.create(name="Chart", description="a chart", type="html-app")
+    folder = store.folder_for(art.slug)
+    (folder / "index.html").write_text("<title>Old Title</title>\n")
+    store.rescan_files(art.slug)
+    return session, store, art.slug
+
+
+async def drain(session, tc_input) -> tuple[list[str], ToolOutcome]:
+    """Run the handler, separating progress lines from the result."""
+    lines, result = [], None
+    async for item in handle_edit_artifact(session, tc_input):
+        if isinstance(item, ToolProgress):
+            lines.append(item.text)
+        else:
+            result = item
+    return lines, result
+
+
+RETITLE = Change(
+    summary="Retitled it",
+    files=["index.html"],
+    diff="--- a/index.html\n+++ b/index.html\n@@\n"
+    "-<title>Old Title</title>\n+<title>TicTacTris</title>\n",
+)
+
+
+# ─── The tool contract ──────────────────────────────────────────────────
+
+
+def test_the_tool_tells_the_model_when_not_to_use_it():
+    """Routing is done by the description, not a classifier, so the
+    description has to carry the boundary."""
+    text = EDIT_ARTIFACT_TOOL.description
+    assert "already exists" in text
+    assert "scratchpad" in text  # named as the alternative, twice over
+    assert "data.js" in text  # and the one thing it will not write
+
+
+async def test_a_change_is_applied_and_reported(tmp_path: Path):
+    llm = StubLLM(ReadRequest(paths=["index.html"]), RETITLE)
+    session, store, slug = artifact_with(tmp_path, llm)
+
+    _, result = await drain(session, {"slug": slug, "task": "retitle it"})
+
+    assert result.ok is True
+    assert "Retitled it" in result.content
+    assert "index.html" in result.content
+    assert "TicTacTris" in (store.folder_for(slug) / "index.html").read_text()
+
+
+async def test_progress_streams_while_the_work_runs(tmp_path: Path):
+    """A run makes two model calls. Without streaming it is a silent
+    pause, which is what the whole bridge exists to prevent."""
+    llm = StubLLM(ReadRequest(paths=["index.html"]), RETITLE)
+    session, _, slug = artifact_with(tmp_path, llm)
+
+    lines, result = await drain(session, {"slug": slug, "task": "retitle it"})
+
+    assert result.ok is True
+    trail = "\n".join(lines)
+    assert "reading index.html" in trail
+    assert "plan: Retitled it" in trail
+    assert "wrote index.html" in trail
+
+
+async def test_the_store_is_told_what_changed(tmp_path: Path):
+    """Yolo writes to the folder directly, so nothing updates
+    metadata.json unless the handler says so. The symptom of forgetting
+    is a silently stale file list."""
+    llm = StubLLM(ReadRequest(paths=["index.html"]), RETITLE)
+    session, store, slug = artifact_with(tmp_path, llm)
+
+    await drain(session, {"slug": slug, "task": "retitle it"})
+
+    art = store.open(slug)
+    assert slug in session._artifacts_touched
+    [entry] = art.provenance
+    [turn] = entry.turns
+    assert turn.summary == "Retitled it"
+    assert turn.files_touched == ["index.html"]
+
+
+async def test_a_new_file_shows_up_in_the_metadata(tmp_path: Path):
+    llm = StubLLM(
+        ReadRequest(paths=[]),
+        Change(
+            summary="Added a stylesheet",
+            files=["style.css"],
+            diff="*** Begin Patch\n*** Add File: style.css\n+body { margin: 0; }\n*** End Patch\n",
+        ),
+    )
+    session, store, slug = artifact_with(tmp_path, llm)
+
+    _, result = await drain(session, {"slug": slug, "task": "add a stylesheet"})
+
+    assert result.ok is True
+    assert "style.css" in {f.path for f in store.open(slug).files}
+
+
+# ─── Failing back to the scratchpad ─────────────────────────────────────
+
+
+async def test_a_failure_writes_nothing_and_points_at_the_scratchpad(tmp_path: Path):
+    """The handoff. The model already has the scratchpad; it needs to be
+    told plainly that nothing was written and what to do next."""
+    doomed = Change(
+        summary="nope",
+        files=["index.html"],
+        diff="--- a/index.html\n+++ b/index.html\n@@\n-<title>WRONG</title>\n+<title>x</title>\n",
+    )
+    llm = StubLLM(ReadRequest(paths=["index.html"]), doomed, doomed, doomed)
+    session, store, slug = artifact_with(tmp_path, llm)
+    before = (store.folder_for(slug) / "index.html").read_text()
+
+    _, result = await drain(session, {"slug": slug, "task": "retitle it"})
+
+    assert result.ok is False
+    assert "Nothing was written" in result.content
+    assert "scratchpad" in result.content
+    assert "could not find" in result.content  # the diagnosis travels with it
+    assert result.reason == "yolo_patch_failed"
+    assert (store.folder_for(slug) / "index.html").read_text() == before
+
+
+async def test_a_failed_run_is_not_recorded_as_a_turn(tmp_path: Path):
+    """Provenance says which turns changed the artifact. One that changed
+    nothing did not."""
+    doomed = Change(summary="", files=[], diff="")
+    llm = StubLLM(ReadRequest(paths=[]), doomed)
+    session, store, slug = artifact_with(tmp_path, llm)
+
+    await drain(session, {"slug": slug, "task": "x"})
+
+    assert store.open(slug).provenance == []
+    assert session._artifacts_touched == set()
+
+
+async def test_an_unknown_slug_is_an_error_not_a_crash(tmp_path: Path):
+    session, _, _ = artifact_with(tmp_path, StubLLM())
+    _, result = await drain(session, {"slug": "nope", "task": "x"})
+    assert result.ok is False
+    assert result.reason == "artifact_not_found"
+
+
+async def test_missing_arguments_are_reported_as_the_agents_own_fault(tmp_path: Path):
+    """These reasons feed root_cause tiering, where a bad argument is
+    self-fixable and must not be counted as an environment wall."""
+    session, _, slug = artifact_with(tmp_path, StubLLM())
+    for tc_input, reason in (
+        ({"task": "x"}, "missing_slug"),
+        ({"slug": slug}, "missing_task"),
+    ):
+        _, result = await drain(session, tc_input)
+        assert result.ok is False
+        assert result.reason == reason
+
+
+async def test_no_workspace_means_no_store(tmp_path: Path):
+    session = FakeSession(tmp_path, StubLLM())
+    session._workspace = None
+    _, result = await drain(session, {"slug": "x", "task": "y"})
+    assert result.ok is False
+    assert result.reason == "store_unavailable"
+
+
+async def test_a_crash_inside_the_editor_surfaces(tmp_path: Path):
+    """A silently empty result would be worse than an exception."""
+
+    class Exploding:
+        async def generate_object_code(self, *a, **k):
+            raise RuntimeError("provider is down")
+
+    session, _, slug = artifact_with(tmp_path, Exploding())
+    with pytest.raises(RuntimeError, match="provider is down"):
+        await drain(session, {"slug": slug, "task": "x"})


### PR DESCRIPTION
Follow-up to #422, which added the library and wired it to nothing. This connects it.

## What the agent can now do

> **User:** rename the title to TicTacTris

```
edit_artifact(slug="tictactris", task="rename the title to TicTacTris")

  choosing what to read...
  reading index.html
  plan: Retitled the app to TicTacTris
  wrote index.html

→ Applied: Retitled the app to TicTacTris
  Files: index.html
```

Two model calls. Previously this was the scratchpad writing a Python program to perform string surgery on the file — a second thing that can be wrong, and a subtly wrong one mangles the file rather than leaving it alone.

## The handoff when it does not work

```
Could not apply the change after 3 attempts. Nothing was written and
the artifact is unchanged.

could not find this hunk's lines in the file:
  <title>WRONG</title>

Make this change with the scratchpad instead: read the file, modify it
in Python, and write it back.
```

A **message, not orchestration**. The model already has the scratchpad and knows how to drive it, so the smallest thing that works is to say plainly that nothing was written and what to do next — and to send the diagnosis along with it.

## Streaming

A run makes two model calls, so without progress it is a silent pause. The awkward part is a direction mismatch: `YoloEditor` reports by *calling* a `Progress` object synchronously from inside the work, while a streaming handler reports by *yielding*. `tools/yolo_bridge.py` puts a queue between them and drains it alongside the work, waiting on both at once so a line appears when it is written.

Awaiting the edit and replaying its log afterwards would have produced exactly the pause the progress exists to prevent.

## Also in here

- **`ChatSession.llm_client`** — a property, so a handler does not reach into `_llm`. Everything a handler runs uses the same provider, coding/planning split and tracing as the rest of the turn.
- **`_track_artifact(..., files=...)`** — yolo knows which files it touched. Existing callers pass nothing and keep their behaviour.
- **`rescan_files` after a successful edit** — yolo writes to the folder directly, so `metadata.json` and the README go stale unless the store is told, and nothing complains when they do.
- **`missing_task` and the `yolo_*` outcomes registered in `root_cause`.** All `TIER_SELF`: nothing in the environment is missing, and a diff that would not apply is something the agent recovers from itself. The `yolo_*` ones are built as an f-string so the tree scan cannot see them — listed explicitly so the runtime classifier does not bucket an ordinary fallback as `unclassified`.

## Testing

**11 new tests**, on the seams rather than the engine — the engine has its own 87 from #422.

| | |
|---|---|
| streaming | progress lines arrive, in order, while the work runs |
| provenance | `_artifacts_touched`, `record_turn`, and `files_touched` all correct |
| a new file | `*** Add File:` shows up in `metadata.json` |
| the handoff | nothing written, artifact byte-identical, diagnosis + scratchpad instruction present |
| a failed run | records **no** turn — provenance says which turns changed the artifact, and one that changed nothing did not |
| bad arguments | surface as `missing_slug` / `missing_task`, which tier as self-inflicted |
| a provider crash | propagates rather than returning a silently empty result |

Full suite: **2859 passed**, 31 skipped, 2 failures in `test_chat_scratchpad.py` pre-existing on `staging`.

Phase 2 (the scratchpad's `emit_data` and the `reconcile()` hook) stays open on [ENG-2186](https://linear.app/mindsdb/issue/ENG-2186/yolo-mode-edit-artifacts-with-diffs-and-let-the-scratchpad-own-the).