### PR TITLE
ENG-2420: never let an unreplayable tool-call id reach conversation history

### DIFF
--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -73,6 +73,22 @@ _INJECTED_HELPER_NAMES = frozenset(
 _INJECTED_HELPERS: dict = {}
 
 
+def _drop_unreplayable_calls(response) -> None:
+    """Strip calls that cannot be replayed in history (ENG-2420)."""
+    from anton.core.llm.provider import usable_call_id
+
+    import logging as _logging
+
+    calls = getattr(response, "tool_calls", None) or []
+    keep = [tc for tc in calls if usable_call_id(tc.id) and tc.name]
+    if len(keep) != len(calls):
+        _logging.getLogger(__name__).error(
+            "ENG-2420: dropped %d unreplayable tool call(s) during scratchpad boot.",
+            len(calls) - len(keep),
+        )
+        response.tool_calls = keep
+
+
 def _inject_helper(name: str, fn) -> None:
     """Expose a helper to scratchpad code, and remember the object we injected.
 
@@ -651,6 +667,14 @@ if _scratchpad_model:
                     max_tokens=max_tokens,
                 )
 
+                if not response.tool_calls:
+                    return response.content
+
+                # Same ENG-2420 belt as the session's tool loop. Blast radius
+                # here is only this boot loop's own `messages` list — nothing
+                # is persisted to a user conversation — but an unreplayable id
+                # still 400s every remaining round of the boot.
+                _drop_unreplayable_calls(response)
                 if not response.tool_calls:
                     return response.content
 

--- a/anton/core/backends/scratchpad_boot.py
+++ b/anton/core/backends/scratchpad_boot.py
@@ -73,20 +73,20 @@ _INJECTED_HELPER_NAMES = frozenset(
 _INJECTED_HELPERS: dict = {}
 
 
-def _drop_unreplayable_calls(response) -> None:
-    """Strip calls that cannot be replayed in history (ENG-2420)."""
-    from anton.core.llm.provider import usable_call_id
-
+def _ensure_replayable_calls(response) -> None:
+    """Make every call on `response` replayable in history (ENG-2420)."""
     import logging as _logging
 
+    from anton.core.llm.provider import ensure_replayable_tool_call, usable_call_id
+
     calls = getattr(response, "tool_calls", None) or []
-    keep = [tc for tc in calls if usable_call_id(tc.id) and tc.name]
-    if len(keep) != len(calls):
+    broken = [tc for tc in calls if not (usable_call_id(tc.id) and usable_call_id(tc.name))]
+    if broken:
         _logging.getLogger(__name__).error(
-            "ENG-2420: dropped %d unreplayable tool call(s) during scratchpad boot.",
-            len(calls) - len(keep),
+            "ENG-2420: %d unreplayable tool call(s) during scratchpad boot.", len(broken),
         )
-        response.tool_calls = keep
+        for tc in broken:
+            ensure_replayable_tool_call(tc)
 
 
 def _inject_helper(name: str, fn) -> None:
@@ -674,9 +674,7 @@ if _scratchpad_model:
                 # here is only this boot loop's own `messages` list — nothing
                 # is persisted to a user conversation — but an unreplayable id
                 # still 400s every remaining round of the boot.
-                _drop_unreplayable_calls(response)
-                if not response.tool_calls:
-                    return response.content
+                _ensure_replayable_calls(response)
 
                 # Build assistant message with text + tool_use blocks
                 assistant_content = []

--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -385,6 +385,12 @@ class AnthropicProvider(LLMProvider):
                                 "id": block.id,
                                 "name": block.name,
                                 "json_parts": [],
+                                # Same record-don't-re-derive rule as both
+                                # OpenAI readers. Nothing updates id/name after
+                                # this on the Anthropic path, so the two are
+                                # equivalent here today — the flag keeps them
+                                # equivalent if that ever changes.
+                                "started": False,
                             }
                             # Gated like both OpenAI readers, which this path
                             # did not match. Unguarded, a blank id opened a UI
@@ -393,6 +399,7 @@ class AnthropicProvider(LLMProvider):
                             # call's id, which is now the MINTED one
                             # (review: pnewsam on #471).
                             if block.id and block.name:
+                                blocks[idx]["started"] = True
                                 yield StreamToolUseStart(id=block.id, name=block.name)
                         elif block.type in ("thinking", "redacted_thinking"):
                             # Adaptive thinking (triggered by output_config.effort,
@@ -435,10 +442,10 @@ class AnthropicProvider(LLMProvider):
                                     parse_error=parse_error, repaired=repaired,
                                 )
                             ))
-                            # Same gate as the Start above, and the ORIGINAL id
-                            # rather than the minted one — an End with no Start
-                            # is a worse event stream than neither.
-                            if info["id"] and info["name"]:
+                            # Gated on whether a Start was emitted, and on the
+                            # ORIGINAL id rather than the minted one — an End
+                            # with no Start is a worse event stream than neither.
+                            if info.get("started"):
                                 yield StreamToolUseEnd(id=info["id"])
 
                     elif event.type == "message_delta":

--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -31,6 +31,7 @@ from .provider import (
     retry_after_seconds,
     compute_context_pressure,
     origin_is_known_third_party,
+    replayable_tool_call,
     wallet_denial_code,
     raise_on_empty_response,
 )
@@ -280,9 +281,16 @@ class AnthropicProvider(LLMProvider):
             if block.type == "text":
                 content_text += block.text
             elif block.type == "tool_use":
-                tool_calls.append(
+                # Anthropic's reader has no empty-id BUFFER path — a missing
+                # `content_block_start` appends nothing at all — but `block.id`
+                # is written straight through, so a relay that sends a blank id
+                # produces the identical poisoned history (ENG-2420). The guard
+                # belongs on the VALUE, not on the missing-start case.
+                call = replayable_tool_call(
                     ToolCall(id=block.id, name=block.name, input=block.input)
                 )
+                if call is not None:
+                    tool_calls.append(call)
 
         # The SDK hands back an already-parsed `input`, so unlike the streaming
         # path there is no raw JSON to check: `stop_reason` is the only evidence
@@ -416,12 +424,16 @@ class AnthropicProvider(LLMProvider):
                             # the session what the body was missing. See
                             # `safe_parse_tool_input`.
                             parsed_input, parse_error, repaired = safe_parse_tool_input(raw_json)
-                            tool_calls.append(
+                            call = replayable_tool_call(
                                 ToolCall(
                                     id=info["id"], name=info["name"], input=parsed_input,
                                     parse_error=parse_error, repaired=repaired,
                                 )
                             )
+                            if call is not None:
+                                tool_calls.append(call)
+                            # Original id, not a minted one — see the matching
+                            # note in the OpenAI chat-completions reader.
                             yield StreamToolUseEnd(id=info["id"])
 
                     elif event.type == "message_delta":

--- a/anton/core/llm/anthropic.py
+++ b/anton/core/llm/anthropic.py
@@ -31,7 +31,7 @@ from .provider import (
     retry_after_seconds,
     compute_context_pressure,
     origin_is_known_third_party,
-    replayable_tool_call,
+    ensure_replayable_tool_call,
     wallet_denial_code,
     raise_on_empty_response,
 )
@@ -286,11 +286,9 @@ class AnthropicProvider(LLMProvider):
                 # is written straight through, so a relay that sends a blank id
                 # produces the identical poisoned history (ENG-2420). The guard
                 # belongs on the VALUE, not on the missing-start case.
-                call = replayable_tool_call(
+                tool_calls.append(ensure_replayable_tool_call(
                     ToolCall(id=block.id, name=block.name, input=block.input)
-                )
-                if call is not None:
-                    tool_calls.append(call)
+                ))
 
         # The SDK hands back an already-parsed `input`, so unlike the streaming
         # path there is no raw JSON to check: `stop_reason` is the only evidence
@@ -388,7 +386,14 @@ class AnthropicProvider(LLMProvider):
                                 "name": block.name,
                                 "json_parts": [],
                             }
-                            yield StreamToolUseStart(id=block.id, name=block.name)
+                            # Gated like both OpenAI readers, which this path
+                            # did not match. Unguarded, a blank id opened a UI
+                            # step keyed "" that nothing could retire: the
+                            # marker that actually closes a step carries the
+                            # call's id, which is now the MINTED one
+                            # (review: pnewsam on #471).
+                            if block.id and block.name:
+                                yield StreamToolUseStart(id=block.id, name=block.name)
                         elif block.type in ("thinking", "redacted_thinking"):
                             # Adaptive thinking (triggered by output_config.effort,
                             # set above when self._reasoning_effort is configured)
@@ -424,17 +429,17 @@ class AnthropicProvider(LLMProvider):
                             # the session what the body was missing. See
                             # `safe_parse_tool_input`.
                             parsed_input, parse_error, repaired = safe_parse_tool_input(raw_json)
-                            call = replayable_tool_call(
+                            tool_calls.append(ensure_replayable_tool_call(
                                 ToolCall(
                                     id=info["id"], name=info["name"], input=parsed_input,
                                     parse_error=parse_error, repaired=repaired,
                                 )
-                            )
-                            if call is not None:
-                                tool_calls.append(call)
-                            # Original id, not a minted one — see the matching
-                            # note in the OpenAI chat-completions reader.
-                            yield StreamToolUseEnd(id=info["id"])
+                            ))
+                            # Same gate as the Start above, and the ORIGINAL id
+                            # rather than the minted one — an End with no Start
+                            # is a worse event stream than neither.
+                            if info["id"] and info["name"]:
+                                yield StreamToolUseEnd(id=info["id"])
 
                     elif event.type == "message_delta":
                         stop_reason = event.delta.stop_reason

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -1283,8 +1283,18 @@ class OpenAIProvider(LLMProvider):
                                 if tc_delta.function and tc_delta.function.name
                                 else "",
                                 "args_parts": [],
+                                # Whether a Start was actually emitted for this
+                                # call. Recorded rather than re-derived at the
+                                # End: id and name can BOTH be filled in by a
+                                # later chunk (the branch just below), so
+                                # re-testing them there would answer "are they
+                                # set now", not "did we announce this call" —
+                                # and emit an End for a step the consumer never
+                                # opened (ENG-2420).
+                                "started": False,
                             }
                             if tc_state[idx]["id"] and tc_state[idx]["name"]:
+                                tc_state[idx]["started"] = True
                                 yield StreamToolUseStart(
                                     id=tc_state[idx]["id"],
                                     name=tc_state[idx]["name"],
@@ -1398,12 +1408,12 @@ class OpenAIProvider(LLMProvider):
                 id=info["id"], name=info["name"], input=parsed,
                 parse_error=parse_error, repaired=repaired,
             )))
-            # Gated on the same condition as the StreamToolUseStart above, and
-            # on the ORIGINAL id rather than a minted one: a call that never
-            # announced a Start must not emit an End, or the consumer is left
-            # with a step it cannot retire (review: pnewsam on #471, reported
-            # against the Anthropic reader — this is the same shape).
-            if info["id"] and info["name"]:
+            # Gated on whether a Start was actually emitted, and carrying the
+            # ORIGINAL id rather than a minted one: a call that never announced
+            # a Start must not emit an End, or the consumer is left with a step
+            # it cannot retire (review: pnewsam on #471, reported against the
+            # Anthropic reader — this is the same shape).
+            if info["started"]:
                 yield StreamToolUseEnd(id=info["id"])
 
         # Missing finish_reason is ambiguous: it's a genuine truncation only when
@@ -1608,8 +1618,17 @@ class OpenAIProvider(LLMProvider):
                         idx = event.output_index
                         call_id = getattr(item, "call_id", "") or getattr(item, "id", "")
                         name = getattr(item, "name", "") or ""
-                        fc_state[idx] = {"call_id": call_id, "name": name, "args_parts": []}
+                        # `started` for the same reason as the chat-completions
+                        # reader: an `output_item.added` carrying a good
+                        # `call_id` but a blank name emits no Start, and gating
+                        # the End on the id alone then closed a step that was
+                        # never opened (ENG-2420).
+                        fc_state[idx] = {
+                            "call_id": call_id, "name": name,
+                            "args_parts": [], "started": False,
+                        }
                         if call_id and name:
+                            fc_state[idx]["started"] = True
                             yield StreamToolUseStart(id=call_id, name=name)
 
                 # Function-call argument deltas
@@ -1619,7 +1638,10 @@ class OpenAIProvider(LLMProvider):
                     info = fc_state.get(idx)
                     if info is None:
                         # output_item.added didn't surface this call yet — buffer
-                        info = {"call_id": "", "name": "", "args_parts": []}
+                        info = {
+                            "call_id": "", "name": "", "args_parts": [],
+                            "started": False,
+                        }
                         fc_state[idx] = info
                     info["args_parts"].append(delta)
                     if info["call_id"]:
@@ -1648,7 +1670,7 @@ class OpenAIProvider(LLMProvider):
                             parse_error=parse_error, repaired=repaired,
                         )
                     ))
-                    if info["call_id"]:
+                    if info["started"]:
                         yield StreamToolUseEnd(id=info["call_id"])
 
                 # Final completion event carries the resolved Response object

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -42,7 +42,7 @@ from .provider import (
     origin_is_known_third_party,
     wallet_denial_code,
     raise_on_empty_response,
-    replayable_tool_call,
+    ensure_replayable_tool_call,
 )
 
 logger = logging.getLogger(__name__)
@@ -1130,7 +1130,7 @@ class OpenAIProvider(LLMProvider):
                 parsed_input, parse_error, repaired = safe_parse_tool_input(tc.function.arguments or "")
                 # The SDK types `id` as a required `str`, which an empty string
                 # satisfies — a non-conforming server can still send one (ENG-2420).
-                call = replayable_tool_call(
+                tool_calls.append(ensure_replayable_tool_call(
                     ToolCall(
                         id=tc.id,
                         name=tc.function.name,
@@ -1138,9 +1138,7 @@ class OpenAIProvider(LLMProvider):
                         parse_error=parse_error,
                         repaired=repaired,
                     )
-                )
-                if call is not None:
-                    tool_calls.append(call)
+                ))
 
         raise_on_empty_response(
             content=content_text, tool_calls=tool_calls,
@@ -1396,16 +1394,17 @@ class OpenAIProvider(LLMProvider):
             # `info["id"]` is seeded `tc_delta.id or ""` and only updated when a
             # later chunk carries one, so a provider that never sends an id
             # leaves it empty here (ENG-2420).
-            call = replayable_tool_call(ToolCall(
+            tool_calls.append(ensure_replayable_tool_call(ToolCall(
                 id=info["id"], name=info["name"], input=parsed,
                 parse_error=parse_error, repaired=repaired,
-            ))
-            if call is not None:
-                tool_calls.append(call)
-            # Yielded on the ORIGINAL id, not a minted one: no StreamToolUseStart
-            # was emitted for a call that had no id at the time, and an End with
-            # no Start is a worse event stream than no pair at all.
-            yield StreamToolUseEnd(id=info["id"])
+            )))
+            # Gated on the same condition as the StreamToolUseStart above, and
+            # on the ORIGINAL id rather than a minted one: a call that never
+            # announced a Start must not emit an End, or the consumer is left
+            # with a step it cannot retire (review: pnewsam on #471, reported
+            # against the Anthropic reader — this is the same shape).
+            if info["id"] and info["name"]:
+                yield StreamToolUseEnd(id=info["id"])
 
         # Missing finish_reason is ambiguous: it's a genuine truncation only when
         # the stream produced NOTHING (empty + no terminal marker). A stream that
@@ -1643,14 +1642,12 @@ class OpenAIProvider(LLMProvider):
                     # on a truthy id; this append was not, which is how an
                     # id-less call reached history and 400'd every later
                     # request in the conversation (ENG-2420).
-                    call = replayable_tool_call(
+                    tool_calls.append(ensure_replayable_tool_call(
                         ToolCall(
                             id=info["call_id"], name=info["name"], input=parsed,
                             parse_error=parse_error, repaired=repaired,
                         )
-                    )
-                    if call is not None:
-                        tool_calls.append(call)
+                    ))
                     if info["call_id"]:
                         yield StreamToolUseEnd(id=info["call_id"])
 
@@ -1788,12 +1785,10 @@ def _parse_response_object(response, model: str) -> LLMResponse:
             # model deliberately sent with no arguments.
             parsed, parse_error, repaired = safe_parse_tool_input(args_str)
             # Same `or ""` fallback as the streaming reader, same consequence.
-            call = replayable_tool_call(ToolCall(
+            tool_calls.append(ensure_replayable_tool_call(ToolCall(
                 id=call_id, name=name, input=parsed,
                 parse_error=parse_error, repaired=repaired,
-            ))
-            if call is not None:
-                tool_calls.append(call)
+            )))
         # Other item types (web_search_call, reasoning, etc.) are skipped —
         # the model's output_text already incorporates their effects.
 

--- a/anton/core/llm/openai.py
+++ b/anton/core/llm/openai.py
@@ -42,6 +42,7 @@ from .provider import (
     origin_is_known_third_party,
     wallet_denial_code,
     raise_on_empty_response,
+    replayable_tool_call,
 )
 
 logger = logging.getLogger(__name__)
@@ -1127,7 +1128,9 @@ class OpenAIProvider(LLMProvider):
                 # Both flags ride on the ToolCall for the session to act
                 # on. See `safe_parse_tool_input`.
                 parsed_input, parse_error, repaired = safe_parse_tool_input(tc.function.arguments or "")
-                tool_calls.append(
+                # The SDK types `id` as a required `str`, which an empty string
+                # satisfies — a non-conforming server can still send one (ENG-2420).
+                call = replayable_tool_call(
                     ToolCall(
                         id=tc.id,
                         name=tc.function.name,
@@ -1136,6 +1139,8 @@ class OpenAIProvider(LLMProvider):
                         repaired=repaired,
                     )
                 )
+                if call is not None:
+                    tool_calls.append(call)
 
         raise_on_empty_response(
             content=content_text, tool_calls=tool_calls,
@@ -1388,10 +1393,18 @@ class OpenAIProvider(LLMProvider):
             info = tc_state[idx]
             raw_json = "".join(info["args_parts"])
             parsed, parse_error, repaired = safe_parse_tool_input(raw_json)
-            tool_calls.append(ToolCall(
+            # `info["id"]` is seeded `tc_delta.id or ""` and only updated when a
+            # later chunk carries one, so a provider that never sends an id
+            # leaves it empty here (ENG-2420).
+            call = replayable_tool_call(ToolCall(
                 id=info["id"], name=info["name"], input=parsed,
                 parse_error=parse_error, repaired=repaired,
             ))
+            if call is not None:
+                tool_calls.append(call)
+            # Yielded on the ORIGINAL id, not a minted one: no StreamToolUseStart
+            # was emitted for a call that had no id at the time, and an End with
+            # no Start is a worse event stream than no pair at all.
             yield StreamToolUseEnd(id=info["id"])
 
         # Missing finish_reason is ambiguous: it's a genuine truncation only when
@@ -1626,12 +1639,18 @@ class OpenAIProvider(LLMProvider):
                     # a body cut mid-JSON must not raise out of this generator,
                     # and the flags are what let the session refuse the call.
                     parsed, parse_error, repaired = safe_parse_tool_input(raw_json)
-                    tool_calls.append(
+                    # The three yields around this append were already guarded
+                    # on a truthy id; this append was not, which is how an
+                    # id-less call reached history and 400'd every later
+                    # request in the conversation (ENG-2420).
+                    call = replayable_tool_call(
                         ToolCall(
                             id=info["call_id"], name=info["name"], input=parsed,
                             parse_error=parse_error, repaired=repaired,
                         )
                     )
+                    if call is not None:
+                        tool_calls.append(call)
                     if info["call_id"]:
                         yield StreamToolUseEnd(id=info["call_id"])
 
@@ -1768,10 +1787,13 @@ def _parse_response_object(response, model: str) -> LLMResponse:
             # into `{}`: an empty dict cannot be told apart from a call the
             # model deliberately sent with no arguments.
             parsed, parse_error, repaired = safe_parse_tool_input(args_str)
-            tool_calls.append(ToolCall(
+            # Same `or ""` fallback as the streaming reader, same consequence.
+            call = replayable_tool_call(ToolCall(
                 id=call_id, name=name, input=parsed,
                 parse_error=parse_error, repaired=repaired,
             ))
+            if call is not None:
+                tool_calls.append(call)
         # Other item types (web_search_call, reasoning, etc.) are skipped —
         # the model's output_text already incorporates their effects.
 

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -508,6 +508,14 @@ def replayable_tool_call(tc: ToolCall) -> ToolCall | None:
       cannot be replayed costs the whole conversation.
 
     Callers append the RESULT, never `tc`, and treat None as "no such call".
+
+    The minted id is random (`call_anton_*`) because it is minted ONCE, at
+    generation, and then persisted with the rest of this turn's rows. The
+    read-time repair in `repair_replayed_tool_ids` uses a different prefix
+    (`call_repaired_*`) and a DETERMINISTIC, content-derived id, because it
+    re-runs on every load and is never written back — a random id there would
+    change the replayed prefix every turn and miss the prompt cache. The two
+    prefixes also make it obvious in a log which layer fixed a given call.
     """
     import logging as _logging
     import uuid as _uuid

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -455,6 +455,90 @@ def safe_parse_tool_input(raw_json: str) -> tuple[dict, str | None, bool]:
     return parsed, None, False
 
 
+#: Name given to a replayed tool call the provider never named (ENG-2420).
+#: History items must carry one — the Responses API declares ``name`` required
+#: — and a name outside the CURRENT tool list already replays fine: anton
+#: rebuilds its tool list every round (``_build_tools()`` in the session's tool
+#: loop, so `recall_skill` can add tools mid-turn), which means a call to a
+#: tool that is no longer offered is an ordinary, working shape in history.
+UNNAMED_REPLAYED_TOOL = "unavailable_tool_call"
+
+
+def usable_call_id(value: object) -> bool:
+    """True when `value` can be replayed as a tool-call handle.
+
+    Non-empty *string*, not merely truthy: a dict or list id is valid JSON and
+    passes a truthiness check, then fails much later and much less legibly.
+    Both provider APIs use string ids, so the strictness costs nothing. Same
+    test cowork-server's `sanitize_turn_history_rows` applies to pod rows.
+    """
+    return isinstance(value, str) and bool(value)
+
+
+def replayable_tool_call(tc: ToolCall) -> ToolCall | None:
+    """`tc` in a form that can be replayed in history, or None to drop it.
+
+    ENG-2420: the readers can build a call with an EMPTY id. Three provider
+    shapes reach it, and only the first is the one the bug was filed for — a
+    `function_call_arguments.delta` with no preceding `output_item.added`; an
+    `output_item.added` that DOES arrive but carries a blank `call_id`; and an
+    item labelled as something other than `function_call`. The last two never
+    touch the buffer path, so guarding that path alone would miss them.
+
+    Every *yield* in the readers was already guarded on a truthy id. Only the
+    append that builds the turn's result was not, so an id-less call escaped
+    into `session.history`, and the next request serialised it back out
+    verbatim (``"call_id": block["id"]``). The provider then rejects the whole
+    request — ``400 Invalid 'input[N].call_id': empty string`` — on that turn
+    and on every later turn of the conversation, which never recovers on its
+    own: the only trimming path anton has runs on a caught
+    `ContextOverflowError` or on pressure computed from a successful
+    response's usage, and a 400 produces neither.
+
+    Two outcomes, because the two shapes differ in what is salvageable:
+
+    - **id missing, name known** — the model's intent survived and only the
+      handle is gone. Mint one: the call dispatches normally, its
+      `tool_result` pairs with the minted id, and the turn simply works. This
+      is strictly better than dropping, and it matters because neither
+      streaming path calls `raise_on_empty_response` — dropping the only call
+      of a streaming turn yields a silently empty turn, not an error.
+    - **name missing too** — there is no tool to dispatch and no way to ask
+      for one. Drop it: a call that cannot run buys nothing, and a call that
+      cannot be replayed costs the whole conversation.
+
+    Callers append the RESULT, never `tc`, and treat None as "no such call".
+    """
+    import logging as _logging
+    import uuid as _uuid
+
+    name = tc.name if isinstance(tc.name, str) else ""
+    if usable_call_id(tc.id) and name:
+        return tc
+
+    log = _logging.getLogger(__name__)
+    if not name:
+        log.warning(
+            "ENG-2420: dropping a tool call the provider sent unnamed (id=%r) — "
+            "it cannot be dispatched, and replaying it would reject every later "
+            "request in this conversation.",
+            tc.id,
+        )
+        return None
+
+    was = tc.id
+    # Mutated in place: every caller constructs the ToolCall immediately
+    # before this call, and the readers already mutate one after the fact
+    # (`tool_calls[-1].repaired = True` on the Anthropic max_tokens path).
+    tc.id = f"call_anton_{_uuid.uuid4().hex}"
+    log.warning(
+        "ENG-2420: tool call %r arrived with an unusable id (%r); minted %s so "
+        "the call can still run and replay.",
+        name, was, tc.id,
+    )
+    return tc
+
+
 def damaged_tool_call_result(tc: ToolCall) -> dict | None:
     """The `tool_result` to answer an unfinished tool call with, or None.
 

--- a/anton/core/llm/provider.py
+++ b/anton/core/llm/provider.py
@@ -475,13 +475,13 @@ def usable_call_id(value: object) -> bool:
     return isinstance(value, str) and bool(value)
 
 
-def replayable_tool_call(tc: ToolCall) -> ToolCall | None:
-    """`tc` in a form that can be replayed in history, or None to drop it.
+def ensure_replayable_tool_call(tc: ToolCall) -> ToolCall:
+    """Return `tc` with anything that cannot be replayed made replayable.
 
-    ENG-2420: the readers can build a call with an EMPTY id. Three provider
+    ENG-2420: the readers can build a call with an empty `id`. Three provider
     shapes reach it, and only the first is the one the bug was filed for — a
     `function_call_arguments.delta` with no preceding `output_item.added`; an
-    `output_item.added` that DOES arrive but carries a blank `call_id`; and an
+    `output_item.added` that DOES arrive carrying a blank `call_id`; and an
     item labelled as something other than `function_call`. The last two never
     touch the buffer path, so guarding that path alone would miss them.
 
@@ -495,55 +495,62 @@ def replayable_tool_call(tc: ToolCall) -> ToolCall | None:
     `ContextOverflowError` or on pressure computed from a successful
     response's usage, and a 400 produces neither.
 
-    Two outcomes, because the two shapes differ in what is salvageable:
+    **Salvage, never drop**, and both halves matter:
 
-    - **id missing, name known** — the model's intent survived and only the
-      handle is gone. Mint one: the call dispatches normally, its
-      `tool_result` pairs with the minted id, and the turn simply works. This
-      is strictly better than dropping, and it matters because neither
-      streaming path calls `raise_on_empty_response` — dropping the only call
-      of a streaming turn yields a silently empty turn, not an error.
-    - **name missing too** — there is no tool to dispatch and no way to ask
-      for one. Drop it: a call that cannot run buys nothing, and a call that
-      cannot be replayed costs the whole conversation.
+    - An unusable **id** is replaced with a minted one. The call then
+      dispatches normally and its `tool_result` pairs with the minted id.
+    - An unusable **name** is replaced with `UNNAMED_REPLAYED_TOOL`, which
+      restores the pre-fix behaviour for that shape: the registry raises
+      ``Tool ... not found``, the dispatcher turns that into an ordinary
+      ``Tool 'x' failed`` tool_result, and the model re-emits the call inside
+      the same turn. Dropping it instead looked tidier and was worse — the
+      three non-streaming paths call `raise_on_empty_response`
+      (`anthropic.py`, and both OpenAI ones) but the streaming paths do not,
+      so a dropped sole call ends a streaming turn silently with no error at
+      all. That is the failure this function exists to avoid, so it must not
+      introduce it through the name (review: pnewsam on #471).
 
-    Callers append the RESULT, never `tc`, and treat None as "no such call".
+    Returning unconditionally is deliberate: it is what keeps this layer, the
+    read-time repair in `repair_replayed_tool_ids`, and the session/boot belts
+    agreeing about the same two fields. They disagreed in the first revision
+    and a stored ``{"id": "call_x", "name": ""}`` block slipped through all
+    three.
 
     The minted id is random (`call_anton_*`) because it is minted ONCE, at
     generation, and then persisted with the rest of this turn's rows. The
-    read-time repair in `repair_replayed_tool_ids` uses a different prefix
-    (`call_repaired_*`) and a DETERMINISTIC, content-derived id, because it
-    re-runs on every load and is never written back — a random id there would
-    change the replayed prefix every turn and miss the prompt cache. The two
-    prefixes also make it obvious in a log which layer fixed a given call.
+    read-time repair uses a different prefix (`call_repaired_*`) and a
+    deterministic id, because it re-runs on every load and is never written
+    back — a random id there would change the replayed prefix every turn and
+    miss the prompt cache. The two prefixes also make it obvious in a log
+    which layer fixed a given call.
     """
     import logging as _logging
     import uuid as _uuid
 
-    name = tc.name if isinstance(tc.name, str) else ""
-    if usable_call_id(tc.id) and name:
-        return tc
-
     log = _logging.getLogger(__name__)
-    if not name:
-        log.warning(
-            "ENG-2420: dropping a tool call the provider sent unnamed (id=%r) — "
-            "it cannot be dispatched, and replaying it would reject every later "
-            "request in this conversation.",
-            tc.id,
-        )
-        return None
 
-    was = tc.id
-    # Mutated in place: every caller constructs the ToolCall immediately
-    # before this call, and the readers already mutate one after the fact
-    # (`tool_calls[-1].repaired = True` on the Anthropic max_tokens path).
-    tc.id = f"call_anton_{_uuid.uuid4().hex}"
-    log.warning(
-        "ENG-2420: tool call %r arrived with an unusable id (%r); minted %s so "
-        "the call can still run and replay.",
-        name, was, tc.id,
-    )
+    if not usable_call_id(tc.id):
+        was = tc.id
+        # Mutated in place: every caller constructs the ToolCall immediately
+        # before this call, and the readers already mutate one after the fact
+        # (`tool_calls[-1].repaired = True` on the Anthropic max_tokens path).
+        tc.id = f"call_anton_{_uuid.uuid4().hex}"
+        log.warning(
+            "ENG-2420: tool call %r arrived with an unusable id (%r); minted %s "
+            "so the call can still run and replay.",
+            tc.name, was, tc.id,
+        )
+
+    if not usable_call_id(tc.name):
+        was = tc.name
+        tc.name = UNNAMED_REPLAYED_TOOL
+        log.warning(
+            "ENG-2420: tool call %s arrived with an unusable name (%r); renamed "
+            "to %r so it fails as a normal tool_result the model can recover "
+            "from, instead of vanishing from the turn.",
+            tc.id, was, tc.name,
+        )
+
     return tc
 
 

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -1895,29 +1895,35 @@ class ChatSession:
         )
 
     @staticmethod
