### PR TITLE
ENG-2248: declare explicit ok/reason verdicts on six anton tool handlers

### DIFF
--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -142,17 +142,33 @@ _SENTINEL_REASONS = {
     # A refused package spec (flag/URL/path-shaped entry) is the agent's own
     # bad argument, not an environment wall (ENG-1635).
     "package_install_rejected": (TIER_SELF, "invalid_argument"),
+    # `read_image`, ENG-2248: both are the agent's own file choice, and both
+    # messages tell it what to do instead (use a real image / resize).
+    "not_an_image": (TIER_SELF, "invalid_argument"),
+    "image_too_large": (TIER_SELF, "invalid_argument"),
     # The agent named something that does not exist. Ambiguous — it could be a
     # genuinely absent resource — but the agent chose the identifier and can
     # list the real ones, so it resolves to the non-tripping side.
     "artifact_not_found": (TIER_SELF, "unknown_resource"),
     "unknown_datasource": (TIER_SELF, "unknown_resource"),
+    # Same shape for a path: `read_image` reports the file the agent named as
+    # absent. Genuinely absent files exist, but the agent supplied the path and
+    # can list the directory, so it resolves to the non-tripping side.
+    "missing_file": (TIER_SELF, "unknown_resource"),
     # Genuine walls: the environment is missing something the agent cannot add.
     "package_install_failed": (TIER_WALL, "missing_dependency"),
     "store_unavailable": (TIER_WALL, "service_unavailable"),
     # Could be environment or config and the sentinel does not say which, so it
     # stays out of every trip rung until something distinguishes them.
     "launch_failed": (TIER_UNCLASSIFIED, "unclassified"),
+    # `read_image`'s catch-all read failure wraps a bare `except Exception`, so
+    # one sentinel covers a permissions wall, a corrupt file the agent itself
+    # wrote, and a decode bug. Nothing here distinguishes them, so it stays out
+    # of every trip rung (ENG-2248).
+    "read_failed": (TIER_UNCLASSIFIED, "unclassified"),
+    # A bare `except Exception` around a PIL round-trip: a missing Pillow is a
+    # wall, a corrupt BMP is not, and the sentinel cannot tell them apart.
+    "bmp_convert_failed": (TIER_UNCLASSIFIED, "unclassified"),
 }
 
 # Identifier extraction, per class. Kept narrow on purpose: a wrong identifier

