### PR TITLE
[ENG-1278] Mark the boundary where a forced continuation supersedes its answer

### DIFF
--- a/anton/chat_ui.py
+++ b/anton/chat_ui.py
@@ -416,10 +416,10 @@ class StreamDisplay:
         if not self._active:
             return
 
-        # `continuation` renders identically here: the CLI keeps one text
-        # buffer, so it has no answer bubble to replace, and the raw phase
-        # would otherwise leak into the status line.
-        if phase in ("analyzing", "continuation"):
+        # `continuation` and `handback` render identically here: the CLI keeps
+        # one text buffer, so it has no answer bubble to replace or preserve,
+        # and the raw phase would otherwise leak into the status line.
+        if phase in ("analyzing", "continuation", "handback"):
             self._line1_fun = random.choice(ANALYZING_MESSAGES)  # noqa: S311
             self._line2_status = "Composing response..."
             self._line3_peek = ""

--- a/anton/chat_ui.py
+++ b/anton/chat_ui.py
@@ -416,9 +416,14 @@ class StreamDisplay:
         if not self._active:
             return
 
-        # `continuation` and `handback` render identically here: the CLI keeps
-        # one text buffer, so it has no answer bubble to replace or preserve,
-        # and the raw phase would otherwise leak into the status line.
+        # A forced continuation is told its reply replaces the previous one, so
+        # the buffer that would otherwise print both has to let the earlier
+        # answer go. `finish` prints whatever remains as the final answer.
+        if phase == "continuation":
+            self._pending = ""
+
+        # These three render identically: the status line says the model is
+        # composing, and the raw phase would otherwise leak into it.
         if phase in ("analyzing", "continuation", "handback"):
             self._line1_fun = random.choice(ANALYZING_MESSAGES)  # noqa: S311
             self._line2_status = "Composing response..."

--- a/anton/chat_ui.py
+++ b/anton/chat_ui.py
@@ -416,7 +416,10 @@ class StreamDisplay:
         if not self._active:
             return
 
-        if phase == "analyzing":
+        # `continuation` renders identically here: the CLI keeps one text
+        # buffer, so it has no answer bubble to replace, and the raw phase
+        # would otherwise leak into the status line.
+        if phase in ("analyzing", "continuation"):
             self._line1_fun = random.choice(ANALYZING_MESSAGES)  # noqa: S311
             self._line2_status = "Composing response..."
             self._line3_peek = ""

--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -261,9 +261,13 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
                     seen_tool_progress.add(event.id)
                 # Step-creating/closing phases and the first tool_progress per
                 # id must never be dropped (they open/close renderer steps);
-                # the rest is rate-limited.
+                # the rest is rate-limited. `continuation` is exempt for a
+                # different reason: it marks the text after it as superseding
+                # the text before it, and dropping it leaves the replacement
+                # appended to the answer it was meant to replace. One event per
+                # continuation, so it cannot flood.
                 always = bool(first_progress) or phase in (
-                    "scratchpad_start", "scratchpad_done", "tool_done")
+                    "scratchpad_start", "scratchpad_done", "tool_done", "continuation")
                 now = time.monotonic()
                 if always or now - last_progress_wire >= PROGRESS_WIRE_INTERVAL:
                     if not always:

--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -261,11 +261,12 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
                     seen_tool_progress.add(event.id)
                 # Step-creating/closing phases and the first tool_progress per
                 # id must never be dropped (they open/close renderer steps);
-                # the rest is rate-limited. `continuation` is exempt for a
-                # different reason: it marks the text after it as superseding
-                # the text before it, and dropping it leaves the replacement
-                # appended to the answer it was meant to replace. One event per
-                # continuation, so it cannot flood.
+                # the rest is rate-limited. `continuation` and `handback` are
+                # exempt for a different reason: together they tell a consumer
+                # whether the text that follows replaces the answer or adds to
+                # it, and dropping either corrupts the answer in one direction
+                # or the other. Both fire at most once per continuation, so
+                # exempting them cannot flood.
                 always = bool(first_progress) or phase in (
                     "scratchpad_start", "scratchpad_done", "tool_done",
                     "continuation", "handback")

