### PR TITLE
[ENG-1162] Make /exit leave the chat and advertise it consistently

### DIFF
--- a/anton/chat.py
+++ b/anton/chat.py
@@ -1585,7 +1585,7 @@ async def _chat_loop(
 
     if not first_run and not desktop_first_run:
         console.print(f"[anton.cyan_dim] {'━' * 40}[/]")
-    console.print("[anton.muted] type '/help' for commands or 'exit' to quit.[/]")
+    console.print("[anton.muted] type '/help' for commands or '/exit' to quit.[/]")
     console.print()
 
     from anton.analytics import send_event

--- a/anton/chat.py
+++ b/anton/chat.py
@@ -1404,6 +1404,24 @@ def _default_turn_error_action(exc: BaseException) -> str:
     return "retry" if isinstance(exc, ConnectionError) else "setup"
 
 
+_EXIT_WORDS = ("exit", "quit", "bye")
+
+
+def _is_exit_command(text: str) -> bool:
+    """True for the exit words, bare or written as a slash command.
+
+    The help menu and the completer list the exit command alongside the slash
+    commands, so the slash form has to match the way the dispatch chain below
+    matches every other one: on the first token, arguments tolerated. The bare
+    form stays whole-string so an ordinary sentence starting with "exit" is
+    still a message to the agent.
+    """
+    stripped = text.strip().lower()
+    if stripped.startswith("/"):
+        return stripped.split(maxsplit=1)[0].removeprefix("/") in _EXIT_WORDS
+    return stripped in _EXIT_WORDS
+
+
 def run_chat(
     console: Console, settings: AntonSettings, *, resume: bool = False, first_run: bool = False, desktop_first_run: bool = False
 ) -> None:
@@ -1747,7 +1765,7 @@ async def _chat_loop(
                 if not stripped and message_content is None:
                     continue
 
-            if message_content is None and stripped.lower() in ("exit", "quit", "bye"):
+            if message_content is None and _is_exit_command(stripped):
                 break
 
             # Detect dragged file paths early — a dragged absolute path like

--- a/anton/commands/ui.py
+++ b/anton/commands/ui.py
@@ -50,7 +50,7 @@ COMMANDS = [
     None,
     "General",
     Command("/help", "Show this help menu"),
-    Command("exit",  "Exit the chat"),
+    Command("/exit", "Exit the chat"),
 ]
 
 THEME_COMMANDS = [

--- a/docs/docs/reference/slash-commands.md
+++ b/docs/docs/reference/slash-commands.md
@@ -89,4 +89,4 @@ See [Chat basics](/use/chat-basics) and [Sessions](/use/sessions).
 | Command | What it does |
 |---|---|
 | `/help` | Show the help menu |
-| `exit` | Exit the chat |
+| `/exit` | Exit the chat |

--- a/docs/docs/use/cli.md
+++ b/docs/docs/use/cli.md
@@ -57,7 +57,7 @@ the full list at any time. The complete inventory is in
 | --- | --- | --- |
 | `Esc` | Setup prompts (provider, API key, …) | Go back to the previous step |
 | `Ctrl+D` | Chat prompt | Exit Anton |
-| `/exit` (or `exit`, `quit`, `bye`, each with or without the slash) | Chat prompt | Exit Anton |
+| `/exit`, `exit`, `quit`, or `bye` | Chat prompt | Exit Anton |
 
 ## Themes
 

--- a/docs/docs/use/cli.md
+++ b/docs/docs/use/cli.md
@@ -35,7 +35,7 @@ terminals, and prints the version and a tagline:
     ▐   ▐
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  v2.26.4.30.0 — "autonomous by design"
- type '/help' for commands or 'exit' to quit.
+ type '/help' for commands or '/exit' to quit.
 
 you>
 ```
@@ -57,7 +57,7 @@ the full list at any time. The complete inventory is in
 | --- | --- | --- |
 | `Esc` | Setup prompts (provider, API key, …) | Go back to the previous step |
 | `Ctrl+D` | Chat prompt | Exit Anton |
-| `exit`, `quit`, or `bye` | Chat prompt | Exit Anton |
+| `/exit` (or `exit`, `quit`, `bye`, each with or without the slash) | Chat prompt | Exit Anton |
 
 ## Themes
 

--- a/tests/e2e/scenarios/test_boot_config.py
+++ b/tests/e2e/scenarios/test_boot_config.py
@@ -15,7 +15,7 @@ def test_clean_boot(cfg, stub, tmp_path):
     result = run_anton(["--folder", str(tmp_path)], ["exit"],
                        env=base_env(stub), timeout=cfg.timeout(20))
     assert_exit_ok(result)
-    assert_output(result, "exit' to quit")
+    assert_output(result, "/exit' to quit")
     assert_not_output(result, "Traceback (most recent call last)")
 
 

--- a/tests/e2e/scenarios/test_boot_config.py
+++ b/tests/e2e/scenarios/test_boot_config.py
@@ -15,7 +15,7 @@ def test_clean_boot(cfg, stub, tmp_path):
     result = run_anton(["--folder", str(tmp_path)], ["exit"],
                        env=base_env(stub), timeout=cfg.timeout(20))
     assert_exit_ok(result)
-    assert_output(result, "/exit' to quit")
+    assert_output(result, "type '/help' for commands or '/exit' to quit.")
     assert_not_output(result, "Traceback (most recent call last)")
 
 

--- a/tests/e2e/scenarios/test_boot_config.py
+++ b/tests/e2e/scenarios/test_boot_config.py
@@ -19,6 +19,17 @@ def test_clean_boot(cfg, stub, tmp_path):
     assert_not_output(result, "Traceback (most recent call last)")
 
 
+def test_slash_exit_leaves_the_chat(cfg, stub, tmp_path):
+    # The help menu and the completer advertise the slash form, so it has to
+    # end the loop instead of reaching the unknown-command fallthrough. Exit
+    # code alone proves nothing here: stdin EOF also breaks the loop.
+    result = run_anton(["--folder", str(tmp_path)], ["/exit"],
+                       env=base_env(stub), timeout=cfg.timeout(20))
+    assert_exit_ok(result)
+    assert_not_output(result, "Unknown command")
+    assert_not_output(result, "Traceback (most recent call last)")
+
+
 def test_sessions_subcommand_empty_listing(cfg, stub, tmp_path):
     # run_chat writes to HistoryStore, not SessionStore; the sessions command
     # reads SessionStore, so the listing is always empty under this harness.

--- a/tests/test_chat_exit_command.py
+++ b/tests/test_chat_exit_command.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 from anton.chat import _is_exit_command
+from anton.commands.ui import COMMANDS, Command
 
 
 @pytest.mark.parametrize("text", ["exit", "quit", "bye"])
@@ -49,3 +50,15 @@ def test_arguments_after_the_slash_form_are_tolerated():
 )
 def test_everything_else_is_a_message_for_the_agent(text: str):
     assert not _is_exit_command(text)
+
+
+def test_the_advertised_exit_entry_is_one_the_loop_accepts():
+    # The menu advertising a command the dispatch does not take is the whole
+    # bug: the entry has to be the slash form, and it has to end the chat.
+    entry = next(
+        item
+        for item in COMMANDS
+        if isinstance(item, Command) and item.description == "Exit the chat"
+    )
+    assert entry.command.startswith("/")
+    assert _is_exit_command(entry.command)

--- a/tests/test_chat_exit_command.py
+++ b/tests/test_chat_exit_command.py
@@ -55,10 +55,10 @@ def test_everything_else_is_a_message_for_the_agent(text: str):
 def test_the_advertised_exit_entry_is_one_the_loop_accepts():
     # The menu advertising a command the dispatch does not take is the whole
     # bug: the entry has to be the slash form, and it has to end the chat.
-    entry = next(
+    advertised = [
         item
         for item in COMMANDS
-        if isinstance(item, Command) and item.description == "Exit the chat"
-    )
-    assert entry.command.startswith("/")
-    assert _is_exit_command(entry.command)
+        if isinstance(item, Command) and _is_exit_command(item.command)
+    ]
+    assert advertised, "COMMANDS no longer advertises a command that ends the chat"
+    assert all(item.command.startswith("/") for item in advertised)

--- a/tests/test_chat_exit_command.py
+++ b/tests/test_chat_exit_command.py
@@ -48,7 +48,8 @@ def test_arguments_after_the_slash_form_are_tolerated():
         "/Users/someone/exit",
     ],
 )
-def test_everything_else_is_a_message_for_the_agent(text: str):
+def test_other_input_does_not_end_the_chat(text: str):
+    # The slash cases here go on to the dispatch chain, not to the agent.
     assert not _is_exit_command(text)
 
 

--- a/tests/test_chat_exit_command.py
+++ b/tests/test_chat_exit_command.py
@@ -1,0 +1,51 @@
+"""`_is_exit_command` — what ends the interactive chat loop.
+
+The help menu and the completer list the exit command among the slash
+commands, so the slash form has to leave the chat instead of reaching the
+unknown-command fallthrough. `tests/e2e/scenarios/test_boot_config.py` pins
+that end to end through the real CLI; this file pins the edges around it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from anton.chat import _is_exit_command
+
+
+@pytest.mark.parametrize("text", ["exit", "quit", "bye"])
+def test_bare_exit_words_still_end_the_chat(text: str):
+    assert _is_exit_command(text)
+
+
+@pytest.mark.parametrize("text", ["/exit", "/quit", "/bye"])
+def test_slash_forms_end_the_chat(text: str):
+    assert _is_exit_command(text)
+
+
+@pytest.mark.parametrize("text", ["/EXIT", "Exit", "  /exit  "])
+def test_case_and_surrounding_space_are_ignored(text: str):
+    assert _is_exit_command(text)
+
+
+def test_arguments_after_the_slash_form_are_tolerated():
+    # Every other command in the dispatch chain matches on its first token,
+    # so a stray argument must not fall through to "Unknown command: /exit".
+    assert _is_exit_command("/exit now")
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "/",
+        "/exiting",
+        "//exit",
+        "/help",
+        "exit now",
+        "how do I exit",
+        "/Users/someone/exit",
+    ],
+)
+def test_everything_else_is_a_message_for_the_agent(text: str):
+    assert not _is_exit_command(text)


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-1162/anton-cli-mistyped-slash-command-exit-gives-friendly-hint-but-correct

## What changed

- Accept the slash form of the exit words in the interactive chat loop, so /exit ends the session instead of falling through to Unknown command
- Advertise the exit command as /exit in the help menu and the startup banner, so the command the CLI suggests is the command the loop handles
- Pin the banner wording and drop the description-keyed lookup, so both exit assertions fail when the advertised form regresses
- Sync the docs with the advertised exit command, so the transcribed banner and the command tables match what the CLI prints
- Assert the whole banner sentence and rename the non-exit case to what it checks, since slash input reaches the dispatch chain rather than the agent
- List the exit inputs plainly in the keybinds table, so the docs stop implying the slash forms of quit and bye are advertised

## Why this matters

The help menu listed `exit` as the twenty-first entry in a list where the other twenty all begin with a slash, so users typed `/exit` and reached the unknown-command fallthrough. The model's own reply to a mistyped `\exit` tells them to use `/exit`, which is how the ticket was found. The completer made this worse rather than better: it only yields entries beginning with the typed `/`, so the bare `exit` entry meant tab completion offered no way to leave the chat at all.

Three published surfaces quoted the wrong form too. `docs/docs/use/cli.md` transcribes the startup banner verbatim, and `docs.yml` publishes `docs/**`, so the docs and the CLI now agree instead of drifting.

## Notes for the reviewer

- **The slash form matches on the first token, not the whole string.** Every other command in the dispatch chain does. With whole-string matching, `/exit now` would print `Unknown command: /exit`, the ticket's own error text for a near-miss of the ticket's own input. The bare form stays whole-string, so `exit now` is still a message for the agent.
- **`/quit` and `/bye` are accepted but listed nowhere**, not in `/help`, the completer, or the docs. They fall out of the same `_EXIT_WORDS` tuple. Bare `quit` and `bye` were already accepted and already unlisted in `/help` before this change, so this preserves an existing asymmetry rather than creating one; advertising all three would change more printed output than the ticket asks for.
- **The exit check runs ahead of drag-and-drop path detection.** This is the one pre-existing behavior the ordering changes: an actual file named `/exit` at filesystem root would no longer be attachable by dragging it. `_parse_dropped_paths` requires `candidate.is_absolute() and candidate.exists()`, so nothing else is affected.
- **`tests/test_cloud_turn_entrypoint.py::test_action_events_are_logged` fails locally on macOS and is unrelated to this change.** `resolve_trusted_workspace_path` cannot mkdir `/workspace`, so the logged traceback carries the checkout path, and any checkout whose path contains the substring `hi` trips that test's `assert "hi" not in caplog.text`. It fails identically on a detached `origin/staging` in the same worktree.
- **`/skills` is left alone.** It is dispatched at `chat.py` but advertised nowhere, the mirror image of this bug. Pre-existing, working, and out of scope.

## How to test

1. `uv sync`
2. `uv run anton`
3. The banner reads `type '/help' for commands or '/exit' to quit.`
4. Type `/help`. The General section lists `/exit`.
5. Type `/` and check that tab completion now offers `/exit`.
6. Type `/exit`. The chat ends, with no `Unknown command`.
7. Type `/exit now`, and separately `exit`, `quit`, `bye`. All still end the chat.
8. Type `how do I exit` and confirm it still reaches the agent as a message.

## Checks

| Check | Observed result |
| --- | --- |
| `uv run pytest tests/e2e/scenarios/test_boot_config.py::test_slash_exit_leaves_the_chat` before the fix | 1 failed, stdout `you> /exit` then `Unknown command: /exit` |
| `uv run pytest tests/e2e/scenarios/test_boot_config.py tests/test_chat_exit_command.py` | 25 passed |
| `test_clean_boot` with the banner line temporarily reverted | 1 failed, so the banner assertion is load-bearing |
| `uv run pytest` | 1 failed, 3130 passed, 31 skipped in 199s (the failure is the macOS `/workspace` test noted above) |
| `uv run pytest` on the review fixes | 1 failed, 3130 passed, 31 skipped, same single failure |
| `cd docs && npm ci && npm run build` | `[SUCCESS] Generated static files in "build"` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
