### PR TITLE
ENG-1361: Card a provider failure instead of telling the user to rephrase

### DIFF
--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -638,12 +638,20 @@ class TransientProviderError(ConnectionError):
     def __init__(
         self, message: str, *, provider: str = "", code: str | None = None,
         retry_after: float | None = None, session_backoff: bool = True,
-        model: str = "",
+        model: str = "", status_code: int | None = None,
     ) -> None:
         super().__init__(message)
         self.provider = provider
         self.code = code
         self.retry_after = retry_after
+        # The HTTP status this was classified FROM, when there was one
+        # (ENG-1361). `code` cannot carry it: a downstream conversion to
+        # ProviderOverloadedError needs `code` for the card vocabulary, so the
+        # originating status would otherwise be lost before it reaches
+        # telemetry. None for a mid-stream failure (the status was 200) and for
+        # a connection error (no response at all) — those are genuinely absent,
+        # not unknown.
+        self.status_code = status_code
         # The model that was in flight when this failed — so a downstream
         # ProviderOverloadedError names the ACTUAL model (planning OR coding),
         # not whatever the session defaults to (ENG-673).
@@ -928,11 +936,13 @@ def classify_transient(
         return TransientProviderError(
             f"{provider or 'The model provider'} is momentarily overloaded.",
             provider=provider, code=etype, session_backoff=session_backoff, model=model,
+            status_code=status_code,
         )
     if isinstance(status_code, int) and 500 <= status_code < 600:
         return TransientProviderError(
             f"{provider or 'The model provider'} returned {status_code}.",
             provider=provider, code=f"http_{status_code}", session_backoff=False, model=model,
+            status_code=status_code,
         )
     if status_code == 429 and not b.get("detail"):
         # Plain rate-limit ("slow down"), NOT an out-of-quota 429. Quota 429s are
@@ -968,7 +978,7 @@ def classify_transient(
             provider=provider, code="rate_limited",
             session_backoff=velocity_confirmed,
             retry_after=retry_after if velocity_confirmed else None,
-            model=model,
+            model=model, status_code=status_code,
         )
     return None
 
@@ -1123,6 +1133,100 @@ class EndpointConfigurationError(ConnectionError):
     the interactive CLI reads the type to default such a failure to ``setup``
     rather than ``retry`` (ENG-1145 review).
     """
+
+
+# --------------------------------------------------------------------------- #
+# Curated failures + the analytics vocabulary for them (ENG-1361)
+# --------------------------------------------------------------------------- #
+
+# Every CURATED failure: a typed exception carrying user-ready copy that a host
+# maps to an actionable card. These must FAIL a turn, never be wrapped into
+# assistant prose — the card can only fire when the exception propagates, and
+# the generic "please try again or rephrase your request" fallback is actively
+# wrong for all of them (rephrasing cannot fix an outage, a dead credential, or
+# an empty wallet).
+#
+# Listed HERE, beside the class definitions, rather than at the consumer in
+# `session.py`: the previous allowlist lived next to the `except` that used it,
+# and drifted three times — each omission found by a user hitting it in
+# production rather than by the suite (ENG-1361, ENG-1310). Adding a class now
+# means ignoring the comment directly above it, and `test_curated_errors.py`
+# fails on any exception class defined in this module that is neither listed
+# here nor deliberately excluded.
+#
+# NOT a marker base class on purpose: a mixin would change the MRO of every one
+# of these across a version-skew boundary that cowork-server already handles
+# defensively (it imports each type lazily precisely because anton's version
+# floats underneath it). High risk, and the module-walk test gives the same
+# guarantee without touching the hierarchy.
+#
+# Builtin `ConnectionError` is deliberately ABSENT even though the status
+# mapper's terminal catch-all raises one: it is the base class of half this
+# tuple and of unrelated socket failures, so listing it would silently curate
+# everything. Giving that catch-all its own type is ENG-1283.
+CURATED_PROVIDER_ERRORS: tuple[type[BaseException], ...] = (
+    ContextOverflowError,
+    TokenLimitExceeded,
+    ProviderAuthError,
+    StructuredOutputError,
+    TransientProviderError,
+    ProviderOverloadedError,
+    ModelUnavailableError,
+    ContentValidationError,
+    EndpointConfigurationError,
+)
+
+
+# The analytics vocabulary for WHY the provider failed, kept deliberately small
+# and closed (ENG-1361). `code` on the exception cannot serve this purpose: it
+# selects the client's error card (`provider_overloaded` / `rate_limited` are
+# matched literally in ChatView.jsx), so it is a wire contract with the
+# renderer, not a free label. And the raw codes mix cardinalities — `http_503`
+# next to `connection_error` — which would spread one failure mode across many
+# analytics rows. The HTTP status, when there is one, rides in its own field.
+PROVIDER_FAILURE_KINDS: frozenset[str] = frozenset({
+    "overload_signal",     # the provider SAID it was overloaded / erroring
+    "rate_limit",          # velocity 429 — waiting is the remedy
+    "http_5xx",            # request-time 5xx status
+    "connection_failure",  # never reached it, or the connection dropped
+    "bad_response",        # a 200 whose body was unusable
+})
+
+# Codes that mean "we got a 200 and the body was unusable": an unclassifiable
+# mid-stream error event, a stream that stopped early, or one that never
+# started. Distinct from `overload_signal` because the provider told us
+# nothing about why — claiming overload here would over-report incidents.
+_BAD_RESPONSE_CODES = frozenset({"stream_error", "truncated_stream", "empty_response"})
+
+
+def provider_failure_kind(code: str | None) -> str:
+    """Map a `TransientProviderError.code` to `PROVIDER_FAILURE_KINDS`.
+
+    Returns "" for anything unrecognised rather than guessing — an empty value
+    in analytics is a prompt to extend the vocabulary, whereas a wrong one is
+    invisible. Every code anton currently mints is covered; the exhaustiveness
+    check lives in `test_curated_errors.py`.
+    """
+    if not code:
+        return ""
+    if code in _TRANSIENT_ERROR_TYPES:
+        return "overload_signal"
+    if code in _BAD_RESPONSE_CODES:
+        return "bad_response"
+    if code == "rate_limited":
+        return "rate_limit"
+    if code == "connection_error":
+        return "connection_failure"
+    if code.startswith("http_"):
+        # Only 5xx is minted with this prefix (`classify_transient`), but parse
+        # rather than trust it: a future 4xx would otherwise be mislabelled as a
+        # server fault, which is the one direction that misleads an operator.
+        try:
+            status = int(code[len("http_"):])
+        except ValueError:
+            return ""
+        return "http_5xx" if 500 <= status < 600 else ""
+    return ""
 
 
 @dataclass

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -4695,23 +4695,23 @@ class ChatSession:
                             _model = (getattr(_agent_exc, "model", "") or "") or getattr(
                                 self._llm, "planning_model", ""
                             ) or ""
-                            if _agent_exc.code == "rate_limited":
-                                # An UNCONFIRMED velocity 429 reaches the count
-                                # path (session_backoff=False). It must keep the
-                                # rate-limit code and copy: telling a
-                                # rate-limited user the provider is "having an
-                                # incident" is the mis-report ENG-1537 fixed,
-                                # and buying credits cannot lift a per-minute
-                                # ceiling.
-                                raise ProviderOverloadedError(
-                                    "Too many requests too quickly — this didn't clear after "
-                                    f"{_retry_count} attempts. Waiting a moment and continuing "
-                                    "should work; this isn't a credits problem.",
-                                    provider=getattr(_agent_exc, "provider", "") or "",
-                                    model=_model,
-                                    code="rate_limited",
-                                    retry_after=getattr(_agent_exc, "retry_after", None),
-                                ) from _agent_exc
+                            # NO rate-limit special case here, deliberately.
+                            # A 429 reaching the COUNT path is by definition one
+                            # `classify_transient` could NOT confirm was a
+                            # velocity limit (`session_backoff=velocity_confirmed`),
+                            # and its docstring names that exact population: a
+                            # daily quota in a dialect the string-exact billing
+                            # guards miss (Gemini's RESOURCE_EXHAUSTED) "would
+                            # otherwise spend the whole budget waiting out a
+                            # daily quota that resets at midnight — then be told
+                            # it is not a credits problem." Promising "waiting
+                            # should work" and denying a credits problem is
+                            # precisely that mis-report, on precisely that
+                            # population. It also buys nothing: an unconfirmed
+                            # 429 carries `retry_after=None` (same line), so the
+                            # rate_limited card has no interval to time-gate its
+                            # Retry with. The generic branch below is honest —
+                            # anton's own typed message, no claim either way.
                             # KEEP anton's own classification in the copy. The
                             # typed message already says what happened ("The
                             # model provider returned 500.") and ENG-673 put it
@@ -4760,16 +4760,25 @@ class ChatSession:
                                     "error above. Do NOT suggest rephrasing or simplifying the "
                                     "request unless the error was actually about what was asked; "
                                     "for an infrastructure or provider failure, say plainly that "
-                                    "retrying later is the remedy (ENG-1361).\n"
+                                    "retrying later is the remedy.\n"
                                     "Be concise and helpful."
                                 ),
                             }
                         )
                         try:
                             self._validate_history_for_provider(self._history)
-                            async for event in self._llm.plan_stream(
+                            # ...with_recovery, not the raw call: a history too
+                            # long to SUMMARIZE is the one overflow where
+                            # shrinking it is exactly the remedy, and this is
+                            # the only plan_stream site that lacked it. Without
+                            # it a ContextOverflowError here propagates to a
+                            # card-less generic "An unexpected error occurred."
+                            # — strictly less than the prose it replaced, and on
+                            # the one failure whose fix anton can perform
+                            # itself. A fourth consecutive overflow still
+                            # propagates (ENG-1361 review).
+                            async for event in self.plan_stream_with_recovery(
                                 system=await self._build_system_prompt(user_msg_str),
-                                messages=self._history,
                             ):
                                 if isinstance(event, StreamTextDelta):
                                     assistant_text_parts.append(event.text)
@@ -4783,22 +4792,30 @@ class ChatSession:
                                 # how "Server returned 403" ended up mid-chat with
                                 # "please rephrase your request" advice.
                                 #
-                                # ENG-1361 inverted this from an allowlist spelled
-                                # out HERE to membership of the set declared beside
-                                # the exception classes themselves. The allowlist
-                                # shape meant every new type was exposed by default
-                                # and someone had to remember; it was missed three
-                                # times, each found by a user in production rather
-                                # than by the suite. Forgetting now means an
-                                # exception PROPAGATES (a generic card — safe)
-                                # rather than becoming prose that tells the user to
-                                # rephrase (harmful).
+                                # ENG-1361 moved the membership list from HERE to
+                                # `provider.py`, beside the classes themselves, so
+                                # a new type is triaged where it is born.
                                 #
-                                # NOTE: not every member has a dedicated card yet —
-                                # EndpointConfigurationError has none server-side,
-                                # so it renders the generic message. Re-raising
-                                # still stops the misleading advice; it just doesn't
-                                # get a *better* card until that mapping exists.
+                                # Be precise about what that does and does NOT buy
+                                # (review of #433): this is STILL an allowlist at
+                                # runtime — an unlisted type still becomes prose.
+                                # The default-safe property comes only from
+                                # `test_every_exception_defined_in_a_provider_module_is_triaged`,
+                                # which is why that test's module list must cover
+                                # every module that defines one of these.
+                                #
+                                # And propagating is not automatically better.
+                                # Four members currently have NO card on either
+                                # transport (ContextOverflowError,
+                                # StructuredOutputError, TransientProviderError,
+                                # EndpointConfigurationError): cowork-server
+                                # replaces the message with a flat "An unexpected
+                                # error occurred." and the client renders a
+                                # BUTTONLESS alert, so for those the turn trades
+                                # anton's own diagnosis for less text. It is still
+                                # the right trade — the prose asserted a remedy
+                                # that could not work — but it is a trade, not a
+                                # free win, and the cards are the follow-up.
                                 raise
                             if _is_provider_auth_error(e):
                                 # Preserve a refusal after failed confirmation,

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -40,6 +40,7 @@ from anton.core.llm.prompts import (
     SCRATCHPAD_TIMEOUT_NUDGE,
 )
 from anton.core.llm.provider import (
+    CURATED_PROVIDER_ERRORS,
     ContextOverflowError,
     EndpointConfigurationError,
     LLMResponse,
@@ -59,6 +60,7 @@ from anton.core.llm.provider import (
     TransientProviderError,
     context_window,
     damaged_tool_call_result,
+    provider_failure_kind,
 )
 from anton.core.llm.structured import looks_truncated, truncation_verdict, usable_tool_call
 from anton.core.llm.thalamus import (
@@ -707,6 +709,33 @@ def _verifier_error_type(exc: BaseException | None) -> str:
     if isinstance(exc, StructuredOutputError):
         return name + (":unusable_call" if exc.reached_tool_call else ":no_call")
     return name
+
+
+def _stamp_retry_terminal(
+    tc: "TurnCost | None", exc: BaseException, reason: str
+) -> None:
+    """Record WHY the retry flow terminated, plus the provider failure behind it.
+
+    Called immediately before each terminal raise so the books carry the split
+    that `ended_by` and `error_type` cannot express: after ENG-1361 the
+    request-time and mid-stream terminals raise the SAME
+    ``ProviderOverloadedError``, and the ``code`` that separates the rate-limit
+    case is a card contract that never reaches analytics.
+
+    Reads the ORIGINATING exception, not the one about to be raised — the
+    conversion to ``ProviderOverloadedError`` is exactly where the cause would
+    otherwise be lost. Never raises: it runs on the failure path, where an
+    escape would turn a handled failure into a dead turn.
+    """
+    if tc is None:
+        return
+    try:
+        tc.retry_terminal_reason = reason
+        tc.provider_failure_kind = provider_failure_kind(getattr(exc, "code", None))
+        status = getattr(exc, "status_code", None)
+        tc.provider_http_status = status if isinstance(status, int) else None
+    except Exception:  # pragma: no cover - defensive
+        pass
 
 
 def _is_provider_auth_error(exc: BaseException) -> bool:
@@ -2912,6 +2941,12 @@ class ChatSession:
             # not exotic. Leaving the stale value would let plain Stops appear
             # in an error-cause breakdown, which is the opposite of the point.
             tc.error_type = ""
+            # Same reasoning for ENG-1361's fields, and the same site stamps
+            # them: a Stop during the summarize call would otherwise book a
+            # retry terminal that the turn never actually reached.
+            tc.retry_terminal_reason = ""
+            tc.provider_failure_kind = ""
+            tc.provider_http_status = None
         elif exc is not None:
             tc.ended_by = "error"
             # The exception was in scope here and thrown away until ENG-1689,
@@ -3070,6 +3105,26 @@ class ChatSession:
                 # `TurnCost.verifier_failure`.
                 verifier_failure=tc.verifier_failure,
                 verifier_error_type=tc.verifier_error_type,
+                # WHY the retry flow terminated + WHAT failed underneath
+                # (ENG-1361). `ended_by`/`error_type` cannot express either:
+                # the request-time and mid-stream terminals now raise the same
+                # ProviderOverloadedError, and the `code` that splits the
+                # rate-limit case is a card contract, not analytics. Empty
+                # strings for turns that did not retry, consistent with every
+                # other unset string property here.
+                retry_terminal_reason=tc.retry_terminal_reason,
+                provider_failure_kind=tc.provider_failure_kind,
+                # `provider_http_status` is OMITTED rather than sent blank when
+                # there was no status (a mid-stream failure carried a 200; a
+                # connection error had no response at all). The transport is
+                # string-typed, so a placeholder would have to be "" — which
+                # sorts and groups alongside real statuses and makes the column
+                # unusable. Absent is the honest encoding of absent.
+                **(
+                    {"provider_http_status": str(tc.provider_http_status)}
+                    if tc.provider_http_status is not None
+                    else {}
+                ),
                 tokens_total=str(tc.total_tokens),
                 input_tokens=str(tc.input_tokens),
                 output_tokens=str(tc.output_tokens),
@@ -4473,6 +4528,9 @@ class ChatSession:
                         # decide it for them by stalling the turn.
                         _hint = getattr(_agent_exc, "retry_after", None)
                         if _rate_limited and _hint is not None and _hint > max_delay:
+                            _stamp_retry_terminal(
+                                self._turn_cost, _agent_exc, "rate_limit_wait_too_long"
+                            )
                             raise ProviderOverloadedError(
                                 "Too many requests too quickly — the limit clears in about "
                                 f"{int(_hint)}s. This isn't a credits problem.",
@@ -4531,6 +4589,9 @@ class ChatSession:
                             # one. Never say "incident": nothing is broken, and
                             # never imply credits — buying more cannot raise a
                             # per-minute ceiling (ENG-1537).
+                            _stamp_retry_terminal(
+                                self._turn_cost, _agent_exc, "rate_limit_wait_limit"
+                            )
                             raise ProviderOverloadedError(
                                 "Too many requests too quickly — the rate limit didn't "
                                 "clear in time. Waiting a moment and continuing should work; "
@@ -4540,6 +4601,9 @@ class ChatSession:
                                 code="rate_limited",
                                 retry_after=getattr(_agent_exc, "retry_after", None),
                             ) from _agent_exc
+                        _stamp_retry_terminal(
+                            self._turn_cost, _agent_exc, "provider_recovery_timeout"
+                        )
                         raise ProviderOverloadedError(
                             f"{_agent_exc.provider or 'The model provider'} is experiencing an "
                             "incident and didn't recover in time.",
@@ -4585,12 +4649,83 @@ class ChatSession:
                         # again with the error context now in history
                         continue
                     else:
+                        # A transient that outlasted the COUNT budget is the
+                        # same product event as one that outlasted the TIME
+                        # budget on the backoff path above: the provider is
+                        # unreachable and the user needs the provider_overloaded
+                        # card — with Retry, and the MindsHub failover nudge for
+                        # BYOK — not prose (ENG-1361).
+                        #
+                        # Before this, the count path had NO exit that produced
+                        # a card: it asked the model to explain the outage, a
+                        # call that needs the very provider that is failing, and
+                        # when that call failed too the turn ended as "An
+                        # unexpected error occurred: <our own message>. Please
+                        # try again or rephrase your request." Rephrasing cannot
+                        # reach an unreachable provider, and users followed the
+                        # advice — the incident this ticket came from shows the
+                        # user retyping the same request, then leaving.
+                        #
+                        # Raised BEFORE the SYSTEM message is appended below:
+                        # appending first would leave "The task has failed N
+                        # times" dangling in a history the next turn replays.
+                        if isinstance(_agent_exc, TransientProviderError):
+                            _stamp_retry_terminal(
+                                self._turn_cost, _agent_exc, "request_attempt_limit"
+                            )
+                            # Name the model that actually failed (planning OR
+                            # coding) so the card's provider lookup — and so the
+                            # BYOK-vs-managed nudge it picks — is right.
+                            _model = (getattr(_agent_exc, "model", "") or "") or getattr(
+                                self._llm, "planning_model", ""
+                            ) or ""
+                            if _agent_exc.code == "rate_limited":
+                                # An UNCONFIRMED velocity 429 reaches the count
+                                # path (session_backoff=False). It must keep the
+                                # rate-limit code and copy: telling a
+                                # rate-limited user the provider is "having an
+                                # incident" is the mis-report ENG-1537 fixed,
+                                # and buying credits cannot lift a per-minute
+                                # ceiling.
+                                raise ProviderOverloadedError(
+                                    "Too many requests too quickly — this didn't clear after "
+                                    f"{_retry_count} attempts. Waiting a moment and continuing "
+                                    "should work; this isn't a credits problem.",
+                                    provider=getattr(_agent_exc, "provider", "") or "",
+                                    model=_model,
+                                    code="rate_limited",
+                                    retry_after=getattr(_agent_exc, "retry_after", None),
+                                ) from _agent_exc
+                            # KEEP anton's own classification in the copy. The
+                            # typed message already says what happened ("The
+                            # model provider returned 500.") and ENG-673 put it
+                            # there deliberately; replacing it with a generic
+                            # "could not be reached" would throw away the one
+                            # detail that tells a user — or a support thread —
+                            # which failure this was. Only the attempt count is
+                            # new information.
+                            _detail = str(_agent_exc).rstrip()
+                            if _detail and _detail[-1] not in ".!?":
+                                _detail += "."
+                            raise ProviderOverloadedError(
+                                f"{_detail} Retried {_retry_count} times without success.",
+                                provider=getattr(_agent_exc, "provider", "") or "",
+                                model=_model,
+                            ) from _agent_exc
                         # Exhausted retries — stop and summarize for the user.
                         # Mark the terminal: the apology below is yielded as
                         # ordinary text and nothing is in flight when the
                         # finally runs, so without this the turn reported
                         # "completed" — undercounting the most common failure
                         # mode in any error-rate query (#309 review).
+                        #
+                        # Still reached by NON-transient failures (a 400, a tool
+                        # crash), which keep the summarize-and-explain behaviour:
+                        # for those the model genuinely can say something useful,
+                        # and there is no card to route them to.
+                        _stamp_retry_terminal(
+                            self._turn_cost, _agent_exc, "request_attempt_limit"
+                        )
                         if self._turn_cost is not None:
                             self._turn_cost.ended_by = "retry_exhausted"
                             # Same exception the SYSTEM message below shows the
@@ -4605,8 +4740,11 @@ class ChatSession:
                                     "Stop retrying. Please:\n"
                                     "1. Summarize what you accomplished so far.\n"
                                     "2. Explain what went wrong in plain language.\n"
-                                    "3. Suggest next steps — what the user can try (e.g. rephrase, "
-                                    "simplify the request, or ask you to continue from where you left off).\n"
+                                    "3. Suggest next steps — but only ones that follow from the "
+                                    "error above. Do NOT suggest rephrasing or simplifying the "
+                                    "request unless the error was actually about what was asked; "
+                                    "for an infrastructure or provider failure, say plainly that "
+                                    "retrying later is the remedy (ENG-1361).\n"
                                     "Be concise and helpful."
                                 ),
                             }
@@ -4621,31 +4759,44 @@ class ChatSession:
                                     assistant_text_parts.append(event.text)
                                 yield event
                         except Exception as e:
-                            if isinstance(e, (TokenLimitExceeded, ModelUnavailableError, EndpointConfigurationError)):
+                            if isinstance(e, CURATED_PROVIDER_ERRORS):
                                 # Curated provider failures must FAIL the turn, not
                                 # get wrapped into assistant prose: the server maps
-                                # token_limit/model_unavailable to actionable cards,
-                                # which can only fire when the exception propagates.
-                                # Wrapping them as text is how "Server returned 403"
-                                # ended up mid-chat with "please rephrase your
-                                # request" advice. EndpointConfigurationError added
-                                # here to match the immediate re-raise site above —
-                                # this wrap-up call had been the one place it still
-                                # fell through (review feedback on ENG-1310). NOTE:
-                                # cowork-server has no dedicated card for
-                                # EndpointConfigurationError yet (grepped — zero
-                                # hits, friendly_turn_error falls through to the
-                                # generic message for it); re-raising it here still
-                                # stops the misleading "adjust your approach" prose,
-                                # it just doesn't get a *better* card until that
-                                # mapping exists server-side.
+                                # them to actionable cards, which can only fire when
+                                # the exception propagates. Wrapping them as text is
+                                # how "Server returned 403" ended up mid-chat with
+                                # "please rephrase your request" advice.
+                                #
+                                # ENG-1361 inverted this from an allowlist spelled
+                                # out HERE to membership of the set declared beside
+                                # the exception classes themselves. The allowlist
+                                # shape meant every new type was exposed by default
+                                # and someone had to remember; it was missed three
+                                # times, each found by a user in production rather
+                                # than by the suite. Forgetting now means an
+                                # exception PROPAGATES (a generic card — safe)
+                                # rather than becoming prose that tells the user to
+                                # rephrase (harmful).
+                                #
+                                # NOTE: not every member has a dedicated card yet —
+                                # EndpointConfigurationError has none server-side,
+                                # so it renders the generic message. Re-raising
+                                # still stops the misleading advice; it just doesn't
+                                # get a *better* card until that mapping exists.
                                 raise
                             if _is_provider_auth_error(e):
                                 # Preserve a refusal after failed confirmation,
                                 # or the first refusal after stream output, for
                                 # the host's auth-error mapping.
                                 raise
-                            fallback = f"An unexpected error occurred: {e}. Please try again or rephrase your request."
+                            # No "rephrase your request": everything reaching
+                            # this line is an UNEXPECTED failure, and we have no
+                            # basis to claim the user's wording caused it. The
+                            # curated failures — where we DO know the cause, and
+                            # where rephrasing provably cannot help — are re-
+                            # raised above (ENG-1361). Say what happened and stop
+                            # inventing a remedy.
+                            fallback = f"An unexpected error occurred: {e}"
                             assistant_text_parts.append(fallback)
                             yield StreamTextDelta(text=fallback)
                         break

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -4669,6 +4669,22 @@ class ChatSession:
                         # Raised BEFORE the SYSTEM message is appended below:
                         # appending first would leave "The task has failed N
                         # times" dangling in a history the next turn replays.
+                        #
+                        # KNOWINGLY DEFERRED: this is scoped on the exception
+                        # TYPE, so it also sweeps in the `bad_response` codes
+                        # (`empty_response`, `truncated_stream`) — which anton
+                        # classifies as "a weak incident signal and a STRONG
+                        # broken/misconfigured-endpoint signal", and which
+                        # therefore inherit a card whose primary action is
+                        # Retry (and, in the CLI, a prompt defaulting to
+                        # `retry` rather than `setup`). For a wrong base URL
+                        # that is the wrong steer. It is not a regression — the
+                        # prose this replaces also said "try again in a moment"
+                        # — and the signal is genuinely ambiguous by the
+                        # classifier's own wording, so it is left alone rather
+                        # than guessed at. `provider_failure_kind=bad_response`
+                        # (added by this change) is what will size the
+                        # population; routing it is ENG-2264.
                         if isinstance(_agent_exc, TransientProviderError):
                             _stamp_retry_terminal(
                                 self._turn_cost, _agent_exc, "request_attempt_limit"
@@ -4708,7 +4724,7 @@ class ChatSession:
                             if _detail and _detail[-1] not in ".!?":
                                 _detail += "."
                             raise ProviderOverloadedError(
-                                f"{_detail} Retried {_retry_count} times without success.",
+                                f"{_detail} It did not recover after {_retry_count} attempts.",
                                 provider=getattr(_agent_exc, "provider", "") or "",
                                 model=_model,
                             ) from _agent_exc

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3535,6 +3535,7 @@ class ChatSession:
         tools: list[dict] | None = None,
         max_tokens: int | None = None,
         messages_factory: Callable[[], list[dict]] | None = None,
+        allow_native_web_tools: bool = True,
     ) -> AsyncIterator[StreamEvent]:
         """Streaming analogue of plan_with_recovery.
 
@@ -3542,6 +3543,16 @@ class ChatSession:
         ContextOverflowError, yields StreamContextCompacted, shrinks
         history (summarize+compact, then hard-truncate on a repeat
         overflow), and restarts the stream. A fourth overflow propagates.
+
+        ``allow_native_web_tools=False`` suppresses the session's native web
+        tools for this call. Default True, so every agent-loop caller is
+        unchanged: there the tools are the point. It exists for the
+        retry-exhausted wrap-up (ENG-1361 review of #433), which asks the model
+        to STOP and explain a failure — handing it a research tool contradicts
+        the instruction, and the prompt embeds the raw error, so a provider-side
+        search could carry file paths or user content from it to a search
+        backend. That call needs this method for the COMPACTION, not for the
+        capabilities that ride along with it.
         """
         factory = messages_factory if messages_factory is not None else (lambda: self._history)
         # Same defensive pre-flight as plan_with_recovery — see the
@@ -3556,7 +3567,7 @@ class ChatSession:
             kwargs["tools"] = tools
         if max_tokens is not None:
             kwargs["max_tokens"] = max_tokens
-        if self._native_web_tools:
+        if allow_native_web_tools and self._native_web_tools:
             kwargs["native_web_tools"] = self._native_web_tools
 
         try:
@@ -4779,6 +4790,14 @@ class ChatSession:
                             # propagates (ENG-1361 review).
                             async for event in self.plan_stream_with_recovery(
                                 system=await self._build_system_prompt(user_msg_str),
+                                # This call wants the compaction, NOT the
+                                # session's web tools: the prompt above says
+                                # "Stop retrying" and asks for an explanation,
+                                # and it embeds the raw error text. Leaving them
+                                # on would both contradict the instruction and
+                                # let a provider-side search carry paths or user
+                                # content out of that error (#433 review).
+                                allow_native_web_tools=False,
                             ):
                                 if isinstance(event, StreamTextDelta):
                                     assistant_text_parts.append(event.text)

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -183,12 +183,20 @@ class TurnCost:
     # beside `connection_error`), so it is unfit for a groupable analytics
     # dimension. Empty when the failure was not a provider failure.
     provider_failure_kind: str = ""
-    # The HTTP status the failure was classified from, when there was one.
-    # `int | None`, never "" — a mid-stream failure (status 200) and a
+    # The HTTP status of the failure that ended the turn, whenever it carried
+    # one. `int | None`, never "" — a mid-stream failure (status 200) and a
     # connection error (no response) are genuinely ABSENT, and an empty string
     # beside integers is the shape that makes an analytics column unqueryable.
     # Omitted from the event entirely when None, rather than sent as a
     # placeholder.
+    #
+    # INDEPENDENT of `provider_failure_kind`, deliberately. The kind classifies
+    # PROVIDER failures and is empty for anything else; the status is a plain
+    # fact about the exception. So a non-transient terminal (an SDK
+    # `BadRequestError` exhausting the attempt budget) books
+    # kind="" with status=400 — not a hole, just the two fields answering two
+    # different questions. Suppressing a real status to keep the pair
+    # symmetrical would discard the only signal those turns carry.
     provider_http_status: int | None = None
     started_monotonic: float = field(default_factory=time.monotonic)
     # Set when these books have been reported. Replaces "the shared slot is

--- a/anton/core/turn_cost.py
+++ b/anton/core/turn_cost.py
@@ -158,6 +158,38 @@ class TurnCost:
     # needs. Empty when no exception ended the verdict (verdict produced, or
     # latched skip with no call made).
     verifier_error_type: str = ""
+    # WHY the retry flow terminated, when a turn ended after retrying (ENG-1361).
+    # Named for TERMINATION, not exhaustion: `rate_limit_wait_too_long` is a
+    # terminal where nothing ran out — the server named an interval past our cap
+    # and we declined to wait — so an "exhaustion" name would be a lie on a
+    # quarter of its own values.
+    #
+    # It exists because ENG-1361 makes the request-time and mid-stream terminals
+    # raise the SAME ProviderOverloadedError, and `code` (which splits the
+    # rate-limit case) is a card contract that never reaches analytics. Without
+    # this, three distinct outcomes become one indistinguishable bucket. Note
+    # the retry count itself is a local in `turn_stream` and reaches nothing —
+    # there is no other telemetry saying a turn retried at all.
+    #   "request_attempt_limit"     — the count-based attempt budget ran out
+    #   "provider_recovery_timeout" — the mid-stream incident budget ran out
+    #   "rate_limit_wait_limit"     — the rate-limit wait allowance ran out
+    #   "rate_limit_wait_too_long"  — Retry-After exceeded our cap; we carded
+    #                                 immediately rather than stalling the turn
+    # Empty for every terminal that did not retry.
+    retry_terminal_reason: str = ""
+    # WHAT kind of provider failure ended the turn — a closed vocabulary
+    # (`PROVIDER_FAILURE_KINDS`), NOT the raw exception `code` (ENG-1361).
+    # `code` selects the client's card and mixes cardinalities (`http_503`
+    # beside `connection_error`), so it is unfit for a groupable analytics
+    # dimension. Empty when the failure was not a provider failure.
+    provider_failure_kind: str = ""
+    # The HTTP status the failure was classified from, when there was one.
+    # `int | None`, never "" — a mid-stream failure (status 200) and a
+    # connection error (no response) are genuinely ABSENT, and an empty string
+    # beside integers is the shape that makes an analytics column unqueryable.
+    # Omitted from the event entirely when None, rather than sent as a
+    # placeholder.
+    provider_http_status: int | None = None
     started_monotonic: float = field(default_factory=time.monotonic)
     # Set when these books have been reported. Replaces "the shared slot is
     # None" as the double-emit guard, because a late finalizer now emits the

--- a/tests/e2e/scenarios/test_error_handling.py
+++ b/tests/e2e/scenarios/test_error_handling.py
@@ -74,7 +74,7 @@ def test_http_500_handled_gracefully(cfg, tmp_path):
     # message when converting to the terminal error — the diagnosis is the part
     # a user or a support thread needs, and only the attempt count is added.
     assert_output(result, "returned 500")
-    assert_output(result, "Retried 3 times without success")
+    assert_output(result, "did not recover after 3 attempts")
     # The turn offers a real remedy instead of blaming the user's wording.
     assert_output(result, "setup/retry")
     assert_not_output(result, "rephrase")

--- a/tests/e2e/scenarios/test_error_handling.py
+++ b/tests/e2e/scenarios/test_error_handling.py
@@ -10,6 +10,27 @@ from tests.e2e.harness import (
     assert_exit_fail, assert_exit_ok, assert_not_output, assert_output,
     base_env, run_anton,
 )
+
+# ENG-1361 note for both provider-failure scenarios below.
+#
+# A provider failure that outlasts the retry budget now FAILS the turn instead
+# of being wrapped into assistant prose, so the host can offer recovery — the
+# `provider_overloaded` card on cowork-server, and the setup/retry prompt here.
+# Previously the count-based path had no such terminal at all: it asked the
+# model to explain the outage (a call needing the very provider that was
+# failing) and, when that failed too, emitted "An unexpected error occurred:
+# <message>. Please try again or rephrase your request." Rephrasing cannot
+# reach an unreachable provider.
+#
+# Consequence for a SCRIPTED run: the CLI now asks a question, and `["hello",
+# "exit"]` cannot answer it — "exit" is consumed as an invalid choice, stdin
+# runs out, and click aborts with a non-zero exit. That is NOT new behaviour
+# introduced here: every provider error that raises into the recovery prompt
+# already did this (verified against a 401 on pristine staging, same abort).
+# These two scenarios simply joined that class, which is the point of the fix.
+# So the assertions below check what "gracefully" actually means — an honest
+# diagnosis, an actionable choice, no traceback, and no bogus rephrase advice —
+# rather than an exit code that only reflects the scripted stdin.
 from tests.e2e.stub_server import StubServer
 
 
@@ -45,12 +66,18 @@ def test_http_500_handled_gracefully(cfg, tmp_path):
     finally:
         httpd.shutdown()
 
-    assert_exit_ok(result)
+    assert_exit_fail(result)   # scripted stdin cannot answer the prompt — see note above
     assert_not_output(result, "Traceback (most recent call last)")
-    # ENG-673: a request-time 5xx is now classified as a transient provider error
-    # and (since the SDK already retried it) fails fast with the honest typed
-    # message rather than the old "Server returned 500" phrasing.
+    # ENG-673: a request-time 5xx is classified as a transient provider error and
+    # (since the SDK already retried it) fails fast with the honest typed message
+    # rather than the old "Server returned 500" phrasing. ENG-1361 keeps that
+    # message when converting to the terminal error — the diagnosis is the part
+    # a user or a support thread needs, and only the attempt count is added.
     assert_output(result, "returned 500")
+    assert_output(result, "Retried 3 times without success")
+    # The turn offers a real remedy instead of blaming the user's wording.
+    assert_output(result, "setup/retry")
+    assert_not_output(result, "rephrase")
 
 
 @pytest.mark.stub_only
@@ -76,8 +103,13 @@ def test_malformed_json_handled_gracefully(cfg, tmp_path):
     finally:
         httpd.shutdown()
 
-    assert_exit_ok(result)
+    assert_exit_fail(result)   # scripted stdin cannot answer the prompt — see note above
     assert_not_output(result, "Traceback (most recent call last)")
+    # Same ENG-1361 terminal as the 5xx case: an unusable response body is a
+    # provider failure, so it earns a diagnosis and a choice, not prose telling
+    # the user to reword a request that was never the problem.
+    assert_output(result, "setup/retry")
+    assert_not_output(result, "rephrase")
 
 
 @pytest.mark.stub_only

--- a/tests/test_curated_errors.py
+++ b/tests/test_curated_errors.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -342,6 +342,82 @@ def test_builtin_connectionerror_is_not_curated():
     catch-all is ENG-1283."""
     assert ConnectionError not in CURATED_PROVIDER_ERRORS
     assert not isinstance(ConnectionError("boom"), CURATED_PROVIDER_ERRORS)
+
+
+# --------------------------------------------------------------------------- #
+# The wrap-up call takes the COMPACTION, not the capabilities
+# --------------------------------------------------------------------------- #
+
+async def test_the_wrapup_call_does_not_get_the_sessions_web_tools():
+    """Routing the wrap-up through `plan_stream_with_recovery` (review finding 4)
+    silently attached the session's native web tools, which the raw `plan_stream`
+    call did not. That contradicts the prompt — which says "Stop retrying" — and
+    the prompt embeds the raw error, so a provider-side search could carry file
+    paths or user content out of it. Regression guard for #433's review."""
+    s = _session()
+    s._native_web_tools = {"web_search"}          # a session that HAS them
+    seen = {}
+
+    class _Boom(Exception):
+        pass
+
+    s._stream_and_handle_tools = _always_raise(lambda: _Boom("nope"))
+
+    async def _capture(*a, **kw):
+        seen.update(kw)
+        yield StreamTextDelta(text="explaining")
+
+    s._llm.plan_stream = _capture
+    _ = [e async for e in s.turn_stream("do it")]
+
+    assert seen, "the wrap-up call never happened"
+    assert "native_web_tools" not in seen
+
+
+async def test_other_recovery_callers_keep_their_web_tools():
+    """The opt-out must be surgical: default True, so the agent loop — where the
+    tools ARE the point — is untouched."""
+    s = _session()
+    s._native_web_tools = {"web_search"}
+    seen = {}
+
+    async def _capture(*a, **kw):
+        seen.update(kw)
+        yield StreamTextDelta(text="ok")
+
+    s._llm.plan_stream = _capture
+    _ = [e async for e in s.plan_stream_with_recovery(system="sys")]
+
+    assert seen.get("native_web_tools") == {"web_search"}
+
+
+async def test_the_wrapup_still_compacts_on_overflow():
+    """Finding 4's actual benefit must survive the opt-out: a history too long to
+    summarize gets shrunk and retried, rather than dying on a card-less error."""
+    s = _session()
+    s._native_web_tools = {"web_search"}
+    calls = {"n": 0}
+
+    class _Boom(Exception):
+        pass
+
+    s._stream_and_handle_tools = _always_raise(lambda: _Boom("nope"))
+    s._summarize_history = AsyncMock(return_value=True)
+    s._compact_scratchpads = MagicMock()
+
+    async def _overflow_then_ok(*a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ContextOverflowError("too long")
+        yield StreamTextDelta(text="summarised after compaction")
+
+    s._llm.plan_stream = _overflow_then_ok
+    events = [e async for e in s.turn_stream("do it")]
+
+    text = "".join(e.text for e in events if isinstance(e, StreamTextDelta))
+    assert "summarised after compaction" in text
+    assert calls["n"] == 2                      # overflowed, compacted, retried
+    s._summarize_history.assert_awaited()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_curated_errors.py
+++ b/tests/test_curated_errors.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -33,6 +33,7 @@ from anton.core.llm.provider import (
     StructuredOutputError,
     TokenLimitExceeded,
     TransientProviderError,
+    classify_transient,
     provider_failure_kind,
 )
 from anton.core.session import ChatSessionConfig
@@ -58,9 +59,10 @@ def _unreachable(**kw):
     """The failure from the ENG-1361 incident: request-time, SDK already retried."""
     kw.setdefault("code", "connection_error")
     kw.setdefault("provider", "The model provider")
+    kw.setdefault("model", "latest:sonnet")
     return TransientProviderError(
         "Could not reach the model provider — check your connection or try again in a moment.",
-        session_backoff=False, model="latest:sonnet", **kw,
+        session_backoff=False, **kw,
     )
 
 
@@ -94,8 +96,24 @@ async def test_count_exhausted_transient_raises_the_card_not_prose():
         _ = [e async for e in s.turn_stream("research local AI coding models")]
 
     assert ei.value.code == "provider_overloaded"
-    assert ei.value.model == "latest:sonnet"          # the card names the real model
     assert "rephrase" not in str(ei.value).lower()
+
+
+async def test_the_card_names_the_failing_model_not_the_planning_one():
+    """cowork-server maps this model back to its provider to decide
+    `reconnectable` (responses.py), so mis-attribution suppresses the BYOK
+    failover nudge. The two candidate sources must differ or the assertion is
+    vacuous — which it was until the #433 review."""
+    s = _session()                      # planning_model = latest:sonnet
+    s._stream_and_handle_tools = _always_raise(
+        lambda: _unreachable(model="latest:haiku")   # the CODING model failed
+    )
+    s._llm.plan_stream = _summarize_raises(_unreachable)
+
+    with pytest.raises(ProviderOverloadedError) as ei:
+        _ = [e async for e in s.turn_stream("do it")]
+
+    assert ei.value.model == "latest:haiku"   # not the session's planning model
 
 
 async def test_the_card_terminal_does_not_need_the_summarize_call_to_fail():
@@ -114,22 +132,28 @@ async def test_the_card_terminal_does_not_need_the_summarize_call_to_fail():
         _ = [e async for e in s.turn_stream("do it")]
 
 
-async def test_an_unconfirmed_429_keeps_the_rate_limit_code_and_copy():
-    """A velocity 429 the gateway didn't confirm reaches the COUNT path. Carding
-    it as an "incident" is the ENG-1537 mis-report; it must keep rate_limited."""
+async def test_an_unconfirmed_429_makes_no_claim_about_credits_or_waiting():
+    """A 429 on the COUNT path is one `classify_transient` could NOT confirm was
+    a velocity limit — the population its docstring warns about, where a daily
+    quota in an unrecognised dialect "would otherwise spend the whole budget
+    waiting out a daily quota that resets at midnight — then be told it is not a
+    credits problem." So this branch must promise nothing about waiting and deny
+    nothing about credits. Guards against reintroducing that copy (#433 review)."""
     s = _session()
     s._stream_and_handle_tools = _always_raise(
-        lambda: _unreachable(code="rate_limited", retry_after=None)
+        lambda: _unreachable(code="rate_limited", status_code=429)
     )
     s._llm.plan_stream = _summarize_raises(lambda: _unreachable(code="rate_limited"))
 
     with pytest.raises(ProviderOverloadedError) as ei:
         _ = [e async for e in s.turn_stream("do it")]
 
-    assert ei.value.code == "rate_limited"
     body = str(ei.value).lower()
-    assert "incident" not in body          # nothing is broken
-    assert "credits" in body               # ...and it is explicitly not a credits problem
+    assert "credits" not in body      # we do not know that it isn't one
+    assert "should work" not in body  # nor that waiting will help
+    assert "incident" not in body     # nor that anything is broken
+    # Falls to the generic branch, so the card is the plain overloaded one.
+    assert ei.value.code == "provider_overloaded"
 
 
 async def test_the_card_keeps_antons_own_classification():
@@ -272,24 +296,31 @@ async def test_an_uncurated_error_still_becomes_prose_without_rephrase_advice():
 _DELIBERATELY_UNCURATED: frozenset[str] = frozenset()
 
 
-def test_every_exception_defined_in_provider_is_triaged():
+def test_every_exception_defined_in_a_provider_module_is_triaged():
     """Fails on the NEXT exception class, at authoring time.
 
-    Scoped to classes DEFINED in `provider.py` (`__module__` check) — imported
-    exceptions belong to their own modules' hierarchies and are not this set's
-    to police.
+    Covers EVERY module that defines a provider-facing exception, not just
+    `provider.py` — scoping it to one file was the gap found reviewing #433:
+    adding `class ProviderRegionBlockedError(ConnectionError)` to `openai.py`
+    left the whole suite green and the type uncurated, which is exactly the
+    drift this test exists to stop. The `__module__` check keeps each module
+    responsible only for what it defines, so an import doesn't double-count.
     """
+    from anton.core.llm import anthropic as anthropic_mod
+    from anton.core.llm import openai as openai_mod
+
     defined = {
         name
-        for name, obj in vars(provider_mod).items()
+        for mod in (provider_mod, openai_mod, anthropic_mod)
+        for name, obj in vars(mod).items()
         if inspect.isclass(obj)
         and issubclass(obj, BaseException)
-        and obj.__module__ == provider_mod.__name__
+        and obj.__module__ == mod.__name__
     }
     curated = {t.__name__ for t in CURATED_PROVIDER_ERRORS}
     assert defined == curated | _DELIBERATELY_UNCURATED, (
-        "New exception class in provider.py — add it to CURATED_PROVIDER_ERRORS, "
-        "or to _DELIBERATELY_UNCURATED with a reason."
+        "New exception class in a provider module — add it to "
+        "CURATED_PROVIDER_ERRORS, or to _DELIBERATELY_UNCURATED with a reason."
     )
 
 
@@ -299,6 +330,29 @@ def test_builtin_connectionerror_is_not_curated():
     catch-all is ENG-1283."""
     assert ConnectionError not in CURATED_PROVIDER_ERRORS
     assert not isinstance(ConnectionError("boom"), CURATED_PROVIDER_ERRORS)
+
+
+# --------------------------------------------------------------------------- #
+# classify_transient must PLUMB the status, not just accept one
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "status,body,expected",
+    [
+        (503, {}, 503),                                              # 5xx branch
+        (503, {"error": {"type": "service_unavailable"}}, 503),       # body-type branch
+        (429, {}, 429),                                              # rate-limit branch
+        (200, {"error": {"type": "overloaded_error"}}, 200),          # mid-stream
+    ],
+)
+def test_classify_transient_carries_the_status_it_classified_from(status, body, expected):
+    """`provider_failure_kind`/`provider_http_status` have exactly one production
+    writer — this function. Every field test above hand-builds the exception, so
+    a mutant deleting the plumbing survived the whole suite until the #433
+    review, and `test_status_error_mapper.py` never asserts `.status_code`."""
+    exc = classify_transient(status, body, provider="p", model="m")
+    assert exc is not None
+    assert exc.status_code == expected
 
 
 # --------------------------------------------------------------------------- #
@@ -484,6 +538,53 @@ async def test_a_stop_after_a_retry_terminal_books_no_terminal_reason():
     assert k["retry_terminal_reason"] == ""
     assert k["provider_failure_kind"] == ""
     assert "provider_http_status" not in k
+
+
+async def test_the_summarize_prompt_does_not_teach_the_model_to_say_rephrase():
+    """Half of fix 3, and the half that governs the path SURVIVING this change:
+    a non-transient failure still summarizes, and the model writes that reply.
+    If the SYSTEM prompt asks for "rephrase / simplify", the advice comes back
+    out of the model's mouth instead of the template's. Untested until the #433
+    review."""
+    s = _session()
+
+    class _Boom(Exception):
+        pass
+
+    s._stream_and_handle_tools = _always_raise(lambda: _Boom("nope"))
+
+    async def _summarize_succeeds(*a, **kw):
+        yield StreamTextDelta(text="ok")
+
+    s._llm.plan_stream = _summarize_succeeds
+    _ = [e async for e in s.turn_stream("do it")]
+
+    prompt = json.dumps(s._history).lower()
+    assert "the task has failed" in prompt          # we did reach the wrap-up
+    assert "rephrase" not in prompt
+    assert "simplify the request" not in prompt
+
+
+async def test_the_rate_limit_wait_budget_terminal_is_labelled():
+    """The one row of the five-terminal table with no telemetry test."""
+    s = _session()
+    s._rate_limit_budget_s = 0.05
+    s._stream_and_handle_tools = _always_raise(
+        lambda: TransientProviderError(
+            "rate-limiting requests", provider="MindsHub", code="rate_limited",
+            session_backoff=True, model="latest:sonnet", status_code=429,
+        )
+    )
+    s._backoff_sleep = AsyncMock(return_value=False)
+
+    with patch("anton.analytics.send_event") as send:
+        with pytest.raises(ProviderOverloadedError):
+            _ = [e async for e in s.turn_stream("do it")]
+
+    k = _fields(send)
+    assert k["retry_terminal_reason"] == "rate_limit_wait_limit"
+    assert k["provider_failure_kind"] == "rate_limit"
+    assert k["provider_http_status"] == "429"
 
 
 async def test_a_turn_that_never_retried_leaves_the_fields_empty():

--- a/tests/test_curated_errors.py
+++ b/tests/test_curated_errors.py
@@ -1,0 +1,428 @@
+"""ENG-1361 — curated provider failures must fail the turn, never become prose.
+
+Three guarantees:
+  * the count-based retry path has a terminal that produces the
+    `provider_overloaded` card (it previously had none, ever);
+  * no member of `CURATED_PROVIDER_ERRORS` can be wrapped into assistant text
+    on the summarize path;
+  * the curated set stays exhaustive as new exception classes are added — the
+    check that fails at authoring time rather than in production.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from unittest.mock import patch
+
+import pytest
+
+from anton.chat import ChatSession
+from anton.core.llm import provider as provider_mod
+from anton.core.llm.provider import (
+    CURATED_PROVIDER_ERRORS,
+    PROVIDER_FAILURE_KINDS,
+    ContentValidationError,
+    ContextOverflowError,
+    EndpointConfigurationError,
+    ModelUnavailableError,
+    ProviderAuthError,
+    ProviderOverloadedError,
+    StreamTextDelta,
+    StructuredOutputError,
+    TokenLimitExceeded,
+    TransientProviderError,
+    provider_failure_kind,
+)
+from anton.core.session import ChatSessionConfig
+from tests.conftest import make_mock_llm
+
+
+def _session() -> ChatSession:
+    # A session_id, deliberately: a turn with none and zero LLM calls is dropped
+    # before the analytics sink as script traffic (ENG-1692), and the telemetry
+    # tests below assert on the emitted event.
+    s = ChatSession(ChatSessionConfig(llm_client=make_mock_llm(), session_id="conv-1361"))
+    s._llm.planning_model = "latest:sonnet"
+    return s
+
+
+def _fields(send_event_mock) -> dict:
+    """ENG-1361's properties on the last emitted `turn_completed`."""
+    assert send_event_mock.called, "no turn_completed event emitted"
+    return send_event_mock.call_args.kwargs
+
+
+def _unreachable(**kw):
+    """The failure from the ENG-1361 incident: request-time, SDK already retried."""
+    kw.setdefault("code", "connection_error")
+    kw.setdefault("provider", "The model provider")
+    return TransientProviderError(
+        "Could not reach the model provider — check your connection or try again in a moment.",
+        session_backoff=False, model="latest:sonnet", **kw,
+    )
+
+
+def _always_raise(exc_factory):
+    async def _gen(user_msg):
+        raise exc_factory()
+        yield  # pragma: no cover  (makes this an async generator)
+    return _gen
+
+
+def _summarize_raises(exc_factory):
+    async def _gen(*a, **kw):
+        raise exc_factory()
+        yield  # pragma: no cover
+    return _gen
+
+
+# --------------------------------------------------------------------------- #
+# Fix 1 — the count path now has a card terminal
+# --------------------------------------------------------------------------- #
+
+async def test_count_exhausted_transient_raises_the_card_not_prose():
+    """The reported bug: provider unreachable at request time, still unreachable
+    when we ask the model to explain it. Used to end as assistant text telling
+    the user to rephrase; must now fail the turn so the card renders."""
+    s = _session()
+    s._stream_and_handle_tools = _always_raise(_unreachable)
+    s._llm.plan_stream = _summarize_raises(_unreachable)
+
+    with pytest.raises(ProviderOverloadedError) as ei:
+        _ = [e async for e in s.turn_stream("research local AI coding models")]
+
+    assert ei.value.code == "provider_overloaded"
+    assert ei.value.model == "latest:sonnet"          # the card names the real model
+    assert "rephrase" not in str(ei.value).lower()
+
+
+async def test_the_card_terminal_does_not_need_the_summarize_call_to_fail():
+    """Even when the provider recovers in time to answer the summarize call, the
+    turn must card — otherwise the same failure has two different UIs depending
+    on timing."""
+    s = _session()
+    s._stream_and_handle_tools = _always_raise(_unreachable)
+
+    async def _summarize_succeeds(*a, **kw):
+        yield StreamTextDelta(text="here is what I managed to do")
+
+    s._llm.plan_stream = _summarize_succeeds
+
+    with pytest.raises(ProviderOverloadedError):
+        _ = [e async for e in s.turn_stream("do it")]
+
+
+async def test_an_unconfirmed_429_keeps_the_rate_limit_code_and_copy():
+    """A velocity 429 the gateway didn't confirm reaches the COUNT path. Carding
+    it as an "incident" is the ENG-1537 mis-report; it must keep rate_limited."""
+    s = _session()
+    s._stream_and_handle_tools = _always_raise(
+        lambda: _unreachable(code="rate_limited", retry_after=None)
+    )
+    s._llm.plan_stream = _summarize_raises(lambda: _unreachable(code="rate_limited"))
+
+    with pytest.raises(ProviderOverloadedError) as ei:
+        _ = [e async for e in s.turn_stream("do it")]
+
+    assert ei.value.code == "rate_limited"
+    body = str(ei.value).lower()
+    assert "incident" not in body          # nothing is broken
+    assert "credits" in body               # ...and it is explicitly not a credits problem
+
+
+async def test_the_card_keeps_antons_own_classification():
+    """The typed message says WHICH failure this was ("returned 500"), which
+    ENG-673 put there on purpose. Converting to the card must add the attempt
+    count, not replace the diagnosis with a generic "could not be reached"."""
+    s = _session()
+    s._stream_and_handle_tools = _always_raise(
+        lambda: TransientProviderError(
+            "The model provider returned 500.", provider="The model provider",
+            code="http_500", session_backoff=False, model="latest:sonnet",
+            status_code=500,
+        )
+    )
+    s._llm.plan_stream = _summarize_raises(_unreachable)
+
+    with pytest.raises(ProviderOverloadedError) as ei:
+        _ = [e async for e in s.turn_stream("do it")]
+
+    assert "returned 500" in str(ei.value)
+    assert "3 times" in str(ei.value)
+
+
+async def test_the_card_copy_never_doubles_a_period():
+    """The fingerprint of the bug this ticket came from: concatenating a curated
+    message that already ends in '.' with a template that adds its own."""
+    s = _session()
+    s._stream_and_handle_tools = _always_raise(_unreachable)   # message ends in '.'
+    s._llm.plan_stream = _summarize_raises(_unreachable)
+
+    with pytest.raises(ProviderOverloadedError) as ei:
+        _ = [e async for e in s.turn_stream("do it")]
+
+    assert ".." not in str(ei.value)
+
+
+async def test_the_raise_leaves_no_dangling_system_message_in_history():
+    """Raising AFTER appending the summarize prompt would poison the next turn
+    with an orphan "The task has failed N times"."""
+    s = _session()
+    s._stream_and_handle_tools = _always_raise(_unreachable)
+    s._llm.plan_stream = _summarize_raises(_unreachable)
+
+    with pytest.raises(ProviderOverloadedError):
+        _ = [e async for e in s.turn_stream("do it")]
+
+    assert "The task has failed" not in json.dumps(s._history)
+
+
+async def test_a_non_transient_failure_still_summarizes():
+    """Fix 1 is scoped to transients. A 400 has no card to route to and the model
+    can genuinely explain it, so that path must be unchanged."""
+    s = _session()
+
+    class _BadRequest(Exception):
+        pass
+
+    s._stream_and_handle_tools = _always_raise(lambda: _BadRequest("bad tool schema"))
+
+    async def _summarize_succeeds(*a, **kw):
+        yield StreamTextDelta(text="I hit a bad request; here is what happened")
+
+    s._llm.plan_stream = _summarize_succeeds
+
+    with patch("anton.analytics.send_event") as send:
+        events = [e async for e in s.turn_stream("do it")]
+
+    text = "".join(e.text for e in events if isinstance(e, StreamTextDelta))
+    assert "here is what happened" in text
+    assert _fields(send)["ended_by"] == "retry_exhausted"
+
+
+# --------------------------------------------------------------------------- #
+# Fix 2 — no curated failure becomes prose on the summarize path
+# --------------------------------------------------------------------------- #
+
+_CURATED_SAMPLES = {
+    ContextOverflowError: lambda: ContextOverflowError("too long"),
+    TokenLimitExceeded: lambda: TokenLimitExceeded("out of credits"),
+    ProviderAuthError: lambda: ProviderAuthError("Invalid API key"),
+    StructuredOutputError: lambda: StructuredOutputError("no tool call"),
+    TransientProviderError: _unreachable,
+    ProviderOverloadedError: lambda: ProviderOverloadedError("overloaded"),
+    ModelUnavailableError: lambda: ModelUnavailableError(
+        "no such model", code="model_not_found", model="x"
+    ),
+    ContentValidationError: lambda: ContentValidationError("bad image block"),
+    EndpointConfigurationError: lambda: EndpointConfigurationError("bad base url"),
+}
+
+
+def test_every_curated_error_has_a_sample():
+    """Keeps the parametrised test below honest as the set grows."""
+    assert set(_CURATED_SAMPLES) == set(CURATED_PROVIDER_ERRORS)
+
+
+@pytest.mark.parametrize("exc_type", list(CURATED_PROVIDER_ERRORS), ids=lambda t: t.__name__)
+async def test_a_curated_error_on_the_summarize_path_fails_the_turn(exc_type):
+    """Table-driven over the whole set on purpose. Written per-type, this test
+    would have passed for the two members the old allowlist happened to hold
+    while three others were missing — which is how each was found by a user
+    instead of by CI."""
+    s = _session()
+
+    class _Boom(Exception):
+        pass
+
+    # A NON-transient first failure, so we reach the summarize call rather than
+    # Fix 1's card terminal — this is testing the wrap-up guard specifically.
+    s._stream_and_handle_tools = _always_raise(lambda: _Boom("something broke"))
+    s._llm.plan_stream = _summarize_raises(_CURATED_SAMPLES[exc_type])
+
+    with pytest.raises(exc_type):
+        _ = [e async for e in s.turn_stream("do it")]
+
+
+async def test_an_uncurated_error_still_becomes_prose_without_rephrase_advice():
+    """The fallback still exists for genuinely unexpected failures — it just no
+    longer claims the user's wording was the problem."""
+    s = _session()
+
+    class _Boom(Exception):
+        pass
+
+    s._stream_and_handle_tools = _always_raise(lambda: _Boom("first failure"))
+    s._llm.plan_stream = _summarize_raises(lambda: _Boom("and again"))
+
+    events = [e async for e in s.turn_stream("do it")]
+    text = "".join(e.text for e in events if isinstance(e, StreamTextDelta))
+    assert "An unexpected error occurred" in text
+    assert "rephrase" not in text.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Fix 2 — the set stays exhaustive as classes are added
+# --------------------------------------------------------------------------- #
+
+# Exception classes DEFINED in provider.py that deliberately stay uncurated.
+# Empty today; an entry here is a decision with a reason, not an oversight.
+_DELIBERATELY_UNCURATED: frozenset[str] = frozenset()
+
+
+def test_every_exception_defined_in_provider_is_triaged():
+    """Fails on the NEXT exception class, at authoring time.
+
+    Scoped to classes DEFINED in `provider.py` (`__module__` check) — imported
+    exceptions belong to their own modules' hierarchies and are not this set's
+    to police.
+    """
+    defined = {
+        name
+        for name, obj in vars(provider_mod).items()
+        if inspect.isclass(obj)
+        and issubclass(obj, BaseException)
+        and obj.__module__ == provider_mod.__name__
+    }
+    curated = {t.__name__ for t in CURATED_PROVIDER_ERRORS}
+    assert defined == curated | _DELIBERATELY_UNCURATED, (
+        "New exception class in provider.py — add it to CURATED_PROVIDER_ERRORS, "
+        "or to _DELIBERATELY_UNCURATED with a reason."
+    )
+
+
+def test_builtin_connectionerror_is_not_curated():
+    """It is the base of half the set AND of unrelated socket failures, so
+    curating it would silently curate everything. Typing the status mapper's
+    catch-all is ENG-1283."""
+    assert ConnectionError not in CURATED_PROVIDER_ERRORS
+    assert not isinstance(ConnectionError("boom"), CURATED_PROVIDER_ERRORS)
+
+
+# --------------------------------------------------------------------------- #
+# Fix 5 — the terminal stays measurable
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "code,expected_kind",
+    [
+        ("overloaded_error", "overload_signal"),
+        ("overloaded", "overload_signal"),
+        ("api_error", "overload_signal"),
+        ("server_error", "overload_signal"),
+        ("service_unavailable", "overload_signal"),
+        ("stream_error", "bad_response"),
+        ("truncated_stream", "bad_response"),
+        ("empty_response", "bad_response"),
+        ("rate_limited", "rate_limit"),
+        ("connection_error", "connection_failure"),
+        ("http_500", "http_5xx"),
+        ("http_503", "http_5xx"),
+    ],
+)
+def test_every_code_anton_mints_maps_to_a_kind(code, expected_kind):
+    """Exhaustive over the codes anton actually constructs. An unmapped code
+    would silently emit "" and hide a whole population."""
+    assert provider_failure_kind(code) == expected_kind
+    assert expected_kind in PROVIDER_FAILURE_KINDS
+
+
+@pytest.mark.parametrize("code", [None, "", "something_new", "http_404", "http_abc"])
+def test_an_unknown_code_is_blank_not_guessed(code):
+    """Blank is a prompt to extend the vocabulary; a wrong value is invisible.
+    `http_404` specifically must NOT read as a server fault."""
+    assert provider_failure_kind(code) == ""
+
+
+async def test_the_count_terminal_records_reason_kind_and_status():
+    s = _session()
+    s._stream_and_handle_tools = _always_raise(
+        lambda: _unreachable(code="http_503", status_code=503)
+    )
+    s._llm.plan_stream = _summarize_raises(_unreachable)
+
+    with patch("anton.analytics.send_event") as send:
+        with pytest.raises(ProviderOverloadedError):
+            _ = [e async for e in s.turn_stream("do it")]
+
+    k = _fields(send)
+    assert k["retry_terminal_reason"] == "request_attempt_limit"
+    assert k["provider_failure_kind"] == "http_5xx"
+    assert k["provider_http_status"] == "503"
+
+
+async def test_a_connection_failure_records_no_status_rather_than_a_placeholder():
+    s = _session()
+    s._stream_and_handle_tools = _always_raise(_unreachable)
+    s._llm.plan_stream = _summarize_raises(_unreachable)
+
+    with patch("anton.analytics.send_event") as send:
+        with pytest.raises(ProviderOverloadedError):
+            _ = [e async for e in s.turn_stream("do it")]
+
+    k = _fields(send)
+    assert k["provider_failure_kind"] == "connection_failure"
+    # OMITTED, not "" — an empty string would sort and group beside real
+    # statuses and make the column unusable.
+    assert "provider_http_status" not in k
+
+
+async def test_the_time_budget_terminal_is_distinguishable_from_the_count_one():
+    """The whole point of the field: after Fix 1 both terminals raise the same
+    exception type, so nothing else can tell them apart."""
+    s = _session()
+    s._transient_budget_s = 0.05
+    s._stream_and_handle_tools = _always_raise(
+        lambda: TransientProviderError(
+            "momentarily overloaded", provider="Anthropic",
+            code="overloaded_error", model="latest:sonnet",
+        )
+    )
+
+    with patch("anton.analytics.send_event") as send:
+        with pytest.raises(ProviderOverloadedError):
+            _ = [e async for e in s.turn_stream("do it")]
+
+    k = _fields(send)
+    assert k["retry_terminal_reason"] == "provider_recovery_timeout"
+    assert k["provider_failure_kind"] == "overload_signal"
+
+
+async def test_a_long_retry_after_records_the_decline_not_an_exhaustion():
+    """Nothing ran out here — we declined to wait. `retry_terminal_reason` is
+    named for termination precisely so this value isn't a lie."""
+    s = _session()
+    s._stream_and_handle_tools = _always_raise(
+        lambda: TransientProviderError(
+            "rate-limiting requests", provider="MindsHub", code="rate_limited",
+            retry_after=600.0, session_backoff=True, model="latest:sonnet",
+            status_code=429,
+        )
+    )
+
+    with patch("anton.analytics.send_event") as send:
+        with pytest.raises(ProviderOverloadedError) as ei:
+            _ = [e async for e in s.turn_stream("do it")]
+
+    assert ei.value.code == "rate_limited"
+    k = _fields(send)
+    assert k["retry_terminal_reason"] == "rate_limit_wait_too_long"
+    assert k["provider_failure_kind"] == "rate_limit"
+    assert k["provider_http_status"] == "429"
+
+
+async def test_a_turn_that_never_retried_leaves_the_fields_empty():
+    s = _session()
+
+    async def _ok(user_msg):
+        yield StreamTextDelta(text="done")
+
+    s._stream_and_handle_tools = _ok
+    with patch("anton.analytics.send_event") as send:
+        _ = [e async for e in s.turn_stream("do it")]
+
+    k = _fields(send)
+    assert k["retry_terminal_reason"] == ""
+    assert k["provider_failure_kind"] == ""
+    assert "provider_http_status" not in k

--- a/tests/test_curated_errors.py
+++ b/tests/test_curated_errors.py
@@ -55,6 +55,18 @@ def _fields(send_event_mock) -> dict:
     return send_event_mock.call_args.kwargs
 
 
+class _FakeStatusError(Exception):
+    """Minimal stand-in for an SDK ``APIStatusError`` — mirrors the one in
+    `test_transient_retry.py`. `_stamp_retry_terminal` only reads `.status_code`
+    via getattr, so a real SDK exception buys nothing and costs an import that
+    is not order-stable under CI's random test ordering (#433)."""
+
+    def __init__(self, status_code, body=None):
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = status_code
+        self.body = body
+
+
 def _unreachable(**kw):
     """The failure from the ENG-1361 incident: request-time, SDK already retried."""
     kw.setdefault("code", "connection_error")
@@ -472,15 +484,9 @@ async def test_a_non_transient_terminal_still_books_its_http_status():
     classifies provider failures and is empty here, but the status is a plain
     fact about the exception and is the only signal these turns carry. Pins the
     asymmetry so nobody "tidies" it away — self-review finding 1."""
-    import httpx
-    import openai
-
     s = _session()
-    req = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
-    resp = httpx.Response(400, request=req, json={"error": {"code": "invalid_request_error"}})
-
     s._stream_and_handle_tools = _always_raise(
-        lambda: openai.BadRequestError("bad tool schema", response=resp, body=None)
+        lambda: _FakeStatusError(400, {"error": {"code": "invalid_request_error"}})
     )
 
     async def _summarize_succeeds(*a, **kw):

--- a/tests/test_curated_errors.py
+++ b/tests/test_curated_errors.py
@@ -11,6 +11,7 @@ Three guarantees:
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 from unittest.mock import patch
@@ -149,7 +150,7 @@ async def test_the_card_keeps_antons_own_classification():
         _ = [e async for e in s.turn_stream("do it")]
 
     assert "returned 500" in str(ei.value)
-    assert "3 times" in str(ei.value)
+    assert "after 3 attempts" in str(ei.value)
 
 
 async def test_the_card_copy_never_doubles_a_period():
@@ -410,6 +411,79 @@ async def test_a_long_retry_after_records_the_decline_not_an_exhaustion():
     assert k["retry_terminal_reason"] == "rate_limit_wait_too_long"
     assert k["provider_failure_kind"] == "rate_limit"
     assert k["provider_http_status"] == "429"
+
+
+async def test_a_non_transient_terminal_still_books_its_http_status():
+    """`provider_http_status` is INDEPENDENT of `provider_failure_kind`: the kind
+    classifies provider failures and is empty here, but the status is a plain
+    fact about the exception and is the only signal these turns carry. Pins the
+    asymmetry so nobody "tidies" it away — self-review finding 1."""
+    import httpx
+    import openai
+
+    s = _session()
+    req = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    resp = httpx.Response(400, request=req, json={"error": {"code": "invalid_request_error"}})
+
+    s._stream_and_handle_tools = _always_raise(
+        lambda: openai.BadRequestError("bad tool schema", response=resp, body=None)
+    )
+
+    async def _summarize_succeeds(*a, **kw):
+        yield StreamTextDelta(text="explaining the 400")
+
+    s._llm.plan_stream = _summarize_succeeds
+
+    with patch("anton.analytics.send_event") as send:
+        _ = [e async for e in s.turn_stream("do it")]
+
+    k = _fields(send)
+    assert k["ended_by"] == "retry_exhausted"
+    assert k["retry_terminal_reason"] == "request_attempt_limit"
+    assert k["provider_failure_kind"] == ""     # not a classified PROVIDER failure
+    assert k["provider_http_status"] == "400"   # ...but the status is still real
+
+
+async def test_a_stop_after_a_retry_terminal_books_no_terminal_reason():
+    """A user who has sat through failed retries is exactly the user who presses
+    Stop. Without the clearing, a plain cancel would appear in an error-cause
+    breakdown carrying a terminal it never reached — self-review finding 3."""
+    s = _session()
+
+    async def _fail_then_hang(user_msg):
+        raise _unreachable()
+        yield  # pragma: no cover
+
+    s._stream_and_handle_tools = _fail_then_hang
+
+    async def _summarize_hangs(*a, **kw):
+        await asyncio.sleep(30)   # cancelled here, after the terminal was stamped
+        yield StreamTextDelta(text="never reached")  # pragma: no cover
+
+    # A NON-transient first failure would reach summarize; use one so the stamp
+    # happens and the cancel lands after it.
+    class _Boom(Exception):
+        pass
+
+    s._stream_and_handle_tools = _always_raise(lambda: _Boom("first"))
+    s._llm.plan_stream = _summarize_hangs
+
+    with patch("anton.analytics.send_event") as send:
+        async def _consume():
+            async for _ in s.turn_stream("do it"):
+                pass
+
+        task = asyncio.create_task(_consume())
+        await asyncio.sleep(0.2)   # let it reach the hanging summarize call
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    k = _fields(send)
+    assert k["ended_by"] == "cancelled"
+    assert k["retry_terminal_reason"] == ""
+    assert k["provider_failure_kind"] == ""
+    assert "provider_http_status" not in k
 
 
 async def test_a_turn_that_never_retried_leaves_the_fields_empty():


### PR DESCRIPTION
Closes ENG-1361.

## The bug

A provider failure **at request time** — a 5xx, an unreachable host, an unconfirmed 429 — takes anton's count-based retry path. That path had **no terminal capable of producing an error card**. It asked the model to explain the outage (a call that needs the very provider that is failing) and, when that call failed too, emitted:

> An unexpected error occurred: Could not reach the model provider — check your connection or try again in a moment.. Please try again or rephrase your request.

Rephrasing cannot reach an unreachable provider. Users follow the advice anyway — the reported incident shows the user retyping the same request, then leaving.

**127 turns / 55 users in 30 days** (PostHog `turn_completed`, project 424726), on the current builds, desktop **and** web. Reproduced byte-for-byte against `origin/staging` before writing the fix.

## What changed

**1. Convert at exhaustion.** A transient that outlasts the COUNT budget now raises `ProviderOverloadedError`, exactly as the TIME budget already did — the same product event, reported the same way. It is mapped on *both* transports (`provider_overloaded_info()` for desktop, `remote_turn_error()`'s type-name branch for web) — as are four other curated types; what makes it the right pick here is that it is the one whose card matches this failure.

**Zero server/UI changes is true on DESKTOP only.** On web, two pre-existing transport gaps mean the card lands degraded, and this PR routes a new population into them: (a) `_scrub` serialises as `"Type: message"` and `remote_turn_error` keys on the type name, so `code` never survives — an unconfirmed 429 renders the plain overloaded card with no time-gated Retry; (b) the remote payload carries only `{code, error}` (no `reconnectable`), and the renderer treats absent as BYOK by design, making **"Set up MindsHub" the primary action for org-mode users who are managed by construction** — the ENG-514 mis-nudge, into a Settings section org mode hides. Both are tracked as **ENG-2297** — out of scope here (cross-repo), and the ticket prefers sending `reconnectable` on the remote path over the one-line renderer patch, since that fixes the payload asymmetry rather than one symptom of it.

Three details that are easy to get wrong, each covered by a test:
- Raised **before** the summarize prompt is appended, or an orphan `SYSTEM: The task has failed N times` poisons the next turn.
- **Keeps anton's typed message** (ENG-673's "returned 500") and adds only the attempt count. My first pass replaced it with generic copy and silently broke an existing e2e assertion — caught by the suite.
- **Preserves `code="rate_limited"`** for an unconfirmed 429, since telling a rate-limited user the provider is "having an incident" is the exact mis-report ENG-1537 fixed.

**2. Invert the guard.** The summarize path's re-raise allowlist becomes membership of `CURATED_PROVIDER_ERRORS`, declared in `provider.py` beside the classes themselves. The allowlist shape exposed every new type by default; the new parametrised test shows it was short **five** members. Staging's guard was a 3-tuple plus `ProviderAuthError` via a separate branch (4 effective); the new set is 9, so 6 added, of which exactly 5 change behaviour: the two the ticket named — **`TransientProviderError` and `ProviderOverloadedError`, which are the two with the real behaviour change** — plus `ContextOverflowError`, `StructuredOutputError` and `ContentValidationError`. Of those last three, `StructuredOutputError` and `ProviderOverloadedError` are defensive: traced to their raise sites, they cannot reach that `except` in production. Forgetting now means an exception *propagates* (a generic card — safe) rather than becoming prose that blames the user's wording.

Deliberately a tuple, not a marker base class: a mixin would change the MRO of nine exception classes across a version-skew boundary cowork-server already handles defensively. A module-walk test fails on the *next* class, at authoring time.

**Disclosure:** four of the nine curated types have **no card on either transport** (`ContextOverflowError`, `StructuredOutputError`, `TransientProviderError`, `EndpointConfigurationError`) — cowork-server replaces the message with a flat "An unexpected error occurred." and the client renders a buttonless alert. Two are newly moved in here, so for those the turn trades anton's own diagnosis for less text. Still the right trade (the prose asserted a remedy that could not work), but a trade. Adding those cards is the follow-up.

**3. The copy.** The rephrase advice is gone from the generic fallback **and** from the SYSTEM summarize prompt, which was teaching the model to give the same advice on every successful summarization.

**4. Keep it measurable.** `retry_terminal_reason`, `provider_failure_kind`, `provider_http_status`. Without these, change 1 would make the request-time and mid-stream terminals byte-identical in analytics — `code` splits them but is a card contract that never reaches PostHog, and the retry count was a local variable reaching nothing at all.

| Terminal | `ended_by` | `error_type` | `provider_failure_kind` | `retry_terminal_reason` |
|---|---|---|---|---|
| Mid-stream, incident budget out | `error` | `ProviderOverloadedError` | `overload_signal` | `provider_recovery_timeout` |
| Velocity 429, wait allowance out | `error` | `ProviderOverloadedError` | `rate_limit` | `rate_limit_wait_limit` |
| `Retry-After` beyond cap | `error` | `ProviderOverloadedError` | `rate_limit` | `rate_limit_wait_too_long` |
| Request-time, attempts out | `error` | `ProviderOverloadedError` | `http_5xx` / `connection_failure` | `request_attempt_limit` |
| Non-transient, attempts out | `retry_exhausted` | `BadRequestError` | — (see note) | `request_attempt_limit` |

`provider_http_status` is **independent** of `provider_failure_kind`: the kind classifies *provider* failures and is empty on the last row, but the status is a plain fact about the exception and is still recorded when it has one (an SDK `BadRequestError` books `400`). Self-review finding — the two fields answer different questions, and suppressing a real status to keep the pair symmetrical would discard the only signal those turns carry.

Named for *termination*, not exhaustion: `rate_limit_wait_too_long` is a terminal where nothing ran out. `provider_http_status` is omitted rather than sent blank when absent.

## Behaviour change to know about

`ended_by=retry_exhausted` **does not disappear** — non-transient failures (87 turns / 30 users) still exhaust the attempt budget and still summarize, which is right: the model can genuinely explain a 400, and there is no card to route it to.

**In the CLI**, a request-time 5xx now reaches the setup/retry prompt instead of printing prose — the same treatment a mid-stream overload already gets. Two e2e scenarios asserted the old prose behaviour and are updated, with the reasoning in-file. Their non-zero exit under scripted stdin is *not* new: verified on pristine `staging` that a 401 already aborts a scripted run identically.

## Testing

`tests/test_curated_errors.py` — 51 tests. **Every one mutation-verified**: nine targeted mutants (conversion disabled, old allowlist restored, rephrase copy restored, stamping disabled) each killed by exactly the tests that should catch them, and nothing else.

Full suite: **2970 passed, 31 skipped, 0 failed**.

**Also expected side effects, not regressions:** the new terminal drops tool-history rows, so the card's Retry replays into a conversation missing the tool work — the identical trade already governs Path A and is documented at three sites. And when a *curated* exception ends the summarize call, `ended_by` flips to `error` and `error_type` records the summarize exception rather than the originating one; `retry_terminal_reason` still stamps, so those rows stay identifiable.

## Security

Reviewed. Every `TransientProviderError` message is anton-authored template text plus a validated integer status and a hard-coded provider label — audited all construction sites — so interpolating it into the card forwards no provider body to the client. Change 2 strictly **reduces** exposure: types that previously rendered `str(exc)` as assistant text now propagate and get the server's redacted stand-in instead. No credentials, input validation, path or authz surface is touched.

## Delivery

cowork-server pins anton to git **`main`**, so this reaches users only once it lands there — merging to `staging` ships nothing on its own. `remote_turn_error` already maps the type name, but the scratchpad pod runs a **sha-pinned** image (`values.yaml` / `values-prod.yaml`), so web needs anton on `main` **and a manual `SCRATCHPAD_IMAGE` bump** — it is not automatic.

## Not in scope

- Bare `ConnectionError` from the status mapper's catch-all (28 turns / 4 users), incl. the BYOK out-of-credits 402 — a **builtin**, so it cannot join a curated set without swallowing unrelated socket errors. Needs a type: ENG-1283.
- A BYOK provider's own quota routing to the MindsHub top-up card: ENG-2263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


