### PR TITLE
ci: build the staging and production scratchpad images from the release pipelines (ENG-2129)

### DIFF
--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,28 +1,13 @@
 name: Staging pre-release and publish to PyPI
 
-# rc pre-release stream: on every push to staging, validate, cut a PEP 440
-# pre-release (2.YY.M.DD.SEQrcN), and publish it to PyPI so cowork-server staging
-# consumes an immutable, versioned Anton artifact instead of a mutable git branch
-# or a hand-pinned commit (ENG-1159). Resolvers ignore pre-releases unless a
-# specifier names one, and PyPI's `info.version` (which the prod desktop updater
-# reads) excludes them, so prod installs can never pick these up.
+# On every push to staging: run the tests, cut a PEP 440 rc pre-release
+# (2.YY.M.DD.SEQrcN) and publish it to PyPI (ENG-1159). Resolvers skip
+# pre-releases unless a specifier names one, so prod installs never pick these up.
 #
-# The publish job MUST live in this top-level workflow — PyPI Trusted Publishing
-# does not support reusable workflows and matches the OIDC claim on THIS
-# filename. Register publish-staging.yml as a trusted publisher (environment
-# `pypi`) at the anton-agent PyPI project's publishing settings.
-#
-# Anton has nothing to self-pin (it does not depend on itself) — unlike
-# cowork-server's staging publisher — so this builds from a clean checkout of
-# the tag. It still pins the build to the version the release job just minted
-# (SETUPTOOLS_SCM_PRETEND_VERSION on the build step): a re-run or re-dispatch on
-# an already-tagged head leaves two rc tags on one commit, and hatch-vcs would
-# otherwise resolve the older one via `git describe` and build a duplicate PyPI
-# rejects. release.yml pins the same way for the same reason.
-#
-# No workflow-level `permissions:` block: only the release job needs
-# `contents: write`; every other job declares its own, so the repo default
-# (read) applies to the rest.
+# The publish job stays in this top-level file: PyPI Trusted Publishing matches
+# the OIDC claim on this filename. The build pins SETUPTOOLS_SCM_PRETEND_VERSION
+# to the version just minted so a re-run on an already-tagged head does not
+# describe to the older tag.
 #
 # run-tree-ok: PyPI Trusted Publishing binds to this top-level workflow file.
 

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -53,6 +53,17 @@ jobs:
       prerelease: true
       runs-on: ubuntu-latest
 
+  # The worker image staging scratchpad-controller and the PR environments pull
+  # as minds-anton-scratchpad:staging (ENG-2129).
+  scratchpad-image:
+    needs: release
+    permissions:
+      contents: read
+    uses: ./.github/workflows/scratchpad-dev-build.yml
+    with:
+      environment: staging
+      version: ${{ needs.release.outputs.version }}
+
   publish:
     name: Build and publish pre-release to PyPI
     needs: release
@@ -91,7 +102,7 @@ jobs:
     # One job covers both outcomes: a `uses:` job cannot branch on status, so
     # the aggregate result picks the failed or recovered message, and a
     # cancelled run stays silent.