--- a/anton/core/root_cause.py
+++ b/anton/core/root_cause.py
@@ -154,7 +154,15 @@ _SENTINEL_REASONS = {
     # Same shape for a path: `read_image` reports the file the agent named as
     # absent. Genuinely absent files exist, but the agent supplied the path and
     # can list the directory, so it resolves to the non-tripping side.
-    "missing_file": (TIER_SELF, "unknown_resource"),
+    #
+    # NOT named `missing_file`, though that is what it describes (#435 review).
+    # `missing_file` is already a CLASS in this module, reached by a different
+    # path — `_WALL_TYPES` maps FileNotFoundError to it, `_STATUS_WALLS` maps
+    # 404 to it, it is the sole member of `_EXACT_ONLY_CLASSES`, and it gets
+    # path-identifier extraction below. A sentinel KEY of the same name that
+    # resolves to a DIFFERENT class is the kind of collision a future editor
+    # reads straight past.
+    "path_not_found": (TIER_SELF, "unknown_resource"),
     # Genuine walls: the environment is missing something the agent cannot add.
     "package_install_failed": (TIER_WALL, "missing_dependency"),
     "store_unavailable": (TIER_WALL, "service_unavailable"),

--- a/anton/core/tools/recall_skill.py
+++ b/anton/core/tools/recall_skill.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from anton.core.tools.registry import ToolOutcome
 from anton.core.tools.tool_defs import ToolDef
 
 if TYPE_CHECKING:
@@ -115,20 +116,50 @@ def _already_in_history(session, label: str) -> bool:
         return False
 
 
-async def handle_recall_skill(session: "ChatSession", tc_input: dict) -> str:
-    """Look up a skill by label and return its declarative procedure."""
+async def handle_recall_skill(
+    session: "ChatSession", tc_input: dict
+) -> "str | ToolOutcome":
+    """Look up a skill by label and return its declarative procedure.
+
+    Verdicts (ENG-2248). `ok` drives the per-tool error streak, so it fires the
+    resilience nudge at 2 consecutive failures and the circuit breaker at 5 —
+    a verdict here is a behaviour decision, not a label. This tool ran 1,150
+    times across 452 installs in 30 days, so a wrong `ok=False` reaches
+    everyone.
+
+    * `ok=True`  — a procedure was returned, INCLUDING the already-recalled
+      stub: that is a success with a deliberately short body, not a failure.
+    * `ok=False` — the call could not be served at all: no label, or no store.
+      Repeating either cannot help, so it SHOULD reach the streak. This is the
+      intended, accepted behaviour change.
+    * `ok=None`  — the NO MATCH family, left unmigrated ON PURPOSE. See the
+      comments at those returns.
+    """
     label_in = (tc_input.get("label") or "").strip()
     if not label_in:
-        return (
-            "ERROR: recall_skill requires a non-empty 'label' parameter. "
-            "Pick one from the procedural memory list in your system prompt."
+        # Tier 2 (ENG-2248): a malformed call. Retrying it unchanged cannot
+        # work, so repetition IS thrash and belongs in the streak.
+        return ToolOutcome(
+            content=(
+                "ERROR: recall_skill requires a non-empty 'label' parameter. "
+                "Pick one from the procedural memory list in your system prompt."
+            ),
+            ok=False,
+            reason="missing_name",
         )
 
     store = getattr(session, "_skill_store", None)
     if store is None:
-        return (
-            "ERROR: no skill store is wired into this session. "
-            "Procedural memory is unavailable right now."
+        # Tier 2: the host wired no store, so no label can ever work.
+        # `store_unavailable` is an existing `_SENTINEL_REASONS` key mapping to
+        # external_wall/service_unavailable — reused, not invented.
+        return ToolOutcome(
+            content=(
+                "ERROR: no skill store is wired into this session. "
+                "Procedural memory is unavailable right now."
+            ),
+            ok=False,
+            reason="store_unavailable",
         )
 
     skill = store.load(label_in)
@@ -137,6 +168,13 @@ async def handle_recall_skill(session: "ChatSession", tc_input: dict) -> str:
         closest = store.closest_match(label_in)
         if closest is None:
             available = [s["label"] for s in store.list_summaries()]
+            # Tier 3 (ENG-2248): deliberately ok=None, NOT a failure. The tool
+            # worked — it looked, found nothing, and told the model to proceed.
+            # This is the most common non-success on the highest-volume tool, so
+            # ok=False here would push normal exploration into the error streak
+            # and trip the breaker on correct behaviour. If it should ever
+            # count, that needs its own ticket and its own before/after on the
+            # nudge rate.
             if not available:
                 return (
                     f"NO MATCH: no skill named '{label_in}', and the procedural "
@@ -148,7 +186,11 @@ async def handle_recall_skill(session: "ChatSession", tc_input: dict) -> str:
             )
         skill = store.load(closest)
         if skill is None:
-            # Race or filesystem flake — be defensive
+            # Race or filesystem flake — be defensive.
+            # Tier 3: left ok=None with the rest of the NO MATCH family.
+            # Arguably a real failure (a load that should have worked), but it
+            # is indistinguishable from a plain miss without a store-level
+            # signal, and guessing wrong costs a breaker trip.
             return (
                 f"NO MATCH: '{label_in}' was not found and the closest "
                 f"candidate '{closest}' could not be loaded."
@@ -171,18 +213,29 @@ async def handle_recall_skill(session: "ChatSession", tc_input: dict) -> str:
         # procedure header — otherwise a stub surviving compaction would
         # satisfy _already_in_history forever and the full contract would
         # never be re-sent.
-        return (
-            f"Skill '{skill.label}' was already recalled in this conversation "
-            "— its full procedure is in your context above, under the "
-            f"'# Skill: {skill.name}' heading, and still applies. Not "
-            "re-sending the body."
+        # Tier 1 (ENG-2248): a SUCCESS with a deliberately short body. The
+        # procedure is already in context and still applies, so the tool did
+        # its job. Behaviourally identical to today — a bare-string return
+        # already resets the streak, since the legacy matcher finds none of its
+        # five markers in this text.
+        return ToolOutcome(
+            content=(
+                f"Skill '{skill.label}' was already recalled in this conversation "
+                "— its full procedure is in your context above, under the "
+                f"'# Skill: {skill.name}' heading, and still applies. Not "
+                "re-sending the body."
+            ),
+            ok=True,
         )
 
     # Increment the recommended counter for the *resolved* label, not the
     # input. If the LLM typo'd 'csv-sumary', we credit 'csv-summary'.
     store.increment_recommended(skill.label, stage=1)
 
-    return _format_skill_response(skill, warning=warning)
+    # Tier 1: the procedure was returned. Also covers the closest-match path,
+    # where `warning` explains the substitution — a substitution is still a
+    # served request.
+    return ToolOutcome(content=_format_skill_response(skill, warning=warning), ok=True)
 
 
 RECALL_SKILL_TOOL = ToolDef(

--- a/anton/core/tools/skill_draft.py
+++ b/anton/core/tools/skill_draft.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from anton.core.tools.skill_format import SKILL_FILE, normalize_name
+from anton.core.tools.registry import ToolOutcome
 from anton.core.tools.tool_defs import ToolDef
 
 if TYPE_CHECKING:
@@ -88,36 +89,55 @@ def _seed_from_store(folder: Path, slug: str, store) -> None:
         logger.warning("skill draft %r: could not seed from the store", slug, exc_info=True)
 
 
-async def handle_create_skill_draft(session: "ChatSession", tc_input: dict) -> str:
+async def handle_create_skill_draft(
+    session: "ChatSession", tc_input: dict
+) -> "str | ToolOutcome":
     """Claim `<skill_drafts_root>/<slug>`; return `{slug, path, skill_file}`."""
     root = getattr(session, "_skill_drafts_root", None)
     if root is None:
-        return json.dumps({"error": "Skill drafts are unavailable in this session."})
+        # Tier 2 (ENG-2248): the host wired no draft store; no input can work.
+        return ToolOutcome(
+            content=json.dumps({"error": "Skill drafts are unavailable in this session."}),
+            ok=False, reason="store_unavailable",
+        )
 
     name = str(tc_input.get("name") or "").strip()
     if not name:
-        return json.dumps({"error": "`name` is required."})
+        # Tier 2: malformed call.
+        return ToolOutcome(
+            content=json.dumps({"error": "`name` is required."}),
+            ok=False, reason="missing_name",
+        )
     slug = normalize_name(name)
     if not slug:
-        return json.dumps({"error": "`name` must contain at least one letter or digit."})
+        # Tier 2: malformed call.
+        return ToolOutcome(
+            content=json.dumps({"error": "`name` must contain at least one letter or digit."}),
+            ok=False, reason="invalid_type",
+        )
 
     folder = Path(root) / slug
     try:
         folder.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
         logger.warning("skill draft %r: could not claim a folder", slug, exc_info=True)
-        return json.dumps({"error": f"Could not claim a folder for {slug!r}: {exc}"})
+        # Tier 2: the filesystem refused; the draft does not exist.
+        return ToolOutcome(
+            content=json.dumps({"error": f"Could not claim a folder for {slug!r}: {exc}"}),
+            ok=False, reason="store_unavailable",
+        )
 
     # Only seed an unclaimed folder: a second call in the same turn must not
     # overwrite what the agent has already written into it.
     if not (folder / SKILL_FILE).is_file():
         _seed_from_store(folder, slug, getattr(session, "_skill_store", None))
 
-    return json.dumps({
+    # Tier 1: a draft folder was claimed and its descriptor returned.
+    return ToolOutcome(content=json.dumps({
         "slug": slug,
         "path": str(folder),
         "skill_file": str(folder / SKILL_FILE),
-    })
+    }), ok=True)
 
 
 CREATE_SKILL_DRAFT_TOOL = ToolDef(

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -474,7 +474,9 @@ async def handle_launch_backend(session: "ChatSession", tc_input: dict) -> ToolO
     ).to_outcome()
 
 
-async def handle_list_artifacts(session: "ChatSession", tc_input: dict) -> str:
+async def handle_list_artifacts(
+    session: "ChatSession", tc_input: dict
+) -> "str | ToolOutcome":
     """List every artifact in the workspace, newest first.
 
     Output is a JSON array of summaries — slug, name, type,
@@ -486,7 +488,13 @@ async def handle_list_artifacts(session: "ChatSession", tc_input: dict) -> str:
 
     store = _artifact_store(session)
     if store is None:
-        return "Artifact store unavailable (no workspace bound to this session)."
+        # Tier 2 (ENG-2248): the tool cannot operate at all, so a retry
+        # cannot help and repetition is thrash. Reuses the existing
+        # `store_unavailable` sentinel key (external_wall/service_unavailable).
+        return ToolOutcome(
+            content="Artifact store unavailable (no workspace bound to this session).",
+            ok=False, reason="store_unavailable",
+        )
 
     artifacts = store.list()
     summaries = [
@@ -500,10 +508,14 @@ async def handle_list_artifacts(session: "ChatSession", tc_input: dict) -> str:
         }
         for a in artifacts
     ]
-    return json.dumps(summaries, indent=2)
+    # Tier 1: a listing was produced. An EMPTY list is still a success —
+    # "there are no artifacts" is the correct answer, not a failure.
+    return ToolOutcome(content=json.dumps(summaries, indent=2), ok=True)
 
 
-async def handle_open_artifact(session: "ChatSession", tc_input: dict) -> str:
+async def handle_open_artifact(
+    session: "ChatSession", tc_input: dict
+) -> "str | ToolOutcome":
     """Load an existing artifact's metadata + folder path.
 
     Returns the same shape as `create_artifact` plus the file list
@@ -514,13 +526,29 @@ async def handle_open_artifact(session: "ChatSession", tc_input: dict) -> str:
 
     store = _artifact_store(session)
     if store is None:
-        return "Artifact store unavailable (no workspace bound to this session)."
+        # Tier 2 (ENG-2248): the tool cannot operate at all, so a retry
+        # cannot help and repetition is thrash. Reuses the existing
+        # `store_unavailable` sentinel key (external_wall/service_unavailable).
+        return ToolOutcome(
+            content="Artifact store unavailable (no workspace bound to this session).",
+            ok=False, reason="store_unavailable",
+        )
 
     slug = (tc_input.get("slug") or "").strip()
     if not slug:
-        return "Error: `slug` is required."
+        # Tier 2: a malformed call; retrying it unchanged cannot work.
+        return ToolOutcome(
+            content="Error: `slug` is required.",
+            ok=False, reason="missing_slug",
+        )
     artifact = store.open(slug)
     if artifact is None:
+        # Tier 3 (ENG-2248): deliberately left ok=None. Same shape as
+        # `recall_skill`'s NO MATCH — the store worked and the artifact simply
+        # does not exist. The model can list artifacts and pick a real slug, so
+        # this is arguably its own error; but it is also how a model discovers
+        # what exists, and ok=False would feed that exploration to the breaker.
+        # Needs its own decision, not a side effect of this pass.
         return f"Error: no artifact found for slug `{slug}`."
     folder = store.folder_for(artifact.slug)
     # Opening is how the agent gets an artifact's path in order to write to
@@ -528,7 +556,8 @@ async def handle_open_artifact(session: "ChatSession", tc_input: dict) -> str:
     # rather than at write time because the writes themselves happen in
     # scratchpad cells the tool layer never sees.
     _track_artifact(session, store, artifact.slug, summary=f"Opened artifact: {artifact.name}")
-    return json.dumps({
+    # Tier 1: the artifact was opened and its descriptor returned.
+    return ToolOutcome(content=json.dumps({
         "id": artifact.id,
         "slug": artifact.slug,
         "name": artifact.name,
@@ -536,7 +565,7 @@ async def handle_open_artifact(session: "ChatSession", tc_input: dict) -> str:
         "description": artifact.description,
         "path": str(folder),
         "files": [{"path": f.path, "bytes": f.bytes} for f in artifact.files],
-    }, indent=2)
+    }, indent=2), ok=True)
 
 
 async def handle_recall(session: ChatSession, tc_input: dict) -> str:
@@ -557,7 +586,9 @@ async def handle_recall(session: ChatSession, tc_input: dict) -> str:
     return session._episodic.recall_formatted(query, **kwargs)
 
 
-async def handle_memorize(session: ChatSession, tc_input: dict) -> str:
+async def handle_memorize(
+    session: ChatSession, tc_input: dict
+) -> "str | ToolOutcome":
     """Process a memorize tool call and return a result string.
 
     Encoding is fire-and-forget so it never blocks scratchpad execution.
@@ -565,16 +596,29 @@ async def handle_memorize(session: ChatSession, tc_input: dict) -> str:
     import asyncio
 
     if session._cortex is None:
-        return "Memory system not available."
+        # Tier 2 (ENG-2248): no memory system wired, so no entry can ever be
+        # stored. Retrying cannot help.
+        return ToolOutcome(
+            content="Memory system not available.",
+            ok=False, reason="store_unavailable",
+        )
 
     if session._cortex.mode == "off":
+        # Tier 3 (ENG-2248): deliberately ok=None. This is a CONFIGURED state,
+        # not a failure — the user turned memory off, and the tool reported that
+        # correctly. Marking it ok=False would nudge and then break the tool for
+        # every user who has memory disabled on purpose.
         return "Memory encoding is disabled. Change memory mode via /setup to enable."
 
     from anton.core.memory.base import Engram
 
     raw_entries = tc_input.get("entries", [])
     if not raw_entries:
-        return "No entries provided."
+        # Tier 2: a malformed call.
+        return ToolOutcome(
+            content="No entries provided.",
+            ok=False, reason="missing_name",
+        )
 
     engrams: list[Engram] = []
     for entry in raw_entries:
@@ -602,7 +646,12 @@ async def handle_memorize(session: ChatSession, tc_input: dict) -> str:
         )
 
     if not engrams:
-        return "No valid entries provided."
+        # Tier 2: every entry was rejected by the shape checks above, so the
+        # call carried nothing usable.
+        return ToolOutcome(
+            content="No valid entries provided.",
+            ok=False, reason="invalid_type",
+        )
 
     # Always encode immediately via fire-and-forget — the LLM explicitly
     # chose to memorize these, so we never interrupt the user mid-turn
@@ -618,7 +667,10 @@ async def handle_memorize(session: ChatSession, tc_input: dict) -> str:
     session._track_memory_write(asyncio.create_task(_encode_bg(session._cortex, engrams)))
 
     descriptions = [f"Encoded {e.kind}: {e.text}" for e in engrams]
-    return "Memory updated: " + "; ".join(descriptions)
+    # Tier 1: at least one entry was stored.
+    return ToolOutcome(
+        content="Memory updated: " + "; ".join(descriptions), ok=True
+    )
 
 
 async def handle_scratchpad(
@@ -769,7 +821,7 @@ async def handle_scratchpad(
 
 async def handle_read_image(
     session: "ChatSession", tc_input: dict
-) -> str | list[dict]:
+) -> "ToolOutcome":
     """Read an image file from disk and return it as an image content block.
 
     Returns a list of content blocks (image + text) on success so the model
@@ -788,7 +840,11 @@ async def handle_read_image(
 
     file_path = (tc_input.get("file_path") or "").strip()
     if not file_path:
-        return "Error: file_path is required."
+        # Tier 2 (ENG-2248): a malformed call; a retry cannot fix it.
+        return ToolOutcome(
+            content="Error: file_path is required.",
+            ok=False, reason="missing_name",
+        )
 
     try:
         path = Path(file_path).expanduser()
@@ -803,21 +859,44 @@ async def handle_read_image(
             root = Path(base) if base else Path.cwd()
             path = (root / path).resolve()
     except OSError as exc:
-        return f"Error: invalid path '{file_path}': {exc}"
+        # Tier 2: the model supplied a path that will not parse.
+        return ToolOutcome(
+            content=f"Error: invalid path '{file_path}': {exc}",
+            ok=False, reason="invalid_type",
+        )
 
     if not path.is_file():
-        return f"Error: file not found: {path}"
+        # Tier 2: the file is genuinely absent. Unlike `recall_skill`'s NO
+        # MATCH, there is no listing the model can consult to self-correct and
+        # nothing here tells it to proceed regardless, so repeating the same
+        # path IS thrash and belongs in the streak.
+        return ToolOutcome(
+            content=f"Error: file not found: {path}",
+            ok=False, reason="missing_file",
+        )
 
     if not is_image_path(path.name):
-        return (
-            f"Error: '{path.name}' is not a supported image format "
-            "(expected .png/.jpg/.jpeg/.gif/.webp/.bmp)."
+        # Tier 2: the model pointed the image tool at a non-image. Its own
+        # argument, and the message names the accepted extensions.
+        return ToolOutcome(
+            content=(
+                f"Error: '{path.name}' is not a supported image format "
+                "(expected .png/.jpg/.jpeg/.gif/.webp/.bmp)."
+            ),
+            ok=False, reason="not_an_image",
         )
 
     try:
         raw = path.read_bytes()
     except OSError as exc:
-        return f"Error: cannot read '{path}': {exc}"
+        # Tier 2: the read itself failed. `ok=False` is certain — the model got
+        # no image. The CAUSE is not: this wraps a bare `except Exception`, so
+        # `read_failed` is mapped TIER_UNCLASSIFIED rather than guessing at a
+        # permissions wall.
+        return ToolOutcome(
+            content=f"Error: cannot read '{path}': {exc}",
+            ok=False, reason="read_failed",
+        )
 
     suffix = path.suffix.lstrip(".").lower()
     if suffix == "bmp":
@@ -830,13 +909,24 @@ async def handle_read_image(
             raw = buf.getvalue()
             suffix = "png"
         except Exception as exc:
-            return f"Error: failed to convert BMP to PNG: {exc}"
+            # Tier 2 for the verdict, unclassified for the cause: a bare
+            # `except Exception` around a PIL call covers a missing Pillow (a
+            # wall) and a corrupt BMP (self-inflicted) with one sentinel.
+            return ToolOutcome(
+                content=f"Error: failed to convert BMP to PNG: {exc}",
+                ok=False, reason="bmp_convert_failed",
+            )
 
     if len(raw) * 4 // 3 > MAX_IMAGE_BYTES:
-        return (
-            f"Error: image is too large ({human_size(len(raw))}); "
-            "the API limit is ~3.7 MB raw / 5 MB base64. "
-            "Resize the image and try again."
+        # Tier 2: over the API's hard limit. The model chose the file and the
+        # message tells it what to do instead.
+        return ToolOutcome(
+            content=(
+                f"Error: image is too large ({human_size(len(raw))}); "
+                "the API limit is ~3.7 MB raw / 5 MB base64. "
+                "Resize the image and try again."
+            ),
+            ok=False, reason="image_too_large",
         )
 
     b64 = base64.standard_b64encode(raw).decode("ascii")
@@ -851,17 +941,32 @@ async def handle_read_image(
     except Exception:
         pass
 
-    return [
-        {
-            "type": "image",
-            "source": {
-                "type": "base64",
-                "media_type": media_type,
-                "data": b64,
+    # Tier 1, and the ONLY multimodal verdict in the tree. `ok=True` is free
+    # here: the list arms of both tool loops already treat a list result as a
+    # success unless a handler says otherwise, so this changes the emitted
+    # `ok` from "unknown" to `true` and nothing else.
+    #
+    # It must stay `ok=True`. A list carrying `ok=False` would reach two
+    # documented gaps in the list arms — the nudge/breaker text is never
+    # appended there, and `_record_root_cause` is never called — so the model
+    # would be silently retried past the breaker. `_tool_failure_cause`'s
+    # docstring in session.py describes that shape as unreachable; it stays
+    # unreachable because every failure above returns a plain string.
+    # Pinned by `test_read_image_never_pairs_a_list_with_a_failure_verdict`.
+    return ToolOutcome(
+        content=[
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": media_type,
+                    "data": b64,
+                },
             },
-        },
-        {"type": "text", "text": summary},
-    ]
+            {"type": "text", "text": summary},
+        ],
+        ok=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/anton/core/tools/tool_handlers.py
+++ b/anton/core/tools/tool_handlers.py
@@ -872,7 +872,7 @@ async def handle_read_image(
         # path IS thrash and belongs in the streak.
         return ToolOutcome(
             content=f"Error: file not found: {path}",
-            ok=False, reason="missing_file",
+            ok=False, reason="path_not_found",
         )
 
     if not is_image_path(path.name):

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -184,12 +184,21 @@ class TestRecallIdempotence:
         history: list = []
         session = self._session(store, history)
         first = await handle_recall_skill(session, {"label": "build-html-dashboard"})
-        assert "## Procedure" in first
-        # simulate the tool result landing in history
-        history.append({"role": "user", "content": [{"type": "tool_result", "content": first}]})
+        # ENG-2248: both paths are successes — the stub is a success with a
+        # deliberately short body, not a failure.
+        assert first.ok is True
+        assert "## Procedure" in first.content
+        # Simulate the tool result landing in history. `.content` is what the
+        # dispatch loop puts there (`result = outcome.content`), so passing the
+        # ToolOutcome itself would make this test diverge from production.
+        history.append(
+            {"role": "user",
+             "content": [{"type": "tool_result", "content": first.content}]}
+        )
         second = await handle_recall_skill(session, {"label": "build-html-dashboard"})
-        assert "already recalled" in second
-        assert "## Procedure" not in second
+        assert second.ok is True
+        assert "already recalled" in second.content
+        assert "## Procedure" not in second.content
 
     @pytest.mark.asyncio
     async def test_compacted_history_resends_full_body(self, store):
@@ -199,7 +208,8 @@ class TestRecallIdempotence:
         history = [{"role": "user", "content": "[compacted] recalled build-html-dashboard earlier"}]
         session = self._session(store, history)
         result = await handle_recall_skill(session, {"label": "build-html-dashboard"})
-        assert "## Procedure" in result
+        assert result.ok is True
+        assert "## Procedure" in result.content
 
     @pytest.mark.asyncio
     async def test_surviving_stub_does_not_suppress_resend(self, store):
@@ -211,14 +221,21 @@ class TestRecallIdempotence:
         history: list = []
         session = self._session(store, history)
         full = await handle_recall_skill(session, {"label": "build-html-dashboard"})
-        history.append({"role": "user", "content": [{"type": "tool_result", "content": full}]})
+        history.append(
+            {"role": "user",
+             "content": [{"type": "tool_result", "content": full.content}]}
+        )
         stub = await handle_recall_skill(session, {"label": "build-html-dashboard"})
-        assert "already recalled" in stub
+        assert "already recalled" in stub.content
         # simulate compaction: full body evicted, stub survives
         history.clear()
-        history.append({"role": "user", "content": [{"type": "tool_result", "content": stub}]})
+        history.append(
+            {"role": "user",
+             "content": [{"type": "tool_result", "content": stub.content}]}
+        )
         result = await handle_recall_skill(session, {"label": "build-html-dashboard"})
-        assert "## Procedure" in result
+        assert result.ok is True
+        assert "## Procedure" in result.content
 
     @pytest.mark.asyncio
     async def test_summary_quoting_marker_does_not_suppress_resend(self, store):
@@ -229,4 +246,5 @@ class TestRecallIdempotence:
         history = [{"role": "user", "content": f"[compacted] earlier: {_recall_marker('build-html-dashboard')}"}]
         session = self._session(store, history)
         result = await handle_recall_skill(session, {"label": "build-html-dashboard"})
-        assert "## Procedure" in result
+        assert result.ok is True
+        assert "## Procedure" in result.content

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -481,7 +481,9 @@ async def test_memorize_registers_its_write_for_settling(tmp_path, monkeypatch, 
     result = await handle_memorize(session, {"entries": [
         {"text": "Answer in Spanish", "kind": "always", "scope": "global"},
     ]})
-    assert "Memory updated" in result
+    # ENG-2248 tier 1: a stored entry is an explicit success.
+    assert result.ok is True
+    assert "Memory updated" in result.content
     assert len(session._memory_writes) == 1        # registered, not yet awaited
 
     await session.settle_memory_writes()
@@ -610,9 +612,11 @@ def test_a_skill_the_agent_builds_comes_back_out(tmp_path, monkeypatch, skills_t
     from anton.core.tools.skill_draft import handle_create_skill_draft
 
     session = _real_cloud_session(tmp_path, monkeypatch)
-    claimed = json.loads(asyncio.run(
+    claimed = asyncio.run(
         handle_create_skill_draft(session, {"name": "Competitive Analysis"})
-    ))
+    )
+    assert claimed.ok is True          # ENG-2248: a claimed folder is a success
+    claimed = json.loads(claimed.content)
     Path(claimed["skill_file"]).write_text("---\nname: competitive-analysis\n---\nsteps")
 
     entries = drain_pending_skills(session)
@@ -631,7 +635,8 @@ async def test_recall_skill_returns_the_staged_procedure(tmp_path, monkeypatch, 
 
     session = _real_cloud_session(tmp_path, monkeypatch, skills=_SKILLS)
     out = await handle_recall_skill(session, {"label": "csv-summary"})
-    assert "Describe the columns" in out
+    assert out.ok is True
+    assert "Describe the columns" in out.content
 
 
 async def test_recall_stats_stay_in_the_staging_dir(tmp_path, monkeypatch, skills_tmp):

--- a/tests/test_desktop_memory.py
+++ b/tests/test_desktop_memory.py
@@ -62,7 +62,8 @@ async def test_desktop_memorize_writes_straight_to_disk(tmp_path, memory_dirs):
         {"text": "Name: Zoran", "kind": "profile", "scope": "global"},
         {"text": "CoinGecko rate-limits at 50/min", "kind": "lesson", "scope": "global"},
     ]})
-    assert "Memory updated" in result
+    assert result.ok is True
+    assert "Memory updated" in result.content
     await session.settle_memory_writes()
 
     assert "Use httpx instead of requests" in (global_dir / "rules.md").read_text()

--- a/tests/test_recall_skill.py
+++ b/tests/test_recall_skill.py
@@ -88,10 +88,12 @@ class TestExactMatch:
     async def test_returns_procedure(self, store: SkillStore):
         session = _session_with(store)
         result = await handle_recall_skill(session, {"label": "csv_summary"})
-        assert "CSV Summary" in result
-        assert "Load the CSV" in result
-        assert "Infer types" in result
-        assert "Print summary" in result
+        # ENG-2248 tier 1: a served procedure is an explicit success.
+        assert result.ok is True
+        assert "CSV Summary" in result.content
+        assert "Load the CSV" in result.content
+        assert "Infer types" in result.content
+        assert "Print summary" in result.content
 
     @pytest.mark.asyncio
     async def test_increments_recommended_counter(self, store: SkillStore):
@@ -135,10 +137,13 @@ class TestTypoFallback:
     async def test_typo_returns_closest_match(self, store: SkillStore):
         session = _session_with(store)
         result = await handle_recall_skill(session, {"label": "csv_sumary"})
-        assert "⚠" in result
-        assert "csv-summary" in result
+        # ENG-2248 tier 1: a SUBSTITUTION is still a served request, so the
+        # closest-match path is ok=True, warning and all.
+        assert result.ok is True
+        assert "⚠" in result.content
+        assert "csv-summary" in result.content
         # The full procedure is still included after the warning
-        assert "Load the CSV" in result
+        assert "Load the CSV" in result.content
 
     @pytest.mark.asyncio
     async def test_typo_credits_resolved_label_not_input(self, store: SkillStore):
@@ -152,10 +157,11 @@ class TestTypoFallback:
     async def test_dash_to_underscore_recovered(self, store: SkillStore):
         session = _session_with(store)
         result = await handle_recall_skill(session, {"label": "web__scraping"})
-        assert "web-scraping" in result
+        assert result.ok is True
+        assert "web-scraping" in result.content
         # Could match exactly via slugify, in which case there's no warning,
         # or via fuzzy match. Either way the procedure should be returned.
-        assert "BeautifulSoup" in result
+        assert "BeautifulSoup" in result.content
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -192,19 +198,31 @@ class TestUnknownSlug:
     async def test_empty_label_returns_error(self, store: SkillStore):
         session = _session_with(store)
         result = await handle_recall_skill(session, {"label": ""})
-        assert "ERROR" in result
+        # ENG-2248 tier 2, and this is the accepted BEHAVIOUR CHANGE: ok=False
+        # feeds the per-tool error streak, so two of these in a row now nudge
+        # the model and five trip the breaker. Deliberate — a call with no
+        # label cannot succeed on retry, so repeating it is thrash.
+        assert result.ok is False
+        assert result.reason == "missing_name"
+        assert "ERROR" in result.content
 
     @pytest.mark.asyncio
     async def test_missing_label_returns_error(self, store: SkillStore):
         session = _session_with(store)
         result = await handle_recall_skill(session, {})
-        assert "ERROR" in result
+        assert result.ok is False
+        assert result.reason == "missing_name"
+        assert "ERROR" in result.content
 
     @pytest.mark.asyncio
     async def test_no_store_on_session_returns_error(self):
         session = SimpleNamespace()  # no _skill_store
         result = await handle_recall_skill(session, {"label": "csv_summary"})
-        assert "ERROR" in result
+        # `store_unavailable` is an existing sentinel key (external_wall /
+        # service_unavailable), reused rather than invented.
+        assert result.ok is False
+        assert result.reason == "store_unavailable"
+        assert "ERROR" in result.content
 
     @pytest.mark.asyncio
     async def test_empty_store_unrelated_label(self, tmp_path: Path):

--- a/tests/test_skill_draft_tool.py
+++ b/tests/test_skill_draft_tool.py
@@ -13,7 +13,15 @@ from anton.core.tools.skill_draft import handle_create_skill_draft
 
 
 def _call(session, **args) -> dict:
-    return json.loads(asyncio.run(handle_create_skill_draft(session, args)))
+    """Unwrap the handler's ToolOutcome the way the tool loop does (ENG-2248).
+
+    `.content` is what reaches the model and lands in history; `.ok` is the
+    verdict the streak reads. These tests assert on the content, so they read
+    exactly what they read before the migration — see
+    `test_tool_verdict_migration.py` for the `.ok` half.
+    """
+    outcome = asyncio.run(handle_create_skill_draft(session, args))
+    return json.loads(getattr(outcome, "content", outcome))
 
 
 def _session(drafts_root, store=None):

--- a/tests/test_tool_verdict_migration.py
+++ b/tests/test_tool_verdict_migration.py
@@ -1,0 +1,342 @@
+"""The ENG-2248 verdict migration is NOT measurement-only — proof, both ways.
+
+`_apply_error_tracking` opens with `if ok is not None:` and uses the handler's
+verdict DIRECTLY to drive `error_streak[tool_name]`, which fires the resilience
+nudge at `resilience_nudge_at` and the circuit breaker at
+`max_consecutive_errors`. So every `ok=` in a migrated handler is a behaviour
+decision, not a label, and these tests exist to make that explicit instead of
+discovered in production.
+
+Two claims, one per direction:
+
+* **Tier 1 is free.** A migrated SUCCESS must behave exactly as the bare-string
+  return did — the streak resets either way, because the legacy substring
+  matcher finds none of its five markers in a success body. If this ever
+  diverges, `ok=True` has stopped being a no-op and the "zero behaviour risk"
+  argument for tier 1 is void.
+* **Tier 2 is a real, accepted change.** A migrated FAILURE now reaches the
+  streak where a bare string did not. Two in a row nudges, five trips the
+  breaker. That is intended for calls that cannot succeed on retry, and it is
+  asserted here so nobody has to infer it from the diff.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from anton.core.session import ChatSession, ChatSessionConfig
+from anton.core.tools.registry import ToolOutcome
+from tests.conftest import make_mock_llm
+
+_LEGACY_MARKERS = ("[error]", "Task failed:", "failed", "timed out", "Rejected:")
+
+
+def _bare_session():
+    """Minimal session: only `_apply_error_tracking` is under test."""
+    return ChatSession(ChatSessionConfig(llm_client=make_mock_llm()))
+
+
+# ── Tier 1: a migrated success must be behaviourally identical ───────
+
+
+def test_a_migrated_success_resets_the_streak_exactly_as_a_bare_string_did():
+    """The whole "tier 1 is free" claim, pinned.
+
+    Runs the SAME success body twice — once as `ok=None` (what shipped before
+    the migration, classified by the legacy matcher) and once as `ok=True` —
+    and requires an identical streak outcome. Not "both are falsy": the same
+    value, from a primed non-zero streak, so a reset is observable.
+    """
+    session = _bare_session()
+    body = "# Skill recalled: `csv-summary`\n\nLoad the CSV, infer types."
+
+    # Precondition that makes this test able to fail: the success body must
+    # contain none of the legacy markers, which is WHY ok=None reset the
+    # streak. If a future success body happens to contain "failed", the two
+    # paths genuinely diverge and this test should be the thing that says so.
+    assert not any(m in body for m in _LEGACY_MARKERS)
+
+    outcomes = {}
+    for label, ok in (("legacy", None), ("migrated", True)):
+        streak = {"recall_skill": 3}          # primed, so a reset is visible
+        session._apply_error_tracking(
+            body, "recall_skill", streak, set(), ok=ok
+        )
+        outcomes[label] = streak["recall_skill"]
+
+    assert outcomes["legacy"] == outcomes["migrated"] == 0, outcomes
+
+
+def test_a_migrated_success_appends_nothing_to_what_the_model_reads():
+    """Tier 1 must not change the tool result the model sees, either."""
+    session = _bare_session()
+    body = "# Skill recalled: `csv-summary`"
+    legacy = session._apply_error_tracking(body, "recall_skill", {}, set(), ok=None)
+    migrated = session._apply_error_tracking(body, "recall_skill", {}, set(), ok=True)
+    assert legacy == migrated == body
+
+
+# ── Tier 2: the accepted behaviour change ────────────────────────────
+
+
+def test_a_migrated_failure_now_reaches_the_streak_where_a_bare_string_did_not():
+    """The change, isolated to one call.
+
+    `recall_skill`'s missing-label text carries none of the five legacy
+    markers, so before the migration it RESET the streak. Now it increments.
+    """
+    session = _bare_session()
+    body = (
+        "ERROR: recall_skill requires a non-empty 'label' parameter. "
+        "Pick one from the procedural memory list in your system prompt."
+    )
+    assert not any(m in body for m in _LEGACY_MARKERS)   # why it used to reset
+
+    legacy_streak = {"recall_skill": 0}
+    session._apply_error_tracking(body, "recall_skill", legacy_streak, set(), ok=None)
+    assert legacy_streak["recall_skill"] == 0, "pre-migration behaviour changed"
+
+    migrated_streak = {"recall_skill": 0}
+    session._apply_error_tracking(body, "recall_skill", migrated_streak, set(), ok=False)
+    assert migrated_streak["recall_skill"] == 1
+
+
+def test_two_consecutive_migrated_failures_nudge_the_model_accepted():
+    """ACCEPTED CONSEQUENCE, asserted rather than discovered.
+
+    At `resilience_nudge_at` the tool result gains advice text the model reads.
+    For a call that cannot succeed on retry — no label supplied — that is the
+    intended outcome of the migration.
+    """
+    session = _bare_session()
+    body = "ERROR: recall_skill requires a non-empty 'label' parameter."
+    streak: dict[str, int] = {}
+    nudged: set[str] = set()
+
+    first = session._apply_error_tracking(body, "recall_skill", streak, nudged, ok=False)
+    assert streak["recall_skill"] == 1
+    assert first == body, "no nudge before the threshold"
+
+    second = session._apply_error_tracking(body, "recall_skill", streak, nudged, ok=False)
+    assert streak["recall_skill"] == session._resilience_nudge_at
+    assert len(second) > len(body), "the nudge is appended to what the model reads"
+    assert "recall_skill" in nudged
+
+
+def test_five_consecutive_migrated_failures_trip_the_breaker_accepted():
+    """ACCEPTED CONSEQUENCE: at `max_consecutive_errors` the model is told to stop."""
+    session = _bare_session()
+    body = "ERROR: recall_skill requires a non-empty 'label' parameter."
+    streak: dict[str, int] = {}
+    nudged: set[str] = set()
+
+    out = body
+    for _ in range(session._max_consecutive_errors):
+        out = session._apply_error_tracking(body, "recall_skill", streak, nudged, ok=False)
+
+    assert streak["recall_skill"] == session._max_consecutive_errors
+    assert "Stop retrying this approach" in out
+    assert f"failed {session._max_consecutive_errors} times" in out
+
+
+def test_one_success_clears_a_streak_built_from_migrated_failures():
+    """The streak is consecutive, so the blast radius of tier 2 is bounded.
+
+    Without this, "two failures nudge" reads as a permanent state. It is not:
+    a single success resets the counter AND re-arms the nudge.
+    """
+    session = _bare_session()
+    fail = "ERROR: recall_skill requires a non-empty 'label' parameter."
+    streak: dict[str, int] = {}
+    nudged: set[str] = set()
+    for _ in range(3):
+        session._apply_error_tracking(fail, "recall_skill", streak, nudged, ok=False)
+    assert streak["recall_skill"] == 3 and "recall_skill" in nudged
+
+    session._apply_error_tracking("# Skill recalled: `x`", "recall_skill",
+                                  streak, nudged, ok=True)
+    assert streak["recall_skill"] == 0
+    assert "recall_skill" not in nudged
+
+
+# ── Tier 3: the deliberately-unmigrated returns ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_no_match_family_is_still_unverdicted_on_purpose():
+    """Tier 3 must stay `ok=None` — a bare string, not a ToolOutcome.
+
+    `NO MATCH` is the most common non-success on the highest-volume tool. If a
+    later change quietly gives it a verdict, normal skill exploration starts
+    feeding the breaker, and this test is the thing that notices.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from anton.core.memory.skills import SkillStore
+    from anton.core.tools.recall_skill import handle_recall_skill
+
+    with tempfile.TemporaryDirectory() as tmp:
+        store = SkillStore(root=Path(tmp) / "skills")
+        # Same minimal shape `test_recall_skill.py::_session_with` uses.
+        session = SimpleNamespace(_skill_store=store)
+        result = await handle_recall_skill(session, {"label": "does_not_exist"})
+
+    assert not isinstance(result, ToolOutcome), (
+        "NO MATCH gained a verdict — see the tier-3 comment in recall_skill.py; "
+        "this needs its own ticket and a before/after on the nudge rate"
+    )
+    assert "NO MATCH" in result
+
+
+# ── The migrated handlers themselves, end to end ─────────────────────
+#
+# The tests above pin the MECHANISM (`_apply_error_tracking`). These pin the
+# handlers: that each one emits the verdict the tier table claims, and that the
+# text the model reads is byte-identical to what it read before the migration.
+
+
+def _read_image(tmp_path, **args):
+    import asyncio
+
+    from anton.core.tools.tool_handlers import handle_read_image
+
+    session = SimpleNamespace(_workspace=SimpleNamespace(base=tmp_path))
+    return asyncio.run(handle_read_image(session, args))
+
+
+# A real 1x1 PNG, so the success path runs the whole base64/media-type chain
+# rather than a mocked stand-in.
+_PNG_1X1 = bytes.fromhex(
+    "89504e470d0a1a0a0000000d4948445200000001000000010806000000"
+    "1f15c4890000000d4944415478da63f8ffff3f0005fe02fea735d18b00"
+    "00000049454e44ae426082"
+)
+
+
+@pytest.mark.parametrize("args, expected_text, expected_reason", [
+    ({}, "Error: file_path is required.", "missing_name"),
+    ({"file_path": "  "}, "Error: file_path is required.", "missing_name"),
+])
+def test_read_image_malformed_calls_are_failures_with_the_same_text(
+    tmp_path, args, expected_text, expected_reason
+):
+    outcome = _read_image(tmp_path, **args)
+    assert outcome.content == expected_text       # unchanged for the model
+    assert outcome.ok is False                    # newly visible to the streak
+    assert outcome.reason == expected_reason
+
+
+def test_read_image_absent_file_is_a_failure_that_cannot_trip_the_breaker(tmp_path):
+    """`ok=False` for the streak, TIER_SELF for the ledger — both deliberate.
+
+    The streak SHOULD climb: re-reading a path that does not exist is thrash.
+    The root-cause ledger should NOT, because the agent chose the path and can
+    list the directory — resolving away from `external_wall` exactly as
+    `artifact_not_found` does.
+    """
+    from anton.core.root_cause import classify
+
+    outcome = _read_image(tmp_path, file_path="nope.png")
+    assert outcome.ok is False
+    assert outcome.content.startswith("Error: file not found: ")
+    assert not classify(outcome.reason).trip_eligible
+
+
+def test_read_image_a_non_image_is_a_failure_the_model_can_fix(tmp_path):
+    from anton.core.root_cause import classify
+
+    (tmp_path / "notes.txt").write_text("not a picture")
+    outcome = _read_image(tmp_path, file_path="notes.txt")
+    assert outcome.ok is False
+    assert "is not a supported image format" in outcome.content
+    assert not classify(outcome.reason).trip_eligible
+
+
+def test_read_image_success_is_the_same_content_blocks_plus_a_verdict(tmp_path):
+    (tmp_path / "shot.png").write_bytes(_PNG_1X1)
+    outcome = _read_image(tmp_path, file_path="shot.png")
+
+    assert outcome.ok is True
+    # The model's view is unchanged: the same two blocks, same order.
+    assert isinstance(outcome.content, list)
+    assert [b["type"] for b in outcome.content] == ["image", "text"]
+    assert outcome.content[0]["source"]["media_type"] == "image/png"
+    assert outcome.content[1]["text"].startswith("Loaded shot.png (")
+
+
+def test_read_image_never_pairs_a_list_with_a_failure_verdict():
+    """The seam that keeps two documented gaps unreachable.
+
+    Both tool loops' list arms skip the nudge/breaker TEXT and skip
+    `_record_root_cause` (see the NOTE at session.py's non-streaming list arm
+    and `_tool_failure_cause`'s docstring). A handler returning
+    `ToolOutcome(content=[...], ok=False)` would therefore climb the streak,
+    trip nothing the model can see, and put a cause on no turn tally.
+
+    `read_image` is the first and only multimodal handler, and it returns a
+    list ONLY on success. This is an AST scan rather than a call-path test
+    because the property worth protecting is "nobody writes that shape",
+    across the whole tree — not "today's inputs don't reach it".
+    """
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "anton"
+    offenders = []
+    for path in root.rglob("*.py"):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "ToolOutcome"):
+                continue
+            kwargs = {kw.arg: kw.value for kw in node.keywords}
+            content = kwargs.get("content")
+            if not isinstance(content, (ast.List, ast.ListComp)):
+                continue
+            ok = kwargs.get("ok")
+            if not (isinstance(ok, ast.Constant) and ok.value is True):
+                offenders.append(f"{path.name}:{node.lineno}")
+
+    assert not offenders, (
+        "multimodal ToolOutcome without ok=True: " + ", ".join(offenders)
+        + " — a list result must be a success, or the list arms of both tool "
+          "loops must first learn to append the nudge and record the cause"
+    )
+
+
+def _skill_draft(tmp_path, store=None, **args):
+    import asyncio
+
+    from anton.core.tools.skill_draft import handle_create_skill_draft
+
+    session = SimpleNamespace(_skill_drafts_root=tmp_path, _skill_store=store)
+    return asyncio.run(handle_create_skill_draft(session, args))
+
+
+def test_create_skill_draft_success_is_a_verdict_over_the_same_json(tmp_path):
+    import json
+
+    outcome = _skill_draft(tmp_path / "drafts", name="Competitive Analysis")
+    assert outcome.ok is True
+    payload = json.loads(outcome.content)        # still the same JSON envelope
+    assert "skill_file" in payload and "error" not in payload
+
+
+def test_create_skill_draft_with_no_store_is_an_accepted_wall(tmp_path):
+    """The one tier-2 case in this PR that IS trip-eligible, stated on purpose.
+
+    No drafts root means the host wired no store: no argument the agent can
+    pass will work, and `store_unavailable` was already TIER_WALL before this
+    PR (`recall_skill` uses it). So five of these in a row can trip the
+    breaker — which is the correct outcome for a capability that is absent.
+    """
+    from anton.core.root_cause import classify
+
+    outcome = _skill_draft(None, name="anything")
+    assert outcome.ok is False
+    assert "unavailable" in outcome.content
+    assert classify(outcome.reason).trip_eligible

--- a/tests/test_tool_verdict_migration.py
+++ b/tests/test_tool_verdict_migration.py
@@ -191,6 +191,82 @@ async def test_the_no_match_family_is_still_unverdicted_on_purpose():
     assert "NO MATCH" in result
 
 
+async def test_every_no_match_branch_is_unverdicted_not_just_the_empty_store():
+    """The test above pins ONE input; `recall_skill` has three NO MATCH exits.
+
+    Found by mutation (#435 review): inserting a verdict at the *third* branch
+    survived the whole suite, because the test above only ever reaches the
+    first. A verdict added to a sibling — the fuzzy-match path especially —
+    would have shipped unnoticed on a tool called ~1,150 times a month.
+
+    The three exits, and what reaches each:
+
+      1. empty store            -> "…the procedural memory is empty."
+      2. populated, no near-miss -> "…Available skills: …"
+      3. near-miss found, load   -> "…the closest candidate '…' could not be
+         returns None               loaded."   (a race or filesystem flake)
+    """
+    import tempfile
+    from pathlib import Path
+
+    from anton.core.memory.skills import Skill, SkillStore
+    from anton.core.tools.recall_skill import handle_recall_skill
+
+    def _skill(label):
+        return Skill(
+            label=label,
+            name=label.replace("-", " ").title(),
+            description="fixture",
+            declarative_md="1. do it",
+            created_at="2026-01-01T00:00:00+00:00",
+            provenance="manual",
+        )
+
+    results = {}
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "skills"
+
+        # 1 — nothing stored at all.
+        empty = SkillStore(root=root)
+        results["empty_store"] = await handle_recall_skill(
+            SimpleNamespace(_skill_store=empty), {"label": "does_not_exist"}
+        )
+
+        # 2 — something stored, but nothing close enough to suggest.
+        populated = SkillStore(root=root)
+        populated.save(_skill("csv-summary"))
+        results["no_near_miss"] = await handle_recall_skill(
+            SimpleNamespace(_skill_store=populated),
+            {"label": "zzzzzzzzzzzzzzz"},
+        )
+        assert populated.closest_match("zzzzzzzzzzzzzzz") is None, (
+            "fixture drift: this label must be too far to suggest, or the test "
+            "silently exercises the fuzzy-match path instead"
+        )
+
+        # 3 — a near-miss IS found, but loading it fails underneath us.
+        flaky = SkillStore(root=root)
+        flaky.save(_skill("csv-summary"))
+        assert flaky.closest_match("csv-summry") == "csv-summary", (
+            "fixture drift: this label must be close enough to suggest"
+        )
+        flaky.load = lambda *_a, **_k: None          # the race, forced
+        results["load_race"] = await handle_recall_skill(
+            SimpleNamespace(_skill_store=flaky), {"label": "csv-summry"}
+        )
+
+    for case, result in results.items():
+        assert not isinstance(result, ToolOutcome), (
+            f"the '{case}' NO MATCH branch gained a verdict — see the tier-3 "
+            "comment in recall_skill.py; a verdict on any of these pushes "
+            "normal skill exploration into the error streak"
+        )
+        assert "NO MATCH" in result, (case, result)
+
+    # …and they really are three DIFFERENT exits, not one branch reached thrice.
+    assert len(set(results.values())) == 3, results
+
+
 # ── The migrated handlers themselves, end to end ─────────────────────
 #
 # The tests above pin the MECHANISM (`_apply_error_tracking`). These pin the
@@ -340,3 +416,116 @@ def test_create_skill_draft_with_no_store_is_an_accepted_wall(tmp_path):
     assert outcome.ok is False
     assert "unavailable" in outcome.content
     assert classify(outcome.reason).trip_eligible
+
+
+# ── The seam guard: the nineteenth handler must arrive LOUDLY ────────
+
+
+#: EVERY module-level handler under `anton/core/tools/`, as of ENG-2248.
+#: Pinning only the verdict-declaring set is not enough: a new handler with no
+#: verdicts at all is absent from that set, so it slips through silently —
+#: which is the precise failure this guard exists to prevent. Mutation-checked
+#: both ways (a new handler; a migrated one regressing to bare returns).
+_ALL_HANDLERS = frozenset({
+    "handle_ask_user",
+    "handle_create_artifact",
+    "handle_create_skill_draft",
+    "handle_launch_backend",
+    "handle_list_artifacts",
+    "handle_memorize",
+    "handle_open_artifact",
+    "handle_read_image",
+    "handle_recall",
+    "handle_recall_skill",
+    "handle_scratchpad",
+    "handle_select_path",
+    "handle_update_artifact_metadata",
+    "handle_web_fetch_fallback",
+    "handle_web_search_fallback",
+})
+
+#: The subset of the above that declares at least one explicit `ToolOutcome`
+#: verdict. Not a wish list — a lock.
+_VERDICT_DECLARING_HANDLERS = frozenset({
+    "handle_create_skill_draft",
+    "handle_list_artifacts",
+    "handle_memorize",
+    "handle_open_artifact",
+    "handle_read_image",
+    "handle_recall_skill",
+    "handle_scratchpad",          # partially migrated before this ticket
+})
+
+
+def test_the_set_of_verdict_declaring_handlers_is_pinned():
+    """ENG-2248's durable half: a new handler cannot arrive silently unverdicted.
+
+    The ticket asked for "an AST seam guard [that] fails when a handler returns
+    a bare value where a `ToolOutcome` is expected". Taken literally that guard
+    cannot exist while this migration is deliberately partial — 11 handlers are
+    still unmigrated on purpose, and three MIGRATED ones keep bare tier-3
+    returns by design (`recall_skill`'s NO MATCH family, `open_artifact`'s "no
+    artifact found", `memorize`'s "encoding is disabled"). A guard that failed
+    on a bare return would fail on all of those on day one.
+
+    So it is inverted into an inventory lock, which gets the property the
+    ticket actually wanted — the nineteenth handler arrives LOUDLY — without
+    requiring the migration to be finished first. It fails when:
+
+      * a NEW handler is added without a verdict (not in the set),
+      * a migrated handler REGRESSES to all-bare returns,
+      * a handler is migrated without saying so here (a one-line, deliberate
+        update, and the moment to check the tier table on the ticket).
+
+    Scoped to `anton/core/tools/` — the package the tool registry dispatches
+    into. Module-level functions only, so `HTMLParser.handle_data` and friends
+    in the web-fetch parser are not mistaken for tool handlers.
+    """
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "anton" / "core" / "tools"
+    declaring: set[str] = set()
+    seen: set[str] = set()
+
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in tree.body:                     # module level only
+            if not (isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and node.name.startswith("handle_")):
+                continue
+            seen.add(node.name)
+            for ret in ast.walk(node):
+                if (isinstance(ret, ast.Return)
+                        and isinstance(ret.value, ast.Call)
+                        and getattr(ret.value.func, "id", "") == "ToolOutcome"):
+                    declaring.add(node.name)
+                    break
+
+    assert seen, "the AST scan found no handlers at all — the guard is vacuous"
+
+    # 1. The census. This is the half that catches the nineteenth handler:
+    #    one with NO verdicts is absent from `declaring`, so checking only the
+    #    declaring set lets it through (measured — the first version of this
+    #    guard did exactly that).
+    added = seen - _ALL_HANDLERS
+    removed = _ALL_HANDLERS - seen
+    assert not (added or removed), (
+        f"the handler census moved. Added: {sorted(added)}. "
+        f"Removed: {sorted(removed)}. A NEW handler must make a deliberate "
+        "tier decision before it ships — tier 1 verified success, tier 2 "
+        "indisputable failure, tier 3 ambiguous and left `ok=None` WITH a "
+        "comment saying why. Then add it to `_ALL_HANDLERS`, and to "
+        "`_VERDICT_DECLARING_HANDLERS` if it declares one."
+    )
+
+    # 2. The verdict subset, so a migrated handler cannot quietly regress.
+    gained = declaring - _VERDICT_DECLARING_HANDLERS
+    lost = _VERDICT_DECLARING_HANDLERS - declaring
+    assert not (gained or lost), (
+        f"the verdict inventory moved. Newly declaring: {sorted(gained)}. "
+        f"No longer declaring: {sorted(lost)}. If you migrated a handler, add "
+        "it here and record its tier decisions on ENG-2248. If a handler "
+        "STOPPED declaring, that is a regression — an unverdicted result is "
+        "classified by the ENG-1276 substring fallback, not by the handler."
+    )


### PR DESCRIPTION
## What

18 of 27 tools never declare success or failure. **3,038 of 18,108 `tool_completed` rows in the last 30 days carry `ok="unknown"` (16.8%)**, and for every one of them the ENG-1276 substring fallback — not the handler — decides whether the agent's error streak climbs.

This migrates the six highest-volume anton handlers to an explicit `ToolOutcome` verdict: `recall_skill` (1,153 calls), `open_artifact` (279), `list_artifacts` (273), `memorize` (129), `read_image` (128), `create_skill_draft` (72). Together **2,034 of the 3,038 unknown rows**.

## This is not a measurement-only change

The ticket originally said it was. That was wrong, and it has been corrected.

`_apply_error_tracking` opens with `if ok is not None:` and uses the handler's verdict **directly** to drive `error_streak[tool_name]`, which fires the resilience nudge at 2 and the circuit breaker at 5. Every `ok=` added here is a behaviour decision. So the migration is tiered on purpose:

| Tier | What | Verdict | Behaviour |
|---|---|---|---|
| 1 | Verified successes | `ok=True` | **Free.** The legacy matcher finds none of its five markers in a success body, so the streak reset either way. Proven, not asserted — see below. |
| 2 | Indisputable failures | `ok=False` | **A real change, accepted.** The call cannot succeed on retry, so it belongs in the streak. |
| 3 | Ambiguous outcomes | left `ok=None` | `recall_skill`'s three `NO MATCH` returns, `open_artifact`'s "no artifact found", `memorize`'s "Memory encoding is disabled" — each with a comment saying why. These keep reporting `unknown`. |

The tier-3 line is the one worth arguing about. `NO MATCH` is not a failure: the response *lists the skills that do exist* and tells the model to proceed without one. Giving it `ok=False` would mean five consecutive "no skill for this" answers trip the breaker on an agent that is working fine.

## `read_image` — the tree's first multimodal verdict

`read_image` returns a `list[dict]` (image block + text block) on success. It now returns `ToolOutcome(content=[...], ok=True)`, and it must stay `ok=True`.

Both tool loops' list arms skip the nudge/breaker **text** and skip `_record_root_cause` — documented in the NOTE at `session.py`'s non-streaming list arm and in `_tool_failure_cause`'s docstring, which calls the shape "unreachable today". A handler returning a list with `ok=False` would climb the streak, trip nothing the model can see, and put a cause on no turn tally. Every failure branch in `read_image` returns a plain string, and `test_read_image_never_pairs_a_list_with_a_failure_verdict` is an AST scan that keeps that shape shut tree-wide rather than relying on today's inputs not reaching it.

## Tests

`tests/test_tool_verdict_migration.py` — 15 tests that state both directions explicitly instead of leaving them to be discovered in production:

- each migrated success produces the **same streak outcome** and the **same result text** as the bare string did (tier 1 is free);
- a migrated failure **now reaches the streak where a bare string did not** (tier 2 is real);
- the **two-failure nudge** and **five-failure breaker** are asserted as *accepted consequences*, named as such in the test names;
- one success clears a streak built from migrated failures;
- the `NO MATCH` family is asserted **still unverdicted on purpose** — so removing that deliberate gap fails a test rather than passing silently;
- `create_skill_draft` with no store is the one tier-2 case here that **is** trip-eligible (`store_unavailable` was already `TIER_WALL` before this PR), stated explicitly.

Seven mutations verified, each killed by the intended test: giving `NO MATCH` a verdict, flipping a tier-1 success to `ok=False`, removing the nudge threshold, `read_image` success → `ok=False` on a list, `missing_file` remapped to `TIER_WALL`, `read_image` not-found reverted to a bare string, `create_skill_draft` success verdict dropped.

Full suite: **2,944 passed, 31 skipped.**

## What is still unknown after this — not complete, and not claimed to be

Projected residual **~1,004 rows (5.5%)**, by owner:

| Owner | Rows | Tools |
|---|---|---|
| **cowork-server** | 438 | `set_status` 216, `lookup_connector` 85, `request_credentials` 58, `report_success` 40, `report_failure` 25, `set_field_status` 11, `label_connection` 2, `request_extra_field` 1 |
| **anton, not yet migrated** | 532 | `scratchpad` 216 (1.5% of 14,315 — mostly verdicted already), `web_fetch` 95, `select_path` 81, `connect_new_datasource` 68, `ask_user` 38, `publish_or_preview` 34 |
| **unlocated** | 34 | `generate_artifact` 18, `generate_prd` 16 — no tool definition found in any repo in the workspace |

Two caveats stated rather than buried:

1. **5.5% is a floor.** The deliberate tier-3 branches inside the six migrated handlers keep emitting `unknown`, and their share of those 1,561 calls is not measurable from PostHog today — `unknown` rows carry no `reason`. The exact figure lands one release after this ships, when the `ok` column reports it directly.
2. `select_path` (81) and `ask_user` (38) are **deliberately deferred**. Both return through the shared `_status()` choke point at `tool_handlers.py:968`; migrating them means deciding a vocabulary for that helper, which is its own change and does not belong wedged into this one.

The cowork-server half is smaller than it looks, and **not** the same fix as this PR. Seven of its eight tools are the connector probe, and every one of those handlers returns the literal string `"ok"` — which contains none of the five legacy markers, so the substring fallback already classifies them correctly. For 293 of the 441 rows there is no behavioural harm, only a cosmetic `unknown` where PostHog could say `true`. The three non-probe tools (`lookup_connector` 87, `request_credentials` 59, `label_connection` 2) do return real error strings, some carrying no marker at all, so those failures read as successes and reset the streak — real, but confined to the error branches of ~148 rows a month.

**Correction to an earlier draft of this body.** It claimed this work also resolved the 490 unjoinable rows tracked in the measurement ticket for `tool_completed` — "same tools, same root cause". That is wrong. Those rows are unjoinable because they carry **no `conversation_id`** (the probe runs outside a turn), which is a different field from `ok`; a verdict migration fixes none of them. Measured:

```
tool                     no_cid   no_turn    rows
set_status                  216         0     216
report_success               40         0      40
report_failure               25         0      25
set_field_status             11         0      11
request_extra_field           1         0       1
lookup_connector              0         0      87
request_credentials           0         0      59
label_connection              0         0       2
TOTAL                       293         0     441
```

The two anomalies share a set of tools, not a fix. Tracked as notes on ENG-2301 rather than a separate ticket.

## Security

No new input reaches a shell, a filesystem path, or a log. The `reason` values are fixed literals from the closed `_SENTINEL_REASONS` vocabulary, never interpolated from tool input. The result text the model reads is byte-for-byte what it was before the migration, asserted per handler.

Linear: ENG-2248


