### PR TITLE
[ENG-2193] Skip the completion verifier on a model that cannot produce a verdict

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -171,8 +171,11 @@ _pending_lock = threading.Lock()
 #                    spend-ceiling extensions granted this turn, and the
 #                    ceiling one's size), verifier_failure + verifier_error_type
 #                    (WHY the completion verifier produced no verdict — the
-#                    loop's truncated/transient/hard/denied class and the
-#                    content-free exception type; "" on verified turns; ENG-1858),
+#                    loop's truncated/transient/hard/denied class,
+#                    latched_{hard,denied} when an earlier turn latched, or
+#                    skipped_incapable_model when the coding model cannot
+#                    answer a forced tool call, plus the content-free
+#                    exception type; "" on verified turns; ENG-1858),
 #                    harness, surface (desktop / web / cli — WHERE
 #                    the user was, "" when the host did not say; ENG-1945),
 #                    anton_version, conversation_id, turn_index

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -436,6 +436,35 @@ _DENIED_VERDICT_ERRORS: tuple[type[BaseException], ...] = (
     ModelUnavailableError,
 )
 
+# Models that cannot answer a FORCED tool call, so a verdict call on them is
+# spent to produce nothing. Skipping beats discovering it twice per session:
+# the latch below needs two failures, and a host that rebuilds ChatSession per
+# message never reaches two, so every message paid the ladder AND an "internal
+# error" hand-back on a turn whose work had succeeded.
+#
+#   mindshub_air  narrates past the budget instead of reaching the call — 98.6%
+#                 of prod verdicts returned no tool call (ENG-1081). A MindsHub
+#                 alias, so the name does not collide with anyone's own model.
+#   kimi          rejects forced `tool_choice` outright with a 400 (ENG-1095).
+#                 A property of the model family, not of our gateway, so it
+#                 holds wherever the model is served.
+#
+# Matched on the requested alias, which is what `coding_model` holds — the
+# gateway resolves `mindshub_air` to a real model server-side and only echoes
+# that back on the response.
+#
+# Deliberately NOT provider-gated. The provider string has two vocabularies
+# depending on which host wrote the settings (ENG-1695), and the endpoint
+# classifier reads the PLANNING role, so neither answers the coding-role
+# question this needs. Both entries above justify themselves without it.
+#
+# Being out of date is bounded in both directions: an entry that the gateway
+# has since fixed costs that model its verification until the entry is removed,
+# and a broken model missing from the list falls through to the latch exactly
+# as it does today. This is an optimisation over the latch, not a replacement.
+_VERDICT_INCAPABLE_MODELS: frozenset[str] = frozenset({"mindshub_air", "kimi"})
+
+
 # Turns a latched session skips before spending one verdict call to see whether
 # the cause has gone away (user switched model, gateway fix shipped). Without a
 # re-probe the latch is permanent for the session and "reset on a successful
@@ -1140,6 +1169,9 @@ class ChatSession:
         # (billing/model access, ENG-1632) — so the skip log names the real
         # cause instead of reporting "0 hard failures" for a denied latch.
         self._verifier_latch_reason = ""
+        # The incapable-model skip is a per-turn decision, so its log line would
+        # otherwise repeat every turn saying nothing new.
+        self._verifier_incapable_announced = False
         self._context_pressure_threshold = s.context_pressure_threshold
         self._max_consecutive_errors = s.max_consecutive_errors
         self._resilience_nudge_at = s.resilience_nudge_at
@@ -5358,6 +5390,36 @@ class ChatSession:
             # tool_round==0; raising verify_min_tool_rounds also skips trivial
             # single-round turns) or when we hit the max-rounds hard stop.
             if tool_round < self._verify_min_tool_rounds or _max_rounds_hit or _spend_ceiling_hit:
+                break
+
+            # This model cannot answer a forced tool call, so the verdict call
+            # would spend the whole ladder to produce nothing and then hand the
+            # user an "internal error" for a turn that worked. End on the
+            # model's own reply instead, and book the turn as unverified.
+            #
+            # Ahead of the latch rather than folded into it: the latch LEARNS
+            # this at the cost of two failures per session, which a host that
+            # rebuilds the session per message never finishes paying.
+            #
+            # No auto-upgrade to a capable model. Same call the denied branch
+            # makes below: a missing check beats a surprise bill.
+            if self._llm.coding_model in _VERDICT_INCAPABLE_MODELS:
+                if not self._verifier_incapable_announced:
+                    self._verifier_incapable_announced = True
+                    _verifier_log.info(
+                        "completion-verifier skipped — coding model %s cannot "
+                        "answer a forced tool call; turns end on the model's own "
+                        "reply, unverified",
+                        self._llm.coding_model,
+                    )
+                # Unverified, and analytics must not count it as a clean pass:
+                # without this the turn is byte-identical to a verified one and
+                # joins the honest-stop denominator (the ENG-1632 review's
+                # point, and what the verify_min_tool_rounds skip above still
+                # gets wrong).
+                if self._turn_cost is not None:
+                    self._turn_cost.verification_skipped = True
+                    self._turn_cost.verifier_failure = "skipped_incapable_model"
                 break
 
             # Append the assistant's final text so the verifier can see it.

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -143,7 +143,9 @@ class TurnCost:
     # are the classification the verdict loop already draws for the latch —
     # `truncated` / `transient` / `hard` / `denied` — plus `latched_hard` /
     # `latched_denied` for turns that never made the call because an earlier