-    def _drop_unreplayable_calls(response) -> None:
-        """Belt for ENG-2420: strip any call that cannot be replayed.
+    def _ensure_replayable_calls(response) -> None:
+        """Belt for ENG-2420: make every call on `response` replayable.
 
-        The provider readers already guarantee this (`replayable_tool_call`),
-        so this is expected to be a permanent no-op. It exists because the cost
-        of one escaping is not a failed call but a conversation that can never
-        be used again, and because a host can run an anton older than itself.
+        The provider readers already guarantee this
+        (`ensure_replayable_tool_call`), so this is expected to be a permanent
+        no-op — it logs at ERROR when it is not, because the only way it fires
+        is a reader missing its guard. It exists because the cost of one
+        escaping is not a failed call but a conversation that can never be used
+        again.
 
-        Filters the response ONCE, before the loop reads `tool_calls`, so the
-        history block and the dispatch stay consistent — dropping a `tool_use`
-        while still dispatching it would leave an orphan `tool_result`.
+        Salvages rather than drops, for the same reason the readers do and for
+        one more: this runs before the tool loop reads `tool_calls`, and
+        emptying that list would leave the round with no calls and no content,
+        so both `_append_history` calls below become no-ops and the loop
+        re-issues an identical request until `_max_tool_rounds`
+        (review: pnewsam on #471). Salvaging cannot change the list's length,
+        so that shape is unreachable by construction rather than by a guard.
         """
-        from anton.core.llm.provider import usable_call_id
+        from anton.core.llm.provider import ensure_replayable_tool_call, usable_call_id
 
         calls = getattr(response, "tool_calls", None) or []
-        keep = [tc for tc in calls if usable_call_id(tc.id) and tc.name]
-        if len(keep) != len(calls):
+        broken = [tc for tc in calls if not (usable_call_id(tc.id) and usable_call_id(tc.name))]
+        if broken:
             logging.getLogger(__name__).error(
-                "ENG-2420: %d tool call(s) reached the session with an "
-                "unreplayable id/name and were dropped — a provider reader is "
-                "missing its guard.", len(calls) - len(keep),
+                "ENG-2420: %d tool call(s) reached the session unreplayable — "
+                "a provider reader is missing its guard.", len(broken),
             )
-            response.tool_calls = keep
+            for tc in broken:
+                ensure_replayable_tool_call(tc)
 
     def _validate_history_for_provider(self, messages: list[dict]) -> None:
         """Defensive pre-flight: warn (don't raise) if the messages
@@ -5010,7 +5016,7 @@ class ChatSession:
                         break
 
                 # Build assistant message with content blocks
-                self._drop_unreplayable_calls(llm_response)
+                self._ensure_replayable_calls(llm_response)
                 assistant_content: list[dict] = []
                 if llm_response.content:
                     assistant_content.append(

--- a/anton/core/session.py
+++ b/anton/core/session.py
@@ -29,7 +29,7 @@ from anton.core.memory.cerebellum import Cerebellum
 from anton.core.memory.skills import SkillStore
 from anton.core.tools.recall_skill import RECALL_SKILL_TOOL
 from anton.core.tools.skill_draft import CREATE_SKILL_DRAFT_TOOL
-from anton.memory.history_store import is_user_turn
+from anton.memory.history_store import is_user_turn, repair_replayed_tool_ids
 from anton.core.llm.prompts import (
     RESILIENCE_NUDGE,
     SCRATCHPAD_INSTALL_NUDGE,
@@ -1347,8 +1347,15 @@ class ChatSession:
                 else tool
                 for tool in self._extra_tools
             ]
+        # Repaired at the ingress every surface shares — desktop, the cloud pod
+        # and the CLI all arrive here — so a conversation ENG-2420 already
+        # poisoned starts replying again on its next turn instead of 400ing
+        # forever. Count-preserving on purpose: `_seed_len` below and
+        # `last_compaction`'s `covered_through` are positional, and the host
+        # maps that count onto its OWN message list.
         self._history: list[dict] = (
-            list(config.initial_history) if config.initial_history else []
+            repair_replayed_tool_ids(list(config.initial_history))[0]
+            if config.initial_history else []
         )
         # Seed length + how many leading history messages the last compaction
         # folded into its summary — lets a host map the compaction back onto
@@ -1886,6 +1893,31 @@ class ChatSession:
             "Anthropic role alternation). Combined block count: %d.",
             role, len(merged_blocks),
         )
+
+    @staticmethod
+    def _drop_unreplayable_calls(response) -> None:
+        """Belt for ENG-2420: strip any call that cannot be replayed.
+
+        The provider readers already guarantee this (`replayable_tool_call`),
+        so this is expected to be a permanent no-op. It exists because the cost
+        of one escaping is not a failed call but a conversation that can never
+        be used again, and because a host can run an anton older than itself.
+
+        Filters the response ONCE, before the loop reads `tool_calls`, so the
+        history block and the dispatch stay consistent — dropping a `tool_use`
+        while still dispatching it would leave an orphan `tool_result`.
+        """
+        from anton.core.llm.provider import usable_call_id
+
+        calls = getattr(response, "tool_calls", None) or []
+        keep = [tc for tc in calls if usable_call_id(tc.id) and tc.name]
+        if len(keep) != len(calls):
+            logging.getLogger(__name__).error(
+                "ENG-2420: %d tool call(s) reached the session with an "
+                "unreplayable id/name and were dropped — a provider reader is "
+                "missing its guard.", len(calls) - len(keep),
+            )
+            response.tool_calls = keep
 
     def _validate_history_for_provider(self, messages: list[dict]) -> None:
         """Defensive pre-flight: warn (don't raise) if the messages
@@ -4978,6 +5010,7 @@ class ChatSession:
                         break
 
                 # Build assistant message with content blocks
+                self._drop_unreplayable_calls(llm_response)
                 assistant_content: list[dict] = []
                 if llm_response.content:
                     assistant_content.append(

--- a/anton/memory/history_store.py
+++ b/anton/memory/history_store.py
@@ -97,7 +97,13 @@ def repair_replayed_tool_ids(history: list[dict]) -> tuple[list[dict], int]:
         Keyed on content rather than position so a compaction summary being
         prepended — which shifts every index — does not change the ids of the
         tail it kept. The occurrence counter disambiguates a conversation that
-        made the identical call twice.
+        made the identical call twice; note that counter IS positional in
+        effect, so a compaction that drops one of two identical calls does
+        renumber the survivor. That costs one cache miss on a prefix the
+        compaction had already invalidated, so it is not worth engineering
+        around — but the claim is "stable across repeated loads of the same
+        history", not "stable across every edit of it" (review: pnewsam on
+        #471, which correctly caught the earlier wording overstating this).
         """
         import hashlib
         import json as _json
@@ -123,6 +129,28 @@ def repair_replayed_tool_ids(history: list[dict]) -> tuple[list[dict], int]:
     out = [m for m in history]
     repaired = 0
 
+    # Names first, and separately: renaming never affects tool_use/tool_result
+    # pairing, so it needs none of the pairing machinery below. Keeping it out
+    # of the `broken` predicate is also what stops the two poisoned shapes from
+    # being conflated — pre-fix anton could write a block with a perfectly
+    # usable id and a blank name (a provider sending a good `call_id` with no
+    # name), and selecting on the id alone let that shape through all three
+    # layers untouched and onto the wire as `name: ''` (review: pnewsam on
+    # anton#471).
+    for i, msg in enumerate(out):
+        blocks = _blocks(msg)
+        if blocks is None or msg.get("role") != "assistant":
+            continue
+        if not any(isinstance(b, dict) and b.get("type") == "tool_use"
+                   and not usable_call_id(b.get("name")) for b in blocks):
+            continue
+        new_blocks = [dict(b) if isinstance(b, dict) else b for b in blocks]
+        for b in new_blocks:
+            if isinstance(b, dict) and b.get("type") == "tool_use" and not usable_call_id(b.get("name")):
+                b["name"] = UNNAMED_REPLAYED_TOOL
+                repaired += 1
+        out[i] = {**msg, "content": new_blocks}
+
     for i, msg in enumerate(out):
         blocks = _blocks(msg)
         if blocks is None or msg.get("role") != "assistant":
@@ -133,7 +161,16 @@ def repair_replayed_tool_ids(history: list[dict]) -> tuple[list[dict], int]:
             continue
 
         nxt = out[i + 1] if i + 1 < len(out) else None
-        reply_blocks = _blocks(nxt) if nxt is not None and nxt.get("role") == "user" else None
+        # isinstance BEFORE .get: every other message access in this function
+        # goes through `_blocks`/`_bad`, which are guarded; this one was not,
+        # and a non-dict message directly after a broken assistant message
+        # raised AttributeError straight out of `ChatSession.__init__` —
+        # strictly worse than the 400 being fixed (review: pnewsam on #471).
+        reply_blocks = (
+            _blocks(nxt)
+            if isinstance(nxt, dict) and nxt.get("role") == "user"
+            else None
+        )
         pairable = reply_blocks is not None and any(
             isinstance(b, dict) and b.get("type") == "tool_result" for b in reply_blocks
         )

--- a/anton/memory/history_store.py
+++ b/anton/memory/history_store.py
@@ -12,6 +12,7 @@ import os
 import tempfile
 import uuid
 from datetime import datetime, timezone
+import logging as _logging
 from pathlib import Path
 
 from typing import TYPE_CHECKING
@@ -36,6 +37,154 @@ def is_user_turn(message: dict) -> bool:
         isinstance(block, dict) and block.get("type") == "tool_result"
         for block in content
     )
+
+
+def repair_replayed_tool_ids(history: list[dict]) -> tuple[list[dict], int]:
+    """Re-key replayed tool blocks whose id never survived generation.
+
+    Returns ``(history, repaired_block_count)``; the input list is never
+    mutated (messages that need a change are copied first, so a host that
+    holds the same dicts is not edited underneath it).
+
+    ENG-2420 wrote `tool_use` blocks with ``id: ""`` into stored
+    conversations. Replaying one makes the provider reject the entire request
+    — ``400 Invalid 'input[N].call_id': empty string`` — so every later turn
+    of that conversation fails and it never recovers. Guarding the readers
+    stops NEW ones; this repairs the ones already in users' stored histories,
+    which is why it runs at the single ingress every surface shares
+    (`ChatSessionConfig.initial_history`) rather than in one host.
+
+    **Count-preserving by contract, not by taste.** `ChatSession.last_compaction`
+    reports ``covered_through`` as a positional count into `initial_history`,
+    and the host maps that count onto its own message list (cowork-server's
+    `_persist_history_compaction` does ``tail_start + covered - 1``). Dropping
+    a message here would shift a saved compaction cutoff onto the wrong
+    message and silently drop or duplicate real history on the next turn —
+    a worse bug than the one being fixed, and one that would be blamed on
+    compaction. So blocks are rewritten in place and no message is ever added
+    or removed.
+
+    A tool-reply user message also keeps at least one `tool_result` block, so
+    `is_user_turn` still reads it as a reply rather than a new turn. Rewriting
+    it to plain text would inflate the session's turn count and — in exactly
+    the shape being repaired, where the poisoned turn died and the next
+    message is a real user turn — leave two consecutive user messages, which
+    `_seed_history` and `_validate_history_for_provider` both treat as a
+    provider hazard.
+
+    Pairing uses the adjacent (assistant, user) model because that is the only
+    shape anton writes: a `tool_result` block is only ever built from the
+    `tc.id` of a call in the immediately preceding assistant message. Anything
+    that does not fit it is rewritten to text rather than guessed at.
+    """
+    from anton.core.llm.provider import UNNAMED_REPLAYED_TOOL, usable_call_id
+
+    def _mint() -> str:
+        import uuid
+
+        return f"call_repaired_{uuid.uuid4().hex}"
+
+    def _blocks(msg) -> list | None:
+        content = msg.get("content") if isinstance(msg, dict) else None
+        return content if isinstance(content, list) else None
+
+    def _bad(block, field) -> bool:
+        return isinstance(block, dict) and not usable_call_id(block.get(field))
+
+    out = [m for m in history]
+    repaired = 0
+
+    for i, msg in enumerate(out):
+        blocks = _blocks(msg)
+        if blocks is None or msg.get("role") != "assistant":
+            continue
+        broken = [b for b in blocks
+                  if isinstance(b, dict) and b.get("type") == "tool_use" and _bad(b, "id")]
+        if not broken:
+            continue
+
+        nxt = out[i + 1] if i + 1 < len(out) else None
+        reply_blocks = _blocks(nxt) if nxt is not None and nxt.get("role") == "user" else None
+        pairable = reply_blocks is not None and any(
+            isinstance(b, dict) and b.get("type") == "tool_result" for b in reply_blocks
+        )
+
+        new_blocks = [dict(b) if isinstance(b, dict) else b for b in blocks]
+        if not pairable:
+            # Nothing to pair with, so a minted id would be an orphan
+            # `tool_use` — which is its own 400 on Anthropic. Keep the message
+            # and the block COUNT, drop only the call.
+            for pos, b in enumerate(new_blocks):
+                if isinstance(b, dict) and b.get("type") == "tool_use" and _bad(b, "id"):
+                    new_blocks[pos] = {
+                        "type": "text",
+                        "text": "[a tool call was recorded here without an id and has been removed]",
+                    }
+                    repaired += 1
+            out[i] = {**msg, "content": new_blocks}
+            continue
+
+        minted: list[str] = []
+        for b in new_blocks:
+            if isinstance(b, dict) and b.get("type") == "tool_use" and _bad(b, "id"):
+                b["id"] = _mint()
+                if not isinstance(b.get("name"), str) or not b["name"]:
+                    b["name"] = UNNAMED_REPLAYED_TOOL
+                minted.append(b["id"])
+                repaired += 1
+        out[i] = {**msg, "content": new_blocks}
+
+        queue = list(minted)
+        new_reply = [dict(b) if isinstance(b, dict) else b for b in reply_blocks]
+        for b in new_reply:
+            if not queue:
+                break
+            if isinstance(b, dict) and b.get("type") == "tool_result" and _bad(b, "tool_use_id"):
+                b["tool_use_id"] = queue.pop(0)
+                repaired += 1
+        for orphan in queue:
+            # A block, not a message: still count-preserving.
+            new_reply.append({
+                "type": "tool_result",
+                "tool_use_id": orphan,
+                "content": "[no result was recorded for this call]",
+            })
+            repaired += 1
+        out[i + 1] = {**nxt, "content": new_reply}
+
+    # A bad `tool_result` the pass above never claimed has no matching call in
+    # the message before it. Re-keying it alone would orphan it, so it is
+    # rewritten to text — the one case that can change `is_user_turn`, which is
+    # why it is logged rather than done quietly.
+    for i, msg in enumerate(out):
+        blocks = _blocks(msg)
+        if blocks is None or msg.get("role") != "user":
+            continue
+        if not any(isinstance(b, dict) and b.get("type") == "tool_result"
+                   and _bad(b, "tool_use_id") for b in blocks):
+            continue
+        new_blocks = []
+        for b in blocks:
+            if isinstance(b, dict) and b.get("type") == "tool_result" and _bad(b, "tool_use_id"):
+                new_blocks.append({"type": "text",
+                                   "text": "[a tool result with no matching call was removed]"})
+                repaired += 1
+            else:
+                new_blocks.append(b)
+        out[i] = {**msg, "content": new_blocks}
+        _logging.getLogger(__name__).warning(
+            "ENG-2420: replayed history had a tool_result with no pairable call "
+            "at index %d; rewrote it as text (this message may now count as a "
+            "user turn).", i,
+        )
+
+    if repaired:
+        _logging.getLogger(__name__).warning(
+            "ENG-2420: repaired %d unreplayable tool block(s) in replayed "
+            "history; the conversation would otherwise have been rejected by "
+            "the provider on every turn.", repaired,
+        )
+    return out, repaired
 
 
 class HistoryStore:

--- a/anton/memory/history_store.py
+++ b/anton/memory/history_store.py
@@ -79,10 +79,39 @@ def repair_replayed_tool_ids(history: list[dict]) -> tuple[list[dict], int]:
     """
     from anton.core.llm.provider import UNNAMED_REPLAYED_TOOL, usable_call_id
 
-    def _mint() -> str:
-        import uuid
+    seen: dict[str, int] = {}
 
-        return f"call_repaired_{uuid.uuid4().hex}"
+    def _mint(block: dict | None = None) -> str:
+        """A DETERMINISTIC id, derived from what the block already says.
+
+        Not `uuid4`, and that is the whole point. This repair is re-applied on
+        every load and is never written back: cowork-server leaves
+        `history_store` unset, and it persists only `session.history[seed_len:]`
+        — this turn's messages — so the repaired seed never reaches the
+        `messages` table. A random id would therefore differ on every turn,
+        changing the replayed prefix each time and missing the prompt cache on
+        the WHOLE conversation, forever, for exactly the conversations being
+        healed. Byte-stability of the history prefix is an explicit design goal
+        of the host that builds it (see `_stamp_message`, "cache-safe").
+
+        Keyed on content rather than position so a compaction summary being
+        prepended — which shifts every index — does not change the ids of the
+        tail it kept. The occurrence counter disambiguates a conversation that
+        made the identical call twice.
+        """
+        import hashlib
+        import json as _json
+
+        if block is None:
+            basis = "orphan"
+        else:
+            basis = _json.dumps(
+                [block.get("name") or "", block.get("input")],
+                sort_keys=True, default=str,
+            )
+        seen[basis] = seen.get(basis, 0) + 1
+        digest = hashlib.sha256(f"{basis}|{seen[basis]}".encode()).hexdigest()
+        return f"call_repaired_{digest[:24]}"
 
     def _blocks(msg) -> list | None:
         content = msg.get("content") if isinstance(msg, dict) else None
@@ -127,7 +156,7 @@ def repair_replayed_tool_ids(history: list[dict]) -> tuple[list[dict], int]:
         minted: list[str] = []
         for b in new_blocks:
             if isinstance(b, dict) and b.get("type") == "tool_use" and _bad(b, "id"):
-                b["id"] = _mint()
+                b["id"] = _mint(b)
                 if not isinstance(b.get("name"), str) or not b["name"]:
                     b["name"] = UNNAMED_REPLAYED_TOOL
                 minted.append(b["id"])

--- a/tests/test_eng2420_empty_tool_call_id.py
+++ b/tests/test_eng2420_empty_tool_call_id.py
@@ -1,0 +1,296 @@
+"""ENG-2420 — an empty tool-call id must never reach history.
+
+A `ToolCall` with `id=""` is written into `session.history`, serialised back
+out on the next request as `"call_id": ""`, and the provider then rejects the
+WHOLE request (`400 Invalid 'input[N].call_id': empty string`) on that turn and
+on every later turn of the conversation. Nothing recovers it: the only trimming
+path runs on a caught `ContextOverflowError` or on pressure from a successful
+response's usage, and a 400 produces neither.
+
+These tests drive the readers with the provider shapes that produce it, and the
+repair with a conversation that was already poisoned before the fix shipped.
+"""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from anton.core.llm.openai import (
+    OpenAIProvider,
+    _parse_response_object,
+    _translate_messages_to_responses_input,
+)
+from anton.core.llm.provider import StreamComplete, ToolCall, replayable_tool_call
+from anton.memory.history_store import is_user_turn, repair_replayed_tool_ids
+
+
+async def _fake_async_iter(items):
+    for item in items:
+        yield item
+
+
+def _completed(events):
+    return [e for e in events if isinstance(e, StreamComplete)][-1].response
+
+
+async def _run_responses_stream(events, flavor=OpenAIProvider.FLAVOR_OPENAI):
+    with patch("anton.core.llm.openai.openai") as mock_openai:
+        client = AsyncMock()
+        mock_openai.AsyncOpenAI.return_value = client
+        client.responses.create = AsyncMock(return_value=_fake_async_iter(events))
+        provider = OpenAIProvider(api_key="k", flavor=flavor)
+        return [
+            e
+            async for e in provider.stream(
+                model="gpt-5",
+                system="s",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"name": "scratchpad", "description": "x", "input_schema": {}}],
+            )
+        ]
+
+
+def _args_events(index=0):
+    return [
+        SimpleNamespace(
+            type="response.function_call_arguments.delta",
+            output_index=index,
+            delta='{"action": "exec"}',
+        ),
+        SimpleNamespace(type="response.function_call_arguments.done", output_index=index),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(usage=None, status="completed", model="gpt-5"),
+        ),
+    ]
+
+
+class TestReadersNeverEmitAnUnreplayableCall:
+    """Three provider shapes reach the empty id, not just the filed one.
+
+    Only the first is what ENG-2420 describes. The other two never touch the
+    `output_item.added`-missing buffer path, so a guard written for that path
+    alone would miss them.
+    """
+
+    async def test_arguments_arrive_with_no_output_item_added(self):
+        response = _completed(await _run_responses_stream(_args_events()))
+        # Name is empty too on this shape — there is no tool to dispatch, so
+        # the call is dropped rather than given a synthetic handle.
+        assert response.tool_calls == []
+
+    async def test_output_item_added_carries_a_blank_call_id(self):
+        events = [
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(type="function_call", call_id="", name="scratchpad"),
+            ),
+            *_args_events(),
+        ]
+        calls = _completed(await _run_responses_stream(events)).tool_calls
+        # Name survived, so the call is salvageable: mint a handle and let it run.
+        assert len(calls) == 1
+        assert calls[0].name == "scratchpad"
+        assert calls[0].id, "an id must have been minted"
+        assert calls[0].input == {"action": "exec"}
+
+    async def test_item_is_not_labelled_function_call(self):
+        events = [
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(type="custom_tool_call", call_id="c", name="scratchpad"),
+            ),
+            *_args_events(),
+        ]
+        assert _completed(await _run_responses_stream(events)).tool_calls == []
+
+    async def test_healthy_call_is_untouched(self):
+        events = [
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(type="function_call", call_id="call_ok", name="scratchpad"),
+            ),
+            *_args_events(),
+        ]
+        calls = _completed(await _run_responses_stream(events)).tool_calls
+        assert [(c.id, c.name) for c in calls] == [("call_ok", "scratchpad")]
+
+    async def test_chat_completions_stream_where_the_id_never_arrives(self):
+        """The gateway population runs this transport, not the Responses API."""
+
+        def chunk(tool_calls, finish=None):
+            return SimpleNamespace(
+                model="m",
+                usage=None,
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            content=None, tool_calls=tool_calls, reasoning_content=None
+                        ),
+                        finish_reason=finish,
+                    )
+                ],
+            )
+
+        delta = SimpleNamespace(
+            index=0,
+            id=None,
+            function=SimpleNamespace(name="scratchpad", arguments='{"a": 1}'),
+        )
+        with patch("anton.core.llm.openai.openai") as mock_openai:
+            client = AsyncMock()
+            mock_openai.AsyncOpenAI.return_value = client
+            client.chat.completions.create = AsyncMock(
+                return_value=_fake_async_iter([chunk([delta]), chunk(None, finish="tool_calls")])
+            )
+            provider = OpenAIProvider(
+                api_key="k", flavor=OpenAIProvider.FLAVOR_OPENAI_COMPATIBLE_GENERIC
+            )
+            events = [
+                e
+                async for e in provider.stream(
+                    model="m",
+                    system="s",
+                    messages=[{"role": "user", "content": "hi"}],
+                    tools=[{"name": "scratchpad", "description": "x", "input_schema": {}}],
+                )
+            ]
+        calls = _completed(events).tool_calls
+        assert len(calls) == 1 and calls[0].id and calls[0].name == "scratchpad"
+
+    def test_non_streaming_responses_item_with_no_call_id(self):
+        item = SimpleNamespace(type="function_call", name="scratchpad", arguments='{"a": 1}')
+        response = SimpleNamespace(
+            output=[item], usage=None, status="completed", model="gpt-5"
+        )
+        calls = _parse_response_object(response, "gpt-5").tool_calls
+        assert len(calls) == 1 and calls[0].id
+
+
+class TestReplayableToolCall:
+    def test_unnamed_call_is_dropped(self):
+        assert replayable_tool_call(ToolCall(id="", name="", input={})) is None
+
+    def test_named_call_keeps_its_input_and_gains_an_id(self):
+        call = replayable_tool_call(ToolCall(id="", name="scratchpad", input={"a": 1}))
+        assert call is not None and call.id and call.input == {"a": 1}
+
+    def test_a_non_string_id_is_not_merely_falsy_checked(self):
+        assert replayable_tool_call(ToolCall(id={"oops": 1}, name="", input={})) is None
+
+
+class TestRepairOfAnAlreadyPoisonedConversation:
+    """The bad ids are already in users' stored histories.
+
+    Every assertion here is a constraint the repair may not break, and each one
+    is a bug that a simpler repair actually causes.
+    """
+
+    @staticmethod
+    def _poisoned():
+        return [
+            {"role": "user", "content": "[2026-09-01 10:00] load my csv"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "On it."},
+                    {"type": "tool_use", "id": "", "name": "", "input": {"action": "exec"}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "", "content": "Tool '' not found"}
+                ],
+            },
+            {"role": "user", "content": "[2026-09-01 10:02] hello? are you there"},
+        ]
+
+    def test_nothing_unreplayable_survives_onto_the_wire(self):
+        fixed, repaired = repair_replayed_tool_ids(self._poisoned())
+        assert repaired == 2
+        wire = _translate_messages_to_responses_input(fixed)
+        assert not [i for i in wire if i.get("call_id") == "" or i.get("name") == ""]
+
+    def test_message_count_is_preserved(self):
+        """`last_compaction.covered_through` is a POSITIONAL count into
+        `initial_history` that the host maps onto its own message list
+        (cowork-server's `_persist_history_compaction` does
+        `tail_start + covered - 1`). Removing a message here would move a saved
+        compaction cutoff onto the wrong message and silently drop or duplicate
+        real history on the next turn."""
+        poisoned = self._poisoned()
+        fixed, _ = repair_replayed_tool_ids(poisoned)
+        assert len(fixed) == len(poisoned)
+
+    def test_a_tool_reply_is_still_not_counted_as_a_user_turn(self):
+        """Rewriting the reply to plain text inflates the session's turn count
+        and leaves two consecutive user messages in exactly this shape."""
+        poisoned = self._poisoned()
+        fixed, _ = repair_replayed_tool_ids(poisoned)
+        assert sum(1 for m in fixed if is_user_turn(m)) == sum(
+            1 for m in poisoned if is_user_turn(m)
+        )
+
+    def test_no_new_consecutive_same_role_pair(self):
+        poisoned = self._poisoned()
+        fixed, _ = repair_replayed_tool_ids(poisoned)
+        before = [i for i in range(1, len(poisoned)) if poisoned[i]["role"] == poisoned[i - 1]["role"]]
+        after = [i for i in range(1, len(fixed)) if fixed[i]["role"] == fixed[i - 1]["role"]]
+        assert after == before
+
+    def test_the_pair_stays_paired(self):
+        fixed, _ = repair_replayed_tool_ids(self._poisoned())
+        assert fixed[1]["content"][1]["id"] == fixed[2]["content"][0]["tool_use_id"]
+
+    def test_the_callers_list_is_not_mutated(self):
+        poisoned = self._poisoned()
+        snapshot = copy.deepcopy(poisoned)
+        repair_replayed_tool_ids(poisoned)
+        assert poisoned == snapshot
+
+    def test_repair_is_idempotent(self):
+        fixed, _ = repair_replayed_tool_ids(self._poisoned())
+        again, repaired = repair_replayed_tool_ids(fixed)
+        assert repaired == 0 and again == fixed
+
+    def test_healthy_history_is_untouched(self):
+        healthy = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "call_ok", "name": "scratchpad", "input": {}}
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "call_ok", "content": "done"}
+                ],
+            },
+        ]
+        out, repaired = repair_replayed_tool_ids(copy.deepcopy(healthy))
+        assert repaired == 0 and out == healthy
+
+    def test_a_call_with_nothing_to_pair_with_becomes_text_not_an_orphan(self):
+        """A minted id with no reply would be an orphan `tool_use`, which is
+        its own 400 on Anthropic. Block count is still preserved."""
+        history = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "", "name": "scratchpad", "input": {}}],
+            },
+        ]
+        fixed, repaired = repair_replayed_tool_ids(history)
+        assert repaired == 1
+        assert len(fixed) == 2 and len(fixed[1]["content"]) == 1
+        assert fixed[1]["content"][0]["type"] == "text"

--- a/tests/test_eng2420_empty_tool_call_id.py
+++ b/tests/test_eng2420_empty_tool_call_id.py
@@ -24,7 +24,13 @@ from anton.core.llm.openai import (
     _parse_response_object,
     _translate_messages_to_responses_input,
 )
-from anton.core.llm.provider import StreamComplete, ToolCall, replayable_tool_call
+from anton.core.llm.provider import (
+    UNNAMED_REPLAYED_TOOL,
+    StreamComplete,
+    ToolCall,
+    ensure_replayable_tool_call,
+    usable_call_id,
+)
 from anton.memory.history_store import is_user_turn, repair_replayed_tool_ids
 
 
@@ -78,10 +84,16 @@ class TestReadersNeverEmitAnUnreplayableCall:
     """
 
     async def test_arguments_arrive_with_no_output_item_added(self):
-        response = _completed(await _run_responses_stream(_args_events()))
-        # Name is empty too on this shape — there is no tool to dispatch, so
-        # the call is dropped rather than given a synthetic handle.
-        assert response.tool_calls == []
+        """Both fields are empty on this shape, and BOTH are salvaged.
+
+        Dropping the call looked tidier and was worse: the streaming paths do
+        not call `raise_on_empty_response`, so a dropped sole call ends the
+        turn silently. Renamed, it fails as an ordinary `Tool ... not found`
+        tool_result the model re-emits from inside the same turn.
+        """
+        calls = _completed(await _run_responses_stream(_args_events())).tool_calls
+        assert len(calls) == 1
+        assert calls[0].id and calls[0].name == UNNAMED_REPLAYED_TOOL
 
     async def test_output_item_added_carries_a_blank_call_id(self):
         events = [
@@ -108,7 +120,34 @@ class TestReadersNeverEmitAnUnreplayableCall:
             ),
             *_args_events(),
         ]
