### PR TITLE
Migrate to httpx2 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Auto-release and publish to PyPI
 
 # Stable release stream: on every push to main, validate, cut a CalVer release,
-# publish it to PyPI, and run live release e2e. Staging pre-releases (rc) live in
+# verify the built wheel, then publish it to PyPI. Staging pre-releases (rc) live in
 # publish-staging.yml so each stream keeps its own run tree, permissions,
 # notifications, and publishing identity.
 #
@@ -42,54 +42,49 @@ jobs:
       calver-major: "2"
       runs-on: ubuntu-latest
 
-  publish:
-    name: Publish to PyPI
-    needs: auto-release
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      contents: read
-      id-token: write  # required for trusted publisher (OIDC)
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.auto-release.outputs.tag }}
-          fetch-depth: 0  # hatch-vcs needs tags to derive version
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-
-      - name: Build package
-        env:
-          # A re-run or re-dispatch on an already-tagged head leaves two CalVer
-          # tags on one commit and `git describe` resolves the older one; build
-          # exactly the version the release job minted.
-          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ needs.auto-release.outputs.version }}
-        run: uv build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        # Trusted publisher (OIDC) — release.yml must be registered at the
-        # anton-agent PyPI project's publishing settings (environment: pypi).
-
-  e2e:
+  verify-wheel:
     needs: auto-release
     permissions:
       contents: read
     uses: ./.github/workflows/tests_e2e_release.yml
     with:
       tag: ${{ needs.auto-release.outputs.tag }}
+      version: ${{ needs.auto-release.outputs.version }}
     secrets: inherit
+
+  publish:
+    name: Publish to PyPI
+    # Gated on verify-wheel: a PyPI upload cannot be withdrawn.
+    needs: [auto-release, verify-wheel]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write  # required for trusted publisher (OIDC)
+    steps:
+      # Publish the bytes verify-wheel actually tested, not a rebuild of the
+      # same source — a second build verifies equivalence, not the artifact.
+      - name: Download the verified distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: verified-dist
+          path: dist
+
+      - name: Show what is being published
+        run: ls -l dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Trusted publisher (OIDC) — release.yml must be registered at the
+        # anton-agent PyPI project's publishing settings (environment: pypi).
 
   notify:
     # Alert the eng channel if ANY job in the release pipeline fails (tests, tag,
-    # PyPI publish, or release e2e).
+    # wheel verification, or PyPI publish).
     # One job covers both outcomes: a `uses:` job cannot branch on status, so
     # the aggregate result picks the failed or recovered message, and a
     # cancelled run stays silent.