--- a/anton/cloud_turn/__main__.py
+++ b/anton/cloud_turn/__main__.py
@@ -267,7 +267,8 @@ async def stream_turn(raw_line: str, emit, session_builder=None) -> None:
                 # appended to the answer it was meant to replace. One event per
                 # continuation, so it cannot flood.
                 always = bool(first_progress) or phase in (
-                    "scratchpad_start", "scratchpad_done", "tool_done", "continuation")
+                    "scratchpad_start", "scratchpad_done", "tool_done",
+                    "continuation", "handback")
                 now = time.monotonic()
                 if always or now - last_progress_wire >= PROGRESS_WIRE_INTERVAL:
                     if not always:

--- a/anton/cloud_turn/contract.py
+++ b/anton/cloud_turn/contract.py
@@ -13,6 +13,11 @@ Events written back on stdout (JSONL):
       before it, so cowork replaces the answer rather than appending to it.
       Exempt from the rate limit — dropping it reinstates the duplicated
       answer, since the replacement text still arrives either way.
+      `phase: "handback"` is its counterpart: the turn is explaining instead
+      of delivering that replacement, so the text after it adds to the answer
+      rather than replacing it. Also exempt, and for a sharper reason —
+      dropping it lets the explanation pass as the replacement, and the answer
+      the user already read is lost from the transcript.
   {"kind": "memory", "entries": [...]}  - pre-terminal; cowork persists these
   {"kind": "skill", "entries": [...]}   - pre-terminal; skill drafts the agent
       built this turn, as [{"slug", "files": {name: text}}]. Staged only: cowork

