### PR TITLE
fix(yolo): degrade instead of crashing where no alarm can be armed

### DIFF
--- a/anton/core/yolo/workspace.py
+++ b/anton/core/yolo/workspace.py
@@ -126,7 +126,19 @@ def _time_limit(seconds: float):
 
     This works on a regex specifically because `sre` checks for pending
     signals while it matches — a plain thread could not interrupt it.
+
+    Where no alarm can be armed the block runs unguarded, because
+    `search` has already escaped the pattern to a literal and that is
+    what bounds the cost instead. Arming one anyway is not a stricter
+    reading of the same rule: `signal.signal` raises AttributeError on
+    Windows and ValueError off the main thread, and neither is a
+    TimeoutError, so the caller gets a crash where it expected a
+    degraded result.
     """
+    if not _can_interrupt():
+        yield
+        return
+
     def ring(*_):
         raise TimeoutError
 

--- a/tests/test_yolo_search.py
+++ b/tests/test_yolo_search.py
@@ -11,6 +11,7 @@ feed straight into the read set.
 
 from __future__ import annotations
 
+import threading
 import time
 from pathlib import Path
 
@@ -171,6 +172,35 @@ def test_search_takes_a_regular_expression(tmp_path: Path):
 
 def test_a_plain_word_is_still_a_valid_pattern(tmp_path: Path):
     assert haystack(tmp_path).search("Old Title").matches
+
+
+def test_search_degrades_where_no_alarm_can_be_armed(tmp_path: Path):
+    """`search` already declines to arm an alarm it cannot arm — off the
+    main thread, or on Windows, where SIGALRM does not exist — and escapes
+    the pattern to a literal for exactly those cases. Entering the limit
+    anyway raised ValueError (or AttributeError on Windows) out of every
+    search there, which is a crash where a degraded result was promised.
+
+    A worker thread reproduces it on any platform, so this holds the
+    alarm's availability as the only variable.
+    """
+    workspace = haystack(tmp_path)
+    box: dict[str, object] = {}
+
+    def run():
+        try:
+            box["result"] = workspace.search("Old Title")
+        except BaseException as error:  # the bug is that anything is raised
+            box["error"] = error
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    worker.join(timeout=30)
+
+    assert "error" not in box, f"search raised: {box['error']!r}"
+    result = box["result"]
+    assert [m.path for m in result.matches] == ["c.js"]
+    assert "searched literally" in result.note
 
 
 def test_an_invalid_pattern_comes_back_as_feedback_not_a_crash(tmp_path: Path):


### PR DESCRIPTION
`_time_limit` arms a SIGALRM unconditionally, so every `search` on Windows or off the main thread raises instead of returning a result:

```
AttributeError: module 'signal' has no attribute 'SIGALRM'
```

`search` already anticipates this. It calls `_can_interrupt()` and escapes the pattern to a literal when no alarm is available, so the cost is bounded without one. `_time_limit` was the only place that armed the alarm without asking first, and neither `AttributeError` nor the `ValueError` you get off the main thread is a `TimeoutError`, so the caller sees a crash where a degraded result was promised.

The fix is that same `_can_interrupt()` check, one call earlier.

`tests/test_yolo_search.py` on Windows goes from 1 passed / 15 failed to 12 passed / 5 failed, with no test failing that passed before. The new test uses a worker thread, so it reproduces on Linux and macOS too, holding the alarm's availability as the only variable.

The 5 that still fail are a different problem and fail identically without this change: they pass real regexes and expect regex semantics, which the literal-escaping path cannot give them. Worth its own issue; this only stops the crash.