-        assert _completed(await _run_responses_stream(events)).tool_calls == []
+        calls = _completed(await _run_responses_stream(events)).tool_calls
+        assert len(calls) == 1
+        assert calls[0].id and calls[0].name == UNNAMED_REPLAYED_TOOL
+
+    async def test_chat_completions_non_streaming_with_a_blank_id(self):
+        """The SDK types `id` as a required `str`, which "" satisfies."""
+        tc = SimpleNamespace(
+            id="", function=SimpleNamespace(name="scratchpad", arguments='{"a": 1}')
+        )
+        message = MagicMock()
+        message.content = ""
+        message.tool_calls = [tc]
+        usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+        response = MagicMock(
+            choices=[MagicMock(message=message, finish_reason="tool_calls")], usage=usage
+        )
+        with patch("anton.core.llm.openai.openai") as mock_openai:
+            client = AsyncMock()
+            mock_openai.AsyncOpenAI.return_value = client
+            client.chat.completions.create = AsyncMock(return_value=response)
+            provider = OpenAIProvider(
+                api_key="k", flavor=OpenAIProvider.FLAVOR_OPENAI_COMPATIBLE_GENERIC
+            )
+            out = await provider.complete(
+                model="m", system="s", messages=[{"role": "user", "content": "hi"}],
+                tools=[{"name": "scratchpad", "description": "x", "input_schema": {}}],
+            )
+        assert len(out.tool_calls) == 1 and out.tool_calls[0].id
 
     async def test_healthy_call_is_untouched(self):
         events = [
@@ -174,16 +213,93 @@ class TestReadersNeverEmitAnUnreplayableCall:
         assert len(calls) == 1 and calls[0].id
 
 
-class TestReplayableToolCall:
-    def test_unnamed_call_is_dropped(self):
-        assert replayable_tool_call(ToolCall(id="", name="", input={})) is None
-
+class TestEnsureReplayableToolCall:
     def test_named_call_keeps_its_input_and_gains_an_id(self):
-        call = replayable_tool_call(ToolCall(id="", name="scratchpad", input={"a": 1}))
-        assert call is not None and call.id and call.input == {"a": 1}
+        call = ensure_replayable_tool_call(ToolCall(id="", name="scratchpad", input={"a": 1}))
+        assert call.id and call.name == "scratchpad" and call.input == {"a": 1}
+
+    def test_a_good_id_with_no_name_is_renamed_not_dropped(self):
+        """Pre-fix this call was dispatched and came back as an ordinary
+        "tool not found" result the model recovers from inside the turn.
+        Dropping it was a behaviour change beyond ENG-2420 and a worse failure
+        than the one being fixed (review: pnewsam on #471)."""
+        call = ensure_replayable_tool_call(ToolCall(id="call_ok", name="", input={"a": 1}))
+        assert call.id == "call_ok" and call.name == UNNAMED_REPLAYED_TOOL
 
     def test_a_non_string_id_is_not_merely_falsy_checked(self):
-        assert replayable_tool_call(ToolCall(id={"oops": 1}, name="", input={})) is None
+        """`name` is deliberately GOOD here: with an empty name this exits
+        through the name branch and never exercises the id check at all, which
+        is how a bare `bool(value)` mutation stayed green (review: pnewsam)."""
+        call = ensure_replayable_tool_call(ToolCall(id={"oops": 1}, name="scratchpad", input={}))
+        assert isinstance(call.id, str) and call.id.startswith("call_anton_")
+
+    def test_usable_call_id_rejects_non_strings_directly(self):
+        assert usable_call_id("call_x") is True
+        assert usable_call_id("") is False
+        assert usable_call_id({"nested": 1}) is False
+        assert usable_call_id(None) is False
+        assert usable_call_id(123) is False
+
+
+class TestAnthropicReaderIsGuardedToo:
+    """The Anthropic reader has no empty-id BUFFER path, but writes `block.id`
+    straight through — so a relay sending a blank id poisons history the same
+    way. Neither of these sites was pinned by any test (review: pnewsam)."""
+
+    async def test_non_streaming_block_with_a_blank_id(self):
+        from anton.core.llm.anthropic import AnthropicProvider
+
+        block = SimpleNamespace(type="tool_use", id="", name="scratchpad", input={"a": 1})
+        response = SimpleNamespace(
+            content=[block], stop_reason="tool_use", model="claude",
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+        )
+        with patch("anton.core.llm.anthropic.anthropic") as mock_anthropic:
+            client = AsyncMock()
+            mock_anthropic.AsyncAnthropic.return_value = client
+            client.messages.create = AsyncMock(return_value=response)
+            provider = AnthropicProvider(api_key="k")
+            out = await provider.complete(
+                model="claude", system="s", messages=[{"role": "user", "content": "hi"}],
+            )
+        assert len(out.tool_calls) == 1 and out.tool_calls[0].id
+
+    async def test_streaming_block_with_a_blank_id_and_no_orphan_ui_step(self):
+        from anton.core.llm.anthropic import AnthropicProvider
+        from anton.core.llm.provider import StreamToolUseEnd, StreamToolUseStart
+
+        events = [
+            SimpleNamespace(type="message_start", message=SimpleNamespace(
+                model="claude",
+                usage=SimpleNamespace(input_tokens=1, output_tokens=0,
+                                      cache_read_input_tokens=0, cache_creation_input_tokens=0))),
+            SimpleNamespace(type="content_block_start", index=0, content_block=SimpleNamespace(
+                type="tool_use", id="", name="scratchpad")),
+            SimpleNamespace(type="content_block_delta", index=0, delta=SimpleNamespace(
+                type="input_json_delta", partial_json='{"a": 1}')),
+            SimpleNamespace(type="content_block_stop", index=0),
+            SimpleNamespace(type="message_delta",
+                            delta=SimpleNamespace(stop_reason="tool_use"),
+                            usage=SimpleNamespace(output_tokens=1)),
+        ]
+        with patch("anton.core.llm.anthropic.anthropic") as mock_anthropic:
+            client = AsyncMock()
+            mock_anthropic.AsyncAnthropic.return_value = client
+            # Reuses the canonical stand-in: `messages.stream()` is NOT
+            # awaited, it is used as `async with ... as stream`.
+            from tests.test_provider import _FakeAnthropicStream
+
+            client.messages.stream = MagicMock(return_value=_FakeAnthropicStream(events))
+            provider = AnthropicProvider(api_key="k")
+            out = [e async for e in provider.stream(
+                model="claude", system="s", messages=[{"role": "user", "content": "hi"}])]
+
+        calls = _completed(out).tool_calls
+        assert len(calls) == 1 and calls[0].id
+        # A Start keyed "" could never be retired: the marker that closes a step
+        # carries the call's id, which is now the minted one.
+        assert not [e for e in out if isinstance(e, StreamToolUseStart)]
+        assert not [e for e in out if isinstance(e, StreamToolUseEnd)]
 
 
 class TestRepairOfAnAlreadyPoisonedConversation:
@@ -215,7 +331,9 @@ class TestRepairOfAnAlreadyPoisonedConversation:
 
     def test_nothing_unreplayable_survives_onto_the_wire(self):
         fixed, repaired = repair_replayed_tool_ids(self._poisoned())
-        assert repaired == 2
+        # 3, not 2: the fixture's call has an empty id AND an empty name, and
+        # the name is now repaired as its own concern (review: pnewsam on #471).
+        assert repaired == 3
         wire = _translate_messages_to_responses_input(fixed)
         assert not [i for i in wire if i.get("call_id") == "" or i.get("name") == ""]
 
@@ -327,3 +445,133 @@ class TestRepairOfAnAlreadyPoisonedConversation:
         assert repaired == 1
         assert len(fixed) == 2 and len(fixed[1]["content"]) == 1
         assert fixed[1]["content"][0]["type"] == "text"
+
+
+class TestABadNameIsRepairedToo:
+    """The second poisoned shape: a usable id with a blank name.
+
+    Pre-fix anton wrote this whenever a provider sent a good `call_id` with no
+    name. The first revision of this fix selected on the id alone, so the shape
+    passed through all three layers untouched and reached the wire as
+    `name: ''` (review: pnewsam on #471).
+    """
+
+    def test_a_stored_block_with_a_good_id_and_no_name_is_renamed(self):
+        history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "call_x", "name": "", "input": {}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "call_x", "content": "nope"}]},
+        ]
+        fixed, repaired = repair_replayed_tool_ids(history)
+        assert repaired == 1
+        assert fixed[1]["content"][0]["name"] == UNNAMED_REPLAYED_TOOL
+        # The id was fine and must be left exactly as it was — re-keying it
+        # would needlessly change the replayed prefix.
+        assert fixed[1]["content"][0]["id"] == "call_x"
+        wire = _translate_messages_to_responses_input(fixed)
+        assert not [i for i in wire if i.get("name") == ""]
+
+    def test_a_non_dict_message_after_a_broken_call_does_not_raise(self):
+        """Every other message access in the repair is isinstance-guarded;
+        this one was not, and raised out of `ChatSession.__init__`, which is
+        strictly worse than the 400 being fixed (review: pnewsam on #471)."""
+        history = [
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "", "name": "scratchpad", "input": {}}]},
+            "not a dict at all",
+        ]
+        fixed, _ = repair_replayed_tool_ids(history)  # must not raise
+        assert len(fixed) == 2
+
+
+class TestTheWiringIsPinned:
+    """Each layer past the readers, asserted at its real call site.
+
+    Reverting any of these to its pre-PR form left the full suite green, which
+    is the same structural hole ENG-1808 came from (review: pnewsam on #471).
+    """
+
+    @staticmethod
+    def _session():
+        from anton.core.session import ChatSession, ChatSessionConfig
+        from tests.conftest import make_mock_llm
+
+        poisoned = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "", "name": "", "input": {"a": 1}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "", "content": "x"}]},
+        ]
+        return ChatSession(ChatSessionConfig(
+            llm_client=make_mock_llm(), initial_history=poisoned,
+        )), poisoned
+
+    def test_constructing_a_session_repairs_poisoned_history(self):
+        """The ingress repair is only reachable through `ChatSession.__init__`,
+        and nothing constructed a session with poisoned history."""
+        session, poisoned = self._session()
+        block = session.history[1]["content"][0]
+        assert block["id"] and block["name"] == UNNAMED_REPLAYED_TOOL
+        assert session.history[2]["content"][0]["tool_use_id"] == block["id"]
+        # Count-preserving, so `_seed_len` and the host's positional
+        # `covered_through` mapping still line up.
+        assert len(session.history) == len(poisoned)
+        assert session._seed_len == len(poisoned)
+
+    def test_the_session_belt_salvages_rather_than_empties(self):
+        from anton.core.llm.provider import LLMResponse
+
+        session, _ = self._session()
+        response = LLMResponse(
+            content="", tool_calls=[ToolCall(id="", name="", input={"a": 1})],
+        )
+        session._ensure_replayable_calls(response)
+        # Salvaged, NOT dropped: emptying the list would leave the round with
+        # no calls and no content, so both `_append_history` calls become
+        # no-ops and the loop re-issues an identical request until the round
+        # cap (review: pnewsam on #471).
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].id and response.tool_calls[0].name
+
+    def test_the_tool_loop_calls_the_belt(self):
+        """AST, not behaviour: the belt is expected to be a permanent no-op, so
+        only its presence at the call site can be asserted. Mirrors
+        `tests/test_verifier_truncation.py`'s wiring pins."""
+        import ast
+        import inspect
+
+        from anton.core.session import ChatSession
+
+        src = inspect.getsource(ChatSession._stream_and_handle_tools)
+        called = {
+            n.func.attr
+            for n in ast.walk(ast.parse(textwrap_dedent(src)))
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        }
+        assert "_ensure_replayable_calls" in called
+
+    def test_the_scratchpad_boot_loop_calls_its_belt(self):
+        """AST for the same reason the sibling wiring tests use it: importing
+        `scratchpad_boot` reads stdin at import time."""
+        import ast
+        import pathlib as _pathlib
+
+        import anton
+
+        src = (_pathlib.Path(anton.__file__).parent
+               / "core" / "backends" / "scratchpad_boot.py").read_text()
+        called = {
+            n.func.id
+            for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        }
+        assert "_ensure_replayable_calls" in called
+
+
+def textwrap_dedent(src: str) -> str:
+    import textwrap
+
+    return textwrap.dedent(src)