--- a/anton/cloud_turn/contract.py
+++ b/anton/cloud_turn/contract.py
@@ -4,8 +4,15 @@ Matches what the controller sends (`scratchpad_controller.anton_turn.request_lin
 and what cowork-server consumes off the reply stream. Intentionally minimal and
 data-only: the entrypoint reads ONE newline-terminated JSON line on stdin.
 
-Events written back on stdout (JSONL) are the six the controller translates:
+Events written back on stdout (JSONL):
   {"kind": "delta", "text": "..."}   - streamed assistant text, one per chunk
+  {"kind": "progress", "phase": "...", "message": "..."}  - phase notice, rate
+      limited to one per 250ms except for the phases the entrypoint exempts.
+      `phase: "continuation"` is the boundary the completion verifier crosses
+      when it forces a continuation: the text after it supersedes the text
+      before it, so cowork replaces the answer rather than appending to it.
+      Exempt from the rate limit — dropping it reinstates the duplicated
+      answer, since the replacement text still arrives either way.
   {"kind": "memory", "entries": [...]}  - pre-terminal; cowork persists these
   {"kind": "skill", "entries": [...]}   - pre-terminal; skill drafts the agent
       built this turn, as [{"slug", "files": {name: text}}]. Staged only: cowork
@@ -18,6 +25,10 @@ Events written back on stdout (JSONL) are the six the controller translates:
       on failure, in which case that turn replays text-only.
   {"kind": "turn_completed"}          - terminal success (no payload)
   {"kind": "turn_failed", "error": "..."}  - terminal failure (scrubbed string)
+
+The tool/round step kinds the controller relays unchanged as `turn_step` are
+not spelled out above: `tool_start`, `tool_end`, `tool_result`, `compacted`,
+`round_end`. A `heartbeat` only resets the controller's stall timer.
 """
 
 from __future__ import annotations

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3495,6 +3495,12 @@ class ChatSession:
         and stale-but-real beats blank.
         """
         log = logging.getLogger(__name__)
+        # Cancels a pending continuation boundary. A forced continuation whose
+        # rounds only call tools reaches a hand-back with the boundary still
+        # unspent, and this diagnosis would then be taken for the replacement
+        # answer — discarding the one the user actually read. It explains that
+        # answer, so it adds to it.
+        yield StreamTaskProgress(phase="handback", message="")
         diagnosis_response = None
         async for event in self.plan_stream_with_recovery(system=system):
             yield event
@@ -5995,7 +6001,7 @@ class ChatSession:
             # Its own phase, not `analyzing`: this is the boundary between an
             # answer the user already read and the one that supersedes it, and a
             # client accumulating deltas into one bubble cannot find it
-            # otherwise. Seven other sites emit `analyzing`.
+            # otherwise. `analyzing` is emitted from several unrelated sites.
             yield StreamTaskProgress(
                 phase="continuation",
                 message=f"Task incomplete — continuing ({continuation}/{self._max_continuations})...",

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3485,24 +3485,28 @@ class ChatSession:
     ):
         """Stream a hand-back diagnosis and persist exactly what the user read.
 
-        All three hand-back paths (STUCK, budget-exhausted, verifier-call
-        failure) stream a model-generated message and then stop the turn. The
-        message must be captured into history, because it — not the reply the
-        verifier rejected — is what the user actually saw. Persisting it also
-        keeps `history[-1]` an assistant message, which is what stops the
-        post-loop fallback from re-appending the stale reply (ENG-1155).
+        Every hand-back path (STUCK, budget-exhausted, verifier-call failure,
+        max tool rounds, and the two spend-ceiling gates) streams a
+        model-generated message and then stops the turn. The message must be
+        captured into history, because it — not the reply the verifier
+        rejected — is what the user actually saw. Persisting it also keeps
+        `history[-1]` an assistant message, which is what stops the post-loop
+        fallback from re-appending the stale reply (ENG-1155).
 
         An empty diagnosis is logged rather than appended: an empty assistant
         turn would recreate the same out-of-sync history this exists to fix,
         and stale-but-real beats blank.
+
+        `cancels_continuation` says a continuation boundary is pending, which
+        the callers know from the continuation counter. It announces the
+        hand-back so no consumer mistakes this diagnosis for the replacement
+        answer that boundary promised.
         """
         log = logging.getLogger(__name__)
-        # Cancels a pending continuation boundary. A forced continuation whose
-        # rounds only call tools reaches a hand-back with the boundary still
-        # unspent, and this diagnosis would then be taken for the replacement
-        # answer — discarding the one the user actually read. It explains that
-        # answer, so it adds to it. Gated so a turn that never continued is
-        # unchanged on the wire.
+        # Marks this diagnosis as an explanation, not the replacement answer a
+        # pending continuation boundary promised. Without it a consumer takes
+        # it for one and drops the answer the user actually read. Gated so a
+        # turn that never continued is unchanged on the wire.
         if cancels_continuation:
             yield StreamTaskProgress(phase="handback", message="")
         diagnosis_response = None
@@ -4760,6 +4764,11 @@ class ChatSession:
             self._append_history(
                 {"role": "assistant", "content": _TRUNCATION_FAILURE_NOTICE}
             )
+            # Same reason `_stream_handback_diagnosis` announces itself: this
+            # notice is an explanation, not the replacement a pending
+            # continuation boundary promised, and a consumer that took it for
+            # one would drop the answer already read.
+            yield StreamTaskProgress(phase="handback", message="")
             yield StreamTextDelta(text=_TRUNCATION_FAILURE_NOTICE)
         yield retry
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -3480,7 +3480,9 @@ class ChatSession:
             "Do NOT retry automatically — wait for the user's response."
         )
 
-    async def _stream_handback_diagnosis(self, *, system: str, label: str):
+    async def _stream_handback_diagnosis(
+        self, *, system: str, label: str, cancels_continuation: bool = False
+    ):
         """Stream a hand-back diagnosis and persist exactly what the user read.
 
         All three hand-back paths (STUCK, budget-exhausted, verifier-call
@@ -3499,8 +3501,10 @@ class ChatSession:
         # rounds only call tools reaches a hand-back with the boundary still
         # unspent, and this diagnosis would then be taken for the replacement
         # answer — discarding the one the user actually read. It explains that
-        # answer, so it adds to it.
-        yield StreamTaskProgress(phase="handback", message="")
+        # answer, so it adds to it. Gated so a turn that never continued is
+        # unchanged on the wire.
+        if cancels_continuation:
+            yield StreamTaskProgress(phase="handback", message="")
         diagnosis_response = None
         async for event in self.plan_stream_with_recovery(system=system):
             yield event
@@ -4908,7 +4912,8 @@ class ChatSession:
                     # the highest-traffic one of the four).
                     _reply_persisted = True
                     async for event in self._stream_handback_diagnosis(
-                        system=system, label="max-tool-rounds"
+                        system=system, label="max-tool-rounds",
+                        cancels_continuation=continuation > 0,
                     ):
                         yield event
                     break
@@ -4957,7 +4962,8 @@ class ChatSession:
                             message="Reached this task's token budget — checking in with you...",
                         )
                         async for event in self._stream_handback_diagnosis(
-                            system=system, label="spend-ceiling"
+                            system=system, label="spend-ceiling",
+                            cancels_continuation=continuation > 0,
                         ):
                             yield event
                         break
@@ -5554,7 +5560,8 @@ class ChatSession:
                 if self._turn_cost is not None:
                     self._turn_cost.ended_by = "handback_budget"
                 async for event in self._stream_handback_diagnosis(
-                    system=system, label="budget-exhausted"
+                    system=system, label="budget-exhausted",
+                    cancels_continuation=continuation > 0,
                 ):
                     yield event
                 # Consolidation still runs after diagnosis
@@ -5887,7 +5894,8 @@ class ChatSession:
                 if self._turn_cost is not None:
                     self._turn_cost.ended_by = "handback_verifier_failure"
                 async for event in self._stream_handback_diagnosis(
-                    system=system, label="verifier-failure"
+                    system=system, label="verifier-failure",
+                    cancels_continuation=continuation > 0,
                 ):
                     yield event
                 break
@@ -5927,7 +5935,8 @@ class ChatSession:
                 if self._turn_cost is not None:
                     self._turn_cost.ended_by = "handback_stuck"
                 async for event in self._stream_handback_diagnosis(
-                    system=system, label="stuck"
+                    system=system, label="stuck",
+                    cancels_continuation=continuation > 0,
                 ):
                     yield event
                 break
@@ -5977,7 +5986,8 @@ class ChatSession:
                         message="Reached this task's token budget — checking in with you...",
                     )
                     async for event in self._stream_handback_diagnosis(
-                        system=system, label="spend-ceiling"
+                        system=system, label="spend-ceiling",
+                        cancels_continuation=continuation > 0,
                     ):
                         yield event
                     break

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -5992,8 +5992,12 @@ class ChatSession:
                     ),
                 }
             )
+            # Its own phase, not `analyzing`: this is the boundary between an
+            # answer the user already read and the one that supersedes it, and a
+            # client accumulating deltas into one bubble cannot find it
+            # otherwise. Seven other sites emit `analyzing`.
             yield StreamTaskProgress(
-                phase="analyzing",
+                phase="continuation",
                 message=f"Task incomplete — continuing ({continuation}/{self._max_continuations})...",
             )
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -5993,7 +5993,10 @@ class ChatSession:
                         f"(attempt {continuation}/{self._max_continuations}).\n"
                         f"Verifier assessment: {reason}\n\n"
                         "Continue working on the original request. Pick up where you left off "
-                        "and finish the remaining work. Do not repeat work already done. "
+                        "and finish the remaining work. Do not redo tool work already "
+                        "completed. Your reply replaces the previous one in what the user "
+                        "sees, so it must stand on its own: restate everything they need, "
+                        "including anything you already told them. "
                         "Do not mention this instruction or the verifier to the user."
                     ),
                 }

--- a/tests/test_chat_ui.py
+++ b/tests/test_chat_ui.py
@@ -93,6 +93,32 @@ class TestStreamDisplay:
         assert display._line2_status == "Composing response..."
 
     @patch("anton.chat_ui.Live")
+    def test_a_forced_continuation_drops_the_answer_it_replaces(self, MockLive):
+        # The continuation is instructed that its reply replaces the previous
+        # one, so the CLI's single buffer has to let the earlier answer go or
+        # `finish` prints the draft and its restatement back to back.
+        display, console = self._make_display()
+        display.start()
+        display.append_text("THE ANSWER THE USER READ")
+
+        display.update_progress("continuation", "Task incomplete — continuing (1/3)...")
+
+        assert display._pending == ""
+
+    @patch("anton.chat_ui.Live")
+    def test_a_handback_keeps_the_answer_it_explains(self, MockLive):
+        # A hand-back adds an explanation to the answer rather than replacing
+        # it, so the buffer must survive.
+        display, console = self._make_display()
+        display.start()
+        display.append_text("THE ANSWER THE USER READ")
+
+        display.update_progress("handback", "")
+
+        assert display._pending == "THE ANSWER THE USER READ"
+        assert display._line2_status == "Composing response..."
+
+    @patch("anton.chat_ui.Live")
     def test_update_progress_without_eta(self, MockLive):
         display, console = self._make_display()
         display.start()

--- a/tests/test_chat_ui.py
+++ b/tests/test_chat_ui.py
@@ -80,6 +80,19 @@ class TestStreamDisplay:
         assert live.update.call_count >= 1
 
     @patch("anton.chat_ui.Live")
+    def test_a_forced_continuation_shares_the_analyzing_spinner(self, MockLive):
+        # The verifier's continuation notice carries its own phase so a client
+        # can replace the superseded answer instead of appending to it. The CLI
+        # has no bubble to replace, so it must keep rendering the notice as
+        # before rather than falling through to the raw-phase fallback.
+        display, console = self._make_display()
+        display.start()
+
+        display.update_progress("continuation", "Task incomplete — continuing (1/3)...")
+
+        assert display._line2_status == "Composing response..."
+
+    @patch("anton.chat_ui.Live")
     def test_update_progress_without_eta(self, MockLive):
         display, console = self._make_display()
         display.start()

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -596,3 +596,19 @@ def test_no_trace_block_forwards_no_metadata():
     session = _KwargCapturingSession()
     _drive(session)
     assert session.turn_kwargs["trace_metadata"] is None
+
+
+def test_the_handback_marker_outlives_a_progress_flood_too():
+    """It cancels the continuation boundary, so losing it is as bad as losing
+    the boundary: the hand-back diagnosis would replace the answer it explains."""
+    class _S(_FakeSession):
+        async def turn_stream(self, user_input, **kwargs):
+            for i in range(50):
+                yield StreamTaskProgress(phase="progress", message=f"m{i}")
+            yield StreamTaskProgress(phase="handback", message="")
+
+    events = _drive(_S())
+    phases = [e["phase"] for e in events if e.get("kind") == "progress"]
+    assert phases.count("handback") == 1, (
+        f"the hand-back marker was dropped by the rate limiter; phases: {phases}"
+    )

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -177,6 +177,28 @@ def test_progress_flood_is_rate_limited_but_step_phases_pass():
     assert len(progress) < 10  # the 50-call flood collapses on the wire
 
 
+def test_the_continuation_boundary_outlives_a_progress_flood():
+    """The boundary tells cowork the following text supersedes what came before.
+
+    Rate-limiting it away restores the duplicated-answer bug silently, since the
+    replacement text still arrives — it just appends. One event per continuation,
+    so exempting it cannot flood the wire.
+    """
+    class _S(_FakeSession):
+        async def turn_stream(self, user_input, **kwargs):
+            for i in range(50):
+                yield StreamTaskProgress(phase="progress", message=f"m{i}")
+            yield StreamTaskProgress(
+                phase="continuation", message="Task incomplete — continuing (1/3)..."
+            )
+
+    events = _drive(_S())
+    phases = [e["phase"] for e in events if e.get("kind") == "progress"]
+    assert phases.count("continuation") == 1, (
+        f"the boundary was dropped by the rate limiter; phases on the wire: {phases}"
+    )
+
+
 def test_tool_args_accumulation_is_bounded():
     class _S(_FakeSession):
         async def turn_stream(self, user_input, **kwargs):

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -26,6 +26,7 @@ from anton.core.llm.provider import (
     ModelUnavailableError,
     StreamComplete,
     StreamTaskProgress,
+    StreamTextDelta,
     TokenLimitExceeded,
     ToolCall,
     Usage,
@@ -640,6 +641,74 @@ async def test_text_only_continuation_answer_is_not_dropped(workspace):
         assert "FINAL_ANSWER_USER_READ" in texts[-1]
     finally:
         await session.close()
+
+
+async def test_a_forced_continuation_marks_its_own_boundary(workspace):
+    """Where a superseded answer ends and its replacement begins.
+
+    Consumers accumulate every text delta of a turn into one bubble, so a
+    replacement needs a signal to replace instead of append. `analyzing`
+    cannot carry it: seven other sites emit that phase for unrelated
+    situations, told apart only by free text.
+    """
+    mock_llm = make_mock_llm()
+    verdicts = [_VerifierVerdict(status="INCOMPLETE", reason="not done yet")]
+
+    async def verdict(_schema, *, system, messages, max_tokens):
+        return verdicts.pop(0) if verdicts else _VerifierVerdict(
+            status="COMPLETE", reason="done"
+        )
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=verdict)
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Working.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            return _FakeAsyncIter([
+                StreamTextDelta(text="SUPERSEDED"),
+                StreamComplete(response=_text_response("SUPERSEDED")),
+            ])
+        return _FakeAsyncIter([
+            StreamTextDelta(text="REPLACEMENT"),
+            StreamComplete(response=_text_response("REPLACEMENT")),
+        ])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    try:
+        events = [event async for event in session.turn_stream("write me a summary")]
+    finally:
+        await session.close()
+
+    boundaries = [
+        i for i, event in enumerate(events)
+        if isinstance(event, StreamTaskProgress) and event.phase == "continuation"
+    ]
+    assert len(boundaries) == 1, (
+        "the boundary must be announced exactly once; progress phases seen: "
+        f"{[e.phase for e in events if isinstance(e, StreamTaskProgress)]}"
+    )
+
+    superseded = next(
+        i for i, event in enumerate(events)
+        if isinstance(event, StreamTextDelta) and event.text == "SUPERSEDED"
+    )
+    replacement = next(
+        i for i, event in enumerate(events)
+        if isinstance(event, StreamTextDelta) and event.text == "REPLACEMENT"
+    )
+    assert superseded < boundaries[0] < replacement, (
+        "the boundary must land after the superseded text and before its "
+        "replacement, or a consumer cannot tell which text to drop"
+    )
 
 
 async def test_latched_verifier_reprobes_and_can_recover(workspace):

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -766,13 +766,84 @@ async def test_the_continuation_instruction_asks_for_a_standalone_answer(workspa
         await session.close()
 
 
-async def test_a_handback_announces_itself_before_its_diagnosis(workspace):
-    """The hand-back marker cancels an unspent continuation boundary.
+async def test_a_handback_after_a_continuation_announces_itself(workspace):
+    """The marker cancels the boundary the continuation left pending.
 
-    A continuation whose rounds only call tools reaches a hand-back with the
-    boundary still pending, and a client would then take this diagnosis for the
-    replacement answer and discard the one the user read. The marker has to
-    arrive before the diagnosis text, not with it.
+    A continuation that fails to satisfy the verifier still reaches a
+    hand-back, and without this marker the diagnosis streamed there is read as
+    the replacement answer — discarding the one the user had already read. It
+    has to arrive before the diagnosis text, not with it.
+    """
+    mock_llm = make_mock_llm()
+    verdicts = [
+        _VerifierVerdict(status="INCOMPLETE", reason="not done yet"),
+        _VerifierVerdict(status="STUCK", reason="missing credentials"),
+    ]
+
+    async def verdict(_schema, *, system, messages, max_tokens):
+        return verdicts.pop(0) if verdicts else _VerifierVerdict(
+            status="COMPLETE", reason="done"
+        )
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=verdict)
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Working.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            return _FakeAsyncIter([
+                StreamTextDelta(text="THE ANSWER THE USER READ"),
+                StreamComplete(response=_text_response("THE ANSWER THE USER READ")),
+            ])
+        if call_count == 3:
+            # The continuation must spend a tool round, or the loop breaks at
+            # the verify_min_tool_rounds gate and never verifies a second time.
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Retrying.", "exec", "main", "print(2)"))
+            ])
+        if call_count == 4:
+            return _FakeAsyncIter([StreamComplete(response=_text_response("CONTINUED"))])
+        return _FakeAsyncIter([
+            StreamTextDelta(text="DIAGNOSIS"),
+            StreamComplete(response=_text_response("DIAGNOSIS")),
+        ])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    try:
+        events = [event async for event in session.turn_stream("query my database")]
+    finally:
+        await session.close()
+
+    phases = [
+        (i, e.phase) for i, e in enumerate(events) if isinstance(e, StreamTaskProgress)
+    ]
+    markers = [i for i, phase in phases if phase == "handback"]
+    assert len(markers) == 1, (
+        f"the hand-back must be announced exactly once; phases seen: {phases}"
+    )
+    diagnosis = next(
+        i for i, event in enumerate(events)
+        if isinstance(event, StreamTextDelta) and event.text == "DIAGNOSIS"
+    )
+    assert markers[0] < diagnosis, (
+        "the marker must precede the diagnosis text, or a pending boundary is "
+        "already spent by the time it arrives"
+    )
+
+
+async def test_a_handback_with_no_continuation_announces_nothing(workspace):
+    """No boundary was emitted, so there is none to cancel.
+
+    Most hand-backs are reached without any continuation, and a turn that never
+    continued has to look exactly as it did before this marker existed.
     """
     mock_llm = make_mock_llm()
     mock_llm.generate_object_code = AsyncMock(
@@ -789,14 +860,8 @@ async def test_a_handback_announces_itself_before_its_diagnosis(workspace):
                 StreamComplete(response=_scratchpad_response("Running.", "exec", "main", "print(1)"))
             ])
         if call_count == 2:
-            return _FakeAsyncIter([
-                StreamTextDelta(text="THE ANSWER THE USER READ"),
-                StreamComplete(response=_text_response("THE ANSWER THE USER READ")),
-            ])
-        return _FakeAsyncIter([
-            StreamTextDelta(text="DIAGNOSIS"),
-            StreamComplete(response=_text_response("DIAGNOSIS")),
-        ])
+            return _FakeAsyncIter([StreamComplete(response=_text_response("REPLY"))])
+        return _FakeAsyncIter([StreamComplete(response=_text_response("DIAGNOSIS"))])
 
     mock_llm.plan_stream = fake_plan_stream
 
@@ -806,21 +871,9 @@ async def test_a_handback_announces_itself_before_its_diagnosis(workspace):
     finally:
         await session.close()
 
-    markers = [
-        i for i, event in enumerate(events)
-        if isinstance(event, StreamTaskProgress) and event.phase == "handback"
-    ]
-    assert len(markers) == 1, (
-        "the hand-back must be announced exactly once; progress phases seen: "
-        f"{[e.phase for e in events if isinstance(e, StreamTaskProgress)]}"
-    )
-    diagnosis = next(
-        i for i, event in enumerate(events)
-        if isinstance(event, StreamTextDelta) and event.text == "DIAGNOSIS"
-    )
-    assert markers[0] < diagnosis, (
-        "the marker must precede the diagnosis text, or a pending boundary is "
-        "already spent by the time it arrives"
+    phases = [e.phase for e in events if isinstance(e, StreamTaskProgress)]
+    assert "handback" not in phases, (
+        f"a turn with no continuation gained a wire event; phases: {phases}"
     )
 
 

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -711,6 +711,61 @@ async def test_a_forced_continuation_marks_its_own_boundary(workspace):
     )
 
 
+async def test_the_continuation_instruction_asks_for_a_standalone_answer(workspace):
+    """The injected instruction has to match what the client does with the reply.
+
+    Consumers replace the answer on a continuation boundary, so a model that
+    obeys an increment-shaped instruction and writes only the new findings
+    leaves the user holding a fragment, with the earlier findings unrecoverable.
+    """
+    mock_llm = make_mock_llm()
+    verdicts = [_VerifierVerdict(status="INCOMPLETE", reason="not done yet")]
+
+    async def verdict(_schema, *, system, messages, max_tokens):
+        return verdicts.pop(0) if verdicts else _VerifierVerdict(
+            status="COMPLETE", reason="done"
+        )
+
+    mock_llm.generate_object_code = AsyncMock(side_effect=verdict)
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Working.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            return _FakeAsyncIter([StreamComplete(response=_text_response("DRAFT"))])
+        return _FakeAsyncIter([StreamComplete(response=_text_response("FINAL"))])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    try:
+        async for _ in session.turn_stream("write me a summary"):
+            pass
+
+        injected = [
+            m["content"] for m in session.history
+            if m.get("role") == "user" and str(m.get("content", "")).startswith("SYSTEM:")
+        ]
+        assert injected, "the continuation instruction was never injected"
+        instruction = injected[-1]
+        assert "replaces the previous one" in instruction, (
+            f"the instruction does not tell the model its reply replaces the "
+            f"earlier one: {instruction!r}"
+        )
+        assert "Do not repeat work already done" not in instruction, (
+            "the increment-shaped guard is back; a model obeying it writes only "
+            "the new part, which is all the user would then see"
+        )
+    finally:
+        await session.close()
+
+
 async def test_a_handback_announces_itself_before_its_diagnosis(workspace):
     """The hand-back marker cancels an unspent continuation boundary.
 

--- a/tests/test_verifier_failsafe.py
+++ b/tests/test_verifier_failsafe.py
@@ -711,6 +711,64 @@ async def test_a_forced_continuation_marks_its_own_boundary(workspace):
     )
 
 
+async def test_a_handback_announces_itself_before_its_diagnosis(workspace):
+    """The hand-back marker cancels an unspent continuation boundary.
+
+    A continuation whose rounds only call tools reaches a hand-back with the
+    boundary still pending, and a client would then take this diagnosis for the
+    replacement answer and discard the one the user read. The marker has to
+    arrive before the diagnosis text, not with it.
+    """
+    mock_llm = make_mock_llm()
+    mock_llm.generate_object_code = AsyncMock(
+        return_value=_VerifierVerdict(status="STUCK", reason="missing credentials")
+    )
+
+    call_count = 0
+
+    def fake_plan_stream(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _FakeAsyncIter([
+                StreamComplete(response=_scratchpad_response("Running.", "exec", "main", "print(1)"))
+            ])
+        if call_count == 2:
+            return _FakeAsyncIter([
+                StreamTextDelta(text="THE ANSWER THE USER READ"),
+                StreamComplete(response=_text_response("THE ANSWER THE USER READ")),
+            ])
+        return _FakeAsyncIter([
+            StreamTextDelta(text="DIAGNOSIS"),
+            StreamComplete(response=_text_response("DIAGNOSIS")),
+        ])
+
+    mock_llm.plan_stream = fake_plan_stream
+
+    session = ChatSession(ChatSessionConfig(llm_client=mock_llm, workspace=workspace))
+    try:
+        events = [event async for event in session.turn_stream("query my database")]
+    finally:
+        await session.close()
+
+    markers = [
+        i for i, event in enumerate(events)
+        if isinstance(event, StreamTaskProgress) and event.phase == "handback"
+    ]
+    assert len(markers) == 1, (
+        "the hand-back must be announced exactly once; progress phases seen: "
+        f"{[e.phase for e in events if isinstance(e, StreamTaskProgress)]}"
+    )
+    diagnosis = next(
+        i for i, event in enumerate(events)
+        if isinstance(event, StreamTextDelta) and event.text == "DIAGNOSIS"
+    )
+    assert markers[0] < diagnosis, (
+        "the marker must precede the diagnosis text, or a pending boundary is "
+        "already spent by the time it arrives"
+    )
+
+
 async def test_latched_verifier_reprobes_and_can_recover(workspace):
     """Self-review catch. A latched session makes no verdict calls, so "reset on a
     successful verdict" is unreachable and the latch outlives its cause — the user


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-1278/a-forced-continuation-appends-into-the-same-answer-bubble-the-client

## What changed

- gives the verifier's continuation notice its own `continuation` phase, so a client can find the boundary; `analyzing` cannot carry it, since six unrelated sites emit that phase and only free text tells them apart
- exempts it from the pod's 250ms progress rate limit, which could drop it silently while the replacement text still arrived and appended
- announces `handback` from `_stream_handback_diagnosis`, so a hand-back diagnosis is not mistaken for the replacement answer, and documents the phase in the wire contract cowork-server now depends on for correctness
- asks the continuation for a reply that stands on its own, since "do not repeat work already done" and replace-on-boundary cannot both hold
- gates the hand-back marker on a continuation actually being pending, so a turn that never continued is unchanged on the wire and in the persisted event log
- clears the CLI's own text buffer on the boundary, so the instruction above is true on that surface too rather than printing the draft and its restatement back to back

## Why this matters

The verifier legitimately continues an unfinished task, and the user then reads the answer twice. The client half of the fix needs a signal only anton can send, and the instruction anton injects has to agree with what the client does with the reply.

## Notes for the reviewer

- **The prompt change is a behaviour change, and the deliberate one.** With consumers replacing at the boundary, a model that obeyed the old increment-shaped guard would write only its new findings and the user would see those alone, losing the earlier ones. "Do not repeat" now governs the tool work.
- **The CLI change follows from it, not from the ticket.** The ticket scoped the CLI out, but once the instruction claims the reply replaces the previous one, the surface that appends has to honour it. A hand-back deliberately keeps the buffer, because it explains the answer rather than replacing it.
- **The hand-back marker is gated so turns that never continued are unchanged.** The round cap and the spend ceiling hand back on ordinary turns; emitting there would add a wire event and a persisted event row for a turn with no continuation. Two tests pin the gate in both directions.
- **The truncation-failure notice announces a hand-back too.** It is an explanation reached with a boundary possibly pending, so without it a consumer takes it for the replacement.
- **No new pod event kind, so `scratchpad-controller` needs no change.** Both phases ride the existing `progress` kind, whose payload the controller relays with every key intact. A new kind would have been dropped by `_event_line_to_reply`.
- **Neither phase gets a `PHASE_LABELS` entry in the CLI**, for the reason that dict's own comment gives: the branch they take returns before the label fallback.
- **Merge and deploy this last.** cowork-server must already carry its paired PR, or an older `PHASE_LABELS` leaks the raw phase into the thinking line.

## How to test

1. `uv run pytest tests/test_verifier_failsafe.py tests/test_cloud_turn_entrypoint.py tests/test_chat_ui.py`
2. `uv run pytest`
3. With the paired PRs deployed, force a continuation and confirm one coherent answer live and after reload.

## Ships with

- mindsdb/cowork#957, the renderer half.
- mindsdb/cowork-server#505, which turns these phases into SSE events and owns persistence.
- Merge order: cowork, then cowork-server, then anton.

## Checks

| Check | Observed result |
| --- | --- |
| `uv run pytest` | 3140 passed, 31 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