-    # one latched. Empty when a verdict was produced or the verifier was
+    # one latched, and `skipped_incapable_model` for a coding model known not
+    # to answer a forced tool call, where no call is made at all. Empty when a
+    # verdict was produced or the verifier was
     # not applicable. Stamped at the loop's exits, never read from latch
     # state at emit (late finalizers would see a later turn's latch).
     verifier_failure: str = ""

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -1010,3 +1010,106 @@ async def test_denied_reprobe_stays_latched_and_silent(workspace, caplog):
         )
     finally:
         await session.close()
+
+
+# ── Models that cannot answer a forced tool call ─────────────────────────────
+#
+# The latch learns this at the cost of two failures per session, which a host
+# that rebuilds ChatSession per message never finishes paying. Naming the models
+# skips the call outright, so the ladder is never spent and the user is never
+# told an internal error happened on a turn that worked.
+
+
+async def test_an_incapable_coding_model_skips_the_verdict_call(workspace, caplog):
+    """No verdict call at all, no ladder, and no hand-back — on every turn, not
+    just from the second one like the latch."""
+    import logging
+
+    mock_llm = make_mock_llm()
+    mock_llm.coding_model = "mindshub_air"
+    mock_llm.generate_object_code = AsyncMock(
+        side_effect=AssertionError("the verdict call must not be made")
+    )
+    session = _make_session(workspace, mock_llm)
+
+    diagnoses = 0
+    try:
+        with caplog.at_level(logging.INFO):
+            for turn in range(3):
+                plan, state = _tool_then_text_plan()
+                mock_llm.plan_stream = plan
+                async for _ in session.turn_stream(f"do step {turn}"):
+                    pass
+                # A third plan_stream call on a turn == a diagnosis fired.
+                if state["n"] >= 3:
+                    diagnoses += 1
+
+        assert mock_llm.generate_object_code.await_count == 0
+        assert diagnoses == 0, (
+            f"an incapable model must never produce a hand-back, got {diagnoses}"
+        )
+        # Once per session: the decision is per turn, so an unguarded log line
+        # would repeat every turn saying nothing new.
+        announcements = [
+            r for r in caplog.records
+            if "cannot answer a forced tool call" in r.message
+        ]
+        assert len(announcements) == 1, (
+            f"expected one announcement per session, got {len(announcements)}"
+        )
+        assert "mindshub_air" in announcements[0].message
+    finally:
+        await session.close()
+
+
+async def test_the_skipped_turn_is_booked_as_unverified(workspace):
+    """Without the stamp the turn is byte-identical in analytics to a verified
+    pass and silently joins the honest-stop denominator. That is what the
+    verify_min_tool_rounds skip still gets wrong."""
+    from unittest.mock import patch
+
+    mock_llm = make_mock_llm()
+    mock_llm.coding_model = "kimi"
+    mock_llm.generate_object_code = AsyncMock(
+        side_effect=AssertionError("the verdict call must not be made")
+    )
+    session = _make_session(
+        workspace, mock_llm
+    )
+    session._session_id = "conv-skip"
+    try:
+        with patch("anton.analytics.send_event") as send:
+            plan, _ = _tool_then_text_plan()
+            mock_llm.plan_stream = plan
+            async for _ in session.turn_stream("do the thing"):
+                pass
+            k = send.call_args.kwargs
+        assert k["verification_skipped"] == "true"
+        assert k["verifier_failure"] == "skipped_incapable_model"
+        assert k["verifier_error_type"] == "", "no call was made, so no exception"
+        assert k["ended_by"] == "completed"
+    finally:
+        await session.close()
+
+
+async def test_an_unlisted_model_still_verifies_and_still_latches(workspace):
+    """The list is an optimisation over the latch, not a replacement: a model it
+    does not know about must keep today's behaviour exactly."""
+    mock_llm = make_mock_llm()
+    mock_llm.coding_model = "some-other-model"
+    mock_llm.generate_object_code = AsyncMock(
+        side_effect=RuntimeError("400 tool_choice not supported")
+    )
+    session = _make_session(workspace, mock_llm)
+    try:
+        for turn in range(2):
+            plan, _ = _tool_then_text_plan()
+            mock_llm.plan_stream = plan
+            async for _ in session.turn_stream(f"do step {turn}"):
+                pass
+        assert mock_llm.generate_object_code.await_count == 2
+        assert session._verifier_latched is True, (
+            "an unlisted model must still reach the latch the normal way"
+        )
+    finally:
+        await session.close()

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -1088,6 +1088,14 @@ async def test_the_skipped_turn_is_booked_as_unverified(workspace):
         assert k["verifier_failure"] == "skipped_incapable_model"
         assert k["verifier_error_type"] == "", "no call was made, so no exception"
         assert k["ended_by"] == "completed"
