### PR TITLE
fix(memory): stop rules.md dropping entries on every rewrite

### DIFF
--- a/anton/core/memory/cortex.py
+++ b/anton/core/memory/cortex.py
@@ -34,7 +34,7 @@ from anton.core.llm.structured import (
 )
 from anton.core.memory.base import HippocampusProtocol
 from anton.core.memory.base import Engram
-from anton.core.memory.hippocampus import Hippocampus
+from anton.core.memory.hippocampus import Hippocampus, RULE_SECTIONS as _RULE_SECTIONS
 
 if TYPE_CHECKING:
     from anton.core.llm.client import LLMClient
@@ -161,11 +161,6 @@ You are a memory compaction system. The user message is a numbered list of memor
 
 An index you leave out is deleted. Be conservative — when in doubt, keep the entry: two overlapping entries cost less than losing what only one of them said.
 """
-
-# The `## ` headings of `rules.md`, in file order. `save_rules` writes exactly
-# these three and `get_rules` reads each entry's `kind` off them, so compaction
-# has to round-trip the same set. First one doubles as the fallback heading.
-_RULE_SECTIONS = ("always", "never", "when")
 
 
 class Cortex:

--- a/anton/core/memory/hippocampus.py
+++ b/anton/core/memory/hippocampus.py
@@ -27,6 +27,13 @@ from typing import Literal
 
 from anton.core.memory.base import Engram
 
+# The `## ` headings of rules.md, in file order. save_rules writes exactly
+# these three and get_rules reads each entry's `kind` off them, so both have to
+# round-trip the same set. The first doubles as the fallback heading — the same
+# default Cortex._compact_file already applies to an unrecognised heading.
+RULE_SECTIONS = ("always", "never", "when")
+
+
 def _entry_text(text: str) -> str:
     """Make `text` safe to store as one entry line, changing nothing else.
 
@@ -432,16 +439,21 @@ class Hippocampus:
         except (OSError, UnicodeDecodeError):
             return []
 
-        current_kind = None
+        # get_rules/save_rules is a read-modify-write cycle, so an entry skipped
+        # here is deleted from the file by the next encode_rule(). Entries above
+        # the first heading (a hand-edited file) are read under the fallback
+        # heading rather than dropped.
+        current_kind = RULE_SECTIONS[0]
         entries: list[Engram] = []
 
         for line in content.splitlines():
             stripped = line.strip()
             if stripped.startswith("## "):
-                current_kind = stripped[3:].lower()
-            elif stripped.startswith("- ") and current_kind:
+                heading = stripped[3:].lower()
+                current_kind = heading if heading in RULE_SECTIONS else RULE_SECTIONS[0]
+            elif stripped.startswith("- "):
                 text, meta = _extract_metadata(stripped[2:])
-                if text and current_kind is not None:
+                if text:
                     entries.append(Engram(text=text, kind=current_kind, **meta))
 
         entries.sort(key=lambda x: x.kind)
@@ -476,10 +488,10 @@ class Hippocampus:
 
     def save_rules(self, rules: list[Engram]) -> None:
         self._dir.mkdir(parents=True, exist_ok=True)
-        sections: dict[str, list[Engram]] = {"always": [], "never": [], "when": []}
+        sections: dict[str, list[Engram]] = {name: [] for name in RULE_SECTIONS}
         for rule in rules:
-            if rule.kind in sections:
-                sections[rule.kind].append(rule)
+            kind = (rule.kind or "").lower()
+            sections[kind if kind in sections else RULE_SECTIONS[0]].append(rule)
 
         lines = ["# Rules\n"]
         for section, entries in sections.items():

--- a/tests/test_hippocampus.py
+++ b/tests/test_hippocampus.py
@@ -337,3 +337,45 @@ class TestEntryTextSanitization:
         before = hc.get_rules()[0].text
         hc.encode_rule("Second rule", kind="always")        # rewrites rules.md
         assert [r.text for r in hc.get_rules() if r.text == before] == [before]