--- a/tests/test_eng2420_empty_tool_call_id.py
+++ b/tests/test_eng2420_empty_tool_call_id.py
@@ -256,6 +256,39 @@ class TestRepairOfAnAlreadyPoisonedConversation:
         repair_replayed_tool_ids(poisoned)
         assert poisoned == snapshot
 
+    def test_two_separate_loads_produce_byte_identical_history(self):
+        """The repair is re-applied on EVERY load and never written back —
+        cowork-server leaves `history_store` unset and persists only
+        `session.history[seed_len:]`, so the repaired seed never reaches the
+        messages table. A random minted id would therefore change the replayed
+        prefix every turn and miss the prompt cache on the whole conversation,
+        forever, for exactly the conversations being healed.
+
+        Note this is a strictly stronger property than `test_repair_is_idempotent`
+        below, which re-repairs an ALREADY-repaired list and so cannot catch a
+        non-deterministic mint.
+        """
+        import json
+
+        first, _ = repair_replayed_tool_ids(self._poisoned())
+        second, _ = repair_replayed_tool_ids(self._poisoned())
+        assert json.dumps(first) == json.dumps(second)
+
+    def test_two_identical_calls_still_get_distinct_ids(self):
+        history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "", "name": "scratchpad", "input": {"a": 1}},
+                {"type": "tool_use", "id": "", "name": "scratchpad", "input": {"a": 1}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "", "content": "x"},
+                {"type": "tool_result", "tool_use_id": "", "content": "y"}]},
+        ]
+        fixed, _ = repair_replayed_tool_ids(history)
+        ids = [b["id"] for b in fixed[1]["content"]]
+        assert len(set(ids)) == 2
+        assert ids == [b["tool_use_id"] for b in fixed[2]["content"]]
+
     def test_repair_is_idempotent(self):
         fixed, _ = repair_replayed_tool_ids(self._poisoned())
         again, repaired = repair_replayed_tool_ids(fixed)

