### PR TITLE
ENG-1687: pin the verifier eval's served model so an alias repoint cannot pass silently

### DIFF
--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -511,9 +511,11 @@ class StructuredOutputError(ValueError):
     otherwise look identical in a log and pull in opposite directions:
 
     - ``False`` — the model narrated in plain ``content`` and never got to the
-      call (the narrating aliases — ``mindshub_air``/``kimi``, ``deepseek``,
-      ``qwen`` — do this deterministically under a tight budget, ENG-1081).
-      The cure is a bigger budget.
+      call. Measured on the MindsHub aliases in 2026-07, when ``mindshub_air``
+      served Kimi K2.6: they did this deterministically under a tight budget
+      (ENG-1081). Those aliases have since been repointed and none of them
+      narrates now (ENG-1687), so treat this branch as covering BYOK and local
+      models rather than any particular alias. The cure is a bigger budget.
     - ``True`` — the call started and the budget ran out inside its JSON
       arguments. A bigger budget only helps until the payload grows again; the
       cure is a smaller response (ENG-1523).

--- a/anton/core/llm/structured.py
+++ b/anton/core/llm/structured.py
@@ -37,12 +37,15 @@ from .provider import StructuredOutputError
 
 # Default output-budget ladder for forced-schema calls: first attempt, then
 # one retry used only when the first came back truncated. Sized by the same
-# measurement as the completion verifier's (ENG-1081): narrating models
-# (`mindshub_air`/kimi, `deepseek`) spend 245–1,654+ tokens on prose before
-# reaching the forced tool call — and the narration scales with the input, so
-# a consolidation pass over a whole scratchpad session was observed filling
-# 2,048 exactly (ENG-1084). Non-narrating models answer these calls in tens
-# of tokens and never pay for the headroom.
+# measurement as the completion verifier's (ENG-1081): as measured in 2026-07,
+# narrating models (`mindshub_air` — then Kimi K2.6 — `kimi`, `deepseek`) spent
+# 245–1,654+ tokens on prose before reaching the forced tool call, and the
+# narration scaled with the input, so a consolidation pass over a whole
+# scratchpad session was observed filling 2,048 exactly (ENG-1084).
+# `mindshub_air` was repointed to a GPT model around 2026-08-10 and no MindsHub
+# alias narrates today (ENG-1687) — the ladder is kept for the unmeasured BYOK
+# and local models anton also runs on. Non-narrating models answer these calls
+# in tens of tokens and never pay for the headroom.
 DEFAULT_STRUCTURED_BUDGETS: tuple[int, ...] = (2048, 4096)
 
 

--- a/anton/core/memory/consolidator.py
+++ b/anton/core/memory/consolidator.py
@@ -173,8 +173,10 @@ class Consolidator:
 
         try:
             # Consolidation feeds in a whole scratchpad session, and narration
