### PR TITLE
ENG-2421: carry artifact-delivery guidance in the pod's system prompt

### DIFF
--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -519,6 +519,38 @@ def build_turn_content(base: Path, user_text: str) -> "str | list[dict]":
     return [*image_blocks, {"type": "text", "text": text}]
 
 
+# What the web UI does with a finished file, told to the model because the pod
+# cannot see that UI (ENG-2421). The desktop harness has carried the equivalent
+# guidance since ENG-1636 (cowork-server `_turn_style_context`) — but that
+# harness refuses to run org turns, so the web population never received it and
+# kept handing users pod paths and loopback URLs as "download links" for weeks
+# after every card-side fix shipped. Every claim below is provable from the
+# product: artifact cards carry a Download control on web (ENG-2044), HTML and
+# Markdown artifacts are auto-shared at turn end (ENG-1680) with the link
+# surfaced on the card, and the chat renderer neutralises local-path links into
+# inert text. When the pod is driven outside cowork (dev, CI) the panel it
+# names does not exist; that run has no end user reading prose, so the wrong
+# half of the trade is the one where a real user is told to click a dead path.
+CLOUD_ARTIFACT_DELIVERY_GUIDANCE = (
+    "Files you create as artifacts appear automatically in the Live Artifacts "
+    "panel beside the chat, where the user previews them and uses the Download "
+    "control. When a file is ready, tell the user it is in the Live Artifacts "
+    "panel and can be downloaded there — do NOT hand them its location on "
+    "disk. You are running in a sandboxed cloud workspace: filesystem paths "
+    "(for example /mnt/...) and loopback URLs (for example "
+    "http://127.0.0.1:PORT or http://localhost:PORT) exist only inside this "
+    "workspace and can never be opened from the user's browser. Never put "
+    "such a path or URL into your reply as a markdown link or as text, and "
+    "never invent a download URL such as sandbox:/mnt/data/...; no link of "
+    "that form works. HTML and Markdown artifacts are shared to a live URL "
+    "automatically at the end of the turn and that link appears on the "
+    "artifact card — you do not know the link, so point at the card rather "
+    "than guessing one. If the user says they cannot find, open, or download "
+    "a file, point them again at the Live Artifacts panel's Download control "
+    "— never repeat a path."
+)
+
+
 def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
     """Assemble a cloud-safe ChatSession for one turn.
 
@@ -621,6 +653,11 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
         # line is derived by the session from the provider's response.
         system_prompt_context=SystemPromptContext(
             runtime_context=build_runtime_context(settings),
+            # The delivery half of the prompt context (ENG-2421) — the desktop
+            # harness injects its own via `_turn_style_context`; this is the
+            # web-worded equivalent, which the pod owns because only it runs
+            # web turns.
+            suffix=CLOUD_ARTIFACT_DELIVERY_GUIDANCE,
         ),
         # WHERE the user was, which this pod cannot know on its own — only the
         # deployment does, so cowork sends it (ENG-1459). Absent when the pod is

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -528,7 +528,14 @@ def build_turn_content(base: Path, user_text: str) -> "str | list[dict]":
 # product: artifact cards carry a Download control on web (ENG-2044), HTML and
 # Markdown artifacts are auto-shared at turn end (ENG-1680) with the link
 # surfaced on the card, and the chat renderer neutralises local-path links into
-# inert text. When the pod is driven outside cowork (dev, CI) the panel it
+# inert text. The base ARTIFACTS prompt (anton/core/llm/prompts.py, workflow
+# step 4) instructs the OPPOSITE for the CLI case — "include the primary
+# file's path … so it is clickable/openable in a plain CLI", and for
+# fullstack apps to prefer launch_backend's (loopback) url — so this block
+# overrides both BY NAME rather than merely contradicting them; suffix order
+# gives it the last word, and naming the overridden rule is what makes the
+# model treat it as a deployment exception instead of a conflict (review
+# note from pnewsam on #461). When the pod is driven outside cowork (dev, CI) the panel it
 # names does not exist; that run has no end user reading prose, so the wrong
 # half of the trade is the one where a real user is told to click a dead path.
 CLOUD_ARTIFACT_DELIVERY_GUIDANCE = (
@@ -542,7 +549,13 @@ CLOUD_ARTIFACT_DELIVERY_GUIDANCE = (
     "workspace and can never be opened from the user's browser. Never put "
     "such a path or URL into your reply as a markdown link or as text, and "
     "never invent a download URL such as sandbox:/mnt/data/...; no link of "
-    "that form works. HTML and Markdown artifacts are shared to a live URL "
+    "that form works. This OVERRIDES the ARTIFACTS workflow instruction to "
+    "include the primary file's path in your final message: here, point to "
+    "the artifact by name only — the panel is the pointer. It also overrides "
+    "the fullstack-app instruction to prefer the launch_backend url as the "
+    "pointer: that url is loopback inside this workspace and dead in the "
+    "user's browser; the artifact card's preview is how the user opens the "
+    "app. HTML and Markdown artifacts are shared to a live URL "
     "automatically at the end of the turn and that link appears on the "
     "artifact card — you do not know the link, so point at the card rather "
     "than guessing one. If the user says they cannot find, open, or download "

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -79,6 +79,38 @@ def test_scratchpad_uses_local_factory_and_is_workspace_bound(tmp_path, monkeypa
     assert cfg.session_id == "conv_1"
 
 
+def test_cloud_prompt_carries_artifact_delivery_guidance(tmp_path, monkeypatch):
+    """ENG-2421: ENG-1636 taught the DESKTOP harness to point users at the Live
+    Artifacts panel instead of local paths — but that block lives in
+    cowork-server's in-process harness, which refuses to run org turns, so web
+    agents were never told and handed users sandbox:/mnt/... and loopback
+    "download links" for weeks after every card-side fix shipped. The pod's own
+    prompt context must carry the web-worded equivalent."""
+    _, cfg = _build(tmp_path, monkeypatch)
+    suffix = cfg.system_prompt_context.suffix
+    from anton.cloud_turn.session import CLOUD_ARTIFACT_DELIVERY_GUIDANCE
+    assert suffix == CLOUD_ARTIFACT_DELIVERY_GUIDANCE
+    # Reachability, not just wiring (review finding on #461): the config field
+    # being set proves nothing if the prompt builder stops appending `suffix` —
+    # exactly the "fix shipped while the failure continued" class this ticket
+    # documents. Assemble the real prompt and require the guidance inside it.
+    from anton.core.llm.prompt_builder import ChatSystemPromptBuilder
+    prompt = ChatSystemPromptBuilder().build(
+        system_prompt_context=cfg.system_prompt_context,
+        conversation_started=True,
+        proactive_dashboards=False,
+        output_dir=str(tmp_path),
+    )
+    assert CLOUD_ARTIFACT_DELIVERY_GUIDANCE.strip() in prompt
+    # The load-bearing sentences, pinned individually so a rewrite that drops
+    # one is caught even if the identity assertion above is loosened later.
+    assert "Live Artifacts" in suffix
+    assert "do NOT hand them its location on disk" in suffix
+    assert "sandbox:/mnt/data/" in suffix
+    assert "127.0.0.1" in suffix
+    assert "never repeat a path" in suffix
+
+
 def test_cloud_workspace_does_not_create_anton_md(tmp_path, monkeypatch):
     """ENG-1817: `.anton/anton.md` is cowork-server's staged copy of the project
     instructions. If the pod creates a template there, the next staging pass

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -109,6 +109,11 @@ def test_cloud_prompt_carries_artifact_delivery_guidance(tmp_path, monkeypatch):
     assert "sandbox:/mnt/data/" in suffix
     assert "127.0.0.1" in suffix
     assert "never repeat a path" in suffix
