### PR TITLE
docs(settings): describe the precedence that actually applies

### DIFF
--- a/anton/config/settings.py
+++ b/anton/config/settings.py
@@ -11,7 +11,20 @@ def _build_env_files() -> list[str]:
     """Build .env loading chain: cwd/.env -> .anton/.env -> ~/.anton/.env
     -> ~/.cowork/.env. Later files win, so the consolidated ~/.cowork/.env
     takes precedence; ~/.anton/.env stays as a fallback for installs that
-    haven't migrated yet."""
+    haven't migrated yet.
+
+    That ordering holds only AMONG THESE FILES. pydantic-settings ranks
+    `os.environ` above every `env_file`, so anything promoted into the process
+    environment outranks all four — including `Workspace.apply_env_to_process`,
+    which copies a project's `.anton/.env` into `os.environ` at boot, and
+    `Workspace.set_secret`, which sets the variable as a side effect of writing.
+    Reading only the list below therefore predicts the wrong key whenever a
+    promotion has happened (ENG-1424).
+
+    The list is also built ONCE at import, from the files that existed then and
+    against the then-current `Path.cwd()`. A file created later is not in the
+    chain until something rebuilds it, and `--folder` does not re-evaluate it.
+    """
     files: list[str] = [".env"]
     local_env = Path.cwd() / ".anton" / ".env"
     if local_env.is_file():


### PR DESCRIPTION
## What

Corrects the `_build_env_files` docstring in `anton/config/settings.py`. **Comment-only — no code path changes.**

## Why

It currently says only:

> *"Later files win, so the consolidated `~/.cowork/.env` takes precedence"*

That is true **among the four files** and misleading about the system. pydantic-settings ranks `os.environ` above every `env_file`, so anything promoted into the process environment outranks all four.

Not theoretical: `Workspace.apply_env_to_process` copies a project's `.anton/.env` into `os.environ` at boot, and `Workspace.set_secret` sets the variable as a side effect of writing. Anyone reasoning about key precedence from this docstring predicts the wrong key once either has run — which is the gap ENG-1424 lived in, and that ticket named this docstring as a contributing factor.

The rewrite also records that the chain is built **once at import**, from the files that existed then and against the then-current `cwd`: a file created later is absent until something rebuilds it, and `--folder` does not re-evaluate it. Both facts cost a review round to rediscover on #439.

## Note on timing

anton#313 (ENG-1295) would have rewritten this docstring as a side effect of deleting `~/.cowork/.env` from the chain, but it was closed on 2026-09-08 ("Closing, may reopen in future") after a month as a draft. Nothing else is queued to touch this function, so the misleading text would otherwise stay.

If ENG-1295 is revived, this docstring should be rewritten again rather than patched — the file list changes.

## Security

No behaviour change and no new surface. The diff adds documentation only; it names no credential values and changes nothing about how keys are read or written.

## Testing

Comment-only, so no new tests. Verified the module still imports, `_build_env_files()` returns an unchanged chain, and `tests/test_settings.py` plus `tests/test_publish_identity_reconcile.py` pass (43 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)