### PR TITLE
chore: remove CODEOWNERS entries now enforced org-wide (ENG-2013)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# All workflows, actions, issue templates, etc. require DevOps review.
-.github/ @mindsdb/devops


### PR DESCRIPTION
## What

Deletes `.github/CODEOWNERS`. The org-level ruleset in mindsdb/terraform (`newprod/global/github`) requires a `@mindsdb/devops` review on the paths common to all repos, and enforces each repo's CODEOWNERS through `require_code_owner_review`. So: shared paths leave this file, repo-specific ones stay.

Removed:
```
.github/ @mindsdb/devops
```

## Why

One org-wide policy in terraform for what every repo shares; CODEOWNERS for what only this repo needs. Neither duplicates the other.

Targets `staging` so it reaches `main` with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)