+    # The base ARTIFACTS prompt tells the agent to include the primary file's
+    # path and to prefer launch_backend's (loopback) url — the cloud block must
+    # override both by name, not just coexist (review note on #461).
+    assert "OVERRIDES the ARTIFACTS workflow instruction" in suffix
+    assert "launch_backend" in suffix
 
 
 def test_cloud_workspace_does_not_create_anton_md(tmp_path, monkeypatch):

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -102,6 +102,12 @@ def test_cloud_prompt_carries_artifact_delivery_guidance(tmp_path, monkeypatch):
         output_dir=str(tmp_path),
     )
     assert CLOUD_ARTIFACT_DELIVERY_GUIDANCE.strip() in prompt
+    # Tripwire: the override sentence targets the base ARTIFACTS step-4 text.
+    # If the durable fix lands (web-specific assembly REMOVES that base
+    # instruction), this assertion fails on purpose — the override sentence in
+    # CLOUD_ARTIFACT_DELIVERY_GUIDANCE is then stale and must be cleaned up
+    # rather than left referencing an instruction that no longer exists.
+    assert "include the primary file's path" in prompt
     # The load-bearing sentences, pinned individually so a rewrite that drops
     # one is caught even if the identity assertion above is loosened later.
     assert "Live Artifacts" in suffix

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -94,7 +94,7 @@ def test_cloud_prompt_carries_artifact_delivery_guidance(tmp_path, monkeypatch):
     # being set proves nothing if the prompt builder stops appending `suffix` —
     # exactly the "fix shipped while the failure continued" class this ticket
     # documents. Assemble the real prompt and require the guidance inside it.