+        # The skip breaks BEFORE the verification block appends the reply, so
+        # the post-loop fallback owns it. Appending in both places is what put
+        # the reply in history twice on every hand-back turn (ENG-1155).
+        replies = [
+            m for m in session.history
+            if m.get("role") == "assistant" and m.get("content") == "REPLY"
+        ]
+        assert len(replies) == 1, f"reply must land in history exactly once: {replies}"
     finally:
         await session.close()
 


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-2193

> [!WARNING]
> **DRAFT, and should not merge as it stands.** The idea may still be right, but the evidence I built it on turned out to be out of date. See Notes for the reviewer.

## Background, if you don't work in this file

After a turn that used tools, anton runs a **completion check**. It asks the cheap coding model one question, "is this task actually finished?", and requires the answer as a structured tool call. If the check fails to produce an answer, the user is told an internal error stopped verification.

That message is what the ticket is about. A customer asked anton to create a file. Anton created it. The reply still ended with an internal-error notice, they read it as "the agent cannot save files", and filed it as a blocker.

Two terms used below:

- **forced tool call** — the check requires the answer in a specific structured form. Some models cannot do this, either because they talk past it or because the provider rejects the request outright.
- **ladder** — if the answer is cut off, anton retries once with a bigger budget, 2048 then 4096.

## What changed

- **Names the models that cannot answer a forced tool call**, with the evidence for each and what would take it off the list.
- **Skips the check entirely on those models**, instead of spending both budgets and then telling the user an internal error happened on a turn that actually worked.
- **Marks the skipped turn as unverified in analytics.** Without this the turn looks identical to one that passed its check, which would quietly inflate our success numbers.
- Added a test that the reply still lands in the transcript exactly once. The skip exits early, and adding the reply twice was a real bug once before.

## Why this matters

On a default free-tier account the check runs on a model that we believed could not answer it. The latch that normally silences a repeated failure needs two failures to trigger, and the desktop app builds a fresh session for every message, so it never gets to two. Every message pays the full cost and shows the error.

## Notes for the reviewer

> [!IMPORTANT]
> **The premise does not hold at the budgets this code actually uses.** Both entries on the list are wrong, and I verified both against the source after review. This is why it is a draft.

**`kimi` was fixed at the gateway.** anton asks for a specific named tool. `mindshub_inference` knows moonshot rejects that form, and rewrites it to a permissive one before sending. Under that rewrite kimi returns correct tool calls in 197 tokens. The rejection this entry cites no longer reaches anton at all, so listing it would switch off a working check for any paid user who picks kimi.

`providers/registry.py:77` sets `supports_named_tool_choice=False` for moonshot, and `InferenceService._effective_tool_request` carries the measurements.

**`mindshub_air`'s evidence is from a budget we no longer use.** The "98.6% of checks returned no answer" figure is from the old 256-token budget. `session.py:378-391` says so in the same paragraph, and gives the current numbers: 245 to 1654 tokens across 16 calls, median about 290, with a 4096 retry behind it. Nearly everything fits. When the same chattiness showed up at two other call sites, the fix was a bigger budget, not a skip.

**Take both off and the list is empty**, so this is a no-op at best, and switches off a working check at worst.

**What is actually still unknown** is which failure really fires on a live free-tier account. anton#423 shipped the WARNING log line that answers it. That measurement should come before this is revived, because it also decides whether the problem is latch-shaped or skip-shaped.

**Smaller things to fix if this is revived:**

- The log line is INFO and should be WARNING. The root logger defaults to WARNING, and the ticket explicitly asks that a customer's default log show the failure.
- The model name is matched by exact string, so a `latest:`-prefixed setting from cowork-server would slip past it. `core/llm/identity.py sanitize_model_name` already handles that prefix.
- Skipping means no verification at all for those accounts, which is the product trade-off the ticket reserved for a decision. This PR decides it by default, and that should be explicit.

## How to test

1. `uv run pytest tests/test_verifier_failsafe.py tests/test_verifier_truncation.py tests/test_turn_cost_terminals.py`
2. Before reviving: reproduce on a free-tier minds-cloud account and read the `completion-verifier verdict=` line to see which failure actually fires at the current budgets.

## Ships with

mindsdb/anton#426, which fixes a separate bug in the same area. Independent, either order.

## Checks

| Check | Observed result |
| -- | -- |
| `uv run pytest` | 2892 passed, 31 skipped |
| All GitHub checks on the head | 13 passing, including the live `verdict-eval` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