-    needs: [unit-tests, auto-release, publish, e2e]
+    needs: [unit-tests, auto-release, verify-wheel, publish]
     if: ${{ github.ref == 'refs/heads/main' && !cancelled() && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read

--- a/.github/workflows/tests_e2e_release.yml
+++ b/.github/workflows/tests_e2e_release.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Run E2E scenarios against the installed wheel (live)
         env:
-          ANTON_E2E_WHEEL_PYTHON: /tmp/wheelenv/bin/python
+          ANTON_E2E_WHEEL_PYTHON: ${{ env.WHEEL_VENV }}/bin/python
           ANTON_OPENAI_API_KEY: ${{ secrets.ANTON_OPENAI_API_KEY }}
           ANTON_PLANNING_PROVIDER: openai
           ANTON_CODING_PROVIDER: openai
@@ -113,4 +113,8 @@ jobs:
           name: verified-dist
           path: dist/
           if-no-files-found: error
-          retention-days: 1
+          # Long enough that a delayed or re-run publish (environment approval,
+          # transient PyPI failure retried the next day) still finds the bytes.
+          # If it has expired anyway, re-run this whole workflow for the tag —
+          # never rebuild in the publish job, that skips verification.
+          retention-days: 14

--- a/.github/workflows/tests_e2e_release.yml
+++ b/.github/workflows/tests_e2e_release.yml
@@ -1,5 +1,9 @@
 name: Release e2e scenarios
 
+# Verifies the artifact, not the checkout: builds the wheel for the tagged
+# commit, installs it into a clean venv, and runs the live E2E scenarios
+# through that install. Publishing is irreversible, so this must gate it.
+
 permissions:
   contents: read
 
@@ -7,15 +11,24 @@ on:
   workflow_call:
     inputs:
       tag:
-        description: "Release tag the caller just created (e.g. v2.0.5)"
+        description: "Release tag to verify (e.g. v2.0.5)"
+        required: true
+        type: string
+      version:
+        description: "Version the release job minted (e.g. 2.0.5)"
         required: true
         type: string
 
 jobs:
-  e2e-live:
+  verify-wheel:
     runs-on: ubuntu-latest
+    env:
+      WHEEL_VENV: /tmp/wheelenv
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0  # hatch-vcs needs tags to derive version
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -23,11 +36,81 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Run E2E tests (live)
+      - name: Build the distributions
         env:
+          # Match the publish job: build exactly the version that was minted.
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ inputs.version }}
+        run: uv build
+
+      - name: Install the wheel into a clean venv
+        run: |
+          uv venv --python 3.12 "$WHEEL_VENV"
+          uv pip install --python "$WHEEL_VENV/bin/python" dist/*.whl
+
+      - name: Wheel must not resolve to the source tree
+        # A green run that imported anton/ from the repo would prove nothing.
+        run: |
+          loc=$(cd /tmp && "$WHEEL_VENV/bin/python" -c \
+            "import anton, pathlib; print(pathlib.Path(anton.__file__).resolve())")
+          echo "anton imported from: $loc"
+          case "$loc" in
+            "$WHEEL_VENV"/*) ;;
+            *) echo "::error::anton resolved outside the wheel venv: $loc"; exit 1 ;;
+          esac
+
+      - name: Installed version matches the release
+        env:
+          EXPECTED: ${{ inputs.version }}
+        # Compare as PEP 440 versions: packaging strips leading zeros, so the
+        # CalVer tag 2026.08.31.4 installs as 2026.8.31.4.
+        run: |
+          cd /tmp && "$WHEEL_VENV/bin/python" - <<'PY'
+          import os, sys
+          from packaging.version import Version
+          import anton
+          got, expected = anton.__version__, os.environ["EXPECTED"]
+          print(f"installed={got} expected={expected}")
+          if Version(got) != Version(expected):
+              sys.exit(f"::error::wheel reports {got}, release minted {expected}")
+          PY
+
+      - name: Console script entry point works
+        # `anton` is what users type; the E2E harness uses `python -m anton`.
+        run: cd /tmp && "$WHEEL_VENV/bin/anton" --help > /dev/null
+
+      - name: Sdist builds, installs and runs
+        # uv build produces a wheel and an sdist, and both get published, so
+        # both must be verified.
+        run: |
+          uv venv --python 3.12 /tmp/sdistenv
+          uv pip install --no-cache --python /tmp/sdistenv/bin/python dist/*.tar.gz
+          cd /tmp && /tmp/sdistenv/bin/anton --help > /dev/null
+
+      - name: Installer path resolves and runs on a cold cache
+        # install.sh installs from the git tag, not the wheel, and a warm local
+        # env can hide a dependency that is no longer pulled in transitively.
+        run: |
+          uv venv --python 3.12 /tmp/gitenv
+          uv pip install --no-cache --python /tmp/gitenv/bin/python \
+            "git+https://github.com/${{ github.repository }}.git@${{ inputs.tag }}"
+          cd /tmp && /tmp/gitenv/bin/anton --help > /dev/null
+
+      - name: Run E2E scenarios against the installed wheel (live)
+        env:
+          ANTON_E2E_WHEEL_PYTHON: /tmp/wheelenv/bin/python
           ANTON_OPENAI_API_KEY: ${{ secrets.ANTON_OPENAI_API_KEY }}
           ANTON_PLANNING_PROVIDER: openai
           ANTON_CODING_PROVIDER: openai
           ANTON_PLANNING_MODEL: gpt-4.1-mini
           ANTON_CODING_MODEL: gpt-4.1-mini
         run: uv run --group dev pytest tests/e2e/ --live -v
+
+      # Hand the publish job these exact bytes. Last step, so a failed
+      # verification never leaves a publishable artifact behind.
+      - name: Upload the verified distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: verified-dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -339,7 +339,7 @@ async def _handle_connect(
     global_ws.apply_env_to_process()
     console.print()
 
-    return rebuild_session(
+    return await rebuild_session(
         settings=settings,
         state=state,
         self_awareness=self_awareness,
@@ -1318,7 +1318,19 @@ def run_chat(
     console: Console, settings: AntonSettings, *, resume: bool = False, first_run: bool = False, desktop_first_run: bool = False
 ) -> None:
     """Launch the interactive chat REPL."""
-    asyncio.run(_chat_loop(console, settings, resume=resume, first_run=first_run, desktop_first_run=desktop_first_run))
+
+    async def _main() -> None:
+        from anton.core.llm.provider import close_live_providers, install_asyncgen_noise_filter
+
+        install_asyncgen_noise_filter()
+        try:
+            await _chat_loop(console, settings, resume=resume, first_run=first_run, desktop_first_run=desktop_first_run)
+        finally:
+            # Release provider HTTP pools before the loop dies, whatever path
+            # the loop exited on (see anton/core/llm/provider.py).
+            await close_live_providers()
+
+    asyncio.run(_main())
 
 
 async def _chat_loop(
@@ -1829,7 +1841,7 @@ async def _chat_loop(
                 elif cmd == "/remote":
                     await _handle_remote(console, settings)
                     # Rebuild session so scratchpad uses remote/local factory
-                    session = rebuild_session(
+                    session = await rebuild_session(
                         settings=settings,
                         state=state,
                         self_awareness=self_awareness,
@@ -2021,7 +2033,7 @@ async def _chat_loop(
                 from anton.cli import _ensure_api_key
 
                 _ensure_api_key(settings)
-                session = rebuild_session(
+                session = await rebuild_session(
                     settings=settings,
                     state=state,
                     self_awareness=self_awareness,
@@ -2104,7 +2116,10 @@ async def _chat_loop(
                 continue
     except KeyboardInterrupt:
         pass
+    finally:
+        # In a finally, not after the except: an exception escaping the loop
+        # must still close scratchpads and provider pools on its way out.
+        await session.close()
 
     console.print()
     console.print("[anton.muted]See you.[/]")
-    await session.close()

--- a/anton/chat_session.py
+++ b/anton/chat_session.py
@@ -46,7 +46,7 @@ def get_runtime_factory(settings: AntonSettings):
     return local_scratchpad_runtime_factory
 
 
-def rebuild_session(
+async def rebuild_session(
     *,
     settings: AntonSettings,
     state: dict,
@@ -65,7 +65,12 @@ def rebuild_session(
     from anton.core.session import ChatSessionConfig
     from anton.tools import DEFAULT_SESSION_TOOLS
 
+    outgoing = state.get("llm_client")
     state["llm_client"] = LLMClient.from_settings(settings)
+    if outgoing is not None:
+        # Nothing references the outgoing client again; release its provider
+        # HTTP pools now rather than leaving them open until process exit.
+        await outgoing.aclose()
 
     # Update cortex with new LLM client and memory mode
     if cortex is not None:

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -21,6 +21,7 @@ from rich.table import Table
 from rich.text import Text
 
 from anton import __version__
+from anton.core.llm.provider import close_live_providers
 
 from anton.utils.prompt import prompt_or_cancel
 from anton.core.llm.openai import build_chat_completion_kwargs, _is_azure_endpoint
@@ -38,6 +39,16 @@ from anton.commands.datasource import (
     handle_test_datasource
 )
 from anton.minds_client import minds_v1_base, resolve_and_probe, test_llm
+
+
+def _run_and_close(coro):
+    """Run a coroutine, then release provider HTTP pools before the loop dies."""
+    async def _wrapped():
+        try:
+            return await coro
+        finally:
+            await close_live_providers()
+    return asyncio.run(_wrapped())
 
 
 def _build_scratchpad_manager(
@@ -510,7 +521,7 @@ def _onboard(settings) -> None:
     ]
 
     if sys.stdout.isatty():
-        asyncio.run(
+        _run_and_close(
             _animate_onboard(
                 console, __version__, _INTRO_LINES, settings=settings, ws=ws
             )
@@ -1371,7 +1382,7 @@ def _setup_exa(settings, ws) -> None:
 
         def _test():
             # Sync httpx call — _validate_with_spinner runs us inside a Live.
-            import httpx as _httpx
+            import httpx2 as _httpx
 
             resp = _httpx.post(
                 "https://api.exa.ai/search",
@@ -1424,7 +1435,7 @@ def _setup_brave(settings, ws) -> None:
     try:
 
         def _test():
-            import httpx as _httpx
+            import httpx2 as _httpx
 
             resp = _httpx.get(
                 "https://api.search.brave.com/res/v1/web/search",
@@ -1652,7 +1663,7 @@ def connect_data_source(
         )
         await scratchpads.close_all()
 
-    asyncio.run(_run())
+    _run_and_close(_run())
 
 
 @app.command("list")
@@ -1687,7 +1698,7 @@ def edit_data_source(
         )
         await scratchpads.close_all()
 
-    asyncio.run(_run())
+    _run_and_close(_run())
 
 
 @app.command("remove")
@@ -1699,7 +1710,7 @@ def remove_data_source(
 ) -> None:
     """Remove a saved connection from the Local Vault."""
 
-    asyncio.run(handle_remove_data_source(console, name))
+    _run_and_close(handle_remove_data_source(console, name))
 
 
 @app.command("test")
@@ -1720,4 +1731,4 @@ def test_data_source(
         await _handle_test_datasource(console, scratchpads, name)
         await scratchpads.close_all()
 
-    asyncio.run(_run())
+    _run_and_close(_run())

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -21,7 +21,7 @@ from rich.table import Table
 from rich.text import Text
 
 from anton import __version__
-from anton.core.llm.provider import close_live_providers
+from anton.core.llm.provider import close_live_providers, install_asyncgen_noise_filter
 
 from anton.utils.prompt import prompt_or_cancel
 from anton.core.llm.openai import build_chat_completion_kwargs, _is_azure_endpoint
@@ -44,6 +44,7 @@ from anton.minds_client import minds_v1_base, resolve_and_probe, test_llm
 def _run_and_close(coro):
     """Run a coroutine, then release provider HTTP pools before the loop dies."""
     async def _wrapped():
+        install_asyncgen_noise_filter()
         try:
             return await coro
         finally:
@@ -143,8 +144,9 @@ def _reexec() -> None:
 
 # Core dependencies from pyproject.toml that anton needs at runtime
 _REQUIRED_PACKAGES: dict[str, str] = {
-    "anthropic": "anthropic>=0.42.0",
-    "openai": "openai>=1.0",
+    "anthropic": "anthropic>=1.0",
+    "openai": "openai>=3.0",
+    "httpx2": "httpx2>=2.7,<3",
     "pydantic": "pydantic>=2.0",
     "pydantic_settings": "pydantic-settings>=2.0",
     "prompt_toolkit": "prompt-toolkit>=3.0",

--- a/anton/commands/session.py
+++ b/anton/commands/session.py
@@ -110,7 +110,7 @@ async def restore_session(
         await session._scratchpads.close_all()
 
     # Build new session with restored history
-    new_session = rebuild_session(
+    new_session = await rebuild_session(
         settings=settings,
         state=state,
         self_awareness=self_awareness,

--- a/anton/commands/setup.py
+++ b/anton/commands/setup.py
@@ -95,7 +95,7 @@ async def handle_setup_models(
     console.print("[anton.success]Configuration updated.[/]")
     console.print()
 
-    return rebuild_session(
+    return await rebuild_session(
         settings=settings,
         state=state,
         self_awareness=self_awareness,

--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -8,7 +8,7 @@ import anthropic
 
 from anton.utils.datasources import scrub_credentials
 
-from .provider import safe_parse_tool_input
+from .provider import register_provider, safe_parse_tool_input, unregister_provider
 from .provider import (
     ContextOverflowError,
     LLMProvider,
@@ -192,6 +192,12 @@ def _build_native_web_tools(
 class AnthropicProvider(LLMProvider):
     name: str = "anthropic"
 
+    async def aclose(self) -> None:
+        client = getattr(self, "_client", None)
+        if client is not None:
+            await client.close()
+        unregister_provider(self)
+
     def native_web_tools(self) -> set[str]:
         # Anthropic's Messages API ships both server-side web_search and
         # web_fetch tools; we route both through the provider when enabled.
@@ -212,6 +218,7 @@ class AnthropicProvider(LLMProvider):
         if api_key:
             kwargs["api_key"] = api_key
         self._client = anthropic.AsyncAnthropic(**kwargs)
+        register_provider(self)
 
     def export_connection_info(self) -> ProviderConnectionInfo:
         return ProviderConnectionInfo(provider=self.name, api_key=self._api_key)

--- a/anton/core/llm/client.py
+++ b/anton/core/llm/client.py
@@ -81,6 +81,18 @@ class LLMClient:
         # swallowed (see _notify_usage).
         self.usage_listener = None  # Callable[[str, str, Usage], None] | None
 
+    async def aclose(self) -> None:
+        """Close provider transports. The three roles may share objects."""
+        seen: set[int] = set()
+        for p in (self._planning_provider, self._coding_provider, self._router_provider):
+            if p is None or id(p) in seen:
+                continue
+            seen.add(id(p))
+            try:
+                await p.aclose()
+            except Exception:
+                pass  # a cleanup-only failure must not break shutdown; cancellation propagates
+
     def _notify_usage(self, role: str, model: str, usage, listener=None) -> None:
         """Report one call's usage to the turn-cost accumulator.
 

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -7,11 +7,13 @@ from collections.abc import AsyncIterator
 from typing import NoReturn
 
 import openai
+from contextlib import aclosing
+
 from openai import AsyncAzureOpenAI
 
 from anton.utils.datasources import scrub_credentials
 
-from .provider import safe_parse_tool_input
+from .provider import register_provider, safe_parse_tool_input, unregister_provider
 from .provider import (
     ContentValidationError,
     ContextOverflowError,
@@ -807,6 +809,24 @@ def _split_cached_input(usage) -> tuple[int, int, int]:
     return total - read - write, read, write
 
 
+
+async def _aclose_stream(stream: object) -> None:
+    """Release a provider stream and its HTTP pool connection.
+
+    Cleanup-only failures are swallowed so they cannot replace the primary
+    exception; cancellation propagates.
+    """
+    if stream is None:
+        return
+    # SDK streams expose close(); plain async generators expose aclose().
+    closer = getattr(stream, "close", None) or getattr(stream, "aclose", None)
+    if closer is not None:
+        try:
+            await closer()
+        except Exception:
+            pass
+
+
 class OpenAIProvider(LLMProvider):
     name: str = "openai"
 
@@ -816,6 +836,12 @@ class OpenAIProvider(LLMProvider):
     FLAVOR_OPENAI = "openai"  # Direct OpenAI BYOK — uses Responses API.
     FLAVOR_MINDS_PASSTHROUGH = "minds-passthrough"  # mdb.ai — chat.completions w/ native tools.
     FLAVOR_OPENAI_COMPATIBLE_GENERIC = "openai-compatible-generic"  # third-party.
+
+    async def aclose(self) -> None:
+        client = getattr(self, "_client", None)
+        if client is not None:
+            await client.close()
+        unregister_provider(self)
 
     def __init__(
         self,
@@ -858,7 +884,7 @@ class OpenAIProvider(LLMProvider):
         }:
             self._emit_trace_headers = True
 
-        import httpx
+        import httpx2 as httpx
 
         if api_version and _is_azure_endpoint(base_url):
             # Azure OpenAI: use the dedicated client which handles deployment
@@ -871,6 +897,7 @@ class OpenAIProvider(LLMProvider):
             if not ssl_verify:
                 azure_kwargs["http_client"] = httpx.AsyncClient(verify=False)
             self._client = AsyncAzureOpenAI(**azure_kwargs)
+            register_provider(self)
         else:
             kwargs: dict = {}
             if api_key:
@@ -880,6 +907,7 @@ class OpenAIProvider(LLMProvider):
             if not ssl_verify:
                 kwargs["http_client"] = httpx.AsyncClient(verify=False)
             self._client = openai.AsyncOpenAI(**kwargs)
+            register_provider(self)
 
     def export_connection_info(self) -> ProviderConnectionInfo:
         return ProviderConnectionInfo(
@@ -1114,15 +1142,19 @@ class OpenAIProvider(LLMProvider):
         native_web_tools: set[str] | None = None,
     ) -> AsyncIterator[StreamEvent]:
         if self._flavor == self.FLAVOR_OPENAI:
-            async for event in self._stream_via_responses(
+            # aclosing, not a bare `async for`: if the consumer abandons us the
+            # inner generator closes now rather than at asyncgen finalization.
+            inner = self._stream_via_responses(
                 model=model,
                 system=system,
                 messages=messages,
                 tools=tools,
                 max_tokens=max_tokens,
                 native_web_tools=native_web_tools,
-            ):
-                yield event
+            )
+            async with aclosing(inner):
+                async for event in inner:
+                    yield event
             return
 
         oai_messages = _translate_messages(system, messages, supports_vision=self._supports_vision, vision_format=self._vision_format)
@@ -1164,6 +1196,7 @@ class OpenAIProvider(LLMProvider):
         # BEFORE this (request establishment) was already SDK-retried → fail fast.
         stream_started = False
 
+        stream = None
         try:
             stream = await self._client.chat.completions.create(**kwargs)
             stream_started = True
@@ -1308,6 +1341,9 @@ class OpenAIProvider(LLMProvider):
                 provider="The model provider", code="stream_error",
                 session_backoff=True, model=model,
             ) from exc
+
+        finally:
+            await _aclose_stream(stream)
 
         # Finalize tool calls. Same safe-parse protection as the
         # non-streaming path — a model cut off mid-JSON-arguments
@@ -1495,6 +1531,7 @@ class OpenAIProvider(LLMProvider):
         # a failure after this is mid-stream and was never SDK-retried (ENG-673).
         stream_started = False
 
+        stream = None
         try:
             stream = await self._client.responses.create(**kwargs)
             stream_started = True
@@ -1649,6 +1686,9 @@ class OpenAIProvider(LLMProvider):
                 provider="The model provider", code="stream_error",
                 session_backoff=True, model=model,
             ) from exc
+
+        finally:
+            await _aclose_stream(stream)
 
         yield StreamComplete(
             response=LLMResponse(

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
@@ -818,11 +819,15 @@ async def _aclose_stream(stream: object) -> None:
     """
     if stream is None:
         return
-    # SDK streams expose close(); plain async generators expose aclose().
-    closer = getattr(stream, "close", None) or getattr(stream, "aclose", None)
+    # Prefer aclose (plain async generators); SDK streams expose close(). The
+    # order matters: an object with a sync close() beside an async aclose()
+    # must not short-circuit onto the sync one and leak with no diagnostic.
+    closer = getattr(stream, "aclose", None) or getattr(stream, "close", None)
     if closer is not None:
         try:
-            await closer()
+            result = closer()
+            if inspect.isawaitable(result):
+                await result
         except Exception:
             pass
 
@@ -897,7 +902,6 @@ class OpenAIProvider(LLMProvider):
             if not ssl_verify:
                 azure_kwargs["http_client"] = httpx.AsyncClient(verify=False)
             self._client = AsyncAzureOpenAI(**azure_kwargs)
-            register_provider(self)
         else:
             kwargs: dict = {}
             if api_key:
@@ -907,7 +911,10 @@ class OpenAIProvider(LLMProvider):
             if not ssl_verify:
                 kwargs["http_client"] = httpx.AsyncClient(verify=False)
             self._client = openai.AsyncOpenAI(**kwargs)
-            register_provider(self)
+
+        # After the if/else, not per branch: a future client flavor must not be
+        # able to skip registration and leave its pool unclosed.
+        register_provider(self)
 
     def export_connection_info(self) -> ProviderConnectionInfo:
         return ProviderConnectionInfo(

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import weakref
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -10,31 +11,75 @@ if TYPE_CHECKING:
 
 
 # Providers hold an HTTP pool. Unclosed, httpx2 prints a traceback when the
-# event loop finalizes its async generators, so every entry point closes these.
-# Strong refs on purpose: a provider collected before shutdown leaves its pool
-# to the async-generator finalizer, which is the noise we are preventing.
-_LIVE_PROVIDERS: list = []
+# event loop finalizes its async generators, so entry points that own the loop
+# drain this registry before it dies. Weak refs: long-lived hosts that consume
+# anton as a library (cowork-server) build providers per turn and never drain,
+# so strong refs would pin every provider and its pool for the process
+# lifetime. A provider collected before the drain hands its pool to the GC —
+# the pre-registry behavior, and silent while the loop is still running.
+_LIVE_PROVIDERS: weakref.WeakSet[LLMProvider] = weakref.WeakSet()
 
 
-def register_provider(provider: object) -> None:
-    _LIVE_PROVIDERS.append(provider)
+def register_provider(provider: LLMProvider) -> None:
+    _LIVE_PROVIDERS.add(provider)
 
 
-def unregister_provider(provider: object) -> None:
-    """Drop a closed provider so long-running hosts do not accumulate them."""
-    try:
-        _LIVE_PROVIDERS.remove(provider)
-    except ValueError:
-        pass
+def unregister_provider(provider: LLMProvider) -> None:
+    """Drop a closed provider so the exit drain does not close it twice."""
+    _LIVE_PROVIDERS.discard(provider)
 
 
 async def close_live_providers() -> None:
-    providers, _LIVE_PROVIDERS[:] = list(_LIVE_PROVIDERS), []
+    providers = list(_LIVE_PROVIDERS)
+    _LIVE_PROVIDERS.clear()
     for provider in providers:
         try:
             await provider.aclose()
         except Exception:
             pass  # a cleanup-only failure must not break shutdown; cancellation propagates
+
+
+def _is_upstream_asyncgen_noise(context: dict) -> bool:
+    """One known upstream error, matched narrowly.
+
+    httpx2 abandons httpcore2's byte-stream ``__aiter__`` generators
+    (``PoolByteStream``, ``HTTP11ConnectionByteStream``, ...) when a response
+    is closed mid-body — every SSE stream ends this way — and at loop shutdown
+    the ``athrow(GeneratorExit)`` trips httpcore2's ``safe_async_iterate``:
+    RuntimeError("generator didn't stop after athrow()"). Present through
+    httpcore2 2.12; harmless — the pool is already closed — but it prints a
+    traceback on every clean exit. Matched by the generator's source file, not
+    its class name: which stream class is left abandoned varies run to run.
+    """
+    exc = context.get("exception")
+    agen = context.get("asyncgen")
+    code = getattr(agen, "ag_code", None)
+    return (
+        isinstance(exc, RuntimeError)
+        and "didn't stop after athrow" in str(exc)
+        and "httpcore2" in getattr(code, "co_filename", "")
+    )
+
+
+def install_asyncgen_noise_filter() -> None:
+    """Silence the upstream error above on the running loop.
+
+    Everything else still reaches the default handler. Callers that own their
+    event loop (CLI entry points) install this; a host with its own exception
+    handler is left alone.
+    """
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    if loop.get_exception_handler() is not None:
+        return
+
+    def _handler(loop, context):
+        if _is_upstream_asyncgen_noise(context):
+            return
+        loop.default_exception_handler(context)
+
+    loop.set_exception_handler(_handler)
 
 
 @dataclass

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -9,6 +9,34 @@ if TYPE_CHECKING:
     from anton.core.interaction.elicit import AskAnswer, AskRequest
 
 
+# Providers hold an HTTP pool. Unclosed, httpx2 prints a traceback when the
+# event loop finalizes its async generators, so every entry point closes these.
+# Strong refs on purpose: a provider collected before shutdown leaves its pool
+# to the async-generator finalizer, which is the noise we are preventing.
+_LIVE_PROVIDERS: list = []
+
+
+def register_provider(provider: object) -> None:
+    _LIVE_PROVIDERS.append(provider)
+
+
+def unregister_provider(provider: object) -> None:
+    """Drop a closed provider so long-running hosts do not accumulate them."""
+    try:
+        _LIVE_PROVIDERS.remove(provider)
+    except ValueError:
+        pass
+
+
+async def close_live_providers() -> None:
+    providers, _LIVE_PROVIDERS[:] = list(_LIVE_PROVIDERS), []
+    for provider in providers:
+        try:
+            await provider.aclose()
+        except Exception:
+            pass  # a cleanup-only failure must not break shutdown; cancellation propagates
+
+
 @dataclass
 class ToolCall:
     id: str
@@ -1048,6 +1076,10 @@ class ProviderConnectionInfo:
 
 
 class LLMProvider(ABC):
+
+    async def aclose(self) -> None:
+        """Release transport resources. No-op unless the provider holds a client."""
+        return None
     # Human-readable provider id (e.g. "anthropic", "openai-compatible").
     name: str = ""
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import httpx
+import httpx2 as httpx
 import random
 from collections.abc import AsyncIterator, Callable
 from contextlib import aclosing
@@ -2114,8 +2114,14 @@ class ChatSession:
 
     async def close(self) -> None:
         """Clean up scratchpads and other resources."""
-        await self._reap_tracked_backends()
-        await self._scratchpads.close_all()
+        try:
+            await self._reap_tracked_backends()
+            await self._scratchpads.close_all()
+        finally:
+            # Provider clients own an HTTP pool. This runs even if the steps
+            # above raise, or the pool outlives the process.
+            if self._llm is not None:
+                await self._llm.aclose()
 
     async def emit(self, event) -> None:
         """Push an out-of-band event to the host, if one is listening.

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -982,6 +982,9 @@ class ChatSessionConfig:
     to ChatSession — the session never needs to know where values came from.
     """
 
+    # Ownership transfers with it: ChatSession.close() closes the client's
+    # provider transports. A host that shares one client across sessions must
+    # not close both sessions.
     llm_client: LLMClient
     runtime_factory: ScratchpadRuntimeFactory = field(default=local_scratchpad_runtime_factory)
     cells: list[Cell] | None = None

--- a/anton/core/tools/web_tools.py
+++ b/anton/core/tools/web_tools.py
@@ -38,7 +38,7 @@ from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-import httpx
+import httpx2 as httpx
 
 from anton.core.tools.tool_defs import ToolDef
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "anthropic>=0.42.0",
-    "openai>=1.0",
-    # Imported at module scope; arrived transitively via anthropic/openai until
-    # both moved to httpx2.
-    "httpx>=0.27,<1",
+    "anthropic>=1.0",
+    "openai>=3.0",
+    # Declared, not inherited: it arrived transitively via anthropic/openai.
+    # Same range those SDKs require, so the client we hand them matches theirs.
+    "httpx2>=2.7,<3",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "typer>=0.12.4",

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -29,6 +30,7 @@ class RunResult:
     duration: float
     timed_out: bool = False
     cmd: list[str] = field(default_factory=list)
+    upstream_asyncgen_noise: bool = False
 
     def __str__(self) -> str:
         status = "TIMEOUT" if self.timed_out else f"exit {self.returncode}"
@@ -106,6 +108,35 @@ class E2EConfig:
 
 
 
+# httpcore2 raises "generator didn't stop after athrow()" while finalizing a
+# response stream at interpreter exit (upstream, pydantic/httpx2). It is not
+# anton output, so strip it before assertions rather than weakening them.
+_UPSTREAM_ASYNCGEN_NOISE_START = "an error occurred during closing of asynchronous generator"
+_UPSTREAM_ASYNCGEN_NOISE_END = "generator didn't stop after athrow()"
+
+
+def _strip_upstream_asyncgen_noise(text: str) -> tuple[str, bool]:
+    """Return (text without the upstream block, whether one was removed)."""
+    if _UPSTREAM_ASYNCGEN_NOISE_START not in text:
+        return text, False
+    kept, skipping, found = [], False, False
+    for line in text.splitlines(keepends=True):
+        if _UPSTREAM_ASYNCGEN_NOISE_START in line:
+            skipping, found = True, True
+            continue
+        if skipping:
+            if _UPSTREAM_ASYNCGEN_NOISE_END in line:
+                skipping = False
+            continue
+        kept.append(line)
+    return "".join(kept), found
+
+
+def wheel_python() -> str | None:
+    """Interpreter for an installed-wheel run, or None to use the source tree."""
+    return os.environ.get("ANTON_E2E_WHEEL_PYTHON") or None
+
+
 def run_anton(
     cmd_args: list[str],
     input_lines: list[str],
@@ -115,7 +146,17 @@ def run_anton(
     timeout: float = 30.0,
 ) -> RunResult:
     """Run the Anton CLI as a subprocess and capture all output."""
-    cmd = [sys.executable, "-m", "anton"] + cmd_args
+    target = wheel_python()
+    cmd = [target or sys.executable, "-m", "anton"] + cmd_args
+    # `-m` puts cwd on sys.path; the repo root there would shadow the wheel.
+    if target:
+        repo = Path(__file__).parents[2].resolve()
+        if cwd is None:
+            cwd = tempfile.gettempdir()
+        elif Path(cwd).resolve() == repo or repo in Path(cwd).resolve().parents:
+            raise ValueError(
+                f"wheel run would import anton from the checkout via cwd={cwd}"
+            )
     stdin_bytes = "\n".join(input_lines).encode() + b"\n"
 
     t0 = time.monotonic()
@@ -138,6 +179,8 @@ def run_anton(
         stdout = (exc.stdout or b"").decode(errors="replace")
         stderr = (exc.stderr or b"").decode(errors="replace")
 
+    stderr, upstream_noise = _strip_upstream_asyncgen_noise(stderr)
+
     return RunResult(
         returncode=returncode,
         stdout=stdout,
@@ -145,6 +188,7 @@ def run_anton(
         duration=time.monotonic() - t0,
         timed_out=timed_out,
         cmd=cmd,
+        upstream_asyncgen_noise=upstream_noise,
     )
 
 
@@ -169,12 +213,16 @@ def base_env(
         "ANTON_EPISODIC_MEMORY": "true" if memory_enabled else "false",
         "NO_COLOR": "1",
         "TERM": "dumb",
-        "PYTHONPATH": str(Path(__file__).parents[2]),
     }
+    # Source runs need the repo importable; a wheel run must not see it.
+    if not wheel_python():
+        common["PYTHONPATH"] = str(Path(__file__).parents[2])
 
     if isinstance(provider, LiveProvider):
         env = dict(os.environ)
         env.update(common)
+        if wheel_python():
+            env.pop("PYTHONPATH", None)
         return env
 
     return {

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -112,23 +112,36 @@ class E2EConfig:
 # response stream at interpreter exit (upstream, pydantic/httpx2). It is not
 # anton output, so strip it before assertions rather than weakening them.
 _UPSTREAM_ASYNCGEN_NOISE_START = "an error occurred during closing of asynchronous generator"
-_UPSTREAM_ASYNCGEN_NOISE_END = "generator didn't stop after athrow()"
+# The exception line, not the bare phrase: the block's traceback also contains
+# `raise RuntimeError("generator didn't stop after athrow()")`, and ending the
+# strip there would leave the final line behind.
+_UPSTREAM_ASYNCGEN_NOISE_END = "RuntimeError: generator didn't stop after athrow()"
 
 
 def _strip_upstream_asyncgen_noise(text: str) -> tuple[str, bool]:
-    """Return (text without the upstream block, whether one was removed)."""
+    """Return (text without complete upstream blocks, whether one was removed).
+
+    Only a block closed by the end marker is stripped. An unterminated block —
+    upstream wording change, or stderr cut off by the TimeoutExpired path — is
+    not provably noise, and dropping the rest of stderr there would let a real
+    traceback vanish before the assertions see it.
+    """
     if _UPSTREAM_ASYNCGEN_NOISE_START not in text:
         return text, False
-    kept, skipping, found = [], False, False
+    kept: list[str] = []
+    block: list[str] = []  # candidate block, restored if it never closes
+    skipping, found = False, False
     for line in text.splitlines(keepends=True):
-        if _UPSTREAM_ASYNCGEN_NOISE_START in line:
-            skipping, found = True, True
+        if not skipping and _UPSTREAM_ASYNCGEN_NOISE_START in line:
+            skipping, block = True, [line]
             continue
         if skipping:
+            block.append(line)
             if _UPSTREAM_ASYNCGEN_NOISE_END in line:
-                skipping = False
+                skipping, block, found = False, [], True
             continue
         kept.append(line)
+    kept.extend(block)
     return "".join(kept), found
 
 
@@ -256,6 +269,12 @@ def assert_not_output(result: RunResult, *patterns: str) -> None:
 def assert_exit_ok(result: RunResult) -> None:
     assert not result.timed_out, f"Command timed out\n{result}"
     assert result.returncode == 0, f"Expected exit 0, got {result.returncode}\n{result}"
+    # The stripped block is still a regression: it means a provider HTTP pool
+    # reached interpreter exit unclosed. This is the only assertion that would
+    # catch the original symptom coming back.
+    assert not result.upstream_asyncgen_noise, (
+        f"asyncgen finalization noise on stderr — a provider pool was not closed\n{result}"
+    )
 
 
 def assert_exit_fail(result: RunResult) -> None:

--- a/tests/e2e/scenarios/test_error_handling.py
+++ b/tests/e2e/scenarios/test_error_handling.py
@@ -87,5 +87,5 @@ def test_large_input_no_crash(cfg, stub, tmp_path):
     result = run_anton(["--folder", str(tmp_path)], ["x" * 100_000, "exit"],
                        env=base_env(stub), timeout=cfg.timeout(60))
     assert_exit_ok(result)
-    assert_not_output(result, "Traceback (most recent call last)")
     assert_output(result, "Got your big message.")
+    assert_not_output(result, "Traceback (most recent call last)")

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -362,7 +362,7 @@ class TestMindsSetupRecovery:
             ),
         )
         rebuilt = object()
-        monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: rebuilt)
+        monkeypatch.setattr("anton.chat.rebuild_session", AsyncMock(return_value=rebuilt))
 
         workspace_base = tmp_path / "workspace"
         workspace_base.mkdir()
@@ -431,7 +431,7 @@ class TestMindsSetupRecovery:
                 ),
             ),
         )
-        monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: object())
+        monkeypatch.setattr("anton.chat.rebuild_session", AsyncMock(side_effect=lambda **kwargs: object()))
 
         workspace_base = tmp_path / "workspace"
         workspace_base.mkdir()
@@ -489,7 +489,7 @@ class TestMindsSetupRecovery:
             ),
         )
         rebuilt = object()
-        monkeypatch.setattr("anton.chat.rebuild_session", lambda **kwargs: rebuilt)
+        monkeypatch.setattr("anton.chat.rebuild_session", AsyncMock(return_value=rebuilt))
 
         workspace_base = tmp_path / "workspace"
         workspace_base.mkdir()

--- a/tests/test_chat_scratchpad.py
+++ b/tests/test_chat_scratchpad.py
@@ -420,7 +420,7 @@ class TestResumeSessionScratchpadCleanup:
 
         with (
             patch("anton.commands.session.prompt_or_cancel", new=AsyncMock(return_value="1")),
-            patch("anton.commands.session.rebuild_session", return_value=new_session),
+            patch("anton.commands.session.rebuild_session", new=AsyncMock(return_value=new_session)),
         ):
             await handle_resume(
                 console=MagicMock(),

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -156,7 +156,7 @@ async def _do_import(
         return mgr_self._pads[name]
 
     with patch.object(ScratchpadManager, "get_or_create", _mock_get_or_create):
-        with patch("anton.commands.session.rebuild_session", side_effect=_fake_rebuild):
+        with patch("anton.commands.session.rebuild_session", new=AsyncMock(side_effect=_fake_rebuild)):
             new_session = await handle_share_import(
                 console,
                 current_session,

--- a/tests/test_status_error_mapper.py
+++ b/tests/test_status_error_mapper.py
@@ -22,7 +22,7 @@ hand-built fixtures cannot.
 """
 
 import anthropic
-import httpx
+import httpx2 as httpx
 import openai
 import pytest
 
@@ -749,7 +749,7 @@ def test_anthropic_mapper_does_not_wait_on_an_unconfirmed_429():
 
 def _byok_error(host, reason=None, json_body=None, status=402, headers_extra=None):
     """A real SDK error from an arbitrary OPENAI_COMPATIBLE endpoint."""
-    import httpx
+    import httpx2 as httpx
 
     def handler(request):
         headers = {"X-MindsHub-Reason": reason} if reason else {}

--- a/tests/test_transient_retry.py
+++ b/tests/test_transient_retry.py
@@ -254,7 +254,7 @@ def test_provider_overloaded_error_carries_model_and_provider():
 
 from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
 
-import httpx  # noqa: E402
+import httpx2 as httpx  # noqa: E402
 import openai  # noqa: E402
 
 from anton.chat import ChatSession  # noqa: E402

--- a/tests/test_transient_retry_e2e.py
+++ b/tests/test_transient_retry_e2e.py
@@ -19,7 +19,7 @@ canned SSE bytes.
 from __future__ import annotations
 
 import anthropic
-import httpx
+import httpx2 as httpx
 import openai
 import pytest
 

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -15,7 +15,7 @@ import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
-import httpx
+import httpx2 as httpx
 import pytest
 
 from tests.conftest import make_mock_llm

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -10,7 +10,7 @@ import ssl
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
+import httpx2 as httpx
 import pytest
 
 from anton.core.tools.web_tools import (

--- a/tests/test_web_tools_live.py
+++ b/tests/test_web_tools_live.py
@@ -531,7 +531,7 @@ class TestExaLive:
         contract against the live API — if Exa changes their endpoint or
         auth shape, both setup AND runtime would break, and this would
         catch it on the next live run."""
-        import httpx as _httpx
+        import httpx2 as _httpx
 
         # Exact same shape ``cli._setup_exa._test`` uses internally.
         resp = await _httpx.AsyncClient(timeout=15.0).post(
@@ -582,7 +582,7 @@ class TestBraveLive:
     async def test_setup_probe_endpoint_contract(self):
         """Mirror of the Exa probe-contract test for Brave (matches
         ``cli._setup_brave._test``)."""
-        import httpx as _httpx
+        import httpx2 as _httpx
 
         resp = await _httpx.AsyncClient(timeout=15.0).get(
             "https://api.search.brave.com/res/v1/web/search",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' or sys_platform != 'emscripten'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -146,21 +150,20 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.83.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "docstring-parser" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/e5/02cd2919ec327b24234abb73082e6ab84c451182cc3cc60681af700f4c63/anthropic-0.83.0.tar.gz", hash = "sha256:a8732c68b41869266c3034541a31a29d8be0f8cd0a714f9edce3128b351eceb4", size = 534058, upload-time = "2026-02-19T19:26:38.904Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/50/463166f02179ab279edb61de1589a6f69cb3838d6a2fb6f2c92a3f8042f1/anthropic-1.3.0.tar.gz", hash = "sha256:6873492a77ede8849a161ab1bc78bc9a1e492a006d0b5bb4c57ac77845df838a", size = 1148177, upload-time = "2026-09-01T17:37:10.392Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/75/b9d58e4e2a4b1fc3e75ffbab978f999baf8b7c4ba9f96e60edb918ba386b/anthropic-0.83.0-py3-none-any.whl", hash = "sha256:f069ef508c73b8f9152e8850830d92bd5ef185645dbacf234bb213344a274810", size = 456991, upload-time = "2026-02-19T19:26:40.114Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5d/7863a9961d320c23787c7b594956afe4e878f9c0ae2376b11a20e416791d/anthropic-1.3.0-py3-none-any.whl", hash = "sha256:e7e7dbebf9f3c84a23954ab989378af6ae10a4d1804c81e9fea4b5ced695ce75", size = 1296959, upload-time = "2026-09-01T17:37:08.525Z" },
 ]
 
 [[package]]
@@ -170,7 +173,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "dill" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "openai" },
     { name = "packaging" },
     { name = "prompt-toolkit" },
@@ -196,10 +199,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "anthropic", specifier = ">=0.42.0" },
+    { name = "anthropic", specifier = ">=1.0" },
     { name = "dill", specifier = "==0.3.8" },
-    { name = "httpx", specifier = ">=0.27,<1" },
-    { name = "openai", specifier = ">=1.0" },
+    { name = "httpx2", specifier = ">=2.7,<3" },
+    { name = "openai", specifier = ">=3.0" },
     { name = "packaging", specifier = ">=21.0" },
     { name = "pillow", marker = "extra == 'clipboard'", specifier = ">=12.3.0" },
     { name = "prompt-toolkit", specifier = ">=3.0" },
@@ -241,15 +244,6 @@ wheels = [
 ]
 
 [[package]]
-name = "certifi"
-version = "2026.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -277,15 +271,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/17/4d/ac7ffa80c69ea1df30a8aa11b3578692a5118e7cd1aa157e3ef73b092d15/dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca", size = 184847, upload-time = "2024-01-27T23:42:16.145Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/7a/cef76fd8438a42f96db64ddaa85280485a9c395e7df3db8158cfec1eee34/dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7", size = 116252, upload-time = "2024-01-27T23:42:14.239Z" },
-]
-
-[[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -412,40 +397,51 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
+    { name = "h11", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
     { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -459,87 +455,88 @@ wheels = [
 
 [[package]]
 name = "jiter"
-version = "0.13.0"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/29/499f8c9eaa8a16751b1c0e45e6f5f1761d180da873d417996cc7bddc8eef/jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096", size = 311157, upload-time = "2026-02-02T12:35:37.758Z" },
-    { url = "https://files.pythonhosted.org/packages/50/f6/566364c777d2ab450b92100bea11333c64c38d32caf8dc378b48e5b20c46/jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911", size = 319729, upload-time = "2026-02-02T12:35:39.246Z" },
-    { url = "https://files.pythonhosted.org/packages/73/dd/560f13ec5e4f116d8ad2658781646cca91b617ae3b8758d4a5076b278f70/jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701", size = 354766, upload-time = "2026-02-02T12:35:40.662Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/0d/061faffcfe94608cbc28a0d42a77a74222bdf5055ccdbe5fd2292b94f510/jiter-0.13.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7e287d7fbd02cb6e22f9a00dd9c9cd504c40a61f2c61e7e1f9690a82726b4c", size = 362587, upload-time = "2026-02-02T12:35:42.025Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c9/c66a7864982fd38a9773ec6e932e0398d1262677b8c60faecd02ffb67bf3/jiter-0.13.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47455245307e4debf2ce6c6e65a717550a0244231240dcf3b8f7d64e4c2f22f4", size = 487537, upload-time = "2026-02-02T12:35:43.459Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/86/84eb4352cd3668f16d1a88929b5888a3fe0418ea8c1dfc2ad4e7bf6e069a/jiter-0.13.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9da221dca6e0429c2704c1b3655fe7b025204a71d4d9b73390c759d776d165", size = 373717, upload-time = "2026-02-02T12:35:44.928Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/09/9fe4c159358176f82d4390407a03f506a8659ed13ca3ac93a843402acecf/jiter-0.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24ab43126d5e05f3d53a36a8e11eb2f23304c6c1117844aaaf9a0aa5e40b5018", size = 362683, upload-time = "2026-02-02T12:35:46.636Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/5e/85f3ab9caca0c1d0897937d378b4a515cae9e119730563572361ea0c48ae/jiter-0.13.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9da38b4fedde4fb528c740c2564628fbab737166a0e73d6d46cb4bb5463ff411", size = 392345, upload-time = "2026-02-02T12:35:48.088Z" },
-    { url = "https://files.pythonhosted.org/packages/12/4c/05b8629ad546191939e6f0c2f17e29f542a398f4a52fb987bc70b6d1eb8b/jiter-0.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b34c519e17658ed88d5047999a93547f8889f3c1824120c26ad6be5f27b6cf5", size = 517775, upload-time = "2026-02-02T12:35:49.482Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/88/367ea2eb6bc582c7052e4baf5ddf57ebe5ab924a88e0e09830dfb585c02d/jiter-0.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2a6394e6af690d462310a86b53c47ad75ac8c21dc79f120714ea449979cb1d3", size = 551325, upload-time = "2026-02-02T12:35:51.104Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/12/fa377ffb94a2f28c41afaed093e0d70cfe512035d5ecb0cad0ae4792d35e/jiter-0.13.0-cp311-cp311-win32.whl", hash = "sha256:0f0c065695f616a27c920a56ad0d4fc46415ef8b806bf8fc1cacf25002bd24e1", size = 204709, upload-time = "2026-02-02T12:35:52.467Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/16/8e8203ce92f844dfcd3d9d6a5a7322c77077248dbb12da52d23193a839cd/jiter-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0733312953b909688ae3c2d58d043aa040f9f1a6a75693defed7bc2cc4bf2654", size = 204560, upload-time = "2026-02-02T12:35:53.925Z" },
-    { url = "https://files.pythonhosted.org/packages/44/26/97cc40663deb17b9e13c3a5cf29251788c271b18ee4d262c8f94798b8336/jiter-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:5d9b34ad56761b3bf0fbe8f7e55468704107608512350962d3317ffd7a4382d5", size = 189608, upload-time = "2026-02-02T12:35:55.304Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
-    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
-    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
-    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
-    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
-    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
-    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
-    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
-    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
-    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
-    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
-    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
-    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
-    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
-    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
-    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
-    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
-    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
-    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
-    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
-    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
-    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
-    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
-    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
-    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b3/3c29819a27178d0e461a8571fb63c6ae38be6dc36b78b3ec2876bbd6a910/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b1cbfa133241d0e6bdab48dcdc2604e8ba81512f6bbd68ec3e8e1357dd3c316c", size = 307016, upload-time = "2026-02-02T12:37:42.755Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/ae/60993e4b07b1ac5ebe46da7aa99fdbb802eb986c38d26e3883ac0125c4e0/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:db367d8be9fad6e8ebbac4a7578b7af562e506211036cba2c06c3b998603c3d2", size = 305024, upload-time = "2026-02-02T12:37:44.774Z" },
-    { url = "https://files.pythonhosted.org/packages/77/fa/2227e590e9cf98803db2811f172b2d6460a21539ab73006f251c66f44b14/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45f6f8efb2f3b0603092401dc2df79fa89ccbc027aaba4174d2d4133ed661434", size = 339337, upload-time = "2026-02-02T12:37:46.668Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/92/015173281f7eb96c0ef580c997da8ef50870d4f7f4c9e03c845a1d62ae04/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:597245258e6ad085d064780abfb23a284d418d3e61c57362d9449c6c7317ee2d", size = 346395, upload-time = "2026-02-02T12:37:48.09Z" },
-    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
-    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -682,21 +679,19 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.21.0"
+version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
-    { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/76/913b755a1a6b54e2d9140eb8d488aa0d47c7359b1d7eac5e864cb7913bbf/openai-3.6.0.tar.gz", hash = "sha256:18fe3f6e96390ef41ee27b152fc9effefca321c33673bd9b956a572493d3ab9b", size = 1455376, upload-time = "2026-08-28T22:29:18.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/94/805b87ecc951c49ec8f247f5e8eb324ab064bd2ad73b6a0e704dd49aa073/openai-3.6.0-py3-none-any.whl", hash = "sha256:508e2158bf971687f953b62e44b02f207792c815aac306816386d7ba34d37f5f", size = 1699841, upload-time = "2026-08-28T22:29:16.436Z" },
 ]
 
 [[package]]
@@ -1170,18 +1165,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.67.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`anthropic` and `openai` moved to `httpx2`, but we still pinned `httpx<1` and imported it at module scope, so cold installs resolved both libraries and the `AsyncClient` we handed the SDKs was a different library than the one they used.
Nothing closed the provider connection pools either, so `httpcore2` printed an asyncgen traceback at exit after a normal run.

- `httpx>=0.27,<1` -> `httpx2>=2.7,<3`; `anthropic>=1.0`, `openai>=3.0`; lock regenerated.
- `import httpx` -> `import httpx2 as httpx` in session, web tools, the OpenAI
  provider, the CLI search probes, and tests.
- Added `aclose()` on the providers and `LLMClient`, called from
  `ChatSession.close()` and from the CLI's `asyncio.run` wrapper. Streams close
  in a `finally`.

Also , Release e2e now builds the tag, installs the wheel into a clean venv, and runs the scenarios through it — then `publish` uploads those exact bytes. A source-tree test cannot catch a packaging bug like this, and a PyPI upload cannot be withdrawn..

Fixes [ENG-2234](https://linear.app/mindsdb/issue/ENG-2234/anton-migrate-to-httpx2-with-the-sdks-and-close-provider-http-pools), [ENG-2235](https://linear.app/mindsdb/issue/ENG-2235/anton-verify-the-built-wheel-before-publishing-to-pypi-not-beside-it)

