### PR TITLE
[ENG-2620] Date a cloud conversation from its start time, not the pod's clock

### DIFF
--- a/anton/cloud_turn/contract.py
+++ b/anton/cloud_turn/contract.py
@@ -85,6 +85,12 @@ class TurnRequestV1:
     #: empty means no connectors for this turn — see cloud_turn/session.py's
     #: build_cloud_chat_session, which is the only place this is read.
     oauth: dict | None = None
+    #: Optional ISO 8601 creation time of the conversation, as cowork-server
+    #: resolved it. The pod is new every turn and cannot derive this: history
+    #: rows carry no timestamps. Without it the session dates the conversation
+    #: from the pod's own clock, so the prompt says a three week old
+    #: conversation started today and changes at every midnight.
+    started_at: str | None = None
 
     @staticmethod
     def from_json(raw: str) -> "TurnRequestV1":
@@ -104,4 +110,9 @@ class TurnRequestV1:
             trace=d.get("trace") if isinstance(d.get("trace"), dict) else None,
             # Same defensive isinstance check as trace, for the same reason.
             oauth=d.get("oauth") if isinstance(d.get("oauth"), dict) else None,
+            # The controller always sends the key and sends None when
+            # cowork-server could not resolve it, so the guard does real work.
+            started_at=(
+                d.get("started_at") if isinstance(d.get("started_at"), str) else None
+            ),
         )

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -25,6 +25,7 @@ import hashlib
 import logging
 import os
 import tempfile
+from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
@@ -648,11 +649,29 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
 
         clear_ds_env()
 