+
+
+class TestRulesRoundTrip:
+    """get_rules -> save_rules is read-modify-write: anything the read pass
+    skips, or the write pass fails to bucket, is deleted from the file by the
+    next rule Anton learns.
+    """
+
+    META = "<!-- confidence:high source:user ts:2026-01-01 -->"
+
+    def test_reads_entries_above_the_first_heading(self, hc, mem_dir):
+        (mem_dir / "rules.md").write_text(
+            f"# Rules\n- Prefer httpx over requests {self.META}\n"
+            f"\n## Always\n- Call progress() before long API calls {self.META}\n",
+            encoding="utf-8",
+        )
+        texts = [r.text for r in hc.get_rules()]
+        assert "Prefer httpx over requests" in texts
+        assert "Call progress() before long API calls" in texts
+
+    def test_encode_rule_keeps_entries_under_an_unknown_heading(self, hc, mem_dir):
+        (mem_dir / "rules.md").write_text(
+            "# Rules\n\n## Always\n"
+            f"- Call progress() before long API calls {self.META}\n"
+            f"\n## Notes\n- Project uses uv, not pip {self.META}\n",
+            encoding="utf-8",
+        )
+        hc.encode_rule("Never use time.sleep() in scratchpad cells", kind="never")
+        content = (mem_dir / "rules.md").read_text(encoding="utf-8")
+        assert "Project uses uv, not pip" in content
+        assert "Call progress() before long API calls" in content
+        assert "Never use time.sleep() in scratchpad cells" in content
+
+    def test_relocated_entries_stay_readable(self, hc, mem_dir):
+        (mem_dir / "rules.md").write_text(
+            f"# Rules\n\n## Notes\n- Project uses uv, not pip {self.META}\n",
+            encoding="utf-8",
+        )
+        hc.encode_rule("Never hardcode credentials", kind="never")
+        texts = [r.text for r in hc.get_rules()]
+        assert "Project uses uv, not pip" in texts
+        assert "Never hardcode credentials" in texts


### PR DESCRIPTION
`encode_rule` is read-modify-write: `get_rules()` → append → `save_rules()`, which rewrites the whole file. Two gaps in that round-trip mean the next rule Anton learns silently deletes existing ones.

**Entries above the first `## ` heading are never read.** `get_rules` starts at `current_kind = None` and gates entries on `and current_kind`, so a rule hand-written before any heading never reaches the system prompt — and is dropped from the file by the next `save_rules`.

**Entries under a non-canonical heading are dropped on write.** `get_rules` takes `kind` from whatever heading it finds, so `## Notes` yields `kind="notes"`. `save_rules` buckets into a fixed `{"always", "never", "when"}` dict and skips anything that misses. No error, no log.

Before this change, a `rules.md` containing a `## Notes` section loses that section entirely the first time Anton learns any rule:

```
# Rules

## Always
- Call progress() before long API calls

## Never
- Never use time.sleep() in scratchpad cells

## When
```

`Cortex._compact_file` already guards exactly this, defaulting an unrecognised heading to `_RULE_SECTIONS[0]`, with the comment "Entries above the first heading (a hand-edited file) are kept rather than dropped." This applies the same rule in the storage layer so the two paths can't disagree, and moves the section tuple into `hippocampus.py` so there is one definition.

Entries under an unknown heading are relocated under `## Always` — the same thing compaction already does to them. Preserved and readable, not filed under a custom heading.

Adds three round-trip tests to `tests/test_hippocampus.py`; all three fail before the change. After it, `test_hippocampus.py` + `test_cortex.py` are green (104 passed), including the existing newline-injection tests, as are the consolidator, cerebellum, ACC, desktop-memory, self-awareness, history-compaction and reconsolidator suites (139 passed).

Targeting `staging` since that's where feature PRs are landing — `dev` hasn't moved since May. Happy to retarget.
