### PR TITLE
Drop snapshot time that invalidates cache

### DIFF
--- a/anton/core/backends/manager.py
+++ b/anton/core/backends/manager.py
@@ -78,27 +78,6 @@ class ScratchpadManager:
         """Project root this manager serves — discovery needs it for listings."""
         return self._workspace_path
 
-    def pad_snapshot_mtime(self, name: str) -> float | None:
-        """Epoch mtime of `name`'s ENG-1124 snapshot, or None when unknowable.
-
-        None covers every non-answer (unscoped session, no snapshot dir,
-        never persisted): discovery renders those pads without an age rather
-        than failing the block.
-        """
-        if not self._session_id or not name:
-            return None
-        try:
-            from anton.core.backends.local import default_venvs_base, snapshot_file
-
-            path = snapshot_file(
-                default_venvs_base(self._workspace_path), self._session_id, name
-            )
-            return path.stat().st_mtime if path is not None else None
-        except OSError:
-            return None
-        except Exception:
-            return None
-
     def _agent_pads_file(self):
         """Where this conversation's agent-chosen pad names are recorded, or None.
 

--- a/anton/core/utils/scratchpad.py
+++ b/anton/core/utils/scratchpad.py
@@ -106,19 +106,6 @@ _DISCOVERY_MAX_PADS = 10
 _DISCOVERY_MAX_ROOT_ENTRIES = 30
 
 
-def _age_label(mtime: float | None) -> str:
-    if mtime is None:
-        return ""
-    import time
-
-    mins = max(0, int((time.time() - mtime) / 60))
-    if mins < 60:
-        return f" (snapshot {mins}m old)"
-    if mins < 60 * 48:
-        return f" (snapshot {mins // 60}h old)"
-    return f" (snapshot {mins // (60 * 24)}d old)"
-
-
 def build_workspace_discovery_context(manager) -> str:
     """Compact turn-start block: known pads + project-root names (ENG-578).
 
@@ -135,13 +122,10 @@ def build_workspace_discovery_context(manager) -> str:
             shown = known[:_DISCOVERY_MAX_PADS]
             live = set(manager.pads)
             parts = []
+            # Names and the active flag only. A snapshot age would tick every
+            # minute and change the prompt bytes on every turn.
             for name in shown:
-                label = (
-                    " (active)"
-                    if name in live
-                    else _age_label(manager.pad_snapshot_mtime(name))
-                )
-                parts.append(f"{name}{label}")
+                parts.append(f"{name} (active)" if name in live else name)
             more = (
                 f" … and {len(known) - len(shown)} more"
                 if len(known) > len(shown)

--- a/tests/test_workspace_discovery.py
+++ b/tests/test_workspace_discovery.py
@@ -1,11 +1,11 @@
 """ENG-578 slice 2: cold-start discovery — manager accessors + context block."""
 from __future__ import annotations
 
-import time
 from pathlib import Path
 
 from anton.core.backends.local import (
     LocalScratchpadRuntime,
+    default_venvs_base,
     local_scratchpad_runtime_factory,
     snapshot_file,
 )
@@ -31,26 +31,6 @@ def make_manager(tmp_path: Path | None = None, session_id: str | None = "conv1")
 class TestManagerAccessors:
     def test_workspace_path_exposed(self, tmp_path):
         assert make_manager(tmp_path).workspace_path == tmp_path
-
-    def test_snapshot_mtime_none_when_unscoped(self, tmp_path):
-        mgr = make_manager(tmp_path, session_id=None)
-        assert mgr.pad_snapshot_mtime("anything") is None
-
-    def test_snapshot_mtime_none_when_missing(self, tmp_path):
-        assert make_manager(tmp_path).pad_snapshot_mtime("ghost") is None
-
-    def test_snapshot_mtime_reads_existing_snapshot(self, tmp_path):
-        # Compose the snapshot path exactly the way the runtime does, write a
-        # stub snapshot, and confirm the mtime comes back.
-        from anton.core.backends.local import default_venvs_base
-
-        mgr = make_manager(tmp_path)
-        path = snapshot_file(default_venvs_base(tmp_path), "conv1", "campaign")
-        assert path is not None
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(b"stub")
-        got = mgr.pad_snapshot_mtime("campaign")
-        assert got is not None and abs(got - time.time()) < 60
 
 
 from anton.core.utils.scratchpad import build_workspace_discovery_context
@@ -91,6 +71,22 @@ class TestDiscoveryBlock:
         block = build_workspace_discovery_context(mgr)
         assert "catanah (active)" in block
         assert "artifact-slug-pad" not in block
+
+    def test_snapshotted_pad_carries_no_age(self, tmp_path):
+        # A pad with an on-disk snapshot used to render "(snapshot 4m old)".
+        # That label ticked every minute and changed the prompt bytes on
+        # every turn, so the block must stay byte-stable while nothing in the
+        # workspace changes: bare name, no age.
+        mgr = make_manager(tmp_path)
+        seed_agent_pads(mgr, ["campaign"])
+        path = snapshot_file(default_venvs_base(tmp_path), "conv1", "campaign")
+        assert path is not None
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"stub")
+        block = build_workspace_discovery_context(mgr)
+        assert "Scratchpads for this conversation: campaign —" in block
+        assert "snapshot" not in block
+        assert build_workspace_discovery_context(mgr) == block
 
     def test_caps_and_remainders(self, tmp_path):
         for i in range(35):


### PR DESCRIPTION
The workspace block in the system prompt labelled each known scratchpad with its age, "campaign (snapshot 4m old)". The number is computed from the clock, so the prompt bytes changed every minute even when nothing in the workspace changed. That block sits inside the cached system string, so every user turn invalidated the system prompt and the whole conversation history behind it and re-billed them at cache-write prices.

Linear: [ENG-2619](https://linear.app/mindsdb/issue/ENG-2619/scratchpad-age-label-in-the-workspace-listing-changes-the-system)
