### PR TITLE
ENG-2247: stamp the root-cause tier and class on tool_completed

### DIFF
--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -195,16 +195,36 @@ _pending_lock = threading.Lock()
 #                    root_cause_tier + root_cause_class (WHY it failed, in
 #                    `anton/core/root_cause.py`'s vocabulary — `self_inflicted`
 #                    / `transient` / `external_wall` / `unclassified`, and the
-#                    class within it, which for a self-inflicted failure IS the
-#                    exception name). `error_type` above only fills in on a
+#                    class within it, which is USUALLY the exception name but
+#                    is a sentinel class where the handler declared the failure
+#                    itself: `empty_code`, `missing_argument`,
+#                    `invalid_argument`, `unknown_resource`, `missing_name`.
+#                    Do NOT join this against Python exception names — nine
+#                    `_SENTINEL_REASONS` map to `self_inflicted` with non-
+#                    exception classes, and `scratchpad_empty_code` is one of
+#                    scratchpad's own, so that join silently drops every
+#                    argument-validation failure. `timeout` is likewise a
+#                    literal, not a type name. `error_type` above only fills in on a
 #                    RAISE; the dominant tool returns a verdict instead, so 83%
 #                    of failures had no cause before ENG-2247. Both are "" on
 #                    success and on an unmigrated handler (`ok="unknown"`).
 #                    Read them as a PAIR with `ok` — a cause only exists where
 #                    the handler said `ok=false`. Same vocabulary as
-#                    turn_completed's `root_cause_*` tally, so the per-call and
-#                    per-turn views cannot disagree; unlike that tally, these
-#                    are per CALL and carry no cumulative-ledger caveat.
+#                    turn_completed's `root_cause_*` tally, so where both
+#                    populate they agree; unlike that tally, these are per CALL
+#                    and carry no cumulative-ledger caveat.
+#                    They do NOT reconcile row-for-row, and the gap is
+#                    systematic rather than rare. An `ok="unknown"` call (any
+#                    handler returning a plain string — most of them, see
+#                    ENG-2248) is COUNTED by the turn tally as `unclassified`
+#                    and left BLANK here, because inventing a verdict from
+#                    prose the model can influence is the ENG-1276 defect one
+#                    level up. So `sum(tool rows by tier)` runs systematically
+#                    short of `turn_completed.root_cause_failures`; that is the
+#                    design, not drift. (The inverse also exists but is
+#                    unreachable today: a multimodal `ok=false` result would
+#                    populate here and not in the tally — see
+#                    `_tool_failure_cause`.)
 #                    conversation_id + turn_index mirror turn_completed's
 #                    values, so a tool row joins to its parent turn row and,
 #                    via Langfuse sessionId, to the gateway trace.

--- a/anton/analytics.py
+++ b/anton/analytics.py
@@ -192,6 +192,19 @@ _pending_lock = threading.Lock()
 #                    One event per executed tool call; tool arguments and
 #                    result content are deliberately absent (ENG-1486).
 #                    surface mirrors turn_completed's (ENG-1945).
+#                    root_cause_tier + root_cause_class (WHY it failed, in
+#                    `anton/core/root_cause.py`'s vocabulary — `self_inflicted`
+#                    / `transient` / `external_wall` / `unclassified`, and the
+#                    class within it, which for a self-inflicted failure IS the
+#                    exception name). `error_type` above only fills in on a
+#                    RAISE; the dominant tool returns a verdict instead, so 83%
+#                    of failures had no cause before ENG-2247. Both are "" on
+#                    success and on an unmigrated handler (`ok="unknown"`).
+#                    Read them as a PAIR with `ok` — a cause only exists where
+#                    the handler said `ok=false`. Same vocabulary as
+#                    turn_completed's `root_cause_*` tally, so the per-call and
+#                    per-turn views cannot disagree; unlike that tally, these
+#                    are per CALL and carry no cumulative-ledger caveat.
 #                    conversation_id + turn_index mirror turn_completed's
 #                    values, so a tool row joins to its parent turn row and,
 #                    via Langfuse sessionId, to the gateway trace.

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -69,6 +69,23 @@ TRIP_ELIGIBLE_TIERS = frozenset({TIER_WALL})
 #: scores 1 on both rungs and is invisible.
 _EXACT_ONLY_CLASSES = frozenset({"missing_file"})
 
