### PR TITLE
Fix the typo in datasource

### DIFF
--- a/anton/cli.py
+++ b/anton/cli.py
@@ -1741,7 +1741,7 @@ def test_data_source(
     scratchpads = _build_scratchpad_manager(settings)
 
     async def _run() -> None:
-        await _handle_test_datasource(console, scratchpads, name)
+        await handle_test_datasource(console, scratchpads, name)
         await scratchpads.close_all()
 
     _run_and_close(_run())


### PR DESCRIPTION
This PR fixes an issue where the cli.py calls the nonexistent _handle_test_datasource instead of the imported handle_test_datasource. Fix https://linear.app/mindsdb/issue/ENG-2294/anton-test-cli-command-crashes-with-nameerror