+    # When the conversation began, so the prompt dates it from the conversation
+    # rather than from this pod, which is new every turn. Unparsable degrades to
+    # None, which is today, rather than failing a turn over a prompt line — but
+    # it says so, because a silent degrade cannot be told apart from a
+    # controller that stopped sending the field. The value is a timestamp.
+    started_at = None
+    if request.started_at:
+        try:
+            started_at = datetime.fromisoformat(request.started_at)
+        except ValueError:
+            logger.warning(
+                "cloud session ignoring unparsable started_at=%r conversation=%s",
+                request.started_at, request.conversation_id,
+            )
+
     config = ChatSessionConfig(
         llm_client=llm_client,
         settings=settings,
         workspace=workspace,
         session_id=request.conversation_id,
+        # None falls back to today, which is what every cloud turn did before
+        # the server started sending this.
+        started_at=started_at,
         # WHICH AGENT: this pod image is "anton + boot" — the agent running here
         # IS anton, so "cloud" was factually wrong, not merely overloaded
         # (ENG-1694). Where it ran comes from `surface` below, which cowork

--- a/anton/cloud_turn/session.py
+++ b/anton/cloud_turn/session.py
@@ -650,15 +650,15 @@ def build_cloud_chat_session(request: TurnRequestV1) -> "ChatSession":
         clear_ds_env()
 
     # When the conversation began, so the prompt dates it from the conversation
-    # rather than from this pod, which is new every turn. Unparsable degrades to
-    # None, which is today, rather than failing a turn over a prompt line — but
-    # it says so, because a silent degrade cannot be told apart from a
-    # controller that stopped sending the field. The value is a timestamp.
+    # rather than from this pod, which is new every turn.
     started_at = None
     if request.started_at:
         try:
             started_at = datetime.fromisoformat(request.started_at)
         except ValueError:
+            # Degrades to today rather than failing a turn over a prompt line,
+            # but logs the value: silence makes a shape anton cannot read look
+            # exactly like a controller that sends nothing.
             logger.warning(
                 "cloud session ignoring unparsable started_at=%r conversation=%s",
                 request.started_at, request.conversation_id,

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -11,6 +11,8 @@ import asyncio
 import json
 import logging
 
+import pytest
+
 from anton.cloud_turn.contract import TurnRequestV1
 from anton.cloud_turn.__main__ import _clip_result_content, stream_turn
 from anton.core.llm.provider import (
@@ -73,16 +75,16 @@ def test_from_json_keeps_the_conversation_start_time_as_sent():
     assert req.started_at == "2026-09-01T08:15:00+00:00"
 
 
-def test_from_json_drops_a_non_string_conversation_start_time():
+@pytest.mark.parametrize("sent", [None, 1757000000, {"iso": "2026-09-01"}])
+def test_from_json_drops_a_non_string_conversation_start_time(sent):
     """The controller always sends the key, and sends null when the server
     could not resolve it, so this guard is on the live path rather than
     defensive decoration."""
-    for sent in (None, 1757000000, {"iso": "2026-09-01"}):
-        req = TurnRequestV1.from_json(json.dumps({
-            "protocol_version": 1, "conversation_id": "c", "input": "hi",
-            "started_at": sent,
-        }))
-        assert req.started_at is None
+    req = TurnRequestV1.from_json(json.dumps({
+        "protocol_version": 1, "conversation_id": "c", "input": "hi",
+        "started_at": sent,
+    }))
+    assert req.started_at is None
 
 
 # ── streaming event emission ─────────────────────────────────────────────────

--- a/tests/test_cloud_turn_entrypoint.py
+++ b/tests/test_cloud_turn_entrypoint.py
@@ -63,6 +63,28 @@ def test_from_json_llm_defaults_none():
     assert req.llm is None
 
 
+def test_from_json_keeps_the_conversation_start_time_as_sent():
+    """Kept as the wire string. The contract mirrors the JSON line; turning it
+    into a datetime belongs where the value is used and where the fallback is."""
+    req = TurnRequestV1.from_json(json.dumps({
+        "protocol_version": 1, "conversation_id": "c", "input": "hi",
+        "started_at": "2026-09-01T08:15:00+00:00",
+    }))
+    assert req.started_at == "2026-09-01T08:15:00+00:00"
+
+
+def test_from_json_drops_a_non_string_conversation_start_time():
+    """The controller always sends the key, and sends null when the server
+    could not resolve it, so this guard is on the live path rather than
+    defensive decoration."""
+    for sent in (None, 1757000000, {"iso": "2026-09-01"}):
+        req = TurnRequestV1.from_json(json.dumps({
+            "protocol_version": 1, "conversation_id": "c", "input": "hi",
+            "started_at": sent,
+        }))
+        assert req.started_at is None
+
+
 # ── streaming event emission ─────────────────────────────────────────────────
 
 class _FakeSession:

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -142,6 +142,50 @@ def test_cloud_workspace_does_not_create_anton_md(tmp_path, monkeypatch):
     assert not (tmp_path / ".anton" / "anton.md").exists()
 
 
+# ── the conversation's start date, which this pod cannot derive ──────────────
+
+def test_both_stored_timestamp_shapes_reach_the_session(tmp_path, monkeypatch):
+    """The server sends `created_at.isoformat()`. On the Postgres cloud path
+    that column is timezone-aware so the string carries an offset; on SQLite it
+    does not. Both have to arrive, since the naive shape is what a developer
+    and CI actually run against."""
+    from datetime import datetime, timedelta, timezone
+
+    aware = "2026-09-01T08:15:00+00:00"
+    _, cfg = _build(tmp_path, monkeypatch, started_at=aware)
+    assert cfg.started_at == datetime(2026, 9, 1, 8, 15, tzinfo=timezone.utc)
+
+    naive = "2026-09-01T08:15:00"
+    _, cfg = _build(tmp_path, monkeypatch, started_at=naive)
+    assert cfg.started_at == datetime(2026, 9, 1, 8, 15)
+
+    # Trailing Z is accepted too, so a server that formats UTC that way is not
+    # silently discarded.
+    _, cfg = _build(tmp_path, monkeypatch, started_at="2026-09-01T08:15:00Z")
+    assert cfg.started_at == datetime(2026, 9, 1, 8, 15, tzinfo=timezone.utc)
+    assert timedelta(0) == cfg.started_at.utcoffset()
+
+
+def test_a_missing_start_time_leaves_the_session_to_fall_back(tmp_path, monkeypatch):
+    """A controller too old to forward the field, or a server that could not
+    resolve it, must not fail the turn: None is what every cloud turn used
+    before this existed."""
+    _, cfg = _build(tmp_path, monkeypatch)
+    assert cfg.started_at is None
+
+
+def test_an_unparsable_start_time_degrades_but_is_logged(tmp_path, monkeypatch, caplog):
+    """Degrading in silence would make a server sending a shape anton cannot
+    read look identical to a controller that stopped sending the field, and the
+    only symptom either way is a date quietly reverting to today."""
+    with caplog.at_level("WARNING"):
+        _, cfg = _build(tmp_path, monkeypatch, started_at="2026/09/01 08:15")
+
+    assert cfg.started_at is None
+    assert "started_at" in caplog.text
+    assert "2026/09/01 08:15" in caplog.text
+
+
 def test_db_history_is_seeded_not_loaded(tmp_path, monkeypatch):
     _, cfg = _build(
         tmp_path, monkeypatch,

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -11,6 +11,9 @@ Two layers:
 from __future__ import annotations
 
 import os
+# Bound at import so the constants below are built from the real class, which
+# `_pin_today` later replaces on the module.
+from datetime import datetime as _stdlib_datetime
 
 import pytest
 
@@ -163,7 +166,9 @@ def test_both_stored_timestamp_shapes_reach_the_session(tmp_path, monkeypatch):
     # silently discarded.
     _, cfg = _build(tmp_path, monkeypatch, started_at="2026-09-01T08:15:00Z")
     assert cfg.started_at == datetime(2026, 9, 1, 8, 15, tzinfo=timezone.utc)
-    assert timedelta(0) == cfg.started_at.utcoffset()
+    # Pinned explicitly: datetime equality compares instants, so the assertion
+    # above alone would also accept a wrong offset with a matching wall clock.
+    assert cfg.started_at.utcoffset() == timedelta(0)
 
 
 def test_a_missing_start_time_leaves_the_session_to_fall_back(tmp_path, monkeypatch):
@@ -360,6 +365,11 @@ def _real_session_with_workspace(tmp_path, **cfg_overrides):
     return session
 
 
+#: Two pod boots either side of a midnight, for the across-days assertion.
+_DAY_ONE = _stdlib_datetime(2030, 1, 1, 23, 55)
+_DAY_TWO = _stdlib_datetime(2030, 1, 2, 0, 5)
+
+
 def _real_cloud_session(tmp_path, monkeypatch, **req_overrides):
     """A REAL ChatSession off the cloud builder, not a captured config.
 
@@ -381,53 +391,64 @@ def _real_cloud_session(tmp_path, monkeypatch, **req_overrides):
     return session
 
 
-async def test_two_pods_render_one_start_date_for_the_same_conversation(
+def _pin_today(monkeypatch, moment):
+    """Pin what the session sees as "now".
+
+    Patches the class on the `datetime` module rather than on the module that
+    imports it: `_build_system_prompt` does `import datetime as _dt` in the
+    function body, so it re-resolves the module every call and only a patch
+    there is visible to it.
+    """
+    import datetime as _dt
+
+    class _PinnedNow(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return moment
+
+    monkeypatch.setattr(_dt, "datetime", _PinnedNow)
+
+
+async def test_two_pods_on_different_days_render_the_same_prompt(
     tmp_path, monkeypatch,
 ):
-    """Every turn runs in a fresh pod, so before this the date came from
-    whichever day that pod booted and the prefix changed at every midnight.
-    Two independently built sessions for one conversation must render the same
-    prompt, which is the ticket's acceptance stated directly.
+    """The ticket's acceptance, stated as it asks for it. Every turn runs in a
+    fresh pod, so the date used to come from whichever day that pod happened to
+    boot, and a conversation open across midnight got a different prompt the
+    next morning — taking the cached history with it.
     """
     started = "2026-09-01T08:15:00+00:00"
+
+    _pin_today(monkeypatch, _DAY_ONE)
     first = await _real_cloud_session(
         tmp_path, monkeypatch, started_at=started,
     )._build_system_prompt()
+
+    _pin_today(monkeypatch, _DAY_TWO)
     second = await _real_cloud_session(
         tmp_path, monkeypatch, started_at=started,
     )._build_system_prompt()
 
     assert first == second
-    # The equality above cannot carry this on its own: two pods booted on the
-    # same day agree on "today" with the bug fully present, and the ticket's
-    # "on different days" is not reproducible without faking the clock. So the
-    # stored date is what actually proves the clock was not consulted.
     assert "Tuesday, September 01, 2026" in first
 
 
-async def test_the_stored_start_date_wins_over_the_pods_own_clock(
-    tmp_path, monkeypatch,
-):
-    """The clock is consulted only as the fallback. Asserted by rendering a
-    date that is not today rather than by faking time: there is no clock
-    freezing dependency here, and patching the module attribute would do
-    nothing, since `_build_system_prompt` re-imports datetime at call time.
+async def test_the_clock_is_only_the_fallback(tmp_path, monkeypatch):
+    """Both halves of the rule, since the equality above holds trivially if the
+    date is wrong in the same way on both days: a stored value is used instead
+    of today, and today is what renders when there is no stored value.
     """
-    import datetime as _dt
+    _pin_today(monkeypatch, _DAY_TWO)
+    pinned_today = _DAY_TWO.strftime("%A, %B %d, %Y")
 
-    session = _real_cloud_session(
+    stored = await _real_cloud_session(
         tmp_path, monkeypatch, started_at="2026-09-01T08:15:00+00:00",
-    )
-    prompt = await session._build_system_prompt()
+    )._build_system_prompt()
+    assert "Tuesday, September 01, 2026" in stored
+    assert pinned_today not in stored
 
-    assert "Tuesday, September 01, 2026" in prompt
-    today = _dt.datetime.now().strftime("%A, %B %d, %Y")
-    if today != "Tuesday, September 01, 2026":
-        assert today not in prompt
-
-    # And without it, today is what renders — the behavior every cloud turn had.
     fallback = await _real_cloud_session(tmp_path, monkeypatch)._build_system_prompt()
-    assert today in fallback
+    assert pinned_today in fallback
 
 
 def test_final_tool_set_equals_allowlist_after_real_build(tmp_path, monkeypatch):

--- a/tests/test_cloud_turn_session.py
+++ b/tests/test_cloud_turn_session.py
@@ -360,6 +360,76 @@ def _real_session_with_workspace(tmp_path, **cfg_overrides):
     return session
 
 
+def _real_cloud_session(tmp_path, monkeypatch, **req_overrides):
+    """A REAL ChatSession off the cloud builder, not a captured config.
+
+    The date is rendered inside `ChatSession._build_system_prompt`, so a test
+    that calls the prompt builder directly would supply `conversation_started`
+    itself and pass with the whole fix reverted.
+    """
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv(_WORKSPACE_PATH_ENV, str(tmp_path))
+    monkeypatch.setattr(
+        llm_client_mod.LLMClient, "from_settings",
+        classmethod(lambda cls, settings: _mock_llm()),
+    )
+    body = dict(protocol_version=1, conversation_id="conv_1", input="hi")
+    body.update(req_overrides)
+    session = build_cloud_chat_session(TurnRequestV1(**body))
+    session._scratchpads = MagicMock(available_packages=[])
+    return session
+
+
+async def test_two_pods_render_one_start_date_for_the_same_conversation(
+    tmp_path, monkeypatch,
+):
+    """Every turn runs in a fresh pod, so before this the date came from
+    whichever day that pod booted and the prefix changed at every midnight.
+    Two independently built sessions for one conversation must render the same
+    prompt, which is the ticket's acceptance stated directly.
+    """
+    started = "2026-09-01T08:15:00+00:00"
+    first = await _real_cloud_session(
+        tmp_path, monkeypatch, started_at=started,
+    )._build_system_prompt()
+    second = await _real_cloud_session(
+        tmp_path, monkeypatch, started_at=started,
+    )._build_system_prompt()
+
+    assert first == second
+    # The equality above cannot carry this on its own: two pods booted on the
+    # same day agree on "today" with the bug fully present, and the ticket's
+    # "on different days" is not reproducible without faking the clock. So the
+    # stored date is what actually proves the clock was not consulted.
+    assert "Tuesday, September 01, 2026" in first
+
+
+async def test_the_stored_start_date_wins_over_the_pods_own_clock(
+    tmp_path, monkeypatch,
+):
+    """The clock is consulted only as the fallback. Asserted by rendering a
+    date that is not today rather than by faking time: there is no clock
+    freezing dependency here, and patching the module attribute would do
+    nothing, since `_build_system_prompt` re-imports datetime at call time.
+    """
+    import datetime as _dt
+
+    session = _real_cloud_session(
+        tmp_path, monkeypatch, started_at="2026-09-01T08:15:00+00:00",
+    )
+    prompt = await session._build_system_prompt()
+
+    assert "Tuesday, September 01, 2026" in prompt
+    today = _dt.datetime.now().strftime("%A, %B %d, %Y")
+    if today != "Tuesday, September 01, 2026":
+        assert today not in prompt
+
+    # And without it, today is what renders — the behavior every cloud turn had.
+    fallback = await _real_cloud_session(tmp_path, monkeypatch)._build_system_prompt()
+    assert today in fallback
+
+
 def test_final_tool_set_equals_allowlist_after_real_build(tmp_path, monkeypatch):
     """The registry is built LAZILY at turn time, so the allowlist must be
     enforced by the real _build_tools() - assert the EXACT final tool set."""


### PR DESCRIPTION
https://linear.app/mindsdb/issue/ENG-2620/cloud-turns-recompute-the-conversation-start-date-from-the

## Why this matters

The pod is new every turn and had no idea when the conversation began, so the
session fell back to `datetime.now()` and dated every cloud conversation today.
Two consequences, and the second is the bigger one day to day:

The prompt was wrong on every turn. It told the model a three week old
conversation started this morning.

And the "conversation started" line sits in the system string, which the
gateway wraps in a single cached block. A conversation open across midnight
therefore changed that block once, missing the system breakpoint and the
rolling history breakpoint behind it, and re-writing the whole history at
~1.25x instead of reading it at ~0.1x.

The other two hops of this fix already merged: cowork-server puts the
conversation's `created_at` in the job params, and the scratchpad-controller
forwards it. anton was the missing consumer, so the value arrived at the pod
and was dropped, because `from_json` maps known keys one by one.

## What changed

- carries `started_at` on `TurnRequestV1` as the wire string, guarded with the
  same `isinstance` check `trace` and `oauth` use, so the controller's
  always-present-sometimes-null key lands as `None` rather than a bad value
- parses it in `build_cloud_chat_session` and passes it as
  `ChatSessionConfig.started_at`, where the existing fallback to today already
  lives, so nothing in `core/session.py` needed to change
- an unreadable value still degrades to today but logs a warning naming it,
  since silence makes a shape anton cannot read look exactly like a controller
  that sends nothing
- tests two pods either side of a midnight rendering one prompt, which is the
  ticket's stated acceptance

## Notes for the reviewer

- **The field stays a string on the wire.** `TurnRequestV1` is a data-only
  mirror of the JSON line and every other field keeps its wire type. Parsing
  belongs where the value is read, which is also where the fallback is.
- **No timezone normalization, deliberately.** The desktop harness passes
  `conversation.created_at` straight through, and an aware value rendered with
  `strftime` gives the UTC date there too. Converting here would make the two
  surfaces disagree about what day a conversation started. The consequence is
  that a UTC-stored `created_at` can render one day ahead of the user's local
  date; that is pre-existing on both surfaces and not this change.
- **Only `ValueError` is caught**, not `Exception`. On a `str`, that is the
  only thing `datetime.fromisoformat` raises. Absent, empty, non-string and
  unparsable all land on `None`, which is exactly the pre-change behavior, so
  no turn can fail over this field.
- **"Fails at the base revision" would be vacuous here**, which is why the
  falsification below is stated differently: at base the field does not exist,
  so these tests raise `TypeError` rather than failing on the bug.
- **The obvious version of the ticket's own test proves nothing.** Two pods
  booted the same day agree on today with the bug fully present, so the test
  pins the clock either side of a midnight instead. Patching the datetime class
  on the module is what reaches the render site, because it re-imports the
  module inside the function; patching the importing module's attribute does
  not, and a test written that way would pass green for the wrong reason.

## How to test

1. `uv run pytest tests/test_cloud_turn_session.py tests/test_cloud_turn_entrypoint.py`
2. Remove `started_at=started_at` from the `ChatSessionConfig(...)` call in
   `anton/cloud_turn/session.py` and re-run. Both regression tests fail, and
   the across-days one fails on the prompt equality itself, showing
   `Tuesday, January 01, 2030` against `Wednesday, January 02, 2030`.
3. Restore it and confirm they pass.

## Ships with

Nothing. mindsdb/cowork-server#512 and mindsdb/scratchpad-controller#48 are
already merged, so this lands alone and needs no merge ordering. Until it
merges, those two send a value nothing reads.

## Checks

| Check | Observed result |
| --- | --- |
| `uv run pytest` | 3148 passed, 31 skipped |
| falsification (step 2 above) | both regression tests fail, pass again when restored |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