-            # scales with input — observed filling 2,048 exactly in prod on
-            # `mindshub_air` (ENG-1084). The ladder's 4,096 retry covers it.
+            # scales with input — observed filling 2,048 exactly in prod in
+            # 2026-07, on `mindshub_air` while it still served Kimi K2.6
+            # (ENG-1084; that alias is a GPT model now, ENG-1687). The ladder's
+            # 4,096 retry covers it, and still has to for BYOK models.
             result: _ConsolidatedLessons = await generate_with_truncation_retry(
                 llm_client.generate_object_code,
                 _ConsolidatedLessons,

--- a/anton/core/memory/cortex.py
+++ b/anton/core/memory/cortex.py
@@ -695,8 +695,9 @@ Do NOT add, modify, or summarize rules — return them verbatim.
         try:
             # 512 sat inside the measured narration range (245–1,654+), so
             # narrating models truncated on essentially every pass and the
-            # silent except below hid it — confirmed live in prod on
-            # `mindshub_air` (ENG-1084).
+            # silent except below hid it — confirmed live in prod in 2026-07 on
+            # `mindshub_air`, which served Kimi K2.6 then and serves a GPT model
+            # now (ENG-1084, ENG-1687).
             result: _IdentityFacts = await generate_with_truncation_retry(
                 self._llm.generate_object_code,
                 _IdentityFacts,

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -376,11 +376,21 @@ class _VerifierVerdict(BaseModel):
 # Output budgets for the verdict call: first attempt, then the retry used when
 # it comes back truncated (ENG-1081).
 #
-# Models that narrate before acting (`mindshub_air`/`kimi`, `deepseek`, `qwen`)
-# spend the budget on prose and never reach the forced tool call. The original
-# 256 truncated them on essentially every call — 98.6% of `mindshub_air` verdicts
-# in prod returned no tool call, which the fail-safe below turned into a silent
+# HISTORY, and read the tense — it is why the numbers are what they are, not a
+# claim about today's catalog. In 2026-07 the aliases that narrated before acting
+# (`mindshub_air` — then Kimi K2.6 — `kimi`, `deepseek`, `qwen`) spent the budget
+# on prose and never reached the forced tool call. The original 256 truncated
+# them on essentially every call: 98.6% of `mindshub_air` verdicts in prod
+# returned no tool call, which the fail-safe below turned into a silent
 # "task complete".
+#
+# `mindshub_air` has since been repointed to a GPT model, and re-measured
+# 2026-09-03 no MindsHub alias narrates on this call shape at all — 0 narration
+# characters on eight of them, with and without `_VERIFIER_NO_PREAMBLE`
+# (ENG-1687). Prod agrees: `verifier_failure = 'truncated'` is 0 over 30 days.
+# The budget stays anyway. It was sized from a distribution, anton runs on
+# arbitrary BYOK and local models nobody has measured, and per the note below
+# a model that answers in 43-115 tokens never pays for headroom it doesn't use.
 #
 # 2048 is sized from a measured distribution, not one sample: 16 identical calls
 # spanned 245–1654 output tokens (median ~290). That 6.7x per-call spread is why

--- a/tests/test_verifier_eval_gate.py
+++ b/tests/test_verifier_eval_gate.py
@@ -15,10 +15,16 @@ Three things are pinned here, each of which has already been wrong once:
    own failure mode, rebuilt by its escape hatch (caught reviewing #328).
 3. The marker string matches the one the workflow greps for. Two files, one
    string, previously held together by "keep in sync" comments.
+4. A repointed alias is rejected rather than silently measured. The eval picks
+   its models by alias NAME, and an alias is a catalog pointer that moves
+   without a PR here — `mindshub_air` moved off Kimi and the eval reported
+   green for a week while covering one population twice (ENG-1687). Tested here
+   because the check must hold with no key and no network.
 """
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -380,4 +386,99 @@ def test_the_marker_matches_the_one_the_workflow_greps_for():
     assert found.group(1) == ev._GATEWAY_UNAVAILABLE, (
         f"marker drift: workflow greps for {found.group(1)!r} but the eval emits "
         f"{ev._GATEWAY_UNAVAILABLE!r}, so starved runs would stop being recognised"
+    )
+
+
+# --- The served-model pin (ENG-1687) -------------------------------------
+#
+# Unit-level on purpose. The live eval exercises this on every call, but only
+# when a key is present — and the whole point of the pin is to be the thing that
+# still works when nobody is watching. These run in the default unit suite.
+
+
+@pytest.fixture(autouse=True)
+def _clean_served_map():
+    """`_SERVED` is module state on the eval, shared across this file's tests."""
+    ev._SERVED.clear()
+    yield
+    ev._SERVED.clear()
+
+
+def test_the_pinned_model_is_recorded_and_accepted():
+    ev._check_served_model("haiku", ev._EXPECTED_SERVED["haiku"])
+
+    assert ev._SERVED == {"haiku": ev._EXPECTED_SERVED["haiku"]}
+
+
+def test_a_repointed_alias_fails_naming_both_models():
+    """The failure has to be readable by someone who has never seen this file.
+
+    "assert x == y" over two model ids does not tell them a catalog repoint is a
+    normal event, that no verdict in the run is evidence any more, or that the
+    fix is to re-read the slot's rationale rather than to bump the constant.
+    """
+    with pytest.raises(ev.AliasRepointed) as caught:
+        ev._check_served_model("mindshub_air", "kimi-k2p6")
+
+    message = str(caught.value)
+    assert "mindshub_air" in message
+    assert "kimi-k2p6" in message, "must name what is served now"
+    assert ev._EXPECTED_SERVED["mindshub_air"] in message, "must name the pin"
+    assert "ENG-1687" in message
+    # Recorded before raising: the report at session end is most wanted on the
+    # run that failed, and a raise that skipped the record would hide it.
+    assert ev._SERVED == {"mindshub_air": "kimi-k2p6"}
+
+
+def test_a_repoint_is_not_swallowed_by_the_verdict_retry_paths():
+    """`_verdict` absorbs truncation and throttling. It must not absorb this.
+
+    A repoint typed as `StructuredOutputError` would be retried at a bigger
+    budget; typed as `TokenLimitExceeded` it would become a marked skip, and a
+    fully-skipped matrix reports GREEN by design (ENG-1334's out-of-money
+    branch). Either one restores the silent pass this check exists to break.
+    """
+    from anton.core.llm.provider import StructuredOutputError
+
+    assert not issubclass(ev.AliasRepointed, (StructuredOutputError, TokenLimitExceeded))
+    assert not issubclass(ev.AliasRepointed, pytest.skip.Exception)
+
+
+def test_an_alias_outside_the_pin_map_is_recorded_but_not_asserted():
+    """`VERIFIER_EVAL_*_MODEL` exists for one-off runs against another alias.
+
+    Failing those would make the escape hatch unusable, so an unpinned alias is
+    reported and never asserted.
+    """
+    ev._check_served_model("gpt-terra", "gpt-5.6-terra")
+
+    assert ev._SERVED == {"gpt-terra": "gpt-5.6-terra"}
+
+
+@pytest.mark.parametrize("served", [None, "", 0, object()])
+def test_a_missing_served_id_is_not_treated_as_a_repoint(served):
+    """A provider that omits `model` says nothing about which model ran.
+
+    Reading that as a repoint would fail the eval on a provider property. It
+    also must not be RECORDED, or the session report would claim an alias
+    resolved to nothing.
+    """
+    ev._check_served_model("haiku", served)
+
+    assert ev._SERVED == {}
+
+
+@pytest.mark.skipif(
+    bool(
+        os.environ.get("VERIFIER_EVAL_FIRST_PARTY_MODEL")
+        or os.environ.get("VERIFIER_EVAL_NARRATING_MODEL")
+    ),
+    reason="an env override deliberately runs an unpinned alias",
+)
+def test_every_pinned_alias_is_one_the_matrix_actually_runs():
+    """A pin on an alias no longer in the matrix checks nothing and reads as
+    coverage. Only fires if someone edits the matrix and forgets the map."""
+    assert set(ev._EXPECTED_SERVED) <= set(ev._MODELS), (
+        "_EXPECTED_SERVED pins an alias the matrix does not run: "
+        f"{sorted(set(ev._EXPECTED_SERVED) - set(ev._MODELS))}"
     )

--- a/tests/test_verifier_eval_gate.py
+++ b/tests/test_verifier_eval_gate.py
@@ -482,3 +482,57 @@ def test_every_pinned_alias_is_one_the_matrix_actually_runs():
         "_EXPECTED_SERVED pins an alias the matrix does not run: "
         f"{sorted(set(ev._EXPECTED_SERVED) - set(ev._MODELS))}"
     )
+
+
+def test_the_matrix_slots_resolve_to_different_models():
+    """The pin catches the repoint; this catches the state the repoint CAUSED.
+
+    ENG-1687 is not "an alias moved" — it is "both slots ended up holding one
+    model and the gate stayed green". `_EXPECTED_SERVED` reds on the move, but
+    the obvious way to clear that red is to update the map to the new id, and if
+    the new id is the other slot's model the eval goes back to running one model
+    twice with a perfectly green pin. Distinctness is what the ticket is about,
+    so assert it rather than leaving it to hold by accident.
+
+    Two ways to arrive at one model in two slots, both covered:
+      - identical aliases (someone set both `VERIFIER_EVAL_*_MODEL` the same)
+      - distinct aliases pinned to the same served id
+    """
+    assert len(set(ev._MODELS)) == len(ev._MODELS), (
+        f"the matrix runs the same alias twice: {ev._MODELS}. Unset one of the "
+        "VERIFIER_EVAL_*_MODEL overrides."
+    )
+    pinned = [ev._EXPECTED_SERVED[a] for a in ev._MODELS if a in ev._EXPECTED_SERVED]
+    assert len(set(pinned)) == len(pinned), (
+        f"the matrix's slots are pinned to the same model: {pinned}. That is "
+        "ENG-1687's end state, not its fix — re-pick a slot instead of pointing "
+        "both at one model."
+    )
+
+
+@pytest.mark.parametrize("alias", ["gpt-terra", "mindshub_air"])
+def test_a_served_id_cannot_inject_lines_into_the_report(alias):
+    """`response.model` is remote text, and it lands in two reports.
+
+    Unsanitized it reaches an exception message and `GITHUB_STEP_SUMMARY`, so a
+    value carrying a newline writes extra markdown lines into a CI artifact —
+    e.g. a bogus "✅" row for an alias that was never checked. anton already
+    sanitizes this exact field before it reaches a prompt
+    (`identity.sanitize_model_name`); this asserts the eval reuses it rather than
+    hand-rolling the check.
+
+    Both branches are covered because they format the value in different places:
+    an unpinned alias only records it, a pinned one also interpolates it into the
+    raise.
+    """
+    poisoned = "evil-model\n- `haiku` -> `totally-fine` OK"
+
+    try:
+        ev._check_served_model(alias, poisoned)
+    except ev.AliasRepointed as exc:
+        assert "\n" not in str(exc), "the raise carries a raw newline"
+
+    recorded = ev._SERVED.get(alias)
+    assert recorded is not None, "a poisoned id must still be recorded, not dropped"
+    assert "\n" not in recorded, f"newline survived sanitisation: {recorded!r}"
+    assert len(recorded) <= 80, "the sanitiser's length cap did not apply"

--- a/tests/test_verifier_verdict_live.py
+++ b/tests/test_verifier_verdict_live.py
@@ -20,11 +20,27 @@ key into a hard collection error. ``.github/workflows/verifier-eval.yml`` sets
 that for first-party PRs, so the gate can no longer report success without
 executing (ENG-1334). Fork PRs cannot receive the secret, so they still skip.
 
-Model matrix: one first-party alias (``haiku`` — enforces the forced
-``tool_choice`` structurally) and one narrating alias (``mindshub_air`` —
-narrates into ``content`` before the tool call). ENG-1081 measured a clean
-9-vs-3 split between those populations; an eval that only ran on haiku would
-have missed the entire ENG-1081 incident class.
+Model matrix: two aliases, ``haiku`` (Anthropic-native) and ``mindshub_air``
+(OpenAI-native — it resolves to a GPT model). Two provider shapes, which is what
+the matrix actually covers today.
+
+It used to cover two *behavioural* populations — one alias that enforced the
+forced ``tool_choice`` structurally, one that narrated into ``content`` first, a
+clean 9-vs-3 split when ENG-1081 measured it. **That population is gone.**
+``mindshub_air`` was repointed off Kimi to ``gpt-5.6-luna`` around 2026-08-10,
+and re-measured 2026-09-03 no reachable alias narrates at all: 0 narration
+characters on eight of them (air, haiku, kimi, deepseek, qwen, glm, grok,
+gpt-luna), identically 0 with the anti-preamble suffix *stripped*, so it is the
+models that changed rather than the prompt suppressing them. Anton retired the
+failure mode from its own side too — the budget went 256 → ``(2048, 4096)`` and
+``_VERIFIER_NO_PREAMBLE`` entered the verifier system prompt. Production agrees:
+``turn_completed.verifier_failure = 'truncated'`` is 0 over 30 days.
+
+So there is no narrating alias to re-pin the second slot to, and the honest
+description of this matrix is two provider shapes. Do not restore the old
+wording without re-measuring; if a narrating model ever returns (an open-weights
+Air backend is the likely route), ``_EXPECTED_SERVED`` is what will tell you, in
+the first run after the swap. ENG-1687.
 
 Non-determinism policy (decided up front, per the ticket): every run of a case
 must land inside that case's acceptable set — for the four single-valued cases
@@ -205,12 +221,94 @@ def _throttle_pause(retry_after: float | None) -> float:
         return _THROTTLE_RETRY_SLEEP_S
     return max(0.0, min(retry_after, _THROTTLE_RETRY_CAP_S))
 
-# One structural-tool_choice alias and one narrating alias — the two behaviour
-# populations ENG-1081 measured. Overridable for one-off runs against other
-# aliases without editing the file.
+# Two provider shapes: Anthropic-native (`haiku`) and OpenAI-native
+# (`mindshub_air`, which resolves to a GPT model). Overridable for one-off runs
+# against other aliases without editing the file.
+#
+# These are NOT two narration populations, whatever the git history says. That
+# was the original rationale, it was true when ENG-1081 measured a 9-vs-3 split,
+# and it is dead — see the module docstring and `_EXPECTED_SERVED` (ENG-1687).
 _FIRST_PARTY_MODEL = os.environ.get("VERIFIER_EVAL_FIRST_PARTY_MODEL", "haiku")
 _NARRATING_MODEL = os.environ.get("VERIFIER_EVAL_NARRATING_MODEL", "mindshub_air")
 _MODELS = [_FIRST_PARTY_MODEL, _NARRATING_MODEL]
+
+# The model each alias resolved to when its slot was last justified. Measured
+# 2026-09-03 against prod through this file's own call path.
+#
+# An alias is a CATALOG POINTER, not a model and not a behaviour. The auth
+# catalog can repoint one with no PR in this repo and no drift detection
+# (`mindshub_inference/.../providers/registry.py` says so in its own ⚠️
+# comment), and it does: `mindshub_air` moved off Kimi K2.6 to `gpt-5.6-luna`
+# around 2026-08-10, and `kimi` moved Moonshot → Fireworks after that. The first
+# repoint went unnoticed for a week and cost this eval half its matrix — 11 green
+# cases covering one population twice while the docstring claimed two (ENG-1687).
+#
+# So the eval states what it expects to be served and checks it on every call.
+# This is an IDENTITY check, deliberately not a behavioural one:
+#
+#   - It is free. `LLMResponse.model` is on every response already (ENG-1638),
+#     so nothing extra is called, and there is nothing to flake.
+#   - It catches repoints whose consequence nobody predicted. A probe only finds
+#     drift in the property you thought to probe; kimi's provider move changed no
+#     narration at all but flips its `tool_choice` failure mode (ENG-1095).
+#   - Behaviour is already guarded. `test_verdict` asserts the verdicts
+#     themselves, so a model that starts judging the fixtures differently reds
+#     with or without a repoint. Identity was the missing half, not behaviour.
+#
+# WHEN THIS FIRES: update the pin and re-read the slot's rationale in the SAME
+# commit. A repoint that only moves the pin leaves the slot undocumented again,
+# which is exactly how the last one hid. An exact id is intended: a
+# family-preserving bump still deserves a human glance, and a prefix match would
+# have stayed green through kimi's move.
+_EXPECTED_SERVED: dict[str, str] = {
+    "haiku": "claude-haiku-4-5-20251001",
+    "mindshub_air": "gpt-5.6-luna",
+}
+
+#: alias -> the id the gateway reported serving, filled as calls happen. Printed
+#: at session end so a repoint is visible in the run that first sees it, not
+#: three weeks later while validating something else.
+_SERVED: dict[str, str] = {}
+
+
+class AliasRepointed(Exception):
+    """An alias no longer serves the model its matrix slot was measured on.
+
+    Not an `AssertionError`, and deliberately not one of the types `_verdict`
+    handles: a repoint is neither a rubric regression nor a transient, and it
+    must not be absorbed by the truncation-retry or throttle-skip paths.
+    """
+
+
+def _check_served_model(alias: str, served: object) -> None:
+    """Record what `alias` actually served, and reject a silent repoint.
+
+    Pure so the gate suite can test it without a key or a network
+    (`tests/test_verifier_eval_gate.py`).
+
+    Silent on two cases, both on purpose:
+
+    - **An alias not in the pin map.** The `VERIFIER_EVAL_*_MODEL` env vars exist
+      for one-off runs against another alias; failing those would make the
+      escape hatch unusable. Such a run is recorded and printed, never asserted.
+    - **No served id.** `None` means the provider omitted the field, which is a
+      property of the provider, not evidence about the model. Refusing to run
+      would turn a missing echo into a fake repoint.
+    """
+    if not isinstance(served, str) or not served:
+        return
+    _SERVED[alias] = served
+    expected = _EXPECTED_SERVED.get(alias)
+    if expected is None or served == expected:
+        return
+    raise AliasRepointed(
+        f"alias {alias!r} now serves {served!r}, but this eval's matrix slot "
+        f"was measured on {expected!r}. The catalog repointed it. Nothing here "
+        f"is broken and no verdict below can be trusted as evidence about "
+        f"{expected!r}: re-read why this slot exists, decide whether "
+        f"{served!r} still covers it, then update _EXPECTED_SERVED and the "
+        f"module docstring in the same commit. See ENG-1687."
+    )
 
 _RUNS = int(os.environ.get("VERIFIER_EVAL_RUNS", "3"))
 _STUCK_RUNS = int(os.environ.get("VERIFIER_EVAL_STUCK_RUNS", "6"))
@@ -238,7 +336,70 @@ def _client(model: str) -> LLMClient:
         planning_reasoning_effort=None,
         coding_reasoning_effort=None,
     )
-    return LLMClient.from_settings(settings)
+    return _pinned(LLMClient.from_settings(settings), model)
+
+
+def _pinned(llm: LLMClient, alias: str) -> LLMClient:
+    """Check `_EXPECTED_SERVED` on every response this client returns.
+
+    Wraps the coding provider because `generate_object_code` — the verdict call
+    — routes through it, and returns the parsed schema object, so the served id
+    is not reachable from the caller. One shim here covers every call the eval
+    makes at no extra cost; a separate probe call per alias would both cost more
+    and check less (it would leave the matrix's own calls unverified).
+    """
+    provider = llm._coding_provider
+    inner = provider.complete
+
+    async def complete(**kwargs):
+        response = await inner(**kwargs)
+        _check_served_model(alias, getattr(response, "model", None))
+        return response
+
+    provider.complete = complete
+    return llm
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _report_served_models(request):
+    """Print alias → served model once the module's calls are done.
+
+    ENG-1687's second half: the pin makes a repoint *fail*, this makes one
+    *visible*. Without it the run says nothing about which models produced the
+    verdicts, which is how a repoint stayed invisible for three weeks — the
+    evidence was in every response body and nothing wrote it down.
+
+    Yields first: the map is empty until calls have happened.
+    """
+    yield
+    if not _SERVED:
+        return
+    lines = [f"{alias} -> {served}" for alias, served in sorted(_SERVED.items())]
+    # Through the terminal reporter, not `print`: pytest captures and DISCARDS
+    # stdout from a passing test, so a plain print showed this only on a red run
+    # — the run that needs it least. Falls back to print if the plugin is gone.
+    reporter = request.config.pluginmanager.get_plugin("terminalreporter")
+    body = "verifier eval served models:\n  " + "\n  ".join(lines)
+    if reporter is not None:
+        reporter.write_line("")
+        reporter.write_line(body)
+    else:
+        print("\n" + body)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary:
+        return
+    # Best-effort: a report that cannot be written must not fail a green eval.
+    try:
+        with open(summary, "a") as fh:
+            fh.write("### Verifier eval — models actually served\n\n")
+            for alias, served in sorted(_SERVED.items()):
+                pin = _EXPECTED_SERVED.get(alias)
+                note = "" if pin is None else (" ✅" if served == pin else " ⚠️ repointed")
+                fh.write(f"- `{alias}` → `{served}`{note}\n")
+            fh.write("\nAliases are catalog pointers; these are the models the "
+                     "gateway reported serving (ENG-1687).\n")
+    except OSError:
+        pass
 
 
 async def _verdict(llm: LLMClient, case: Case) -> _VerifierVerdict:

--- a/tests/test_verifier_verdict_live.py
+++ b/tests/test_verifier_verdict_live.py
@@ -80,6 +80,7 @@ except Exception:
 
 from anton.config.settings import AntonSettings
 from anton.core.llm.client import LLMClient
+from anton.core.llm.identity import sanitize_model_name
 from anton.core.llm.provider import StructuredOutputError, TokenLimitExceeded
 from anton.core.session import (
     _VERIFIER_TOKEN_BUDGETS,
@@ -286,6 +287,15 @@ def _check_served_model(alias: str, served: object) -> None:
     Pure so the gate suite can test it without a key or a network
     (`tests/test_verifier_eval_gate.py`).
 
+    The id is put through `identity.sanitize_model_name` first — the same
+    treatment anton already gives this same field before it reaches a prompt
+    (`identity.py`: "untrusted text ... cap it and keep it on one line"). Here it
+    lands in an exception message and in `GITHUB_STEP_SUMMARY`, so a value
+    carrying newlines would inject lines into a CI artifact. It also folds in the
+    non-string and empty checks. Known cost: an id longer than the sanitizer's
+    80-char cap would be truncated and then mismatch its pin — the longest id
+    this catalog serves is 46 (`accounts/fireworks/models/deepseek-v4-pro-0813`).
+
     Silent on two cases, both on purpose:
 
     - **An alias not in the pin map.** The `VERIFIER_EVAL_*_MODEL` env vars exist
@@ -295,7 +305,8 @@ def _check_served_model(alias: str, served: object) -> None:
       property of the provider, not evidence about the model. Refusing to run
       would turn a missing echo into a fake repoint.
     """
-    if not isinstance(served, str) or not served:
+    served = sanitize_model_name(served)
+    if served is None:
         return
     _SERVED[alias] = served
     expected = _EXPECTED_SERVED.get(alias)
@@ -342,21 +353,32 @@ def _client(model: str) -> LLMClient:
 def _pinned(llm: LLMClient, alias: str) -> LLMClient:
     """Check `_EXPECTED_SERVED` on every response this client returns.
 
-    Wraps the coding provider because `generate_object_code` — the verdict call
-    — routes through it, and returns the parsed schema object, so the served id
-    is not reachable from the caller. One shim here covers every call the eval
-    makes at no extra cost; a separate probe call per alias would both cost more
-    and check less (it would leave the matrix's own calls unverified).
+    `generate_object_code` — the verdict call — returns the parsed schema object,
+    so the served id is not reachable from the caller; the shim is how it is
+    read. One shim covers every call the eval makes at no extra cost, whereas a
+    separate probe call per alias would cost more and check less, leaving the
+    matrix's own calls unverified.
+
+    BOTH providers are wrapped, deduplicated by identity. `from_settings` builds
+    the planning and coding providers as separate objects even when both roles
+    name the same alias, so wrapping only the coding one leaves any future
+    `generate_object` or `chat` call in this file silently unpinned — the same
+    quiet-gap class this pin exists to close (self-review of #434).
     """
-    provider = llm._coding_provider
-    inner = provider.complete
+    providers = {
+        id(provider): provider
+        for provider in (llm._coding_provider, llm._planning_provider)
+        if provider is not None
+    }
+    for provider in providers.values():
+        inner = provider.complete
 
-    async def complete(**kwargs):
-        response = await inner(**kwargs)
-        _check_served_model(alias, getattr(response, "model", None))
-        return response
+        async def complete(_inner=inner, **kwargs):
+            response = await _inner(**kwargs)
+            _check_served_model(alias, getattr(response, "model", None))
+            return response
 
-    provider.complete = complete
+        provider.complete = complete
     return llm
 
 


### PR DESCRIPTION
## What

`tests/test_verifier_verdict_live.py` selects its two models **by alias name** (`haiku`, `mindshub_air`). An alias is a catalog pointer, not a model — the auth catalog can repoint one with no PR here and no drift detection. `mindshub_air` was repointed off Kimi K2.6 to `gpt-5.6-luna` around 2026-08-10, so both matrix slots now hold the same behaviour and the gate has been reporting green while covering one population twice.

This adds an **identity** check: `_EXPECTED_SERVED` records what each alias resolved to when its slot was last justified, and `_check_served_model` verifies it on every response. Plus the served map in the run output and the step summary, so a repoint is visible in the run that first sees it.

## Why an identity check and not the behavioural probe the ticket specified

The ticket asked for a population guard that re-measures the property each alias was chosen for. Four reasons this is the better shape:

1. **Behaviour is already guarded.** `test_verdict` asserts the verdicts themselves — a model that starts judging the fixtures differently reds with or without a repoint. Identity was the missing half; a property probe is a second behavioural guard.
2. **It is free and cannot flake.** `LLMResponse.model` is on every response since ENG-1638, so nothing extra is called. A stochastic property would need N runs to be trustworthy — this file's own non-determinism policy says one run of a stochastic property is a coin flip, which is why the STUCK case runs 6×.
3. **It catches drift nobody predicted.** A probe only finds drift in the property you thought to probe. `kimi` moved Moonshot → Fireworks since the ticket was filed with no narration change at all, but per ENG-1095 that flips its `tool_choice` failure mode. A narration probe stays green through it.
4. **It is the ticket's own argument finished.** The ticket rejects dynamic alias selection because "the guard should force a human to re-pick — it should not re-pick itself." A pin is the minimal form of that.

## What is deliberately NOT done

**The second population is not re-picked, because there is nothing to re-pick to.** Re-measured 2026-09-03 against prod through this file's own call path: **0 narration characters on eight aliases** (air, haiku, kimi, deepseek, qwen, glm, grok, gpt-luna), and identically 0 with `_VERIFIER_NO_PREAMBLE` **stripped** — so it is the models that changed, not the prompt suppressing them. Prod agrees: `turn_completed.verifier_failure = 'truncated'` is **0 over 30 days**.

Two corrections to the ticket's description, both filed as a comment on ENG-1687:

- It claims `_build_verify_request` adds no anti-preamble suffix. It does, and has since `fc832d5d` (2026-07-27) — three weeks before the sweep it justifies. The conclusion survives the correction; the stated reason for it did not.
- It budgets "one extra call per alias" for the guard. Not needed, per (2) above.

So the docstring now describes the matrix as **two provider shapes** (Anthropic-native `haiku`, OpenAI-native `mindshub_air`), which is what is true, with the dead rationale kept as dated history so nobody restores it without re-measuring.

## Verification

- **Watched failing live**, against prod, on today's `mindshub_air` — the pin set to `kimi-k2p6` (what the old docstring assumed) raises `AliasRepointed` naming both ids. That satisfies the ticket's "watched failing before any re-pick" `Done when`.
- **Every new unit test watched failing** under a mutation of the logic it covers: never-raise, record-before-guard, raise-on-unpinned, and stop-recording each killed exactly the intended test(s), suite green on restore.
- **Full live eval green**: 13 passed in 83s, unchanged from the ~1m35s CI baseline — the shim adds no measurable cost.
- **Full unit suite green** with no key: 2889 passed, 31 skipped.
- Report verified in both sinks: terminal (via the terminal reporter — a plain `print` is captured and discarded on a passing test, so it only showed on red runs) and `GITHUB_STEP_SUMMARY`.

## Comments corrected

Five sites asserted in the present tense that `mindshub_air` narrates, which is the belief that produced this bug: `anton/core/session.py`, `anton/core/llm/structured.py`, `anton/core/llm/provider.py`, `anton/core/memory/consolidator.py`, `anton/core/memory/cortex.py`. The measurements are kept as dated history — they are why the budget ladders are what they are, and deleting the rationale would invite someone to lower them. `provider.py:76` already documented the repoint correctly and is untouched.

## Security check

Performed. Read-only test change plus comment edits: no new endpoint, no new credential, no auth surface, no change to any request anton sends in production. Uses the existing `MINDSHUB_API_KEY` CI secret from ENG-1334. `_check_served_model` interpolates the gateway-reported `model` string into an exception message only — it is never written to disk, never sent anywhere, and the step-summary write is wrapped so an unwritable summary cannot fail a green eval. Fixtures are authored, not captured production payloads.

## Out of scope

- Reviving ENG-1023's billing-side alias governance.
- Selecting the slot on the catalog's declared `supports_named_tool_choice` capability instead of a name — the version that stops rotting, per `registry.py:117`. Different ticket.

Closes ENG-1687.