+#: Classes `classify` returns as literals rather than through one of the tables
+#: below — the runtime WORDS these failures instead of raising a mapped type,
+#: so there is no exception name to look up. Named rather than inlined so
+#: `ALL_CLASSES` is a real derivation: a consumer enumerating the vocabulary
+#: from the tables alone silently misses them.
+#:
+#: `timeout` is the one that bites. It is reachable in production on every
+#: scratchpad cell timeout (`backends/local.py` builds "Cell timed out after
+#: {N}s total", which arrives here as the tool's `reason`) and appears in no
+#: table, so a closed-set guard built from the tables reports a legitimate
+#: value as a novel class. `permission_denied` and `connection_refused` were
+#: covered only by coincidence — they happen to also be `_WALL_TYPES` values.
+CLS_UNCLASSIFIED = "unclassified"
+CLS_TIMEOUT = "timeout"
+CLS_PERMISSION_DENIED = "permission_denied"
+CLS_CONNECTION_REFUSED = "connection_refused"
+
 #: The agent's own bugs. It can fix these by writing better code, so repetition
 #: is iteration, not a wall — however many times it repeats.
 _SELF_INFLICTED = frozenset({
@@ -261,7 +278,7 @@ def classify(reason: str, result_text: str = "") -> RootCause:
     reason = (reason or "").strip()[:_MAX_REASON_CHARS]
     if not reason:
         sig = _normalise_error_signature((result_text or "")[:_MAX_REASON_CHARS])
-        return RootCause(TIER_UNCLASSIFIED, "unclassified", sig[:80], from_reason=False)
+        return RootCause(TIER_UNCLASSIFIED, CLS_UNCLASSIFIED, sig[:80], from_reason=False)
 
     sentinel = _SENTINEL_REASONS.get(reason)
     if sentinel:
@@ -345,23 +362,42 @@ def classify(reason: str, result_text: str = "") -> RootCause:
         if exc == "OSError" and not re.search(
             r"No space|Disk quota|Too many open files|Cannot allocate", reason, re.I
         ):
-            return RootCause(TIER_UNCLASSIFIED, "unclassified",
+            return RootCause(TIER_UNCLASSIFIED, CLS_UNCLASSIFIED,
                              _normalise_error_signature(reason)[:80])
         return RootCause(TIER_WALL, wall_cls, _identifier_for(wall_cls, reason))
 
     # Timeouts and kills the runtime words rather than raises.
     low = reason.lower()
     if "timed out" in low or "timeout" in low or "inactivity" in low or "liveness" in low:
-        return RootCause(TIER_TRANSIENT, "timeout", "")
+        return RootCause(TIER_TRANSIENT, CLS_TIMEOUT, "")
     if "permission denied" in low:
-        return RootCause(TIER_WALL, "permission_denied",
-                         _identifier_for("permission_denied", reason))
+        return RootCause(TIER_WALL, CLS_PERMISSION_DENIED,
+                         _identifier_for(CLS_PERMISSION_DENIED, reason))
     if "connection refused" in low:
-        return RootCause(TIER_WALL, "connection_refused",
-                         _identifier_for("connection_refused", reason))
+        return RootCause(TIER_WALL, CLS_CONNECTION_REFUSED,
+                         _identifier_for(CLS_CONNECTION_REFUSED, reason))
 
-    return RootCause(TIER_UNCLASSIFIED, "unclassified",
+    return RootCause(TIER_UNCLASSIFIED, CLS_UNCLASSIFIED,
                      _normalise_error_signature(reason)[:80])
+
+
+#: Every value `classify` can put in `RootCause.cls`, and every tier. THE
+#: authoritative enumeration — a consumer must read these rather than
+#: reassembling the tables, which is how `timeout` went missing (ENG-2247).
+#: Adding a class means adding it here, and the guard follows automatically.
+ALL_CLASSES: frozenset[str] = frozenset(
+    set(_SELF_INFLICTED)
+    | set(_TRANSIENT)
+    | set(_WALL_TYPES.values())
+    | {cls for _, cls in _SENTINEL_REASONS.values()}
+    | set(_STATUS_WALLS.values())
+    | {f"http_{code}" for code in _STATUS_TRANSIENT}
+    | {CLS_UNCLASSIFIED, CLS_TIMEOUT, CLS_PERMISSION_DENIED, CLS_CONNECTION_REFUSED}
+)
+
+ALL_TIERS: frozenset[str] = frozenset(
+    {TIER_SELF, TIER_TRANSIENT, TIER_WALL, TIER_UNCLASSIFIED}
+)
 
 
 @dataclass

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -384,7 +384,14 @@ def classify(reason: str, result_text: str = "") -> RootCause:
 #: Every value `classify` can put in `RootCause.cls`, and every tier. THE
 #: authoritative enumeration — a consumer must read these rather than
 #: reassembling the tables, which is how `timeout` went missing (ENG-2247).
-#: Adding a class means adding it here, and the guard follows automatically.
+#:
+#: Adding a class means adding it here. That keeps the SET honest; it does not
+#: by itself keep a closed-set guard honest, because such a guard only catches
+#: an unregistered value if some input actually reaches the branch returning
+#: it. Two of ENG-2247's own adversarial inputs missed their branches (an
+#: `OSError: ` prefix sent them down `_WALL_TYPES` instead) and the guard
+#: still passed. So a new literal needs BOTH an entry here and an input that
+#: reaches it.
 ALL_CLASSES: frozenset[str] = frozenset(
     set(_SELF_INFLICTED)
     | set(_TRANSIENT)

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3180,6 +3180,10 @@ class ChatSession:
                 settings = AntonSettings()
             from anton.analytics import send_event
 
+            # Derived here, not handed in — see the docstring. `reason` is
+            # consumed and dropped; only the two closed-vocabulary tokens go on.
+            _rc_tier, _rc_class = _tool_failure_cause(ok, reason)
+
             # send_event takes STRING values only — every extra is a wire
             # parameter (tests/test_ask_user.py:496 exists because a first
             # draft assumed a (name, props) shape).
@@ -3187,9 +3191,6 @@ class ChatSession:
             # the live TurnCost carries the authoritative index (an explicit
             # turn_id on the cloud path, the local counter otherwise), so the
             # values here and on the turn's own row can never disagree.
-            # Derived here, not handed in — see the docstring. `reason` is
-            # consumed and dropped; only the two closed-vocabulary tokens go on.
-            _rc_tier, _rc_class = _tool_failure_cause(ok, reason)
             _tc = getattr(self, "_turn_cost", None)
             turn_index = (
                 getattr(_tc, "turn_index", 0) or (self._turn_count + 1)

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -603,9 +603,20 @@ def _tool_failure_cause(ok: "bool | None", reason: str) -> "tuple[str, str]":
     """`(tier, class)` for one failed tool call, or `("", "")` (ENG-2247).
 
     Reuses `root_cause.classify` — the SAME vocabulary the turn-level
-    `root_cause_*` tally is built from — so a tool row and its turn cannot
-    disagree about what a failure was. A parallel taxonomy here would put two
-    spellings of one failure in two fields.
+    `root_cause_*` tally is built from — so for a string tool result the row
+    and its turn cannot disagree about what a failure was. A parallel taxonomy
+    here would put two spellings of one failure in two fields.
+
+    **Scoped to string results deliberately, and it is not a full agreement
+    guarantee.** This runs unconditionally at the emit, but
+    `_record_root_cause` is reached only from the string branch — the
+    multimodal arms `continue` past it. So a handler returning
+    `content=[...]` with `ok=False` puts a cause on the tool row that the turn
+    tally never counts (measured: row `self_inflicted`/`NameError`, tally
+    `root_cause_failures=0`). Unreachable today — no handler returns
+    multimodal content at all — but `ToolOutcome.content` permits it, so
+    whoever migrates the first one must add `_record_root_cause` to both list
+    arms, alongside the nudge the #308-review NOTE already asks for there.
 
     **Deliberately does NOT touch `RootCauseLedger`.** That ledger drops every
     non-trip-eligible class one line into `add()` (`if not rc.trip_eligible:

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -599,6 +599,44 @@ def _safe_error_detail(exc: BaseException) -> str:
     return name
 
 
+def _tool_failure_cause(ok: "bool | None", reason: str) -> "tuple[str, str]":
+    """`(tier, class)` for one failed tool call, or `("", "")` (ENG-2247).
+
+    Reuses `root_cause.classify` — the SAME vocabulary the turn-level
+    `root_cause_*` tally is built from — so a tool row and its turn cannot
+    disagree about what a failure was. A parallel taxonomy here would put two
+    spellings of one failure in two fields.
+
+    **Deliberately does NOT touch `RootCauseLedger`.** That ledger drops every
+    non-trip-eligible class one line into `add()` (`if not rc.trip_eligible:
+    return`), and that early return is how "structurally cannot trip" is
+    implemented for ENG-1531's breaker — widening it to keep `self_inflicted`
+    names would arm the breaker on the agent's own `NameError`s, the exact
+    ENG-836 ping-pong the tier exists to exclude. Reading the classifier
+    directly bypasses the ledger, so nothing a trip rung reads can change.
+
+    `result_text` is deliberately not taken. `classify` consults it only to
+    build the `identifier` of a reason-less failure; the CLASS in that branch is
+    the constant `"unclassified"` either way. So the class is identical with or
+    without it — which is what lets this run at the emit site, where the result
+    has not been assigned yet, instead of reordering the dispatch loop.
+
+    Only a handler's explicit `ok is False` produces a cause. `ok is None` is an
+    unmigrated handler (ENG-2248): the event already reports `ok="unknown"`, and
+    attaching a cause to a call we cannot say failed would invent a verdict.
+
+    Never raises: it runs on the reporting path, where an escape would turn a
+    handled tool failure into a dead turn.
+    """
+    if ok is not False:
+        return "", ""
+    try:
+        rc = classify_root_cause(reason or "", "")
+        return rc.tier, rc.cls
+    except Exception:  # pragma: no cover - defensive; classify is total
+        return "", ""
+
+
 def _safe_error_type(exc: BaseException) -> str:
     """The exception's class name, and nothing else, for analytics.
 
@@ -3063,6 +3101,8 @@ class ChatSession:
         ok: bool | None,
         duration_ms: float,
         error_type: str,
+        root_cause_tier: str = "",
+        root_cause_class: str = "",
     ) -> None:
         """Per-tool-call analytics event (ENG-1486).
 
@@ -3130,6 +3170,14 @@ class ChatSession:
                 surface=str(getattr(self, "_surface", None) or ""),
                 conversation_id=str(self._session_id or ""),
                 turn_index=str(turn_index),
+                # WHY the call failed, in `root_cause.py`'s vocabulary
+                # (ENG-2247). `error_type` above only fills in when the failure
+                # was a RAISE; `scratchpad` — 79% of tool volume, 9.35% of it
+                # failing — returns a verdict instead, so 83% of failures
+                # reached analytics with no cause at all. Both empty on success
+                # and on an unmigrated handler; see `_tool_failure_cause`.
+                root_cause_tier=root_cause_tier,
+                root_cause_class=root_cause_class,
             )
         except Exception:
             # Analytics must never affect the tool call that just ran.
@@ -3871,11 +3919,16 @@ class ChatSession:
                 # elicitation is structurally unavailable on this path (no
                 # emitter to render a question), so there is no wait to
                 # subtract.
+                _rc_tier, _rc_class = _tool_failure_cause(
+                    outcome.ok, outcome.reason
+                )
                 self._emit_tool_completed(
                     name=tc.name,
                     ok=outcome.ok,
                     duration_ms=(_time.monotonic() - _tool_t0) * 1000.0,
                     error_type=_tool_error_type,
+                    root_cause_tier=_rc_tier,
+                    root_cause_class=_rc_class,
                 )
                 result = outcome.content
 
@@ -5246,6 +5299,9 @@ class ChatSession:
                     # tool performance. Fixing it needs a session-scoped
                     # accumulator behind `prompt_or_cancel`, which is a change
                     # to the CLI prompt path rather than to this event.
+                    _rc_tier, _rc_class = _tool_failure_cause(
+                        tool_ok, tool_reason
+                    )
                     self._emit_tool_completed(
                         name=tc.name,
                         ok=tool_ok,
@@ -5255,6 +5311,8 @@ class ChatSession:
                             0.0,
                         ) * 1000.0,
                         error_type=_tool_error_type,
+                        root_cause_tier=_rc_tier,
+                        root_cause_class=_rc_class,
                     )
 
                     if isinstance(result_text, list):

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -599,7 +599,7 @@ def _safe_error_detail(exc: BaseException) -> str:
     return name
 
 
-def _tool_failure_cause(ok: "bool | None", reason: str) -> "tuple[str, str]":
+def _tool_failure_cause(ok: bool | None, reason: str) -> tuple[str, str]:
     """`(tier, class)` for one failed tool call, or `("", "")` (ENG-2247).
 
     Reuses `root_cause.classify` — the SAME vocabulary the turn-level
@@ -3121,10 +3121,28 @@ class ChatSession:
         ok: bool | None,
         duration_ms: float,
         error_type: str,
-        root_cause_tier: str = "",
-        root_cause_class: str = "",
+        reason: str = "",
     ) -> None:
         """Per-tool-call analytics event (ENG-1486).
+
+        ``reason`` is the handler's own ``ToolOutcome.reason``, taken so the
+        root-cause class can be derived HERE rather than at each call site
+        (ENG-2247 review). Deriving it here is what makes it impossible to
+        forget: there is no cause argument a new dispatch path can omit, and a
+        caller that passes no ``reason`` at all degrades to ``unclassified``
+        — "we do not know why" — instead of to the empty string, which reads
+        as "this call did not fail". Defaulting the CAUSE was the earlier
+        shape and it failed in the wrong direction; making it required instead
+        was worse still, since a missing argument raises ``TypeError`` at the
+        CALL, outside this method's guard, and kills the turn over telemetry.
+
+        **``reason`` is prose and must never be emitted.** It is a traceback
+        line or a handler message and carries file paths and user input; that
+        is the whole reason ``error_type`` was narrowed to a class name. It is
+        consumed by ``_tool_failure_cause`` two lines down and never touched
+        again — do not add it, ``rc.identifier`` or ``rc.key`` to the payload.
+        ``test_no_prose_from_the_reason_reaches_the_payload`` and the
+        exact-keys assertion both fail if you do.
 
         The verdict the dispatch loop already computes for the UI's
         ``tool_done`` marker, sent where it can be aggregated: without this,
@@ -3169,6 +3187,9 @@ class ChatSession:
             # the live TurnCost carries the authoritative index (an explicit
             # turn_id on the cloud path, the local counter otherwise), so the
             # values here and on the turn's own row can never disagree.
+            # Derived here, not handed in — see the docstring. `reason` is
+            # consumed and dropped; only the two closed-vocabulary tokens go on.
+            _rc_tier, _rc_class = _tool_failure_cause(ok, reason)
             _tc = getattr(self, "_turn_cost", None)
             turn_index = (
                 getattr(_tc, "turn_index", 0) or (self._turn_count + 1)
@@ -3196,8 +3217,8 @@ class ChatSession:
                 # failing — returns a verdict instead, so 83% of failures
                 # reached analytics with no cause at all. Both empty on success
                 # and on an unmigrated handler; see `_tool_failure_cause`.
-                root_cause_tier=root_cause_tier,
-                root_cause_class=root_cause_class,
+                root_cause_tier=_rc_tier,
+                root_cause_class=_rc_class,
             )
         except Exception:
             # Analytics must never affect the tool call that just ran.
@@ -3939,16 +3960,12 @@ class ChatSession:
                 # elicitation is structurally unavailable on this path (no
                 # emitter to render a question), so there is no wait to
                 # subtract.
-                _rc_tier, _rc_class = _tool_failure_cause(
-                    outcome.ok, outcome.reason
-                )
                 self._emit_tool_completed(
                     name=tc.name,
                     ok=outcome.ok,
                     duration_ms=(_time.monotonic() - _tool_t0) * 1000.0,
                     error_type=_tool_error_type,
-                    root_cause_tier=_rc_tier,
-                    root_cause_class=_rc_class,
+                    reason=outcome.reason,
                 )
                 result = outcome.content
 
@@ -5319,9 +5336,6 @@ class ChatSession:
                     # tool performance. Fixing it needs a session-scoped
                     # accumulator behind `prompt_or_cancel`, which is a change
                     # to the CLI prompt path rather than to this event.
-                    _rc_tier, _rc_class = _tool_failure_cause(
-                        tool_ok, tool_reason
-                    )
                     self._emit_tool_completed(
                         name=tc.name,
                         ok=tool_ok,
@@ -5331,8 +5345,7 @@ class ChatSession:
                             0.0,
                         ) * 1000.0,
                         error_type=_tool_error_type,
-                        root_cause_tier=_rc_tier,
-                        root_cause_class=_rc_class,
+                        reason=tool_reason,
                     )
 
                     if isinstance(result_text, list):

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -636,6 +636,15 @@ def _tool_failure_cause(ok: "bool | None", reason: str) -> "tuple[str, str]":
     unmigrated handler (ENG-2248): the event already reports `ok="unknown"`, and
     attaching a cause to a call we cannot say failed would invent a verdict.
 
+    **Emit `tier` and `cls` only — never `identifier`, and never `key`.**
+    `key` is `class:identifier` and is the tempting "more useful" field, but the
+    identifier is extracted from the reason and carries absolute paths and
+    internal hostnames verbatim: `permission_denied:/root/.ssh/id_rsa`,
+    `connection_refused:db.internal.corp:5432`. It is the nearer trap than
+    `reason`, because it sits on the object this function already destructures.
+    `test_no_prose_from_the_reason_reaches_the_payload` fails if either is
+    forwarded — verified by mutation, not by hope.
+
     Never raises: it runs on the reporting path, where an escape would turn a
     handled tool failure into a dead turn.
     """

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -521,3 +521,74 @@ async def test_no_prose_from_the_reason_reaches_the_payload(workspace):
     assert secret not in blob
     assert ".aws" not in blob
     assert "someone" not in blob
+
+
+def _closed_vocabulary() -> set:
+    """Every class `classify` can return, derived from the module, not copied.
+
+    Derived so that EXTENDING the vocabulary keeps the guard passing, while a
+    value from outside the tables — the unbounded-cardinality failure — fails it.
+    """
+    import anton.core.root_cause as R
+
+    closed = set(R._SELF_INFLICTED) | set(R._TRANSIENT) | set(R._WALL_TYPES.values())
+    closed |= {cls for _, cls in R._SENTINEL_REASONS.values()}
+    closed |= set(R._STATUS_WALLS.values())
+    closed |= {f"http_{code}" for code in R._STATUS_TRANSIENT}
+    return closed | {"unclassified"}
+
+
+def test_the_emitted_class_is_always_from_the_closed_vocabulary():
+    """Bounded cardinality is a property of the FIELD, not of today's inputs.
+
+    A PostHog property with unbounded values is expensive and useless as a
+    breakdown. `reason` is attacker-and-model-influenced prose, so the guard
+    that matters is that nothing derived from it can widen the value space.
+    Adversarial reasons included: a novel exception type, a bare sentence, an
+    injected-looking string, and text carrying a status code.
+    """
+    from anton.core.session import _tool_failure_cause
+
+    closed = _closed_vocabulary()
+    tiers = {"self_inflicted", "transient", "external_wall", "unclassified"}
+    reasons = [
+        "NameError: x", "ModuleNotFoundError: No module named 'z'",
+        "TimeoutError: slow", "PermissionError: nope", "scratchpad_empty_code",
+        "RuntimeError: boom", "SomeVendorSpecificError: novel type",
+        "just a sentence with no exception in it", "",
+        "HTTPError: 503 upstream", "KeyError: 404",
+        "Error: {'sql': 'DROP TABLE users'} failed",
+        "x" * 4000,
+    ]
+    for reason in reasons:
+        tier, cls = _tool_failure_cause(False, reason)
+        assert cls in closed, f"{reason[:40]!r} minted a novel class {cls!r}"
+        assert tier in tiers, f"{reason[:40]!r} minted a novel tier {tier!r}"
+
+
+async def test_the_tool_row_and_the_turn_tally_agree_on_the_tier(workspace):
+    """The per-call field and the per-turn counter must describe one reality.
+
+    They come from the same classifier but by different routes — this one reads
+    it directly, the tally goes through `RootCauseLedger`. A divergence would
+    mean two published numbers disagreeing about the same failure.
+    """
+    session = _session(workspace, [ToolOutcome(
+        content="[error]\nNameError: name 'wb' is not defined",
+        ok=False, reason="NameError: name 'wb' is not defined",
+    )])
+    with patch("anton.analytics.send_event") as sent:
+        async for _ in session.turn_stream("go"):
+            pass
+    tool = [c.kwargs for c in sent.call_args_list if c.args[1] == "tool_completed"]
+    turn = [c.kwargs for c in sent.call_args_list if c.args[1] == "turn_completed"]
+    assert len(tool) == 1 and len(turn) == 1
+
+    assert tool[0]["root_cause_tier"] == "self_inflicted"
+    # The turn tally counted the SAME failure into the SAME tier.
+    assert str(turn[0]["root_cause_self_inflicted"]) == "1"
+    assert str(turn[0]["root_cause_failures"]) == "1"
+    # And it stayed out of the trip-eligible rungs — the safety contract this
+    # change must not disturb (ENG-1531 / ENG-836).
+    assert str(turn[0]["root_cause_wall"]) == "0"
+    assert turn[0]["root_cause_top_class"] == ""

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -502,6 +502,16 @@ async def test_the_cause_is_the_shared_classifier_verbatim(workspace):
     failure in two fields. Asserted against `classify` itself rather than
     against hardcoded strings, so extending the vocabulary cannot silently
     desync the event.
+
+    KNOWN LIMIT, stated so nobody reads more into a green run than is there:
+    this evaluates the same expression the implementation does, so it pins the
+    values but NOT the choice of inputs — were the correct call
+    `classify(reason, result_text)`, this would pass anyway. That gap is a
+    proven no-op rather than a risk: measured across 12 reasons x 7 result
+    texts, `(tier, cls)` is identical with and without `result_text` in all 84
+    combinations, because the only branch that reads it returns the constant
+    `"unclassified"` class. That equivalence is what lets the cause be derived
+    at the emit site, before the result is assigned.
     """
     from anton.core.root_cause import classify
 
@@ -602,3 +612,28 @@ async def test_the_tool_row_and_the_turn_tally_agree_on_the_tier(workspace):
     # change must not disturb (ENG-1531 / ENG-836).
     assert str(turn[0]["root_cause_wall"]) == "0"
     assert turn[0]["root_cause_top_class"] == ""
+
+
+async def test_the_nonstreaming_turn_path_stamps_the_cause_too(workspace):
+    """`turn()` has its OWN dispatch loop, its own emit, and its own cause call.
+
+    Every other test here drives `turn_stream`. Found by mutation: removing
+    both kwargs from the non-streaming emit alone left the entire suite green
+    (2,927 passed), so nothing guarded that call site — the same gap the
+    streaming tail had before `test_nonstreaming_turn_path_also_emits` was
+    written, one field later.
+
+    Raises `ValueError` rather than the sibling test's `RuntimeError` on
+    purpose: on this path `reason` is `type(exc).__name__`, and `ValueError` is
+    in `_SELF_INFLICTED` so it classifies distinctly, where `RuntimeError`
+    falls through to `unclassified` — too close to "absent" to prove anything.
+    """
+    session = _session(workspace, ValueError("bad argument"))
+    with patch("anton.analytics.send_event") as sent:
+        await session.turn("go")
+    events = [c.kwargs for c in sent.call_args_list if c.args[1] == "tool_completed"]
+    assert len(events) == 1
+    assert events[0]["ok"] == "false"
+    assert events[0]["error_type"] == "ValueError"      # the raise path
+    assert events[0]["root_cause_tier"] == "self_inflicted"
+    assert events[0]["root_cause_class"] == "ValueError"

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -12,8 +12,12 @@ harness shape as ``test_root_cause_wiring.py``) and assert on what
   unconditional success);
 - ``error_type`` is the exception CLASS name and never the message —
   ``str(exc)`` routinely embeds file paths and user input;
-- the payload is exactly {name, ok, duration_ms, error_type, conversation_id,
-  turn_index}, all strings — no tool arguments, no result content;
+- the payload is exactly {name, ok, duration_ms, error_type, surface,
+  conversation_id, turn_index, root_cause_tier, root_cause_class}, all strings
+  — no tool arguments, no result content. ``surface`` joined in ENG-1945 and the
+  two ``root_cause_*`` keys in ENG-2247; the exact-keys assertion is widened
+  deliberately each time rather than loosened, because "no surprise keys" is the
+  property that keeps arguments and result prose out;
 - human wait (``answer_wait_s``, accumulated by ``elicit()``) is subtracted
   from the duration — which covers ``ask_user`` and ``select_path``, the only
   tools that elicit. It does NOT cover the interactive branch, whose tools
@@ -163,14 +167,15 @@ async def test_unmigrated_handler_verdict_is_unknown_not_a_guess(workspace):
 # ── Payload contract ─────────────────────────────────────────────────
 
 
-async def test_payload_is_exactly_the_seven_keys_all_strings(workspace):
+async def test_payload_is_exactly_the_nine_keys_all_strings(workspace):
     """No arguments, no result content, no surprise keys — and str values only,
     because send_event's extras are wire parameters (tests/test_ask_user.py:496).
     """
     session = _session(workspace, [ToolOutcome(content="secret result body", ok=True)])
     events = await _tool_completed_calls(session)
     assert set(events[0]) == {"name", "ok", "duration_ms", "error_type",
-                              "surface", "conversation_id", "turn_index"}
+                              "surface", "conversation_id", "turn_index",
+                              "root_cause_tier", "root_cause_class"}
     assert all(isinstance(v, str) for v in events[0].values())
     assert "secret result body" not in json.dumps(events[0])
     int(events[0]["duration_ms"])  # numeric string, parseable
@@ -417,3 +422,102 @@ def test_tool_completed_goes_to_posthog_not_the_collector(monkeypatch):
     assert body["event"] == "tool_completed"
     assert body["properties"]["name"] == "scratchpad"
     assert body["properties"]["ok"] == "false"
+
+
+# ── Why it failed (ENG-2247) ─────────────────────────────────────────
+
+
+async def test_a_returned_verdict_failure_carries_its_cause(workspace):
+    """The whole point: `scratchpad`'s failure shape gets a groupable cause.
+
+    A cell that errors is a normal outcome, not a raise, so `error_type` is
+    empty here BY DESIGN — that is the 83% of failures that reached analytics
+    with nothing to group on before this.
+    """
+    session = _session(workspace, [ToolOutcome(
+        content="[error]\nNameError: name 'wb' is not defined",
+        ok=False, reason="NameError: name 'wb' is not defined",
+    )])
+    ev = (await _tool_completed_calls(session))[0]
+    assert ev["ok"] == "false"
+    assert ev["error_type"] == ""          # no raise -> no exception class
+    assert ev["root_cause_tier"] == "self_inflicted"
+    assert ev["root_cause_class"] == "NameError"
+
+
+async def test_an_environment_wall_is_distinguishable_from_an_agent_bug(workspace):
+    """The tier is the actionable half: whose fault is it.
+
+    `NameError` and `ModuleNotFoundError` are both `ok=false` with an empty
+    `error_type`; without the tier they are the same row.
+    """
+    session = _session(workspace, [ToolOutcome(
+        content="[error]\nModuleNotFoundError: No module named 'pyodbc'",
+        ok=False, reason="ModuleNotFoundError: No module named 'pyodbc'",
+    )])
+    ev = (await _tool_completed_calls(session))[0]
+    assert ev["root_cause_tier"] == "external_wall"
+    assert ev["root_cause_class"] == "missing_dependency"
+
+
+async def test_success_carries_no_cause(workspace):
+    """Empty, not a placeholder — a cause on a successful call is a lie."""
+    session = _session(workspace, [ToolOutcome(content="fine", ok=True)])
+    ev = (await _tool_completed_calls(session))[0]
+    assert ev["root_cause_tier"] == ""
+    assert ev["root_cause_class"] == ""
+
+
+async def test_an_unmigrated_handler_gets_no_cause(workspace):
+    """`ok=None` means the handler declared nothing (ENG-2248's population).
+
+    The event already reports `ok="unknown"`; attaching a cause would invent a
+    verdict from prose the model can influence — the ENG-1276 defect one level
+    up, and the reason `_record_root_cause` keeps that population
+    non-trip-eligible. Text that LOOKS like a failure must not change this.
+    """
+    session = _session(workspace, [ToolOutcome(
+        content="[error] Task failed: something broke", ok=None)])
+    ev = (await _tool_completed_calls(session))[0]
+    assert ev["ok"] == "unknown"
+    assert ev["root_cause_tier"] == ""
+    assert ev["root_cause_class"] == ""
+
+
+async def test_the_cause_is_the_shared_classifier_verbatim(workspace):
+    """Pins the two views together so they cannot drift.
+
+    The turn-level `root_cause_*` tally and this per-call field must come from
+    ONE vocabulary; a second taxonomy would put two spellings of the same
+    failure in two fields. Asserted against `classify` itself rather than
+    against hardcoded strings, so extending the vocabulary cannot silently
+    desync the event.
+    """
+    from anton.core.root_cause import classify
+
+    for reason in ("NameError: x", "ModuleNotFoundError: No module named 'z'",
+                   "TimeoutError: slow", "scratchpad_empty_code",
+                   "RuntimeError: boom"):
+        session = _session(workspace, [ToolOutcome(
+            content="[error]", ok=False, reason=reason)])
+        ev = (await _tool_completed_calls(session))[0]
+        expected = classify(reason, "")
+        assert ev["root_cause_tier"] == expected.tier, reason
+        assert ev["root_cause_class"] == expected.cls, reason
+
+
+async def test_no_prose_from_the_reason_reaches_the_payload(workspace):
+    """`reason` is prose — traceback lines, handler messages — and carries file
+    paths and user input. Only the closed-vocabulary class may be emitted.
+    """
+    secret = "/Users/someone/.aws/credentials could not be opened"
+    session = _session(workspace, [ToolOutcome(
+        content=f"[error]\nPermissionError: {secret}",
+        ok=False, reason=f"PermissionError: {secret}",
+    )])
+    ev = (await _tool_completed_calls(session))[0]
+    assert ev["root_cause_class"] == "permission_denied"
+    blob = json.dumps(ev)
+    assert secret not in blob
+    assert ".aws" not in blob
+    assert "someone" not in blob

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -544,18 +544,23 @@ async def test_no_prose_from_the_reason_reaches_the_payload(workspace):
 
 
 def _closed_vocabulary() -> set:
-    """Every class `classify` can return, derived from the module, not copied.
+    """THE authoritative class set — `root_cause.ALL_CLASSES`, not a rebuild.
 
-    Derived so that EXTENDING the vocabulary keeps the guard passing, while a
-    value from outside the tables — the unbounded-cardinality failure — fails it.
+    An earlier version reassembled this from the five tables, and that was
+    wrong: `classify()` returns four classes as bare LITERALS, and `timeout`
+    is in no table. It is reachable on every scratchpad cell timeout
+    (`backends/local.py` -> "Cell timed out after {N}s total" -> `reason`), so
+    the guard reported a legitimate enumerated value as a novel class — and
+    the natural reaction to that failure is to loosen the set, the one move
+    this guard exists to prevent. `permission_denied` and `connection_refused`
+    passed only by coincidence, being `_WALL_TYPES` values too.
+
+    Reading the module's own export keeps the derivation honest: a new class
+    must be added there, and this follows automatically.
     """
-    import anton.core.root_cause as R
+    from anton.core.root_cause import ALL_CLASSES
 
-    closed = set(R._SELF_INFLICTED) | set(R._TRANSIENT) | set(R._WALL_TYPES.values())
-    closed |= {cls for _, cls in R._SENTINEL_REASONS.values()}
-    closed |= set(R._STATUS_WALLS.values())
-    closed |= {f"http_{code}" for code in R._STATUS_TRANSIENT}
-    return closed | {"unclassified"}
+    return set(ALL_CLASSES)
 
 
 def test_the_emitted_class_is_always_from_the_closed_vocabulary():
@@ -569,8 +574,10 @@ def test_the_emitted_class_is_always_from_the_closed_vocabulary():
     """
     from anton.core.session import _tool_failure_cause
 
+    from anton.core.root_cause import ALL_TIERS
+
     closed = _closed_vocabulary()
-    tiers = {"self_inflicted", "transient", "external_wall", "unclassified"}
+    tiers = set(ALL_TIERS)
     reasons = [
         "NameError: x", "ModuleNotFoundError: No module named 'z'",
         "TimeoutError: slow", "PermissionError: nope", "scratchpad_empty_code",
@@ -579,6 +586,13 @@ def test_the_emitted_class_is_always_from_the_closed_vocabulary():
         "HTTPError: 503 upstream", "KeyError: 404",
         "Error: {'sql': 'DROP TABLE users'} failed",
         "x" * 4000,
+        # The four classes `classify` returns as literals rather than through a
+        # table. `timeout` is the live one — every scratchpad cell timeout —
+        # and it was uncovered until ENG-2247's review.
+        "Cell timed out after 300s total without producing any output",
+        "Cell exceeded inactivity limit",
+        "OSError: permission denied opening the workspace",
+        "OSError: connection refused by the backend",
     ]
     for reason in reasons:
         tier, cls = _tool_failure_cause(False, reason)
@@ -653,3 +667,41 @@ async def test_the_nonstreaming_turn_path_stamps_the_cause_too(workspace):
     assert events[0]["error_type"] == "ValueError"      # the raise path
     assert events[0]["root_cause_tier"] == "self_inflicted"
     assert events[0]["root_cause_class"] == "ValueError"
+
+
+async def test_a_caller_that_omits_reason_degrades_to_unclassified(workspace):
+    """The reason the derivation lives inside the emit (ENG-2247 review).
+
+    Three shapes were on the table for "a new dispatch path forgets the cause":
+
+    | shape | forgetting yields | turn-safe |
+    | -- | -- | -- |
+    | cause kwargs, defaulted `""` | **"did not fail"** — wrong | yes |
+    | cause kwargs, required | `TypeError` at the CALL, outside this
+      method's guard — **kills the turn over telemetry** | NO |
+    | derive here from `reason` (chosen) | `unclassified` — honest | yes |
+
+    A field whose whole purpose is measuring failures must not fail toward
+    "success", and must not be able to break a turn. This pins the third.
+    """
+    session = _session(workspace, [ToolOutcome(
+        content="[error]\nNameError: name 'wb' is not defined",
+        ok=False, reason="NameError: name 'wb' is not defined",
+    )])
+    with patch("anton.analytics.send_event") as sent:
+        # Exactly what a forgetful new call site looks like: `reason` omitted.
+        session._emit_tool_completed(
+            name="scratchpad", ok=False, duration_ms=1.0, error_type="",
+        )
+    ev = sent.call_args.kwargs
+    assert ev["ok"] == "false"
+    assert ev["root_cause_tier"] == "unclassified", (
+        "a forgotten reason must read as 'we do not know why', never as empty "
+        "— empty is a legal value meaning the call did not fail"
+    )
+    assert ev["root_cause_class"] == "unclassified"
+    # And the keys are still exactly the nine: omitting an input must not
+    # change the payload SHAPE, only the honesty of one value.
+    assert set(ev) == {"name", "ok", "duration_ms", "error_type", "surface",
+                       "conversation_id", "turn_index",
+                       "root_cause_tier", "root_cause_class"}

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -350,6 +350,16 @@ async def test_nonstreaming_turn_path_also_emits(workspace):
     assert events[0]["ok"] == "false"
     assert events[0]["error_type"] == "RuntimeError"
     assert events[0]["name"] == "scratchpad"
+    # The cause too, not just the pre-ENG-2247 fields. `_emit_tool_completed`
+    # DEFAULTS both to "", so dropping them from this call site changes no
+    # payload key and would otherwise trip nothing — verified: the whole suite
+    # passed with them removed here, while the same removal at the streaming
+    # emit failed 5 tests. A seam guard that covers two of four fields is how
+    # the next host on this path silently undercounts again.
+    # `RuntimeError` is in none of _SELF_INFLICTED/_TRANSIENT/_WALL_TYPES, so
+    # it lands in classify()'s residual branch — the 31% `unclassified` bucket.
+    assert events[0]["root_cause_tier"] == "unclassified"
+    assert events[0]["root_cause_class"] == "unclassified"
 
 
 async def test_model_generated_tool_name_is_bounded(workspace):

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -626,7 +626,23 @@ async def test_the_nonstreaming_turn_path_stamps_the_cause_too(workspace):
     Raises `ValueError` rather than the sibling test's `RuntimeError` on
     purpose: on this path `reason` is `type(exc).__name__`, and `ValueError` is
     in `_SELF_INFLICTED` so it classifies distinctly, where `RuntimeError`
-    falls through to `unclassified` — too close to "absent" to prove anything.
+    falls through to `unclassified`.
+
+    COMPLEMENTARY to that test, not stronger — an earlier commit message here
+    claimed a hierarchy and was wrong. Neither subsumes the other, verified by
+    mutation:
+
+    | mutation | `..._also_emits` | this test |
+    | -- | -- | -- |
+    | `_tool_failure_cause` stubbed to the residual constant | passes | FAILS |
+    | `root_cause_class=_tool_error_type` (wrong source) | FAILS | passes |
+
+    The second is the non-obvious one: on the raise path `reason` IS
+    `type(exc).__name__`, so `error_type == root_cause_class == "ValueError"`
+    here and a class copied from `error_type` is invisible to this test — only
+    its tier assertion resists, and only the RuntimeError/`unclassified` pair
+    distinguishes the two sources. Deleting either test as redundant reopens a
+    mutation the other does not cover, with CI green.
     """
     session = _session(workspace, ValueError("bad argument"))
     with patch("anton.analytics.send_event") as sent:

--- a/tests/test_tool_completed.py
+++ b/tests/test_tool_completed.py
@@ -586,13 +586,21 @@ def test_the_emitted_class_is_always_from_the_closed_vocabulary():
         "HTTPError: 503 upstream", "KeyError: 404",
         "Error: {'sql': 'DROP TABLE users'} failed",
         "x" * 4000,
-        # The four classes `classify` returns as literals rather than through a
-        # table. `timeout` is the live one — every scratchpad cell timeout —
-        # and it was uncovered until ENG-2247's review.
+        # The four classes `classify` returns as literals rather than through
+        # a table, each reaching its own branch. `timeout` is the live one —
+        # every scratchpad cell timeout — and it was uncovered until review.
+        #
+        # NO `OSError: ` PREFIX on the last two, deliberately: `_WALL_TYPES`
+        # is consulted before the lowercase-phrase branches, and its OSError
+        # entry falls through to `unclassified` unless the text says "No space
+        # / Disk quota / Too many open files / Cannot allocate". A first draft
+        # prefixed both and they silently classified as `unclassified`, so the
+        # two branches they exist to cover stayed unexercised while the test
+        # still passed (both classes being in `ALL_CLASSES` either way).
         "Cell timed out after 300s total without producing any output",
         "Cell exceeded inactivity limit",
-        "OSError: permission denied opening the workspace",
-        "OSError: connection refused by the backend",
+        "permission denied on /etc/shadow",
+        "connection refused by db.internal:5432",
     ]
     for reason in reasons:
         tier, cls = _tool_failure_cause(False, reason)


### PR DESCRIPTION
Closes [ENG-2247](https://linear.app/mindsdb/issue/ENG-2247).

## What

`tool_completed` gains `root_cause_tier` and `root_cause_class`, drawn from `anton/core/root_cause.py`'s existing vocabulary — so "why do tool calls fail" becomes a grouped query instead of one Langfuse trace at a time.

## Why

`error_type` only fills in when a handler **raises**. `scratchpad` — 79% of tool volume, failing **9.35%** of 13,356 calls — doesn't raise: a cell that errors is a normal outcome, so the handler returns `ToolOutcome(ok=False, reason="NameError: …")`. Result, 30 days prod:

| `error_type` | failures | share |
| -- | --: | --: |
| **(empty)** | **1,122** | **83.4%** |
| `RuntimeError` | 116 | 8.6% |
| `ValueError` | 107 | 8.0% |

Shipping `reason` instead is not an option — it's prose carrying file paths and user input, ruled out by ENG-1486's security check. But anton **already classifies every failure per call** into a content-free vocabulary, and throws the answer away.

Measured, 14 days, mock-excluded, carrying builds only:

| | |
| -- | --: |
| classified failures | 2,216 |
| **self-inflicted** | **1,032 (47%)** — every class name discarded |
| unclassified | 679 (31%) |
| external wall | 438 (20%) |
| transient | 68 (3%) |
| `classify_errors` | **0** — the classifier has never raised |
| reason coverage (turns that had failures) | **97.5%**, p50 = 1.0 |
| failures that gain a real class | **69.4%** |

## The constraint that shaped the implementation

The class is dropped by an early return in `RootCauseLedger.add`:

```python
        if not rc.trip_eligible:
            return                      # ~80% of failures stop here
        self.exact[rc.key] += 1
        self.classes[rc.cls] += 1       # only external_wall reaches this
```

**That early return is load-bearing.** Its comment: *"kept out of the rungs a trip could ever read. This is where 'structurally cannot trip' actually happens."* It's how ENG-1531's breaker is stopped from firing on the agent's own bugs — the ENG-836 ping-pong `self_inflicted` exists to exclude.

**So this does not widen the ledger.** Widening `self.classes` would arm the breaker on `NameError`, and it's the obvious-looking fix. Reading the classifier directly bypasses the ledger entirely, so nothing a trip rung reads can change. That's checked by the full suite, not just by argument.

Second reason the per-call route wins: the ledger is cumulative for its lifetime (`event_fields`' own docstring: *"The names read as per-turn and are not"*). One `tool_completed` row is one call, with no such caveat.

## The ordering problem the ticket described — it dissolved

The ticket warned the emit runs *before* the classification (3874 before 3908; 5249 before 5314) and proposed hoisting or reordering. Neither is needed:

`classify(reason, result_text)` consults `result_text` **only** to build the `identifier` of a reason-less failure — the class in that branch is the constant `"unclassified"` either way. So the class is identical with or without it, and both call sites already have `reason` in scope at the emit. No hoist, no signature change, no statements moved in the dispatch loop.

## Design decisions

- **Two fields, not one.** The ticket asked for the class; the tier is what makes it actionable — `NameError` and `ModuleNotFoundError` are both `ok=false` with an empty `error_type`, and without the tier they're the same row. 4 values, deterministic from the class. Flagging it as beyond the ticket's letter.
- **A cause only where `ok is False`.** `ok is None` is an unmigrated handler (ENG-2248); the event already says `ok="unknown"`, and attaching a cause would invent a verdict from prose the model can influence.
- **`root_cause_*` naming** deliberately matches turn_completed's tally, signalling one vocabulary rather than a parallel taxonomy.

## Verification

- **10 tests** in `tests/test_tool_completed.py` (9 new, plus the widened exact-keys test) and a `_closed_vocabulary()` helper. The four strongest arrived in later commits, so they are easy to miss skimming the first diff:
  - `test_the_emitted_class_is_always_from_the_closed_vocabulary` — the closed set is **derived from `root_cause.py`'s tables**, not copied, so extending the vocabulary keeps it green while a value from outside fails it. Driven with adversarial reasons: a novel exception type, a bare sentence, injected-looking text, a status code, a 4k string.
  - `test_the_tool_row_and_the_turn_tally_agree_on_the_tier` — also asserts `root_cause_wall == 0` and `top_class == ""`, which pins that this change does **not** arm ENG-1531's breaker.
  - `test_nonstreaming_turn_path_also_emits` and `test_the_nonstreaming_turn_path_stamps_the_cause_too` — **complementary, neither subsumes the other**; each catches a mutation the other misses (table below, and in the second test's docstring).
  - `test_the_cause_is_the_shared_classifier_verbatim` pins the emitted values against `classify()` **itself** rather than hardcoded strings, so extending the vocabulary can't silently desync the event.
- **9 mutations, all caught.** The last four came from `/pr-review` and a concurrent review session, and include the two that matter most:

  | mutation | result |
  | -- | -- |
  | drop both kwargs from the emit | 7 failed |
  | stamp a cause on success | 1 failed |
  | **leak the prose `reason` instead of the class** | **4 failed** |
  | invent a parallel taxonomy (constant class) | 4 failed |
  | stamp a cause for unmigrated handlers | 1 failed |
  | **widen `RootCauseLedger.add` to count non-trip-eligible classes** — the obvious-looking fix, which arms ENG-1531's breaker on `NameError` | **1 failed** |
  | **emit `rc.key` (`class:identifier`), leaking absolute paths and internal hostnames** | **4 failed** |
  | drop the kwargs from the **non-streaming** emit only | 1 failed *(survived all 2,927 before the guard was added)* |
  | `root_cause_class` sourced from `error_type` (wrong variable) | 1 failed |

- **End-to-end wire probe**, urlopen patched, a real turn driven through `turn_stream` with a failing `PermissionError` outcome whose reason contains `/Users/someone/.aws/credentials`:

  ```
  tool_completed POSTs captured: 1
    name=scratchpad ok=false error_type=''
    root_cause_tier ='external_wall'
    root_cause_class='permission_denied'
  secret path anywhere on the wire: False
  ```

  This is the ENG-1355/ENG-1495 failure class — a property that looks right in code and reaches nothing, or reaches too much. Both directions checked.

- `test_payload_is_exactly_the_seven_keys_all_strings` → `..._nine_keys...`, widened **deliberately**: "no surprise keys" is the property that keeps arguments and result prose out.
- Full suite, fresh `uv sync`: **2,925 passed, 31 skipped, 0 failed**, on `origin/staging` @ `ca249551`.

## Merge order — reviewer please note

[#431](https://github.com/mindsdb/anton/pull/431) (ENG-2243) adds `turn_attempt_id` to the **same** `send_event` call and moves the same exact-keys assertion. Branched from `staging` rather than stacked, per convention 3.

**Whichever merges second needs a rebase — measured, not estimated.** `git merge-tree` of the two heads gives **4 conflict regions across 2 files** (`analytics.py` and `turn_cost.py` auto-merge):

| file | regions | what |
| -- | --: | -- |
| `anton/core/session.py` | 1 | both PRs append kwargs to the same `send_event(...)`; keep both blocks |
| `tests/test_tool_completed.py` | 3 | the module docstring's payload list, the test **name** (`nine_keys` vs `eight_keys`), and the key-set literal |

Resolution: keep both kwarg blocks, rename to `..._ten_keys_all_strings`, and union the set to `name, ok, duration_ms, error_type, surface, conversation_id, turn_index, turn_attempt_id, root_cause_tier, root_cause_class`. Mechanical — no semantic interaction, the fields are independent — and the exhaustive exact-keys assertion catches a botched union immediately. ~10 minutes.

Merging **#431 first** is marginally cheaper: it has the smaller test-file footprint, so #432 absorbs the union once.

## Expected side effects that are NOT regressions

- **Two new PostHog properties.** Both closed-vocabulary and low-cardinality (4 tiers; the class set is bounded by `root_cause.py`). Safe as breakdown dimensions, unlike `turn_attempt_id`.
- **Empty on success, and on `ok="unknown"` rows.** Read them as a pair with `ok`; absent ≠ "no cause", it means no verdict.
- **The `external_wall` / `transient` shares carry a known skew, and this PR is what makes it matter.** `root_cause.py`'s status branch mis-tiers in both directions, and its own comment defers the fix on the grounds that it is *"tolerable while nothing consumes the tier"* — **this PR is that consumer.** Measured through `_tool_failure_cause`:

  | reason | (tier, class) |
  | -- | -- |
  | `FileNotFoundError: [Errno 2] ... '/data/500/report.csv'` | `transient` / `http_500` |
  | `FileNotFoundError: [Errno 2] ... '/data/report.csv'` | `external_wall` / `missing_file` |
  | `RuntimeError: record 404 not found` | `external_wall` / `missing_file` |

  So a real missing-file wall publishes as a retryable blip whenever a path or port carries a bare 3-digit 4xx/5xx token, and an agent bug publishes as an environment wall. Not fixed here — it needs an HTTP-shape precondition on the status branch, which is ENG-1531's call and touches shared classification every consumer reads. Flagged by @tino097; the direction is the safe one (it inflates walls rather than hiding them), but read the two shares with this in mind.

- **This field does NOT cover the ENG-2193 verifier population.** `generate_object_code(_VerifierVerdict)` is a forced-schema call, not a tool call, so it never enters tool dispatch and never produces a `tool_completed` row. The free-tier verifier failure ENG-2193 is about will not appear under any `root_cause_class`. Stated because the two tickets landed the same week and the field name invites the assumption.

- **~31% will read `unclassified`.** Not missing input — coverage is 97.5%. It's exception types absent from the vocabulary hitting `classify()`'s residual branch (`RuntimeError` alone was 116 of 30 days' raise-shaped failures and is in none of the tables). Cheap follow-up once the residual is visible per tool; deliberately not in this PR.

## Security check

Performed on the diff, and it is the central design constraint rather than a formality. Only the closed-vocabulary `tier`/`cls` tokens are emitted — never `reason`, never `result_text`, both of which are in scope at the emit site and are exactly what a future contributor will reach for. Mutation M3 exists to fail loudly if anyone does. The end-to-end probe confirms a credential-bearing reason produces `permission_denied` on the wire and nothing else. No new destination: the properties ride an event already going to the PostHog direct sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