--- a/tests/test_eng2420_empty_tool_call_id.py
+++ b/tests/test_eng2420_empty_tool_call_id.py
@@ -542,13 +542,14 @@ class TestTheWiringIsPinned:
         `tests/test_verifier_truncation.py`'s wiring pins."""
         import ast
         import inspect
+        import textwrap
 
         from anton.core.session import ChatSession
 
         src = inspect.getsource(ChatSession._stream_and_handle_tools)
         called = {
             n.func.attr
-            for n in ast.walk(ast.parse(textwrap_dedent(src)))
+            for n in ast.walk(ast.parse(textwrap.dedent(src)))
             if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
         }
         assert "_ensure_replayable_calls" in called
@@ -571,7 +572,80 @@ class TestTheWiringIsPinned:
         assert "_ensure_replayable_calls" in called
 
 
-def textwrap_dedent(src: str) -> str:
-    import textwrap
 
-    return textwrap.dedent(src)
+class TestNoToolStepIsLeftOpenOrClosedTwice:
+    """Every `StreamToolUseEnd` must have had a matching Start.
+
+    The first attempt at this gated the End on `id and name` being set at the
+    end of the stream, which is a different question from "did we announce this
+    call": both fields can be filled in by a LATER chunk, so a call that never
+    emitted a Start could still emit an End and close a step the consumer never
+    opened. Caught while auditing the review-response commit.
+    """
+
+    @staticmethod
+    def _pairs(events):
+        from anton.core.llm.provider import StreamToolUseEnd, StreamToolUseStart
+
+        starts = [e.id for e in events if isinstance(e, StreamToolUseStart)]
+        ends = [e.id for e in events if isinstance(e, StreamToolUseEnd)]
+        return starts, ends
+
+    async def test_chat_completions_name_arriving_in_a_later_chunk(self):
+        """id in the first chunk, name only in the second: no Start fires, so
+        no End may either."""
+
+        def chunk(tool_calls, finish=None):
+            return SimpleNamespace(
+                model="m", usage=None,
+                choices=[SimpleNamespace(
+                    delta=SimpleNamespace(content=None, tool_calls=tool_calls,
+                                          reasoning_content=None),
+                    finish_reason=finish)])
+
+        first = SimpleNamespace(index=0, id="call_ok",
+                                function=SimpleNamespace(name=None, arguments=None))
+        second = SimpleNamespace(index=0, id=None,
+                                 function=SimpleNamespace(name="scratchpad", arguments='{"a": 1}'))
+        with patch("anton.core.llm.openai.openai") as mock_openai:
+            client = AsyncMock()
+            mock_openai.AsyncOpenAI.return_value = client
+            client.chat.completions.create = AsyncMock(return_value=_fake_async_iter(
+                [chunk([first]), chunk([second]), chunk(None, finish="tool_calls")]))
+            provider = OpenAIProvider(
+                api_key="k", flavor=OpenAIProvider.FLAVOR_OPENAI_COMPATIBLE_GENERIC)
+            events = [e async for e in provider.stream(
+                model="m", system="s", messages=[{"role": "user", "content": "hi"}],
+                tools=[{"name": "scratchpad", "description": "x", "input_schema": {}}])]
+
+        starts, ends = self._pairs(events)
+        assert starts == ends, f"unbalanced tool steps: {starts} opened, {ends} closed"
+        # The call itself still survives and is dispatchable.
+        assert len(_completed(events).tool_calls) == 1
+
+    async def test_responses_added_with_a_good_id_but_no_name(self):
+        """`output_item.added` arrives with a usable `call_id` and a blank
+        name: no Start fires, so no End may either."""
+        events = [
+            SimpleNamespace(
+                type="response.output_item.added", output_index=0,
+                item=SimpleNamespace(type="function_call", call_id="call_ok", name=""),
+            ),
+            *_args_events(),
+        ]
+        out = await _run_responses_stream(events)
+        starts, ends = self._pairs(out)
+        assert starts == ends, f"unbalanced tool steps: {starts} opened, {ends} closed"
+        calls = _completed(out).tool_calls
+        assert len(calls) == 1 and calls[0].name == UNNAMED_REPLAYED_TOOL
+
+    async def test_a_healthy_call_still_opens_and_closes_exactly_one_step(self):
+        events = [
+            SimpleNamespace(
+                type="response.output_item.added", output_index=0,
+                item=SimpleNamespace(type="function_call", call_id="call_ok", name="scratchpad"),
+            ),
+            *_args_events(),
+        ]
+        starts, ends = self._pairs(await _run_responses_stream(events))
+        assert starts == ["call_ok"] and ends == ["call_ok"]