-    from anton.core.llm.prompt_builder import ChatSystemPromptBuilder
+    from anton.core.llm.prompt_builder import ChatSystemPromptBuilder, SystemPromptContext
     prompt = ChatSystemPromptBuilder().build(
         system_prompt_context=cfg.system_prompt_context,
         conversation_started=True,
@@ -107,7 +107,16 @@ def test_cloud_prompt_carries_artifact_delivery_guidance(tmp_path, monkeypatch):
     # instruction), this assertion fails on purpose — the override sentence in
     # CLOUD_ARTIFACT_DELIVERY_GUIDANCE is then stale and must be cleaned up
     # rather than left referencing an instruction that no longer exists.
-    assert "include the primary file's path" in prompt
+    # Asserted against a prompt built with NO suffix: the override sentence
+    # itself quotes the same phrase, so checking the full prompt was vacuously
+    # true (re-review finding — mutating prompts.py left it green).
+    base_prompt = ChatSystemPromptBuilder().build(
+        system_prompt_context=SystemPromptContext(runtime_context="x"),
+        conversation_started=True,
+        proactive_dashboards=False,
+        output_dir=str(tmp_path),
+    )
+    assert "include the primary file's path" in base_prompt
     # The load-bearing sentences, pinned individually so a rewrite that drops
     # one is caught even if the identity assertion above is loosened later.
     assert "Live Artifacts" in suffix


### PR DESCRIPTION
Cause half of [ENG-2421](https://linear.app/mindsdb/issue/ENG-2421/the-agent-still-hands-users-file-links-that-cannot-open-the-eng-2044): web agents keep telling users *"download it here"* with `sandbox:/mnt/…`, bare `/mnt/…`, or `http://127.0.0.1:PORT` links — 4 web users, 11 dead links in the 09-04 review window, all **after** ENG-2044's card Download shipped.

## Root cause

ENG-1636's "point at the Live Artifacts panel, never hand out paths" guidance lives in cowork-server's `_turn_style_context` — injected by the **in-process harness, which refuses to run org turns**. Web turns execute in the scratchpad pod, whose `SystemPromptContext` carries `runtime_context` only (ENG-1638) and **no delivery guidance at all**. The web population has never received the instruction; the failure pattern matches exactly (every post-deploy complainant on the ticket is a web user).

## What

`build_cloud_chat_session` now passes `CLOUD_ARTIFACT_DELIVERY_GUIDANCE` as the prompt suffix — the web-worded equivalent of the desktop block: files appear in the Live Artifacts panel with a Download control; pod filesystem paths and loopback URLs exist only inside the workspace and can never be opened from the user's browser — never present them as links or text, never invent `sandbox:` URLs; HTML/MD artifacts are auto-shared at turn end with the link on the artifact card, which the model does not know and must not guess; on "I can't find the file", point at the panel again, never repeat a path.

Every sentence is provable from the product (ENG-2044 Download, ENG-1680 autopublish, the renderer's link neutraliser). The constant is pod-owned rather than wired over the Redis seam — no producer→controller→contract change, and the desktop harness keeps its own block (consolidating both into one anton-owned source is a reasonable follow-up once cowork-server naturally migrates, per the ENG-1808 pattern).

## Tests

`test_cloud_turn_session.py` (62/62): pins the suffix identity on the captured `ChatSessionConfig`, its load-bearing sentences individually, **and reachability** — the test assembles the real prompt via `ChatSystemPromptBuilder.build()` and requires the guidance inside it, so a prompt-builder refactor that stops appending `suffix` fails it too (review finding). Mutation-verified both ways: unwiring `suffix=` in session.py and disabling the append in prompt_builder.py each fail the test. Full suite: 3,132 passed, 31 skipped.

## Delivery — the step that gets skipped

**Staging**: since ENG-2129, anton's staging publish builds the pod image and scratchpad-controller's `values-staging.yaml` follows the moving `:staging` tag with `imagePullPolicy: Always` (verified on scratchpad-controller `origin/main`, 2026-09-09 — a temporary sha pin from 09-02 was reverted by `9d6230d` on 09-08). So staging web picks this up automatically after merge. **Production** still pins its worker image by hand — the prod half of ENG-2421 lands only when that pin moves to an image carrying this commit, which goes in the QA comment as Step 0. Desktop is untouched (its guidance ships from cowork-server and is byte-pinned there).

Sibling PR (net half, renderer): mindsdb/cowork#956 — no merge-order constraint; they harden different layers of the same failure.

Security pass: prompt-text only — no new tool surface, no secrets, no user input interpolated into the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


