### PR TITLE
ENG-1424: say which file publishes, once

### DIFF
--- a/anton/cli.py
+++ b/anton/cli.py
@@ -498,10 +498,31 @@ def _reconcile_publish_identity(settings) -> bool:
     # Any branch that tells the user which file publishing now uses has to
     # account for ~/.cowork/.env, which sits AFTER ~/.anton/.env in the chain
     # and silently outranks whatever we do here.
+    # `~/.cowork/.env` sits AFTER `~/.anton/.env` in the chain, so on a
+    # desktop-configured machine it outranks anything reconciliation does here.
+    #
+    # Two different things are needed from that fact, and conflating them is
+    # what this comment exists to prevent:
+    #
+    #   `publishes_from` — the file that will actually be used. A message that
+    #       states the active identity must name THIS, never `~/.anton/.env`
+    #       by assumption.
+    #   `outranked`      — the explanation, appended to a message whose own
+    #       sentence is about a FILE OPERATION ("moved X to Y") and so stays
+    #       true regardless of precedence.
+    #
+    # Appending `outranked` to a sentence that already asserts the active
+    # identity produces a message that contradicts itself — "Publishing now
+    # uses ~/.anton/.env" immediately followed by "publishing still uses that
+    # one" about a different file. ENG-1424 exists because nobody could tell
+    # which account publishes; answering that twice, differently, is the same
+    # defect in a new place.
+    cowork_key = vault_key(Path.home() / ".cowork" / ".env")
+    publishes_from = "~/.cowork/.env" if cowork_key else "~/.anton/.env"
     outranked = (
         "\n  (~/.cowork/.env also has a key and takes precedence,"
         "\n   so publishing still uses that one.)"
-        if vault_key(Path.home() / ".cowork" / ".env")
+        if cowork_key
         else ""
     )
 
@@ -544,10 +565,13 @@ def _reconcile_publish_identity(settings) -> bool:
                 f"ANTON_MINDS_API_KEY={project_key}\n",
             )
             project_ws.remove_secret("ANTON_MINDS_API_KEY")
+            # Names `publishes_from`, not `~/.anton/.env`, and carries no
+            # `outranked` suffix: this sentence IS the active-identity claim,
+            # so it has to be true on its own rather than corrected below it.
             message = (
                 "  This project had a different publish key than ~/.anton/.env.\n"
-                "  Publishing now uses ~/.anton/.env; the project's key was saved to\n"
-                f"  {escape(str(archive))} in case it was the one you wanted." + outranked
+                f"  Publishing now uses {publishes_from}; the project's key was saved to\n"
+                f"  {escape(str(archive))} in case it was the one you wanted."
             )
     finally:
         # In `finally`, not after the branches: `main` catches OSError and boots

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -504,9 +504,10 @@ def _reconcile_publish_identity(settings) -> bool:
     # Two different things are needed from that fact, and conflating them is
     # what this comment exists to prevent:
     #
-    #   `publishes_from` — the file that will actually be used. A message that
-    #       states the active identity must name THIS, never `~/.anton/.env`
-    #       by assumption.
+    #   `publishes_from` — the SOURCE that will actually be used, which is not
+    #       always a file: an exported `ANTON_MINDS_API_KEY` outranks all of
+    #       them. A message that states the active identity must name THIS,
+    #       never `~/.anton/.env` by assumption.
     #   `outranked`      — the explanation, appended to a message whose own
     #       sentence is about a FILE OPERATION ("moved X to Y") and so stays
     #       true regardless of precedence.
@@ -517,8 +518,21 @@ def _reconcile_publish_identity(settings) -> bool:
     # one" about a different file. ENG-1424 exists because nobody could tell
     # which account publishes; answering that twice, differently, is the same
     # defect in a new place.
