### PR TITLE
ENG-2243: stamp a per-attempt turn id so the tool→turn join is exact

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -342,8 +342,17 @@ def get_installation_id() -> str:
     usable as a join key.
 
     Returns:
-        A 16-character hex string (64 bits of entropy), or ``"unknown"`` when
-        the machine cannot be fingerprinted at all.
+        A 16-character hex string, or ``"unknown"`` when the machine cannot be
+        fingerprinted at all.
+
+        64 bits on the real-MAC path (a sha256 prefix). The no-MAC fallback
+        persists ``uuid4().hex[:16]``, which is 60: hex position 12 is uuid4's
+        version nibble, so it is the literal ``4`` in every id that branch ever
+        writes. Left as-is deliberately — changing the derivation would give
+        every already-fingerprinted Docker install a NEW ``aid`` and break the
+        continuity of that identity — but do not repeat the 64-bit claim for
+        it. Noted while correcting the same error in
+        ``TurnCost.attempt_id`` (#431 review).
     """
     global _cached_aid
     if _cached_aid is not None:

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -238,8 +238,14 @@ _pending_lock = threading.Lock()
 #                    turn_attempt_id also mirrors it, and is the key the join
 #                    should actually use: turn_index alone matched every retry
 #                    of the same turn (18.5% of these rows joined to more than
-#                    one turn row before ENG-2243). Empty when the tool ran
-#                    with no turn books open.
+#                    one turn row before ENG-2243).
+#                    Not "empty when no books are open" — both emit sites are
+#                    inside the tool loop, so that state is unreachable. The
+#                    divergence that IS reachable: with books closed,
+#                    turn_index falls back to _turn_count + 1 while this would
+#                    be "", so the two join keys would disagree about whether a
+#                    parent turn row exists. Prefer this key and treat an empty
+#                    value as a pre-ENG-2243 build, never as "no parent".
 #                    (anton/core/session.py::_emit_tool_completed)
 #
 # An event NOT listed here keeps the collector path, so moving one is an
@@ -375,12 +381,19 @@ def _posthog_body(key: str, action: str, params: dict[str, str]) -> bytes:
     moment a queued daemon thread got around to sending, and for a cost event
     that difference is the one you would go on to plot.
 
-    Deliberately no ``$insert_id``.  The natural key would be
-    ``(conversation_id, turn_index)``, but an abandoned turn's books and a
-    later retry can legitimately share both, and dropping that row would lose
-    exactly the runaway a cancel was investigating (anton#309 review).
-    ``TurnCost.emitted`` already stops the same books emitting twice, so
-    dedupe here could only add a way to lose real events.
+    Deliberately no ``$insert_id`` — but not for the reason this comment
+    used to give (#431 review). It said the natural key
+    ``(conversation_id, turn_index)`` was unusable because an abandoned turn's
+    books and a later retry can legitimately share both. True, and ENG-2243
+    then created the key that does not: ``turn_attempt_id`` is unique per turn
+    EXECUTION, so ``(conversation_id, turn_attempt_id)`` would be a sound
+    dedupe key.
+
+    The standing reason is the second half: ``TurnCost.emitted`` already stops
+    the same books emitting twice, one layer earlier and for every sink at
+    once. So dedupe here would be redundant on the path that matters and could
+    only add a way to lose real events. Kept out on those grounds, not on the
+    absence of a key.
     """
     properties = {
         k: v for k, v in params.items()

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -177,7 +177,14 @@ _pending_lock = threading.Lock()
 #                    content-free exception type; "" on verified turns; ENG-1858),
 #                    harness, surface (desktop / web / cli — WHERE
 #                    the user was, "" when the host did not say; ENG-1945),
-#                    anton_version, conversation_id, turn_index
+#                    anton_version, conversation_id, turn_index,
+#                    turn_attempt_id (unique per turn EXECUTION — `turn_index`
+#                    is only a position in the history and REPEATS across a
+#                    retried or cancelled attempt, so the pair
+#                    (conversation_id, turn_index) is NOT a unique key;
+#                    ENG-2243). Count attempts with turn_attempt_id, turns with
+#                    (conversation_id, turn_index). Absent on pre-ENG-2243
+#                    builds — read as unknown, never as a value.
 #
 #   rule_retrieval   outcome, when_rules, kept_rules, rules_chars,
 #                    stop_reason, input_tokens, output_tokens, duration_ms
@@ -228,6 +235,11 @@ _pending_lock = threading.Lock()
 #                    conversation_id + turn_index mirror turn_completed's
 #                    values, so a tool row joins to its parent turn row and,
 #                    via Langfuse sessionId, to the gateway trace.
+#                    turn_attempt_id also mirrors it, and is the key the join
+#                    should actually use: turn_index alone matched every retry
+#                    of the same turn (18.5% of these rows joined to more than
+#                    one turn row before ENG-2243). Empty when the tool ran
+#                    with no turn books open.
 #                    (anton/core/session.py::_emit_tool_completed)
 #
 # An event NOT listed here keeps the collector path, so moving one is an

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -2919,13 +2919,20 @@ class ChatSession:
         except Exception:  # pragma: no cover - defensive
             _root_cause_fields = {}
         logger.info(
-            "turn_cost session=%s turn=%d ended_by=%s verification_skipped=%s "
+            # `attempt` alongside `turn`: `turn_index` is a history position,
+            # so two attempts of one turn used to produce two indistinguishable
+            # log lines (ENG-2243). This line is also the ONLY forensics
+            # surface that survives the collector allowlist (see the note
+            # below) and, per ENG-2193, the only one a desktop customer has —
+            # `cowork-server.log`, not PostHog. Without it the new analytics
+            # property has no fallback at all.
+            "turn_cost session=%s turn=%d attempt=%s ended_by=%s verification_skipped=%s "
             "grace_granted=%s grace_tokens=%d "
             "verifier_failure=%s verifier_error_type=%s tokens_total=%d "
             "input=%d output=%d cache_read=%d cache_creation=%d "
             "llm_calls=%d rounds=%d continuations=%d peak_context=%d duration_ms=%d "
             "by_role=%s %s",
-            self._session_id, turn_index, tc.ended_by,
+            self._session_id, turn_index, tc.attempt_id, tc.ended_by,
             str(tc.verification_skipped).lower(),
             tc.grace_granted or "-", tc.grace_tokens,
             tc.verifier_failure, tc.verifier_error_type, tc.total_tokens,
@@ -3183,17 +3190,27 @@ class ChatSession:
         is reported as ``"unknown"`` rather than coerced either way.
 
         Payload is deliberately name + verdict + duration + exception CLASS
-        + surface (a closed enum, ENG-1945) plus the two join keys, and
-        nothing else. Arguments, result content and ``str(exc)`` routinely
+        + surface (a closed enum, ENG-1945) + the root-cause tier and class
+        (both closed vocabularies, ENG-2247) plus the THREE join keys
+        (``conversation_id``, ``turn_index``, ``turn_attempt_id``), and
+        nothing else — ten keys, and the exact-keys assertion in
+        ``test_tool_completed.py`` is what keeps that number honest. This
+        paragraph is the privacy-audit enumeration, so keep it in step with
+        the payload: arguments, result content and ``str(exc)`` routinely
         carry file paths, user data and credentials-adjacent strings — none
         of them may ever appear here.
 
-        ``conversation_id`` / ``turn_index`` mirror ``turn_completed``'s
-        values exactly (same names, same derivation), so a tool failure spotted
-        in PostHog joins to its parent turn row there and, via
-        ``conversation_id`` → Langfuse ``sessionId``, to the gateway trace of
-        the turn it happened in. Both already ride ``turn_completed`` through
-        this same sink — no new privacy surface.
+        ``conversation_id`` / ``turn_index`` / ``turn_attempt_id`` mirror
+        ``turn_completed``'s values exactly (same names, same derivation), so a
+        tool failure spotted in PostHog joins to its parent turn row there and,
+        via ``conversation_id`` → Langfuse ``sessionId``, to the gateway trace
+        of the turn it happened in. All three already ride ``turn_completed``
+        through this same sink — no new privacy surface.
+
+        Prefer ``turn_attempt_id`` for that join: ``turn_index`` is a history
+        position and repeats across every retry of the same turn, so
+        ``(conversation_id, turn_index)`` matched more than one turn row for
+        18.5% of these rows before ENG-2243.
         """
         try:
             # Same settings resolution as `_emit_turn_cost` above: the

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3126,6 +3126,16 @@ class ChatSession:
                 # forensics.
                 conversation_id=str(self._session_id or ""),
                 turn_index=str(turn_index),
+                # Unique per turn EXECUTION, where `turn_index` is a history
+                # position that repeats across retries (ENG-2243). This is the
+                # key `tool_completed` joins on; `turn_index` stays the field
+                # the Langfuse trace name and the artifact index are built
+                # from, so both readings remain available:
+                #   COUNT(DISTINCT turn_attempt_id) -> attempts
+                #   COUNT(DISTINCT conversation_id, turn_index) -> turns
+                # Absent on a pre-ENG-2243 build: read that as "unknown",
+                # never as a value.
+                turn_attempt_id=tc.attempt_id,
             )
         except Exception:
             # Reporting must never affect the turn that just ran.
@@ -3211,6 +3221,12 @@ class ChatSession:
             turn_index = (
                 getattr(_tc, "turn_index", 0) or (self._turn_count + 1)
             )
+            # Read from the SAME books as `turn_index` above, so a tool row and
+            # its parent turn row can never disagree about which attempt they
+            # belong to (ENG-2243). Empty outside a turn — the tool ran with no
+            # books open, which is not an attempt and must not be given an id
+            # that looks like one.
+            turn_attempt_id = str(getattr(_tc, "attempt_id", "") or "")
             send_event(
                 settings,
                 "tool_completed",
@@ -3236,6 +3252,12 @@ class ChatSession:
                 # and on an unmigrated handler; see `_tool_failure_cause`.
                 root_cause_tier=_rc_tier,
                 root_cause_class=_rc_class,
+                # Makes the tool -> turn join exact (ENG-2243). Before this,
+                # `(conversation_id, turn_index)` matched every retry of the
+                # same turn, so 18.5% of these rows joined to more than one
+                # turn row and "which tools ran in the attempt that hit the
+                # spend ceiling" had no answer.
+                turn_attempt_id=turn_attempt_id,
             )
         except Exception:
             # Analytics must never affect the tool call that just ran.

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -37,6 +37,7 @@ Stated gaps (by design, documented on ENG-1288):
 from __future__ import annotations
 
 import time
+import uuid
 from dataclasses import dataclass, field
 
 from anton.core.llm.provider import Usage
@@ -168,6 +169,28 @@ class TurnCost:
     # there gave the abandoned turn a LATER, unrelated turn's index — the
     # cost→Langfuse hop then pointed at the wrong turn (#309 review follow-up).
     turn_index: int = 0
+    # Unique per turn EXECUTION. `turn_index` is only a POSITION in the history
+    # — `_turn_count` is seeded by counting the user messages the session was
+    # handed — and cowork-server rebuilds the session every turn, so a retried
+    # or cancelled attempt arrives with the same history and stamps the same
+    # `turn_index` (ENG-2243). Measured on prod 2026-08-28..09-01: that collided
+    # on 14.5% of desktop turn keys (worst: 16 rows on one key, spanning 34
+    # hours) and left 18.5% of `tool_completed` rows joining to more than one
+    # `turn_completed` row — the join ENG-1486 stamped the pair to enable.
+    #
+    # Random, not a counter, deliberately: ANY session-local counter resets on
+    # that same rebuild, so nothing derived from session state can be unique
+    # across attempts. 16 hex chars = 64 bits, the same width and reasoning as
+    # the `aid` install fingerprint (see `anton/analytics.py`) — collision-free
+    # at our volume, short enough to read.
+    #
+    # A `default_factory` rather than a value passed in at each construction
+    # site: there are two today (the streaming and non-streaming turns in
+    # `session.py`) and a third that forgot would silently reintroduce the
+    # collision this field exists to remove. Also makes it a stamped-at-open
+    # fact like `turn_index` above, so a late finalizer reports the id of the
+    # turn whose books it holds rather than whichever turn owns the slot now.
+    attempt_id: str = field(default_factory=lambda: uuid.uuid4().hex[:16])
     # When the turn ended. None until resolved. A late finalizer cannot know the
     # real end, so it falls back to `last_activity_monotonic` (the last LLM
     # call) — understating but bounded, rather than measuring up to whenever

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -36,8 +36,8 @@ Stated gaps (by design, documented on ENG-1288):
 
 from __future__ import annotations
 
+import secrets
 import time
-import uuid
 from dataclasses import dataclass, field
 
 from anton.core.llm.provider import Usage
@@ -180,9 +180,17 @@ class TurnCost:
     #
     # Random, not a counter, deliberately: ANY session-local counter resets on
     # that same rebuild, so nothing derived from session state can be unique
-    # across attempts. 16 hex chars = 64 bits, the same width and reasoning as
-    # the `aid` install fingerprint (see `anton/analytics.py`) — collision-free
-    # at our volume, short enough to read.
+    # across attempts. `token_hex(8)` is 16 hex chars of 64 real bits —
+    # collision-free at our volume (the birthday bound is ~5e9 attempts), short
+    # enough to read in a log line.
+    #
+    # NOT `uuid.uuid4().hex[:16]`, which this field shipped as in review and
+    # which is 60 bits, not 64: hex position 12 is uuid4's version nibble, so
+    # it is the literal `4` in every id ever generated (measured 2000/2000).
+    # The width claim was wrong and so was the comparison to the `aid` install
+    # fingerprint — `aid`'s primary path is `sha256(...).hexdigest()[:16]`
+    # (`analytics.py:205`), genuinely 64 bits; its uuid4 form is only the
+    # fallback when no stable node id is available.
     #
     # A `default_factory` rather than a value passed in at each construction
     # site: there are two today (the streaming and non-streaming turns in
@@ -190,7 +198,7 @@ class TurnCost:
     # collision this field exists to remove. Also makes it a stamped-at-open
     # fact like `turn_index` above, so a late finalizer reports the id of the
     # turn whose books it holds rather than whichever turn owns the slot now.
-    attempt_id: str = field(default_factory=lambda: uuid.uuid4().hex[:16])
+    attempt_id: str = field(default_factory=lambda: secrets.token_hex(8))
     # When the turn ended. None until resolved. A late finalizer cannot know the
     # real end, so it falls back to `last_activity_monotonic` (the last LLM
     # call) — understating but bounded, rather than measuring up to whenever

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -188,9 +188,11 @@ class TurnCost:
     # which is 60 bits, not 64: hex position 12 is uuid4's version nibble, so
     # it is the literal `4` in every id ever generated (measured 2000/2000).
     # The width claim was wrong and so was the comparison to the `aid` install
-    # fingerprint — `aid`'s primary path is `sha256(...).hexdigest()[:16]`
-    # (`analytics.py:205`), genuinely 64 bits; its uuid4 form is only the
-    # fallback when no stable node id is available.
+    # fingerprint: `get_installation_id()` in `anton/analytics.py` takes the
+    # `sha256(str(node)).hexdigest()[:16]` branch whenever the machine has a
+    # real MAC, which is genuinely 64 bits; its `uuid4().hex[:16]` branch is
+    # the fallback for a host with no MAC to read (Docker with stripped
+    # networking), and carries the same 60-bit shortfall described above.
     #
     # A `default_factory` rather than a value passed in at each construction
     # site: there are two today (the streaming and non-streaming turns in

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -710,8 +710,14 @@ async def test_a_caller_that_omits_reason_degrades_to_unclassified(workspace):
         "— empty is a legal value meaning the call did not fail"
     )
     assert ev["root_cause_class"] == "unclassified"
-    # And the keys are still exactly the nine: omitting an input must not
+    # And the keys are still exactly the ten: omitting an input must not
     # change the payload SHAPE, only the honesty of one value.
+    #
+    # NOTE for the next person widening this event: git did NOT flag this as a
+    # conflict when ENG-2243 rebased onto ENG-2247, because only one side ever
+    # touched this test. A key-set assertion in a test the OTHER branch added
+    # is invisible to `git merge-tree`, so measuring conflict regions
+    # understates the work. Grep the key set, do not trust the conflict count.
     assert set(ev) == {"name", "ok", "duration_ms", "error_type", "surface",
-                       "conversation_id", "turn_index",
+                       "conversation_id", "turn_index", "turn_attempt_id",
                        "root_cause_tier", "root_cause_class"}

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -13,9 +13,10 @@ harness shape as ``test_root_cause_wiring.py``) and assert on what
 - ``error_type`` is the exception CLASS name and never the message —
   ``str(exc)`` routinely embeds file paths and user input;
 - the payload is exactly {name, ok, duration_ms, error_type, surface,
-  conversation_id, turn_index, root_cause_tier, root_cause_class}, all strings
-  — no tool arguments, no result content. ``surface`` joined in ENG-1945 and the
-  two ``root_cause_*`` keys in ENG-2247; the exact-keys assertion is widened
+  conversation_id, turn_index, turn_attempt_id, root_cause_tier,
+  root_cause_class}, all strings — no tool arguments, no result content.
+  ``surface`` joined in ENG-1945, the two ``root_cause_*`` keys in ENG-2247 and
+  ``turn_attempt_id`` in ENG-2243; the exact-keys assertion is widened
   deliberately each time rather than loosened, because "no surprise keys" is the
   property that keeps arguments and result prose out;
 - human wait (``answer_wait_s``, accumulated by ``elicit()``) is subtracted
@@ -167,7 +168,7 @@ async def test_unmigrated_handler_verdict_is_unknown_not_a_guess(workspace):
 # ── Payload contract ─────────────────────────────────────────────────
 
 
-async def test_payload_is_exactly_the_nine_keys_all_strings(workspace):
+async def test_payload_is_exactly_the_ten_keys_all_strings(workspace):
     """No arguments, no result content, no surprise keys — and str values only,
     because send_event's extras are wire parameters (tests/test_ask_user.py:496).
     """
@@ -175,6 +176,7 @@ async def test_payload_is_exactly_the_nine_keys_all_strings(workspace):
     events = await _tool_completed_calls(session)
     assert set(events[0]) == {"name", "ok", "duration_ms", "error_type",
                               "surface", "conversation_id", "turn_index",
+                              "turn_attempt_id",
                               "root_cause_tier", "root_cause_class"}
     assert all(isinstance(v, str) for v in events[0].values())
     assert "secret result body" not in json.dumps(events[0])

--- a/tests/test_turn_attempt_id.py
+++ b/tests/test_turn_attempt_id.py
@@ -159,11 +159,23 @@ async def test_the_attempt_id_survives_a_non_completed_terminal(workspace):
 
 
 async def test_tool_row_and_turn_row_agree_on_the_attempt_id(workspace):
-    """Both read the same books, so the join cannot be ambiguous.
+    """Both rows carry the same attempt, so the join cannot be ambiguous.
 
-    Reading live session state in `_emit_tool_completed` instead would let a
-    late finalizer pair a tool row with a different attempt — the same class of
-    bug `turn_index`'s stamped-at-open comment records (#309 review).
+    How each side gets there differs, and the earlier version of this docstring
+    had it backwards (#431 review). `_emit_tool_completed` DOES read live
+    session state — `_tc = getattr(self, "_turn_cost", None)` at
+    `session.py:3229`. It is safe because a tool row is always emitted
+    synchronously inside its own live turn and the owning turn nulls the books
+    at close, so the read is never late; not because it reads stamped books.
+
+    The stamped-at-open guarantee is load-bearing on the TURN side, where the
+    emit genuinely can be late — see
+    `test_a_late_finalizer_reports_its_own_attempt_not_the_live_turns`.
+
+    The distinction matters for whoever changes this next: if the tool emit
+    were ever moved off the synchronous path (queued or batched), this test
+    would still pass while the join silently started pairing tool rows with a
+    neighbouring attempt.
     """
     from unittest.mock import AsyncMock
 
@@ -224,6 +236,27 @@ def test_every_turncost_gets_an_id_without_the_caller_passing_one():
     assert all(len(i) == 16 and all(c in "0123456789abcdef" for c in i) for i in ids)
 
 
+def test_all_sixteen_characters_carry_entropy():
+    """The width claim in `turn_cost.py` has to be true, not just plausible.
+
+    The field first shipped as `uuid.uuid4().hex[:16]`, whose comment claimed
+    64 bits. It is 60: hex position 12 is uuid4's version nibble, so it is the
+    literal `4` in every id ever generated. The test above could not catch that
+    — 200 uuid4-derived ids are all unique and all lowercase hex, and a fixed
+    nibble costs 4 bits without failing either assertion.
+
+    So assert the property the comment claims: every position varies. 200
+    samples over 16 possible values makes a false failure ~(15/16)**200 ≈ 3e-6
+    per position, and a positionally-fixed nibble fails deterministically.
+    """
+    ids = [TurnCost().attempt_id for _ in range(200)]
+    fixed = [pos for pos in range(16) if len({i[pos] for i in ids}) == 1]
+    assert not fixed, (
+        f"hex positions {fixed} are constant across 200 ids — the field is "
+        "narrower than the 64 bits its comment claims"
+    )
+
+
 def test_the_id_is_stamped_at_books_open_not_read_at_emit():
     """Stable for the life of the books, like `turn_index`.
 
@@ -235,6 +268,93 @@ def test_the_id_is_stamped_at_books_open_not_read_at_emit():
     tc.add("planning", "m", _usage())
     tc.ended_by = "completed"
     assert tc.attempt_id == first
+
+
+def test_a_late_finalizer_reports_its_own_attempt_not_the_live_turns():
+    """The invariant the stamped-at-open design exists for, at the emit.
+
+    `session.py:4643` calls `_emit_turn_cost(expected=_turn_cost_books, ...)`
+    on the abandoned-generator path — a fresh task, long after the fact, by
+    which point a NEWER turn may own the shared slot. That is the case where
+    `tc is not self._turn_cost`, and `_emit_turn_cost` reads the books it was
+    handed (`session.py:2856`) rather than live session state precisely so the
+    abandoned turn's row carries its own id.
+
+    Nothing covered this. `test_the_id_is_stamped_at_books_open_not_read_at_emit`
+    above never invokes `_emit_turn_cost` — it mutates a `TurnCost` and asserts
+    the field is stable — so changing that line to `self._turn_cost.attempt_id`
+    passed this whole module while stamping the live turn's id on the abandoned
+    turn's row, reintroducing the #309 mis-attribution one layer down.
+    `turn_index` has a guard for that class in `test_turn_cost_terminals.py`
+    (`test_a_late_finalizer_cannot_close_a_newer_turns_books`); this is the
+    matching one for `attempt_id`.
+    """
+    session = ChatSession.__new__(ChatSession)
+    session._llm = MagicMock()
+    session._llm.planning_model = "p"
+    session._llm.coding_model = "c"
+    session._session_id = "s"
+    session._harness = "cowork"
+    session._turn_count = 1
+    session._cancel_event = MagicMock(is_set=lambda: False)
+    session._settings = None
+
+    abandoned, live = TurnCost(turn_index=4), TurnCost(turn_index=5)
+    abandoned.add("planning", "sonnet", _usage())
+    session._turn_cost = live               # the newer turn owns the slot
+
+    with patch("anton.analytics.send_event") as send:
+        session._emit_turn_cost(expected=abandoned)
+
+        assert send.called, "the abandoned turn must still be counted (#309)"
+        emitted = send.call_args.kwargs["turn_attempt_id"]
+        assert emitted == abandoned.attempt_id, (
+            "the late finalizer stamped the LIVE turn's attempt id on the "
+            "abandoned turn's row"
+        )
+        assert emitted != live.attempt_id
+        assert session._turn_cost is live, "only the owner clears the slot"
+
+
+def test_the_structured_log_line_carries_the_attempt_too(caplog):
+    """The only forensics surface that does not depend on the collector.
+
+    `_emit_turn_cost`'s own comment says the `turn_cost` log line is what
+    survives the allowlist that silently dropped `turn_completed`'s properties
+    for weeks (ENG-1355), and per ENG-2193 it is the only channel a desktop
+    customer has — `cowork-server.log`, not PostHog. Without the attempt id
+    there, the analytics property this PR adds has no fallback, and two
+    attempts of one turn still produce two indistinguishable log lines: the
+    exact ambiguity ENG-2243 exists to remove.
+
+    Asserted on the ABANDONED books so this also pins the source, not just the
+    presence of the key.
+    """
+    import logging
+
+    session = ChatSession.__new__(ChatSession)
+    session._llm = MagicMock()
+    session._llm.planning_model = "p"
+    session._llm.coding_model = "c"
+    session._session_id = "s"
+    session._harness = "cowork"
+    session._turn_count = 1
+    session._cancel_event = MagicMock(is_set=lambda: False)
+    session._settings = None
+
+    abandoned, live = TurnCost(turn_index=4), TurnCost(turn_index=5)
+    abandoned.add("planning", "sonnet", _usage())
+    session._turn_cost = live
+
+    with caplog.at_level(logging.INFO, logger="anton.core.session"):
+        with patch("anton.analytics.send_event"):
+            session._emit_turn_cost(expected=abandoned)
+
+    lines = [r.getMessage() for r in caplog.records
+             if r.getMessage().startswith("turn_cost session=")]
+    assert len(lines) == 1, lines
+    assert f"attempt={abandoned.attempt_id}" in lines[0], lines[0]
+    assert live.attempt_id not in lines[0]
 
 
 async def test_the_non_streaming_turn_path_stamps_an_id_too(workspace):

--- a/tests/test_turn_attempt_id.py
+++ b/tests/test_turn_attempt_id.py
@@ -259,3 +259,31 @@ async def test_the_non_streaming_turn_path_stamps_an_id_too(workspace):
     assert seen[0]["turn_index"] == seen[1]["turn_index"]
     assert seen[0]["turn_attempt_id"] != seen[1]["turn_attempt_id"]
     assert all(r["turn_attempt_id"] for r in seen)
+
+
+async def test_two_turns_in_ONE_session_get_different_ids(workspace):
+    """Per TURN, not per session — the CLI never rebuilds.
+
+    Every other test here builds a fresh ChatSession per turn, which is what
+    cowork-server does. The CLI does not: it keeps one session for the whole
+    conversation. So an id that were merely per-SESSION would satisfy all of
+    them while leaving every CLI turn sharing one id and the join ambiguous
+    again. Found by mutation: making `attempt_id` a stable per-session value
+    passed the entire suite before this test existed.
+    """
+    session = _session(workspace)
+    seen = []
+    for _ in range(3):
+        with patch("anton.analytics.send_event") as sent:
+            async for _ in session.turn_stream("go"):
+                pass
+        rows = [c.kwargs for c in sent.call_args_list
+                if c.args[1] == "turn_completed"]
+        assert len(rows) == 1
+        seen.append(rows[0])
+
+    ids = [r["turn_attempt_id"] for r in seen]
+    assert len(set(ids)) == 3, f"expected 3 distinct ids across 3 turns, got {ids}"
+    # turn_index DOES advance here — the session was never rebuilt — so this
+    # also pins that the two fields stay independent.
+    assert len({r["turn_index"] for r in seen}) == 3

--- a/tests/test_turn_attempt_id.py
+++ b/tests/test_turn_attempt_id.py
@@ -1,0 +1,230 @@
+"""`turn_attempt_id`: a key that is unique per turn EXECUTION (ENG-2243).
+
+`turn_index` is a POSITION in the history — `_turn_count` is seeded by counting
+the user messages the session was handed — and cowork-server rebuilds the
+ChatSession on every turn. So a retried or cancelled attempt is handed the same
+history and stamps the same `turn_index`. Measured on prod 2026-08-28..09-01:
+14.5% of desktop turn keys carried more than one row (worst: 16, spanning 34
+hours) and 18.5% of `tool_completed` rows joined to more than one
+`turn_completed` row — the join ENG-1486 stamped the pair to enable.
+
+These tests drive the rebuild that causes it rather than asserting on the
+field's existence, because "the field is present" would have passed before the
+fix too. The load-bearing one is
+`test_a_rebuilt_session_repeats_turn_index_but_not_the_attempt_id`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_mock_llm
+
+from anton.core.llm.provider import LLMResponse, StreamComplete, Usage
+from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.turn_cost import TurnCost
+
+
+@pytest.fixture()
+def workspace():
+    base = Path(__file__).resolve().parents[1] / ".pytest-workspace"
+    base.mkdir(parents=True, exist_ok=True)
+    return MagicMock(base=base)
+
+
+def _usage(n: int = 1_000) -> Usage:
+    return Usage(input_tokens=n // 2, output_tokens=n // 2)
+
+
+def _user(text: str) -> dict:
+    return {"role": "user", "content": text}
+
+
+def _assistant(text: str) -> dict:
+    return {"role": "assistant", "content": text}
+
+
+def _session(workspace, initial_history=None, session_id="conv-attempt"):
+    """A session that completes one turn, optionally seeded with history.
+
+    `initial_history` is the lever: it is what cowork-server hands a freshly
+    rebuilt session, and what `_turn_count` is derived from.
+    """
+    llm = make_mock_llm()
+    llm.usage_listener = None
+
+    def plan_stream(**kw):
+        async def gen():
+            if llm.usage_listener:
+                llm.usage_listener("planning", "m", _usage())
+            yield StreamComplete(response=LLMResponse(
+                content="done", tool_calls=[], usage=_usage(),
+                stop_reason="end_turn",
+            ))
+        return gen()
+
+    llm.plan_stream = plan_stream
+    s = ChatSession(ChatSessionConfig(
+        llm_client=llm, workspace=workspace, session_id=session_id,
+        initial_history=list(initial_history) if initial_history else None,
+    ))
+    s._max_turn_tokens = 0
+    return s
+
+
+async def _turn_row(session, prompt="go") -> dict:
+    """Run a turn; return the kwargs of its `turn_completed` event."""
+    with patch("anton.analytics.send_event") as sent:
+        async for _ in session.turn_stream(prompt):
+            pass
+    rows = [c.kwargs for c in sent.call_args_list if c.args[1] == "turn_completed"]
+    assert len(rows) == 1, f"expected one turn_completed, got {len(rows)}"
+    return rows[0]
+
+
+async def _all_rows(session, prompt="go"):
+    with patch("anton.analytics.send_event") as sent:
+        async for _ in session.turn_stream(prompt):
+            pass
+    return [(c.args[1], c.kwargs) for c in sent.call_args_list]
+
+
+# ── The defect ───────────────────────────────────────────────────────
+
+
+async def test_a_rebuilt_session_repeats_turn_index_but_not_the_attempt_id(workspace):
+    """The production shape: same history in, same turn_index, distinct attempts.
+
+    Two sessions seeded with the SAME `initial_history` is exactly what happens
+    when a turn fails and the user retries — cowork-server rebuilds and the
+    failed attempt's message was never committed. `turn_index` repeating is
+    CORRECT (it is a history position); the attempt id must not.
+    """
+    history = [_user("first"), _assistant("reply"), _user("second"), _assistant("reply")]
+
+    first = await _turn_row(_session(workspace, history))
+    retry = await _turn_row(_session(workspace, history))
+
+    assert first["turn_index"] == retry["turn_index"], (
+        "turn_index is a history position and is expected to repeat — if this "
+        "fails the premise changed, not the fix"
+    )
+    assert first["turn_attempt_id"] != retry["turn_attempt_id"]
+    assert first["turn_attempt_id"] and retry["turn_attempt_id"]
+
+
+async def test_the_attempt_id_survives_a_non_completed_terminal(workspace):
+    """A turn that dies must still be attributable — those ARE the collisions.
+
+    Every observed colliding key in production was a failed/cancelled attempt
+    followed by a success, so an id that only appears on `completed` rows would
+    miss the entire population this exists for.
+    """
+    session = _session(workspace)
+
+    def boom(**kw):
+        async def gen():
+            raise RuntimeError("planning blew up")
+            yield  # pragma: no cover - generator shape
+        return gen()
+
+    session._llm.plan_stream = boom
+    # anton's turn loop SWALLOWS the exception — the stream just ends and the
+    # terminal is recorded on the event. So this asserts on the emitted row,
+    # not on a raise: `pytest.raises` here passed vacuously in a first draft.
+    with patch("anton.analytics.send_event") as sent:
+        async for _ in session.turn_stream("go"):
+            pass
+    rows = [c.kwargs for c in sent.call_args_list if c.args[1] == "turn_completed"]
+    assert len(rows) == 1, "a dead turn must still close its books"
+    assert rows[0]["ended_by"] != "completed", (
+        f"expected a failure terminal, got {rows[0]['ended_by']!r} — if this "
+        "fails the harness stopped reaching the error path and the assertion "
+        "below is vacuous"
+    )
+    assert rows[0]["turn_attempt_id"]
+
+
+# ── The join it exists to fix ────────────────────────────────────────
+
+
+async def test_tool_row_and_turn_row_agree_on_the_attempt_id(workspace):
+    """Both read the same books, so the join cannot be ambiguous.
+
+    Reading live session state in `_emit_tool_completed` instead would let a
+    late finalizer pair a tool row with a different attempt — the same class of
+    bug `turn_index`'s stamped-at-open comment records (#309 review).
+    """
+    from unittest.mock import AsyncMock
+
+    from anton.core.tools.registry import ToolOutcome
+
+    llm = make_mock_llm()
+    llm.usage_listener = None
+    seq = {"i": 0}
+
+    def plan_stream(**kw):
+        async def gen():
+            seq["i"] += 1
+            if llm.usage_listener:
+                llm.usage_listener("planning", "m", _usage())
+            if seq["i"] == 1:
+                from anton.core.llm.provider import ToolCall
+                yield StreamComplete(response=LLMResponse(
+                    content="working",
+                    tool_calls=[ToolCall(id="tc1", name="scratchpad",
+                                         input={"action": "view", "name": "m"})],
+                    usage=_usage(), stop_reason="tool_use"))
+            else:
+                yield StreamComplete(response=LLMResponse(
+                    content="done", tool_calls=[], usage=_usage(),
+                    stop_reason="end_turn"))
+        return gen()
+
+    llm.plan_stream = plan_stream
+    session = ChatSession(ChatSessionConfig(
+        llm_client=llm, workspace=workspace, session_id="conv-join"))
+    session._max_turn_tokens = 0
+    session.tool_registry.dispatch_tool = AsyncMock(
+        side_effect=[ToolOutcome(content="ok", ok=True)])
+
+    rows = await _all_rows(session)
+    turn = [k for n, k in rows if n == "turn_completed"]
+    tools = [k for n, k in rows if n == "tool_completed"]
+    assert len(turn) == 1 and len(tools) == 1
+
+    assert tools[0]["turn_attempt_id"] == turn[0]["turn_attempt_id"] != ""
+    # The old key must still agree too — this fix adds a key, it does not
+    # replace the one the Langfuse trace name and artifact index are built on.
+    assert tools[0]["turn_index"] == turn[0]["turn_index"]
+
+
+# ── Seam guard: no construction site can forget ──────────────────────
+
+
+def test_every_turncost_gets_an_id_without_the_caller_passing_one():
+    """A `default_factory`, not a per-call-site argument.
+
+    There are two construction sites in `session.py` today (streaming and
+    non-streaming). A third that forgot to pass an id would silently
+    reintroduce the collision, so the guarantee lives on the dataclass.
+    """
+    ids = {TurnCost().attempt_id for _ in range(200)}
+    assert len(ids) == 200, "attempt ids must be unique per instance"
+    assert all(len(i) == 16 and all(c in "0123456789abcdef" for c in i) for i in ids)
+
+
+def test_the_id_is_stamped_at_books_open_not_read_at_emit():
+    """Stable for the life of the books, like `turn_index`.
+
+    A late finalizer emits books whose turn ended long ago; if the id were
+    derived at emit it would name whichever turn owns the slot now.
+    """
+    tc = TurnCost(turn_index=3)
+    first = tc.attempt_id
+    tc.add("planning", "m", _usage())
+    tc.ended_by = "completed"
+    assert tc.attempt_id == first

--- a/tests/test_turn_attempt_id.py
+++ b/tests/test_turn_attempt_id.py
@@ -66,7 +66,14 @@ def _session(workspace, initial_history=None, session_id="conv-attempt"):
             ))
         return gen()
 
+    async def plan(**kw):
+        if llm.usage_listener:
+            llm.usage_listener("planning", "m", _usage())
+        return LLMResponse(content="done", tool_calls=[], usage=_usage(),
+                           stop_reason="end_turn")
+
     llm.plan_stream = plan_stream
+    llm.plan = plan
     s = ChatSession(ChatSessionConfig(
         llm_client=llm, workspace=workspace, session_id=session_id,
         initial_history=list(initial_history) if initial_history else None,
@@ -228,3 +235,27 @@ def test_the_id_is_stamped_at_books_open_not_read_at_emit():
     tc.add("planning", "m", _usage())
     tc.ended_by = "completed"
     assert tc.attempt_id == first
+
+
+async def test_the_non_streaming_turn_path_stamps_an_id_too(workspace):
+    """`turn()` opens its OWN books (`session.py:3632`) and emits separately.
+
+    The `default_factory` makes this true by construction, but the path is real
+    — the CLI's non-streaming API uses it — and "covered by construction" is
+    how the streaming path got a field the other one lacked in the first place.
+    Two runs, because the value being PRESENT is weaker than it being DISTINCT.
+    """
+    history = [_user("first"), _assistant("reply")]
+    seen = []
+    for _ in range(2):
+        session = _session(workspace, history)
+        with patch("anton.analytics.send_event") as sent:
+            await session.turn("go")
+        rows = [c.kwargs for c in sent.call_args_list
+                if c.args[1] == "turn_completed"]
+        assert len(rows) == 1
+        seen.append(rows[0])
+
+    assert seen[0]["turn_index"] == seen[1]["turn_index"]
+    assert seen[0]["turn_attempt_id"] != seen[1]["turn_attempt_id"]
+    assert all(r["turn_attempt_id"] for r in seen)

--- a/tests/test_turn_attempt_id.py
+++ b/tests/test_turn_attempt_id.py
@@ -163,8 +163,8 @@ async def test_tool_row_and_turn_row_agree_on_the_attempt_id(workspace):
 
     How each side gets there differs, and the earlier version of this docstring
     had it backwards (#431 review). `_emit_tool_completed` DOES read live
-    session state — `_tc = getattr(self, "_turn_cost", None)` at
-    `session.py:3229`. It is safe because a tool row is always emitted
+    session state — `_tc = getattr(self, "_turn_cost", None)`, near the top of
+    its `try`. It is safe because a tool row is always emitted
     synchronously inside its own live turn and the owning turn nulls the books
     at close, so the read is never late; not because it reads stamped books.
 
@@ -273,12 +273,14 @@ def test_the_id_is_stamped_at_books_open_not_read_at_emit():
 def test_a_late_finalizer_reports_its_own_attempt_not_the_live_turns():
     """The invariant the stamped-at-open design exists for, at the emit.
 
-    `session.py:4643` calls `_emit_turn_cost(expected=_turn_cost_books, ...)`
-    on the abandoned-generator path — a fresh task, long after the fact, by
+    `_turn_stream_inner`'s `finally` calls
+    `_emit_turn_cost(expected=_turn_cost_books, exc=_turn_exc)` on the
+    abandoned-generator path — a fresh task, long after the fact, by
     which point a NEWER turn may own the shared slot. That is the case where
     `tc is not self._turn_cost`, and `_emit_turn_cost` reads the books it was
-    handed (`session.py:2856`) rather than live session state precisely so the
-    abandoned turn's row carries its own id.
+    handed (`tc = expected if expected is not None else self._turn_cost`)
+    rather than live session state, precisely so the abandoned turn's row
+    carries its own id.
 
     Nothing covered this. `test_the_id_is_stamped_at_books_open_not_read_at_emit`
     above never invokes `_emit_turn_cost` — it mutates a `TurnCost` and asserts
@@ -358,7 +360,7 @@ def test_the_structured_log_line_carries_the_attempt_too(caplog):
 
 
 async def test_the_non_streaming_turn_path_stamps_an_id_too(workspace):
-    """`turn()` opens its OWN books (`session.py:3632`) and emits separately.
+    """`turn()` opens its OWN books and emits separately.
 
     The `default_factory` makes this true by construction, but the path is real
     — the CLI's non-streaming API uses it — and "covered by construction" is


### PR DESCRIPTION
Closes [ENG-2243](https://linear.app/mindsdb/issue/ENG-2243).

## What

`turn_completed` and `tool_completed` both carry `(conversation_id, turn_index)`, and ENG-1486 stamped that pair specifically so a tool row could be joined to its parent turn. **The pair is not unique.** This adds `TurnCost.attempt_id`, stamped on both events as `turn_attempt_id`, which is unique per turn *execution*.

## Why

`turn_index` is a **position in the history**, not a turn identifier — `_turn_count` is seeded by counting the user messages the session was handed (`session.py:1203`), and cowork-server rebuilds the ChatSession on every turn. A retried or cancelled attempt therefore arrives with the same history and stamps the same `turn_index`.

Prod PostHog 424726, 2026-08-28 → 09-01 UTC, AsyncMock rows excluded:

| surface | event rows | distinct `(cid, turn_index)` | inflation | worst key |
| -- | --: | --: | --: | --: |
| **desktop** | 923 | 789 | **14.5%** | **16 rows** |
| web | 314 | 314 | 0.0% | 1 |
| cli | 16 | 13 | (n=16) | 2 |

```
tool rows in window                                  9,911
  ...whose (cid, turn_index) matches >1 turn row     1,832   (18.5%)
```

**Web at 0% is the control** — the pod runs one turn per process (`cloud_turn/__main__.py`) and is handed its history explicitly, so nothing is rebuilt mid-conversation. The colliding keys carry exactly the outcome sets a retry produces (`cancelled, completed`; `error, completed, spend_ceiling`), each row with a distinct `tokens_total`, spanning up to 34 hours — **distinct real attempts, not a double-emit.** That distinction matters: the fix for a double-emit would have been dedupe, which would have been wrong.

## ⚠️ This implements the ticket's recommended option — object here if you disagree

ENG-2243 lists three directions and flags the choice as needing sign-off. This PR takes **option 1: add a field, leave `turn_index` alone.** Rejected alternatives and why:

- **Make `turn_index` monotonic** — changes the meaning of a shipped field. The Langfuse trace name is composed `{harness}:turn-{turn_id}` from it, and `core/artifacts/store.py:314` indexes on it. Also, cowork-server has its own unrelated `turn_index` (0-based, assistant-only, for `DELETE /conversations/{id}/turns/{turn_index}`) — there are already two vocabularies, and adding a third meaning to ours is the wrong direction.
- **Document only** — leaves the join permanently ambiguous.

## How

- `TurnCost.attempt_id`, a **`default_factory`** rather than an argument at each call site. There are two construction sites today (`session.py:3632` non-streaming, `:4145` streaming) and a third that forgot would silently reintroduce the collision. It also makes it a stamped-at-books-open fact like `turn_index`, so a late finalizer reports the id of the turn whose books it holds — the `#309 review` failure mode.
- **Random, not a counter.** Any session-local counter resets on the same rebuild that causes the bug, so nothing derived from session state can be unique across attempts. 16 hex chars = 64 bits, same width and reasoning as the `aid` install fingerprint.
- `_emit_tool_completed` reads the id from the **same books** as `turn_index`, so a tool row and its turn row cannot disagree. Empty when no books are open — a tool that ran outside a turn is not an attempt and must not get an id that looks like one.

### Writer inventory (convention 9)

The behaviour is gated on where the id is stamped, so: `TurnCost(` is constructed in **two** places, both in `anton/core/session.py`, both covered by the factory. Grepped `cowork-server`, `cowork`, `scratchpad-controller` and `cowork_evals` — none construct `TurnCost`; cowork-server's nine `turn_index` references are all its own unrelated conversation-delete field plus one hardcoded `turn_index=1` in the hermes artifact path.

## Verification

- `tests/test_turn_attempt_id.py` (new, **10 tests**). The load-bearing one drives the **actual production shape**: two sessions seeded with the same `initial_history`, asserting `turn_index` repeats (correct — it's a position) while the attempt id does not. `test_two_turns_in_ONE_session_get_different_ids` is the strictest: every other test rebuilds the session per turn, so a per-session id would have satisfied them all while leaving every CLI turn sharing one id.
- **Mutation-verified, 8 mutations, all caught:**

  | mutation | result |
  | -- | -- |
  | drop `turn_attempt_id` from `turn_completed` | 3 failed |
  | drop it from `tool_completed` | 2 failed |
  | constant instead of `default_factory` | 2 failed |
  | **derive the id from `turn_index`** (the plausible wrong fix) | 2 failed |
  | **a stable per-SESSION id** (passed the whole suite before `7c136000`) | 1 failed |
  | `(self._turn_cost or tc).attempt_id` at the turn emit — read live state instead of the handed books | 1 failed |
  | revert to `uuid.uuid4().hex[:16]` | 1 failed, naming hex position 12 |
  | drop `attempt=` from the `turn_cost` log line | 1 failed (**passed 41 tests before this round**) |

- **A warning worth more than the tests, from `c0cf6b9e`: `git merge-tree` undercounts.** It reported 4 conflict regions against #432; there were 5 edits. The fifth was an exhaustive key-set assertion living in the *other* branch's new test file — a file `merge-tree` sees as a clean add, so no conflict count can reveal it. I made the same 4-region estimate off the same tool on #432, so it caught me twice. Anyone widening `tool_completed`'s payload should grep both branches for the key-set assertions rather than trusting a conflict count.

- `test_payload_is_exactly_the_seven_keys_all_strings` → `..._eight_keys...` → `..._ten_keys...` after #432 merged, updated **deliberately**, not loosened — "no surprise keys" is the property that keeps tool arguments and result content out. Same call ENG-1945 made going six → seven.
- One of my own tests was wrong first time: it used `pytest.raises`, but anton's turn loop *swallows* the exception and records the terminal on the event, so it passed vacuously. Rewritten to assert on the emitted row, with a message that fails loudly if the harness stops reaching the error path.
- Full suite on `f3bfa6ac`: **3,007 passed, 31 skipped, 0 failed** — including `test_cloud_turn_process`, which usually fails locally on macOS.

## Expected side effects that are NOT regressions

- **A new high-cardinality PostHog property** — one distinct value per turn, higher than `conversation_id`'s one-per-conversation. Fine as a join key and as `COUNT(DISTINCT …)`; **do not use it as a breakdown dimension.** Flagging it because PostHog auto-creates property definitions on first ingest.
- **Absent on pre-fix builds.** Readers must treat missing as "unknown", never as a value. Documented in the register in `anton/analytics.py`.
- **`turn_index` still repeats, on purpose.** That is not a bug left unfixed; it is what the trace name and artifact index want.

## Not in this PR

- **The skills half of the ticket's `Done when`** — "`turn-cost` and `harness-measure` state whether each figure counts attempts or turns". Those skills do not live in this repo, so it cannot ship here. Saying so rather than silently dropping it: it still needs doing, wherever they live.
- **The Langfuse hop stays ambiguous.** The ticket's consequence 3 is "several traces named `anton:turn-6` in one session", and the register advertises a PostHog→Langfuse forensics hop. An analyst who finds the attempt by `turn_attempt_id` still gets N identically-named traces and no way to pick one. `TraceContext.metadata: dict[str, str]` already forwards to `Langfuse-Metadata`, so it is reachable — but it needs the books opened before the trace context is built, which is a real ordering change. Scoped out deliberately, not overlooked.
- **Backfill.** Historical rows keep the ambiguity.
- **Whether `core/artifacts/store.py`'s turn index has a live collision** from the same root cause. Suspected, unverified, scoped out on the ticket.

## Security check

Performed on the diff. The new field is a random 64-bit hex string from `secrets.token_hex(8)` — no machine identity (unlike `aid`, which hashes the MAC), no user content, no paths, no credentials.

**Corrected in review:** this shipped as `uuid.uuid4().hex[:16]` and this section claimed 64 bits. That is 60 — hex position 12 is uuid4's version nibble, the literal `4` in every id ever generated (measured 2000/2000) — and the comparison to `aid` was backwards, since `aid`'s primary path is `sha256(...).hexdigest()[:16]` and uuid4 is only its fallback. Now `secrets.token_hex(8)`, which is 64 real bits. Collision risk was never the issue either way (the birthday bound at 60 bits is ~1e9 attempts); the claim being wrong was. It rides two events that already carry `conversation_id` and `turn_index`, so no new destination and no widened identity surface: the join it enables is between two events that already shared a key. Nothing new is logged.

## Four `Done when` items with no test, true by construction

Named here rather than covered by four more tests, so review can accept or reject that deliberately:

| `Done when` | Why it holds without a test |
| -- | -- |
| a **cancelled** turn gets its own id | `_emit_turn_cost` fires from the turn's `finally`, so every exit path — completion, hand-back, generator close, cancel, error — closes books that were stamped at open. The cancel terminal is covered for `ended_by` in `test_turn_cost_terminals.py`; the id cannot differ by terminal. |
| a **spend-ceiling** turn gets its own id | Same `finally`. The ceiling is a terminal mark, not a separate emit path. |
| the **Langfuse trace name** is unchanged | `turn_index` is untouched by this PR, and the trace name is built from it. Grep confirms no other reader of `attempt_id`. |
| the **artifact-store index** is unchanged | Same reason — `core/artifacts/store.py` reads `turn_index`, which this PR does not modify. |

Only the error terminal has an explicit id test (`test_the_attempt_id_survives_a_non_completed_terminal`), and that is enough given the shared `finally`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