### PR DESCRIPTION
Fixes [ENG-2420](https://linear.app/mindsdb/issue/ENG-2420). Paired with cowork-server PR (link below) — **independent, no merge order required**.

## The bug

A `ToolCall` built with an empty `id` is appended to the turn's result, written into `session.history`, and serialised back out on the next request as `"call_id": ""`. The provider then rejects the **whole request** — `400 Invalid 'input[N].call_id': empty string` — on that turn and on every later turn of the conversation. From the user's side the thread is simply dead, with an error naming an internal field they cannot act on; scratchpad state, datasources and accumulated context are all stranded, and nothing tells them a new conversation is the only way out.

Nothing self-heals it: a 400 is not transient so it is never retried, and the only trimming paths run on a caught `ContextOverflowError` or on pressure computed from a *successful* response's usage — a 400 produces neither.

## What the investigation added to the ticket

Everything below was confirmed **by execution**, not by reading.

**Three trigger shapes, not one.** The ticket describes only the first; the other two never touch the `:1610` buffer path, so a guard written for that path alone would have missed them.

| shape | result |
|---|---|
| `function_call_arguments.delta`/`.done` with no preceding `output_item.added` | `id=''`, `name=''` |
| `output_item.added` **does** arrive, carrying a blank `call_id` | `id=''`, `name='scratchpad'` |
| `output_item.added` arrives with an item type other than `function_call` | `id=''`, `name=''` |

**Four construction sites, not one** — `_stream_via_responses` (the filed one), `_parse_response_object`, the chat-completions stream (**this is the transport the gateway population runs**), and chat-completions non-streaming (the SDK types `id` as a required `str`, which `""` satisfies). Anthropic has no empty-id *buffer* path — a missing `content_block_start` appends nothing — but writes `block.id` straight through, so the guard belongs on the **value**.

## The fix

1. **`ensure_replayable_tool_call`** guards all six `ToolCall` construction sites and **salvages, never drops**: an unusable id is replaced with a minted one, and an unusable *name* is replaced with `UNNAMED_REPLAYED_TOOL` so the call fails as an ordinary `Tool ... not found` tool_result the model recovers from inside the turn. Dropping was the first design and was worse — only the three non-streaming paths call `raise_on_empty_response`, so a dropped sole call ended a streaming turn silently. Returning unconditionally is also what keeps this layer, the read-time repair and the two belts agreeing about the same two fields; they disagreed in the first revision and a stored `{"id": "call_x", "name": ""}` block slipped through all three.
2. **`repair_replayed_tool_ids`** heals conversations already poisoned on disk, at `ChatSessionConfig.initial_history` — the one ingress desktop, the cloud pod and the CLI all share.
3. **A belt** in the session's tool loop and the scratchpad boot loop filters the response once, before either history or dispatch reads it, so a `tool_use` is never dropped while still being dispatched.

### Why the repair is count-preserving

This is the part that is easy to get wrong, and my first two drafts both did. `last_compaction.covered_through` is a **positional** count into `initial_history` that the host maps onto its own message list (cowork-server's `_persist_history_compaction` does `tail_start + covered - 1`). Dropping a message here would move a saved compaction cutoff onto the wrong message and silently drop or duplicate real history on the next turn — a worse bug than this one, and one that would be blamed on compaction.

The obvious workaround (keep the message, swap in a placeholder) is *also* wrong: it inflates `is_user_turn` and, in exactly the shape being repaired, leaves two consecutive user messages — which `_seed_history` and `_validate_history_for_provider` both treat as a provider hazard. So blocks are re-keyed in place, the tool reply keeps a `tool_result` block, and message count never changes. Each of those three constraints has its own test.

## Seam checks (convention 11)

- **Running what CI runs** — `staging` has moved since this opened, so the branch and the merge are no longer identical. Re-verified on the **merged** tree: merge is clean and the merged suite is green (see the comments below for the run at each head). Re-run it again if `staging` moves further.
- **Whose invariant** — ENG-664's compaction mapping (explicitly preserved + tested) and ENG-1808's row validation (not modified; a sibling function added in the paired PR).
- **Storage on write** — a turn whose rows are unreplayable is now persisted text-only rather than poisoning the conversation.
- **How it ships** — cowork-server pins anton from git `main`, so this reaches users only once it lands on anton `main`, not on `staging`.
- **Helper names** — renamed my own `drop_unreplayable_tool_rows` → `reject_unreplayable_tool_rows` in the paired PR, because it refuses the whole set rather than dropping rows individually.
- **Stale descriptions** — the `_turn_history` module docstring was updated in the paired PR; the ticket description has been rewritten to match what actually shipped.

## Security pass

Done, covering the changed lines. The new log lines carry only the unusable id and the tool **name** — never `tc.input` or tool-result content, either of which can hold user credentials; rejections in the paired PR log the offending field's *type*, never its value. No new endpoints, no auth surface, no deserialization, no path handling. The minted ids are `uuid4().hex` and are per-call handles with no security role.

## Tests

39 new tests in `tests/test_eng2420_empty_tool_call_id.py`. Full suite: **3191 passed, 30 skipped**, no regressions.

Mutation-checked rather than assumed:

| mutation | tests that fail |
|---|---|
| reader guard becomes a pass-through | 8 |
| repair drops messages instead of preserving count | 6 |
| repair rewrites the tool reply to plain text | 2 |

## Self-review trail

An adversarial pass ran **before** this was committed, against the fix design rather than the diff, and rejected two earlier versions of the repair (the two failure modes described above) and one earlier version of the persistence change (which would have imported the pod's size budgets onto desktop). Those findings are already addressed here rather than left as review comments. One of my own new tests was also wrong — it assumed the pod sanitizer would drop an oversize turn when it shrinks the result first — and was corrected.

## Not verified

The ticket's origin evidence (5 occurrences, one user, desktop, 2026-09-01) was **not** independently re-checked: Langfuse was unreachable during this work. Every mechanism claim above is independent of it; the claims about frequency and population are not.

**Residual risk:** a repaired call whose name was also empty replays as `unavailable_tool_call`. anton rebuilds its tool list every round, so replaying a call to a tool not currently offered is already an ordinary shape — but that was not confirmed against a live provider. For an already-poisoned history the alternative is a guaranteed 400, so it is strictly better either way.