+    # Read BEFORE `publishes_from` is decided, not just for the `finally`
+    # below: `os.environ` outranks every env_file in pydantic-settings, so an
+    # exported key is what the session resolves no matter what any file holds.
+    # Choosing between the two FILES and calling the winner "what publishes"
+    # was wrong for `ANTON_MINDS_API_KEY=X anton` — measured: the message said
+    # ~/.cowork/.env while the session resolved X (#458 self-review).
+    exported = os.environ.get("ANTON_MINDS_API_KEY")
     cowork_key = vault_key(Path.home() / ".cowork" / ".env")
-    publishes_from = "~/.cowork/.env" if cowork_key else "~/.anton/.env"
+    publishes_from = (
+        "the ANTON_MINDS_API_KEY set in your environment"
+        if exported
+        else "~/.cowork/.env"
+        if cowork_key
+        else "~/.anton/.env"
+    )
     outranked = (
         "\n  (~/.cowork/.env also has a key and takes precedence,"
         "\n   so publishing still uses that one.)"
@@ -532,7 +546,6 @@ def _reconcile_publish_identity(settings) -> bool:
     # have X silently popped here — and pydantic ranks os.environ above every
     # env_file, so X is exactly the key that session was resolving. Snapshot and
     # restore around the whole migration.
-    exported = os.environ.get("ANTON_MINDS_API_KEY")
 
     try:
         if not global_key:

--- a/anton/cli.py
+++ b/anton/cli.py
@@ -526,9 +526,16 @@ def _reconcile_publish_identity(settings) -> bool:
     # ~/.cowork/.env while the session resolved X (#458 self-review).
     exported = os.environ.get("ANTON_MINDS_API_KEY")
     cowork_key = vault_key(Path.home() / ".cowork" / ".env")
+    #
+    # `is not None`, not truthiness: `os.environ` outranks every env_file and
+    # `""` is a VALUE there, so an exported-but-empty key wins the resolution
+    # while reading as absent. Measured — export empty, and the session
+    # resolves `""` from the environment while this said `~/.cowork/.env`
+    # (#458 review). The `finally` below already discriminates on `is None`
+    # for exactly this reason; these two now agree.
     publishes_from = (
         "the ANTON_MINDS_API_KEY set in your environment"
-        if exported
+        if exported is not None
         else "~/.cowork/.env"
         if cowork_key
         else "~/.anton/.env"

--- a/tests/test_publish_identity_reconcile.py
+++ b/tests/test_publish_identity_reconcile.py
@@ -405,7 +405,9 @@ def test_a_quoted_global_vault_is_not_a_divergence(tmp_path, home):
     assert Workspace(home).get_secret("ANTON_MINDS_API_KEY") == '"samekey"'  # untouched
 
 
-def test_both_claiming_branches_disclose_cowork_precedence(tmp_path, home, capsys):
+def test_both_claiming_branches_disclose_cowork_precedence(
+    tmp_path, home, capsys, monkeypatch
+):
     """`~/.cowork/.env` outranks `~/.anton/.env`, so neither branch may imply otherwise.
 
     The promote branch was corrected for this and the divergent branch was not
@@ -434,10 +436,25 @@ def test_both_claiming_branches_disclose_cowork_precedence(tmp_path, home, capsy
     Workspace(project).set_secret("ANTON_MINDS_API_KEY", "PROJ_K")
     Workspace(home).set_secret("ANTON_MINDS_API_KEY", "GLOBAL_K")
 
+    # `set_secret` writes `os.environ` as a documented side effect, so arranging
+    # the vaults leaves the key EXPORTED — a state real boot never reaches,
+    # because `main()` runs reconciliation before `_ensure_workspace` promotes
+    # any vault into the environment. Clear it so the branch under test is the
+    # file one. Do not "fix" a failure here by weakening the assertion: an
+    # exported key legitimately outranks both vaults, and
+    # `test_the_message_names_the_environment_when_a_key_is_exported` covers it.
+    monkeypatch.delenv("ANTON_MINDS_API_KEY", raising=False)
+
     _reconcile_publish_identity(_settings(project))  # divergent branch
     out = capsys.readouterr().out
-    assert "~/.cowork/.env" in out, (
-        "the divergent branch did not disclose that ~/.cowork/.env wins:\n" + out
+    # Scoped to the claim LINE, not the whole output: `~/.cowork/.env` would
+    # still appear somewhere in `out` if the sentence were reverted and the
+    # suffix re-added, so an `in out` check here does less work than the
+    # phrase it replaced (#458 self-review).
+    claim = next(l for l in out.splitlines() if "Publishing now uses" in l)
+    assert "~/.cowork/.env" in claim, (
+        "the divergent branch's active-identity sentence did not name the file "
+        "that actually wins:\n" + out
     )
 
     # ...and the promote branch, with no global key at all.
@@ -445,12 +462,15 @@ def test_both_claiming_branches_disclose_cowork_precedence(tmp_path, home, capsy
     project2 = tmp_path / "proj2"
     project2.mkdir()
     Workspace(project2).set_secret("ANTON_MINDS_API_KEY", "PROJ_K2")
+    monkeypatch.delenv("ANTON_MINDS_API_KEY", raising=False)   # see above
 
     _reconcile_publish_identity(_settings(project2))
     assert "takes precedence" in capsys.readouterr().out   # promote: appended note
 
 
-def test_the_message_never_names_two_different_publishing_files(tmp_path, home, capsys):
+def test_the_message_never_names_two_different_publishing_files(
+    tmp_path, home, capsys, monkeypatch
+):
     """One question, one answer.
 
     `test_both_claiming_branches_disclose_cowork_precedence` above asserts the
@@ -479,6 +499,15 @@ def test_the_message_never_names_two_different_publishing_files(tmp_path, home, 
     Workspace(project).set_secret("ANTON_MINDS_API_KEY", "PROJ_K")
     Workspace(home).set_secret("ANTON_MINDS_API_KEY", "GLOBAL_K")
 
+    # `set_secret` writes `os.environ` as a documented side effect, so arranging
+    # the vaults leaves the key EXPORTED — a state real boot never reaches,
+    # because `main()` runs reconciliation before `_ensure_workspace` promotes
+    # any vault into the environment. Clear it so the branch under test is the
+    # file one. Do not "fix" a failure here by weakening the assertion: an
+    # exported key legitimately outranks both vaults, and
+    # `test_the_message_names_the_environment_when_a_key_is_exported` covers it.
+    monkeypatch.delenv("ANTON_MINDS_API_KEY", raising=False)
+
     _reconcile_publish_identity(_settings(project))     # the divergent branch
     out = capsys.readouterr().out
 
@@ -501,8 +530,49 @@ def test_the_message_never_names_two_different_publishing_files(tmp_path, home, 
     project2.mkdir()
     Workspace(project2).set_secret("ANTON_MINDS_API_KEY", "PROJ_K2")
     Workspace(home).set_secret("ANTON_MINDS_API_KEY", "GLOBAL_K2")
+    monkeypatch.delenv("ANTON_MINDS_API_KEY", raising=False)   # see above
 
     _reconcile_publish_identity(_settings(project2))
     claim2 = [l for l in capsys.readouterr().out.splitlines() if "Publishing now uses" in l]
     assert len(claim2) == 1 and "~/.anton/.env" in claim2[0], claim2
     assert "~/.cowork/.env" not in claim2[0], claim2
+
+
+def test_the_message_names_the_environment_when_a_key_is_exported(
+    tmp_path, home, capsys, monkeypatch
+):
+    """`os.environ` outranks every env_file, so neither file is the answer.
+
+    The gap in the test above, found by reviewing it rather than running it: it
+    only ever distinguishes between the two FILES, so it certifies "names the
+    source that wins" while the message names a file and the session resolves
+    an exported key. Measured before the fix — the message said
+    `~/.cowork/.env` while `AntonSettings().minds_api_key` was `SHELL_K`.
+
+    `test_reconciliation_leaves_an_exported_key_alone` already states the
+    precedence rule this rests on: "pydantic ranks `os.environ` above every
+    env_file". That rule was in the repo; the message just did not honour it.
+    """
+    (home / ".cowork").mkdir(parents=True, exist_ok=True)
+    (home / ".cowork" / ".env").write_text("ANTON_MINDS_API_KEY=COWORK_K\n")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    Workspace(project).set_secret("ANTON_MINDS_API_KEY", "PROJ_K")
+    Workspace(home).set_secret("ANTON_MINDS_API_KEY", "GLOBAL_K")
+
+    # `ANTON_MINDS_API_KEY=SHELL_K anton`
+    monkeypatch.setenv("ANTON_MINDS_API_KEY", "SHELL_K")
+
+    _reconcile_publish_identity(_settings(project))
+    claim = next(
+        l for l in capsys.readouterr().out.splitlines() if "Publishing now uses" in l
+    )
+
+    assert "environment" in claim, (
+        "an exported key outranks both vaults, so naming either one is the "
+        f"wrong answer to which account publishes:\n{claim}"
+    )
+    assert "~/.cowork/.env" not in claim and "~/.anton/.env" not in claim, claim
+    # …and the export itself is still untouched (ENG-1424's original finding).
+    assert os.environ["ANTON_MINDS_API_KEY"] == "SHELL_K"

--- a/tests/test_publish_identity_reconcile.py
+++ b/tests/test_publish_identity_reconcile.py
@@ -576,3 +576,41 @@ def test_the_message_names_the_environment_when_a_key_is_exported(
     assert "~/.cowork/.env" not in claim and "~/.anton/.env" not in claim, claim
     # …and the export itself is still untouched (ENG-1424's original finding).
     assert os.environ["ANTON_MINDS_API_KEY"] == "SHELL_K"
+
+
+def test_an_exported_but_empty_key_still_names_the_environment(
+    tmp_path, home, capsys, monkeypatch
+):
+    """`""` is a VALUE in `os.environ`, and it outranks every env_file.
+
+    Truthiness read it as absent, so the message named `~/.cowork/.env` while
+    `AntonSettings()` resolved `""` from the environment — the same wrong
+    answer to "which account publishes" this PR exists to remove, given once
+    instead of twice (#458 review).
+
+    Reachable without unusual state: `export ANTON_MINDS_API_KEY=` in a
+    profile, `ANTON_MINDS_API_KEY= anton`, or a container that sets it empty.
+    Onboarding does not pre-empt it — `_has_api_key` is False for an empty key
+    so `_onboard()` runs, but reconciliation has already printed by then.
+    """
+    (home / ".cowork").mkdir(parents=True, exist_ok=True)
+    (home / ".cowork" / ".env").write_text("ANTON_MINDS_API_KEY=COWORK_K\n")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    Workspace(project).set_secret("ANTON_MINDS_API_KEY", "PROJ_K")
+    Workspace(home).set_secret("ANTON_MINDS_API_KEY", "GLOBAL_K")
+
+    monkeypatch.setenv("ANTON_MINDS_API_KEY", "")     # exported, empty
+
+    _reconcile_publish_identity(_settings(project))
+    claim = next(
+        l for l in capsys.readouterr().out.splitlines() if "Publishing now uses" in l
+    )
+
+    assert "environment" in claim, (
+        "an empty export still outranks both vaults — naming a file here is "
+        f"the wrong answer:\n{claim}"
+    )
+    assert "~/.cowork/.env" not in claim and "~/.anton/.env" not in claim, claim
+    assert os.environ["ANTON_MINDS_API_KEY"] == "", "the empty export was altered"

--- a/tests/test_publish_identity_reconcile.py
+++ b/tests/test_publish_identity_reconcile.py
@@ -411,6 +411,20 @@ def test_both_claiming_branches_disclose_cowork_precedence(tmp_path, home, capsy
     The promote branch was corrected for this and the divergent branch was not
     — it still said "Publishing now uses ~/.anton/.env" while the session
     resolved the cowork key.
+
+    Asserts the INTENT (each branch discloses that cowork wins), not one
+    phrasing. The two branches disclose it differently on purpose:
+
+      promote   — its sentence is about a file operation ("moved X to Y"),
+                  true whatever outranks it, so the precedence note is
+                  appended.
+      divergent — its sentence IS the active-identity claim, so it names the
+                  winning file outright. Appending the note there instead
+                  produced a message that answered the question twice,
+                  differently; see
+                  `test_the_message_never_names_two_different_publishing_files`.
+
+    Pinning the literal "takes precedence" for both is what let that ship.
     """
     (home / ".cowork").mkdir(parents=True, exist_ok=True)
     (home / ".cowork" / ".env").write_text("ANTON_MINDS_API_KEY=COWORK_K\n")
@@ -421,7 +435,10 @@ def test_both_claiming_branches_disclose_cowork_precedence(tmp_path, home, capsy
     Workspace(home).set_secret("ANTON_MINDS_API_KEY", "GLOBAL_K")
 
     _reconcile_publish_identity(_settings(project))  # divergent branch
-    assert "takes precedence" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "~/.cowork/.env" in out, (
+        "the divergent branch did not disclose that ~/.cowork/.env wins:\n" + out
+    )
 
     # ...and the promote branch, with no global key at all.
     Workspace(home).remove_secret("ANTON_MINDS_API_KEY")
@@ -430,4 +447,62 @@ def test_both_claiming_branches_disclose_cowork_precedence(tmp_path, home, capsy
     Workspace(project2).set_secret("ANTON_MINDS_API_KEY", "PROJ_K2")
 
     _reconcile_publish_identity(_settings(project2))
-    assert "takes precedence" in capsys.readouterr().out
+    assert "takes precedence" in capsys.readouterr().out   # promote: appended note
+
+
+def test_the_message_never_names_two_different_publishing_files(tmp_path, home, capsys):
+    """One question, one answer.
+
+    `test_both_claiming_branches_disclose_cowork_precedence` above asserts the
+    precedence NOTE is present. It cannot see the defect that note introduced:
+    appended to a sentence that already asserted the active identity, the
+    divergent branch printed
+
+        Publishing now uses ~/.anton/.env; …
+        (~/.cowork/.env also has a key and takes precedence,
+         so publishing still uses that one.)
+
+    — two different answers to "which account publishes now?", with the wrong
+    one stated first and flatly. ENG-1424 exists because that question had no
+    reliable answer, so answering it twice is the same defect wearing new
+    clothes, and a presence assertion is structurally unable to catch it.
+
+    This pins the property instead: whatever the message claims about the
+    ACTIVE identity, it names exactly one file, and that file is the one the
+    chain actually resolves.
+    """
+    (home / ".cowork").mkdir(parents=True, exist_ok=True)
+    (home / ".cowork" / ".env").write_text("ANTON_MINDS_API_KEY=COWORK_K\n")
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    Workspace(project).set_secret("ANTON_MINDS_API_KEY", "PROJ_K")
+    Workspace(home).set_secret("ANTON_MINDS_API_KEY", "GLOBAL_K")
+
+    _reconcile_publish_identity(_settings(project))     # the divergent branch
+    out = capsys.readouterr().out
+
+    claims = [line for line in out.splitlines() if "Publishing now uses" in line]
+    assert len(claims) == 1, out
+    claim = claims[0]
+
+    assert "~/.cowork/.env" in claim, (
+        "the active-identity sentence names ~/.anton/.env while ~/.cowork/.env "
+        "outranks it — this is the wrong answer to the only question the "
+        f"message exists to answer:\n{out}"
+    )
+    assert "~/.anton/.env" not in claim, (
+        f"the sentence names two publishing files at once:\n{claim}"
+    )
+
+    # …and with no cowork key, the same sentence names ~/.anton/.env.
+    (home / ".cowork" / ".env").unlink()
+    project2 = tmp_path / "proj2"
+    project2.mkdir()
+    Workspace(project2).set_secret("ANTON_MINDS_API_KEY", "PROJ_K2")
+    Workspace(home).set_secret("ANTON_MINDS_API_KEY", "GLOBAL_K2")
+
+    _reconcile_publish_identity(_settings(project2))
+    claim2 = [l for l in capsys.readouterr().out.splitlines() if "Publishing now uses" in l]
+    assert len(claim2) == 1 and "~/.anton/.env" in claim2[0], claim2
+    assert "~/.cowork/.env" not in claim2[0], claim2


### PR DESCRIPTION
Follow-up to #439. **Copy only** — no key is moved, archived or deleted differently, and no file operation changes.

## The problem

On a machine with both the desktop app and the CLI configured — the normal case for a Cowork user who also uses `anton` — the divergent branch printed this:

```
  This project had a different publish key than ~/.anton/.env.
  Publishing now uses ~/.anton/.env; the project's key was saved to
  /Users/…/.anton/.env.superseded in case it was the one you wanted.
  (~/.cowork/.env also has a key and takes precedence,
   so publishing still uses that one.)
```

Line 2 says publishing uses `~/.anton/.env`. Line 4 says it uses `~/.cowork/.env`. **Line 2 is the false one** — `~/.cowork/.env` sits after `~/.anton/.env` in the chain and wins — and it is the one stated flatly and first, while the correction arrives parenthetically at the end.

ENG-1424 exists because nobody could tell which account publishes. Answering that question twice, with the wrong answer first, is the same defect in a new place.

## After

```
  This project had a different publish key than ~/.anton/.env.
  Publishing now uses ~/.cowork/.env; the project's key was saved to
  /Users/…/.anton/.env.superseded in case it was the one you wanted.
```

With no cowork key, the same sentence names `~/.anton/.env` and the message is unchanged from today.

## Why the two branches now differ

They were given the same `outranked` suffix. That works for one and breaks the other, because their sentences make different kinds of claim:

| Branch | Its sentence | Suffix? |
|---|---|---|
| **promote** | *"Moved this project's saved publish key to ~/.anton/.env"* — a **file operation**, true whatever outranks it afterwards | **Keeps** the note. Unchanged. |
| **divergent** | *"Publishing now uses …"* — the **active identity** | **Drops** the note; names `publishes_from` outright, so it is true on its own rather than corrected below itself |

## The test that let this through

`test_both_claiming_branches_disclose_cowork_precedence` covered this exact scenario and passed, because its assertion was:

```python
assert "takes precedence" in capsys.readouterr().out
```

A presence check. It confirms the note is there — the bug it was written for — and is structurally unable to see that the sentence above the note contradicts it.

It now asserts the **intent** (each branch discloses that cowork wins) rather than one phrasing, and documents why the two disclose it differently.

`test_the_message_never_names_two_different_publishing_files` pins the property itself: exactly one `Publishing now uses` line, naming the file the chain actually resolves, in both the cowork-present and cowork-absent cases.

## Verification

Mutation-verified in both directions:

| mutation | result |
|---|---|
| restore the shipped wording (hardcoded `~/.anton/.env` + appended note) | new test fails |
| pin `publishes_from` to `~/.anton/.env` unconditionally | both tests fail |

Full suite: **3,112 passed, 31 skipped.**

## Note on #439

This is a defect in `8c8256f4`, the final commit on #439. Worth flagging that @tino097's approval there was recorded against `4bc1d158`, the commit before it, so that last commit merged without a human review — GitHub reports the PR as approved either way. No harm done; this is the one thing I found reading it back.

## Security

No new input reaches a shell, path or log. The message names a fixed literal (`~/.cowork/.env` or `~/.anton/.env`), never a user-supplied value; the archive path was already `escape()`d and is untouched. No key material is added to any output.

Linear: ENG-1424