-    needs: [unit-tests, release, publish]
+    needs: [unit-tests, release, scratchpad-image, publish]
     if: ${{ github.ref == 'refs/heads/staging' && !cancelled() && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,19 @@ jobs:
       version: ${{ needs.auto-release.outputs.version }}
     secrets: inherit
 
+  # The worker image prod scratchpad-controller pulls as
+  # minds-anton-scratchpad:production (ENG-2129). Gated on verify-wheel like
+  # the PyPI publish: pods pull the moving tag on their next start, so a bad
+  # image reaches users as fast as a bad wheel would.
+  scratchpad-image:
+    needs: [auto-release, verify-wheel]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/scratchpad-dev-build.yml
+    with:
+      environment: production
+      version: ${{ needs.auto-release.outputs.version }}
+
   publish:
     name: Publish to PyPI
     # Gated on verify-wheel: a PyPI upload cannot be withdrawn.
@@ -84,7 +97,7 @@ jobs:
     # One job covers both outcomes: a `uses:` job cannot branch on status, so
     # the aggregate result picks the failed or recovered message, and a
     # cancelled run stays silent.
-    needs: [unit-tests, auto-release, verify-wheel, publish]
+    needs: [unit-tests, auto-release, verify-wheel, scratchpad-image, publish]
     if: ${{ github.ref == 'refs/heads/main' && !cancelled() && !contains(needs.*.result, 'cancelled') }}
     permissions:
       contents: read

--- a/.github/workflows/scratchpad-dev-build.yml
+++ b/.github/workflows/scratchpad-dev-build.yml
@@ -45,43 +45,9 @@ defaults:
 
 jobs:
 
-  # One gate answering "may this pull request reach the cluster-side build".
-  #
-  # This repo is PUBLIC and `mdb-dev` is a pod inside the newdev cluster with IRSA
-  # into the build/ECR account, so without a guard a pull request from any GitHub
-  # account executes its own code there. Fork PRs get no secrets and a read-only
-  # token, but the runner itself is the prize: cloud credentials, a network
-  # position inside the cluster, and a tool cache later internal jobs reuse.
-  # GitHub's first-time-contributor approval does not cover anyone with a merged
-  # PR, and the approval a maintainer clicks is a courtesy extended before anyone
-  # has read the Dockerfile.
-  #
-  # Four answers, not two. A `workflow_call` run carries `inputs.environment`
-  # and is let through first: the only callers are release.yml and
-  # publish-staging.yml, which run on pushes to main and staging, so the tree
-  # being built is one this repository's branch protection already admitted.
-  # Any workflow a fork can trigger that calls this one has to carry its own
-  # gate; test_fork_build_gate.py's sweep resolves through local `uses:` and
-  # fails it otherwise.
-  #
-  # Then `HEAD_REPO` is read from the pull request payload, so on any other
-  # event it is the empty string and compares unequal, which would skip the
-  # build and tell the run page that a fork was responsible. The same trap is
-  # written up on the `Decide whether live mode is required` step in
-  # verifier-eval.yml, which met it from the other direction. So the event is
-  # checked before the repository and gets its own message: adding a trigger
-  # to this workflow stops the build until somebody says how the gate should
-  # read it.
-  #
-  # The `version` job below stays ungated on purpose. It runs on a GitHub-hosted
-  # runner holding no credentials, and a hosted runner executing a fork's code is
-  # what every fork pull request in the world already does.
-  #
-  # Unlike the same gate in cowork and cowork-server, this one does NOT skip a
-  # `staging` -> `main` promotion PR. There those rebuild an image the release
-  # pipeline already produced; here this workflow is the only thing that builds
-  # minds-anton-scratchpad at all, so skipping a promotion would leave that commit
-  # with no image.
+  # Who may reach the self-hosted build runner: pull requests from branches in
+  # this repository, and calls from the release pipelines. Anything else is
+  # refused with a run-summary line saying why.
   gate:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/scratchpad-dev-build.yml
+++ b/.github/workflows/scratchpad-dev-build.yml
@@ -1,11 +1,21 @@
-name: Scratchpad image - Dev build on PR
+name: Scratchpad image build
 
-# Builds and pushes the minds-anton-scratchpad image (the sandbox pod image) to ECR as
-# development-<sha>, on every pull request whose branch lives in this repository. No label
-# is required and none is checked: `labeled` sits in the trigger list so that adding one
-# rebuilds. The scratchpad-controller references the resulting tag via
-# SCRATCHPAD_CONTROLLER__SCRATCHPAD_IMAGE; there is no Helm chart for this image, so this
-# workflow only builds and scans (no deploy job).
+# Builds and pushes the minds-anton-scratchpad image (the sandbox pod image) to ECR.
+# Two ways in:
+#
+#   - Every pull request whose branch lives in this repository builds for the
+#     `development` environment. No label is required and none is checked:
+#     `labeled` sits in the trigger list so that adding one rebuilds.
+#   - release.yml and publish-staging.yml call this workflow after they mint a
+#     tag, building for `production` and `staging` respectively (ENG-2129).
+#
+# The shared build-push-ecr action tags every build three ways:
+# `<env>-<sha>`, `<env>-head-<pr head sha>` (pull requests only), and the
+# moving `<env>` tag. scratchpad-controller points each environment's
+# SCRATCHPAD_CONTROLLER__SCRATCHPAD_IMAGE at the moving tag and pulls with
+# imagePullPolicy Always, so a release reaches worker pods without anyone
+# editing a sha into a values file. There is no Helm chart for this image, so
+# this workflow only builds (no deploy job).
 #
 # The image is smoke-tested inside the build, not here: the Dockerfile's last layer runs
 # docker/image_smoke.py as UID 1000, which executes both entrypoints the controller execs.
@@ -15,6 +25,16 @@ name: Scratchpad image - Dev build on PR
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
+  workflow_call:
+    inputs:
+      environment:
+        description: "build-push-ecr environment: staging or production. Pull requests build development."
+        type: string
+        required: true
+      version:
+        description: "The anton version the image reports; the tag the caller just minted."
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -22,10 +42,6 @@ permissions:
 defaults:
   run:
     shell: bash
-
-concurrency:
-  group: ${{ github.workflow_ref }}
-  cancel-in-progress: true
 
 jobs:
 
@@ -40,13 +56,22 @@ jobs:
   # PR, and the approval a maintainer clicks is a courtesy extended before anyone
   # has read the Dockerfile.
   #
-  # Three answers, not two. `HEAD_REPO` is read from the pull request payload, so
-  # on any other event it is the empty string and compares unequal, which would
-  # skip the build and tell the run page that a fork was responsible. The same
-  # trap is written up on the `Decide whether live mode is required` step in
+  # Four answers, not two. A `workflow_call` run carries `inputs.environment`
+  # and is let through first: the only callers are release.yml and
+  # publish-staging.yml, which run on pushes to main and staging, so the tree
+  # being built is one this repository's branch protection already admitted.
+  # Any workflow a fork can trigger that calls this one has to carry its own
+  # gate; test_fork_build_gate.py's sweep resolves through local `uses:` and
+  # fails it otherwise.
+  #
+  # Then `HEAD_REPO` is read from the pull request payload, so on any other
+  # event it is the empty string and compares unequal, which would skip the
+  # build and tell the run page that a fork was responsible. The same trap is
+  # written up on the `Decide whether live mode is required` step in
   # verifier-eval.yml, which met it from the other direction. So the event is
-  # checked first and gets its own message: adding a trigger to this workflow
-  # stops the build until somebody says how the gate should read it.
+  # checked before the repository and gets its own message: adding a trigger
+  # to this workflow stops the build until somebody says how the gate should
+  # read it.
   #
   # The `version` job below stays ungated on purpose. It runs on a GitHub-hosted
   # runner holding no credentials, and a hosted runner executing a fork's code is
@@ -62,15 +87,19 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - name: Decide whether this pull request may reach the runner
+      - name: Decide whether this run may reach the runner
         id: decide
         env:
           IS_PR: ${{ github.event_name == 'pull_request' }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           THIS_REPO: ${{ github.repository }}
+          # Empty on every event except a workflow_call from a release pipeline.
+          CALLED_FOR: ${{ inputs.environment }}
         run: |
           set -euo pipefail
-          if [ "$IS_PR" != "true" ]; then
+          if [ -n "${CALLED_FOR:-}" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "$IS_PR" != "true" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             {
               echo "### Build skipped: this run is not a pull request"
@@ -100,21 +129,30 @@ jobs:
   # dependency in front of the image. And keeping it separate leaves the build's
   # checkout shallow: .git never enters the docker context (see .dockerignore),
   # so only this job needs the history.
+  #
+  # A release pipeline passes the version it just minted instead, for the same
+  # reason publish-staging.yml pins SETUPTOOLS_SCM_PRETEND_VERSION: a re-run on
+  # an already-tagged head leaves two tags on one commit, and `git describe`
+  # would resolve the older. The shape checks below run on both paths.
   version:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.resolve.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+        if: inputs.version == ''
         with:
           # hatch-vcs derives the version by describing against tags, and the
           # default fetch-depth of 1 fetches none of them.
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
+        if: inputs.version == ''
         with:
           python-version: "3.12"
       - id: resolve
         name: Resolve the anton version from tags
+        env:
+          PINNED_VERSION: ${{ inputs.version }}
         # The image reported a hardcoded 2.0.0 until 2026-08-26, so a pod turn
         # could not say which anton served it and bumping the image pin produced
         # no observable change at all.
@@ -129,7 +167,7 @@ jobs:
           # `tail -n 1`: hatch prints progress to stderr today, but a stray line
           # on stdout would otherwise ride along into $GITHUB_OUTPUT, where a
           # second line is parsed as another key=value pair rather than failing.
-          version="$(uvx hatch version | tail -n 1)"
+          version="${PINNED_VERSION:-$(uvx hatch version | tail -n 1)}"
 
           # Whole-line match, PEP 440 characters only. This is a boundary, not a
           # formatting nicety: the shared action expands `extra-build-args`
@@ -161,6 +199,14 @@ jobs:
     needs: [version, gate]
     if: needs.gate.outputs.run == 'true'
     runs-on: mdb-dev
+    # Job-level rather than workflow-level so it holds when this workflow is
+    # called: a pull request cancels its own superseded build; a release build
+    # queues behind the previous one for the same environment and is never
+    # cancelled, because a half-finished push has already moved nothing but a
+    # cancelled one leaves the release without an image.
+    concurrency:
+      group: scratchpad-image-${{ inputs.environment || github.workflow_ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     outputs:
       image: ${{ steps.build.outputs.image }}
     env:
@@ -174,7 +220,7 @@ jobs:
         with:
           # Override the repo-slug default so the image lands at .../minds-anton-scratchpad.
           module-name: minds-anton-scratchpad
-          build-for-environment: development
+          build-for-environment: ${{ inputs.environment || 'development' }}
           # Expanded unquoted by the shared action, so the value must not contain
           # whitespace — a PEP 440 version never does, and the shape check in the
           # `version` job would have rejected it.

--- a/tests/test_fork_build_gate.py
+++ b/tests/test_fork_build_gate.py
@@ -162,7 +162,11 @@ def _decide_step(workflow: dict) -> dict:
 
 
 def _run_the_gate(
-    workflow: dict, tmp_path: Path, head_repo: str, is_pr: str = "true"
+    workflow: dict,
+    tmp_path: Path,
+    head_repo: str,
+    is_pr: str = "true",
+    called_for: str = "",
 ) -> _GateRun:
     """Execute the gate's real shell and hand back what it wrote."""
     script = tmp_path / "decide.sh"
@@ -180,6 +184,7 @@ def _run_the_gate(
             "IS_PR": is_pr,
             "HEAD_REPO": head_repo,
             "THIS_REPO": _THIS_REPO,
+            "CALLED_FOR": called_for,
             "GITHUB_OUTPUT": str(output),
             "GITHUB_STEP_SUMMARY": str(summary),
         },
@@ -252,6 +257,51 @@ def test_an_event_with_no_pull_request_is_refused_for_the_right_reason(
         "the run summary blames a fork on an event that has no pull request at "
         f"all: {run.summary.strip()!r}"
     )
+
+
+def test_a_release_pipeline_call_is_allowed(workflow: dict, tmp_path: Path) -> None:
+    """release.yml and publish-staging.yml call this workflow from a push.
+
+    A push carries no pull request, so the case above would refuse it. The
+    `environment` input is what says a release pipeline is asking, and those
+    only ever run on main and staging, whose trees branch protection admitted.
+    """
+    run = _run_the_gate(
+        workflow, tmp_path, head_repo="", is_pr="false", called_for="production"
+    )
+    assert run.outputs.get("run") == "true", (
+        "the gate refuses a release pipeline's call, so no release builds the "
+        "staging or production scratchpad image"
+    )
+
+
+# The release pipelines and the environment each one builds the image for. The
+# moving `<env>` tag scratchpad-controller pulls exists only because a caller
+# here names that environment (ENG-2129).
+_RELEASE_CALLERS = {"release.yml": "production", "publish-staging.yml": "staging"}
+
+
+def test_each_release_pipeline_builds_its_environment_image(
+    workflows: dict[str, dict],
+) -> None:
+    """Dropping the job, or its input, leaves that environment's tag frozen at
+    the last image anyone built, and nothing downstream notices."""
+    for filename, environment in _RELEASE_CALLERS.items():
+        callers = [
+            job
+            for job in (workflows[filename].get("jobs") or {}).values()
+            if str(job.get("uses", "")).endswith(_WORKFLOW.name)
+        ]
+        assert len(callers) == 1, f"{filename} must call {_WORKFLOW.name} exactly once"
+        passed = callers[0].get("with") or {}
+        built_for = passed.get("environment")
+        assert built_for == environment, (
+            f"{filename} builds the scratchpad image for {built_for!r}, not {environment!r}"
+        )
+        assert "outputs.version" in str(passed.get("version", "")), (
+            f"{filename} does not hand the minted version to the image build, so "
+            "a re-run on a tagged head would resolve the older tag"
+        )
 
 
 def test_the_gate_reads_the_head_repository_from_the_event(workflow: dict) -> None:


### PR DESCRIPTION
## What

Build `minds-anton-scratchpad` for staging and production from the release pipelines, so the moving `:staging` and `:production` ECR tags exist. Until now only pull requests built this image (`development-*` tags), and every environment's `SCRATCHPAD_CONTROLLER__SCRATCHPAD_IMAGE` was a sha typed by hand (ENG-2129, filed out of the 2026-08-31 outage in ENG-2126).

## How

`scratchpad-dev-build.yml` gains a `workflow_call` trigger with `environment` and `version` inputs. The existing build job is reused unchanged apart from `build-for-environment: ${{ inputs.environment || 'development' }}`; the shared `build-push-ecr` action already pushes the moving `<env>` tag on every build.

- `release.yml` calls it with `environment: production` after `verify-wheel`, the same gate the PyPI publish sits behind.
- `publish-staging.yml` calls it with `environment: staging` after the rc release.
- Both pass the version calver-release just minted, for the reason `publish-staging.yml` already pins `SETUPTOOLS_SCM_PRETEND_VERSION`: a re-run on a tagged head would otherwise `git describe` to the older tag. The version job skips its checkout when a version is passed and still runs the PEP 440 and 2.0.0 checks on it.
- The fork gate lets a `workflow_call` run through first. The only callers run on pushes to main and staging. The sweep in `test_fork_build_gate.py` still requires any fork-reachable workflow that calls this one to carry its own gate.
- Concurrency moves from workflow level to the build job so it holds when called: PR builds still cancel their superseded run; release builds queue per environment and are never cancelled.
- A `release: published` trigger was not an option: calver-release creates the release with `GITHUB_TOKEN`, and events raised by that token do not start workflows.

The filename stays `scratchpad-dev-build.yml`: two test modules and a scratchpad-controller values comment reference it.

## Tests

- `test_a_release_pipeline_call_is_allowed`: runs the gate shell with the input set and a non-PR event.
- `test_each_release_pipeline_builds_its_environment_image`: both pipelines call the build exactly once with the right environment and the minted version.

`uv run --group dev pytest tests/test_fork_build_gate.py tests/test_pod_image_version.py`: 21 passed. `actionlint` clean on the three workflows.

## Follow-up (not in this PR)

scratchpad-controller: `image_pull_policy="Always"` in `live_pod.py`, and point `values-staging.yaml` / `values-prod.yaml` and argocd-envs `scratchpadWorkerImage` at the moving tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
